### PR TITLE
Add HTTPS proxy support for OpenAgents Studio

### DIFF
--- a/studio/src/components/chat/AttachmentDisplay.tsx
+++ b/studio/src/components/chat/AttachmentDisplay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { buildNetworkUrl } from '../../utils/httpClient';
 
 interface AttachmentDisplayProps {
   // 新的统一附件格式
@@ -32,7 +33,13 @@ const AttachmentDisplay: React.FC<AttachmentDisplayProps> = ({
   const handleDownload = (fileId: string, filename: string) => {
     // Use a dummy agent_id for now - in a real implementation, this would come from context
     const agentId = 'file-uploader-agent';
-    const downloadUrl = `${window.location.protocol}//${window.location.hostname}:9572/api/workspace/download/${fileId}?agent_id=${agentId}`;
+    
+    // Build download URL with automatic proxy support for HTTPS frontend
+    const downloadUrl = buildNetworkUrl(
+      window.location.hostname,
+      9572,
+      `/api/workspace/download/${fileId}?agent_id=${agentId}`
+    );
     
     // Create a temporary anchor element to trigger download
     const link = document.createElement('a');

--- a/studio/src/components/network/NetworkSelectionView.tsx
+++ b/studio/src/components/network/NetworkSelectionView.tsx
@@ -3,6 +3,7 @@ import OpenAgentsLogo from "../icons/OpenAgentsLogo";
 import LocalNetwork from "./LocalNetwork";
 import ManualNetwork from "./ManualNetwork";
 import PublicNetwork from "./PublicNetwork";
+import { isHttps } from "../../utils/httpClient";
 
 const NetworkSelectionView: React.FC = () => {
   const Header = React.memo(() => {
@@ -25,7 +26,7 @@ const NetworkSelectionView: React.FC = () => {
         <Header />
 
         <div className="p-8">
-          <LocalNetwork />
+          {!isHttps() && <LocalNetwork />}
 
           <ManualNetwork />
 

--- a/studio/src/services/eventConnector.ts
+++ b/studio/src/services/eventConnector.ts
@@ -79,8 +79,8 @@ export class HttpEventConnector {
       }
 
       // Register agent
-      console.log(`📡 Sending registration to ${this.baseUrl}/api/register`);
-      const registerResponse = await this.sendHttpRequest("/api/register", "POST", {
+      console.log(`📡 Sending registration to ${this.baseUrl}/register`);
+      const registerResponse = await this.sendHttpRequest("/register", "POST", {
         agent_id: this.agentId,
         metadata: {
           display_name: this.agentId,
@@ -140,7 +140,7 @@ export class HttpEventConnector {
     }
 
     try {
-      await this.sendHttpRequest("/api/unregister", "POST", {
+      await this.sendHttpRequest("/unregister", "POST", {
         agent_id: this.agentId,
       });
     } catch (error) {
@@ -188,7 +188,7 @@ export class HttpEventConnector {
         `📤 Sending event: ${event.event_name} from ${event.source_id}`
       );
 
-      const response = await this.sendHttpRequest("/api/send_event", "POST", {
+      const response = await this.sendHttpRequest("/send_event", "POST", {
         event_id: event.event_id,
         event_name: event.event_name,
         source_id: event.source_id,
@@ -441,7 +441,7 @@ export class HttpEventConnector {
   private async pollEvents(): Promise<void> {
     try {
       const response = await this.sendHttpRequest(
-        `/api/poll?agent_id=${this.agentId}`,
+        `/poll?agent_id=${this.agentId}`,
         "GET"
       );
 
@@ -489,7 +489,7 @@ export class HttpEventConnector {
     method: "GET" | "POST",
     data?: any
   ): Promise<any> {
-    const isPolling = endpoint.includes('/api/poll?agent_id=');
+    const isPolling = endpoint.includes('/poll?agent_id=');
     
     if (!isPolling) {
       console.log(`🌐 ${method} ${endpoint}`, data ? { body: data } : "");

--- a/studio/src/services/eventConnector.ts
+++ b/studio/src/services/eventConnector.ts
@@ -69,8 +69,8 @@ export class HttpEventConnector {
       console.log(`👤 Agent: ${this.agentId}`);
 
       // Health check
-      console.log(`📡 Sending health check to ${this.baseUrl}/health`);
-      const healthResponse = await this.sendHttpRequest("/health", "GET");
+      console.log(`📡 Sending health check to ${this.baseUrl}/api/health`);
+      const healthResponse = await this.sendHttpRequest("/api/health", "GET");
       console.log("📡 Health check response:", healthResponse);
       if (!healthResponse.success) {
         throw new Error(
@@ -350,7 +350,7 @@ export class HttpEventConnector {
 
   async getNetworkHealth(): Promise<any> {
     try {
-      const response = await this.sendHttpRequest("/health", "GET");
+      const response = await this.sendHttpRequest("/api/health", "GET");
       return response.data || {};
     } catch (error) {
       console.error("Failed to get network health:", error);

--- a/studio/src/services/eventConnector.ts
+++ b/studio/src/services/eventConnector.ts
@@ -79,8 +79,8 @@ export class HttpEventConnector {
       }
 
       // Register agent
-      console.log(`📡 Sending registration to ${this.baseUrl}/register`);
-      const registerResponse = await this.sendHttpRequest("/register", "POST", {
+      console.log(`📡 Sending registration to ${this.baseUrl}/api/register`);
+      const registerResponse = await this.sendHttpRequest("/api/register", "POST", {
         agent_id: this.agentId,
         metadata: {
           display_name: this.agentId,
@@ -140,7 +140,7 @@ export class HttpEventConnector {
     }
 
     try {
-      await this.sendHttpRequest("/unregister", "POST", {
+      await this.sendHttpRequest("/api/unregister", "POST", {
         agent_id: this.agentId,
       });
     } catch (error) {
@@ -188,7 +188,7 @@ export class HttpEventConnector {
         `📤 Sending event: ${event.event_name} from ${event.source_id}`
       );
 
-      const response = await this.sendHttpRequest("/send_event", "POST", {
+      const response = await this.sendHttpRequest("/api/send_event", "POST", {
         event_id: event.event_id,
         event_name: event.event_name,
         source_id: event.source_id,
@@ -441,7 +441,7 @@ export class HttpEventConnector {
   private async pollEvents(): Promise<void> {
     try {
       const response = await this.sendHttpRequest(
-        `/poll?agent_id=${this.agentId}`,
+        `/api/poll?agent_id=${this.agentId}`,
         "GET"
       );
 
@@ -489,7 +489,7 @@ export class HttpEventConnector {
     method: "GET" | "POST",
     data?: any
   ): Promise<any> {
-    const isPolling = endpoint.includes('/poll?agent_id=');
+    const isPolling = endpoint.includes('/api/poll?agent_id=');
     
     if (!isPolling) {
       console.log(`🌐 ${method} ${endpoint}`, data ? { body: data } : "");

--- a/studio/src/services/networkService.ts
+++ b/studio/src/services/networkService.ts
@@ -1,4 +1,5 @@
-import { ConnectionStatusEnum, NetworkConnection } from "@/types/connection";
+import { ConnectionStatusEnum, NetworkConnection } from "../types/connection";
+import { networkFetch } from "../utils/httpClient";
 
 export interface NetworkProfile {
   name: string;
@@ -35,11 +36,13 @@ export const detectLocalNetwork =
 
     for (const httpPort of commonPorts) {
       try {
-        const response = await fetch(
-          `http://localhost:${httpPort}/api/health`,
+        const response = await networkFetch(
+          "localhost",
+          httpPort,
+          "/api/health",
           {
             method: "GET",
-            signal: AbortSignal.timeout(3000), // 3 second timeout
+            timeout: 3000, // 3 second timeout
           }
         );
 
@@ -71,22 +74,21 @@ export const ManualNetworkConnection = async (
   const startTime = Date.now();
 
   try {
-    // Connect directly to the HTTP port
-    const protocol = window.location.protocol === "https:" ? "https" : "http";
-    const testUrl = `${protocol}://${host}:${port}/api/health`;
-
-    console.log(`Testing connection to HTTP endpoint: ${testUrl}`);
+    console.log(`Testing connection to network: ${host}:${port}`);
 
     // Use health check endpoint to test connectivity
-    const response = await fetch(testUrl, {
-      method: "GET",
-      mode: "cors", // Enable CORS
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-      signal: AbortSignal.timeout(5000), // 5 second timeout
-    });
+    const response = await networkFetch(
+      host,
+      port,
+      "/api/health",
+      {
+        method: "GET",
+        timeout: 5000, // 5 second timeout
+        headers: {
+          Accept: "application/json",
+        },
+      }
+    );
 
     const latency = Date.now() - startTime;
 

--- a/studio/src/utils/httpClient.ts
+++ b/studio/src/utils/httpClient.ts
@@ -10,7 +10,7 @@ const PROXY_BASE_URL = 'https://bridge.openagents.org';
 export interface HttpClientOptions {
   timeout?: number;
   headers?: HeadersInit;
-  signal?: AbortSignal;
+  signal?: AbortSignal | null;
 }
 
 /**

--- a/studio/src/utils/httpClient.ts
+++ b/studio/src/utils/httpClient.ts
@@ -1,0 +1,161 @@
+/**
+ * HTTP Client utility with automatic proxy support for HTTPS frontend
+ * 
+ * When the frontend is running on HTTPS, this utility automatically routes
+ * requests to HTTP-only OpenAgents networks through bridge.openagents.org proxy.
+ */
+
+const PROXY_BASE_URL = 'https://bridge.openagents.org';
+
+export interface HttpClientOptions {
+  timeout?: number;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+/**
+ * Check if the current frontend is running on HTTPS
+ */
+export const isHttps = (): boolean => {
+  return window.location.protocol === 'https:';
+};
+
+/**
+ * Check if a URL is an HTTP URL (not HTTPS)
+ */
+export const isHttpUrl = (url: string): boolean => {
+  return url.startsWith('http://');
+};
+
+/**
+ * Extract host and port from a URL
+ */
+export const extractHostPort = (url: string): { host: string; port?: string } => {
+  try {
+    const urlObj = new URL(url);
+    const host = urlObj.hostname;
+    const port = urlObj.port;
+    return { host, port };
+  } catch (error) {
+    console.error('Failed to parse URL:', url, error);
+    return { host: '', port: undefined };
+  }
+};
+
+/**
+ * Transform URL to use proxy when frontend is HTTPS and target is HTTP
+ */
+export const transformUrlForProxy = (originalUrl: string): { url: string; headers: Record<string, string> } => {
+  const frontendIsHttps = isHttps();
+  const targetIsHttp = isHttpUrl(originalUrl);
+  
+  // Only use proxy when frontend is HTTPS and target is HTTP
+  if (frontendIsHttps && targetIsHttp) {
+    const { host, port } = extractHostPort(originalUrl);
+    const targetHost = port ? `${host}:${port}` : host;
+    
+    // Replace the protocol and host with proxy URL, keep the path
+    const urlObj = new URL(originalUrl);
+    const proxyUrl = `${PROXY_BASE_URL}${urlObj.pathname}${urlObj.search}`;
+    
+    return {
+      url: proxyUrl,
+      headers: {
+        'X-Target-Host': targetHost
+      }
+    };
+  }
+  
+  // Direct connection for HTTP frontend or HTTPS targets
+  return {
+    url: originalUrl,
+    headers: {}
+  };
+};
+
+/**
+ * Enhanced fetch function with automatic proxy support
+ */
+export const httpFetch = async (
+  url: string, 
+  options: RequestInit & HttpClientOptions = {}
+): Promise<Response> => {
+  const { url: transformedUrl, headers: proxyHeaders } = transformUrlForProxy(url);
+  
+  // Merge headers
+  const mergedHeaders = {
+    ...options.headers,
+    ...proxyHeaders
+  };
+  
+  const fetchOptions: RequestInit = {
+    ...options,
+    headers: mergedHeaders
+  };
+  
+  // Add timeout if specified
+  if (options.timeout && !options.signal) {
+    fetchOptions.signal = AbortSignal.timeout(options.timeout);
+  }
+  
+  try {
+    console.log(`🌐 HTTP Request: ${options.method || 'GET'} ${transformedUrl}`);
+    if (proxyHeaders['X-Target-Host']) {
+      console.log(`🔄 Using proxy for target: ${proxyHeaders['X-Target-Host']}`);
+    }
+    
+    const response = await fetch(transformedUrl, fetchOptions);
+    
+    if (!response.ok) {
+      console.error(`❌ HTTP Error ${response.status}: ${response.statusText}`);
+    }
+    
+    return response;
+  } catch (error) {
+    console.error(`❌ Request failed for ${transformedUrl}:`, error);
+    throw error;
+  }
+};
+
+/**
+ * Build URL for OpenAgents network endpoint with automatic proxy support
+ */
+export const buildNetworkUrl = (host: string, port: number, endpoint: string): string => {
+  const baseUrl = `http://${host}:${port}`;
+  const fullUrl = `${baseUrl}${endpoint.startsWith('/') ? endpoint : '/' + endpoint}`;
+  
+  const { url } = transformUrlForProxy(fullUrl);
+  return url;
+};
+
+/**
+ * Build headers for OpenAgents network request with automatic proxy support
+ */
+export const buildNetworkHeaders = (host: string, port: number, additionalHeaders: Record<string, string> = {}): Record<string, string> => {
+  const baseUrl = `http://${host}:${port}`;
+  const { headers: proxyHeaders } = transformUrlForProxy(baseUrl);
+  
+  return {
+    'Content-Type': 'application/json',
+    ...additionalHeaders,
+    ...proxyHeaders
+  };
+};
+
+/**
+ * Convenience method for OpenAgents network requests
+ */
+export const networkFetch = async (
+  host: string,
+  port: number,
+  endpoint: string,
+  options: RequestInit & HttpClientOptions = {}
+): Promise<Response> => {
+  const url = buildNetworkUrl(host, port, endpoint);
+  const headers = buildNetworkHeaders(host, port, options.headers as Record<string, string>);
+  
+  return httpFetch(url, {
+    ...options,
+    headers
+  });
+};

--- a/studio/src/utils/httpClient.ts
+++ b/studio/src/utils/httpClient.ts
@@ -74,7 +74,7 @@ export const transformUrlForProxy = (originalUrl: string): { url: string; header
 };
 
 /**
- * Enhanced fetch function with automatic proxy support
+ * Enhanced fetch function with automatic proxy support and CORS fallback
  */
 export const httpFetch = async (
   url: string, 
@@ -111,7 +111,15 @@ export const httpFetch = async (
     }
     
     return response;
-  } catch (error) {
+  } catch (error: any) {
+    // Check if this is a CORS error when using proxy
+    if (proxyHeaders['X-Target-Host'] && error.message?.includes('CORS')) {
+      console.warn(`⚠️ CORS error with proxy, this indicates a server configuration issue:`);
+      console.warn(`   - The proxy at ${PROXY_BASE_URL} needs proper CORS headers`);
+      console.warn(`   - Target: ${proxyHeaders['X-Target-Host']}`);
+      console.warn(`   - Original URL: ${url}`);
+    }
+    
     console.error(`❌ Request failed for ${transformedUrl}:`, error);
     throw error;
   }


### PR DESCRIPTION
Implements automatic proxy routing through bridge.openagents.org when the studio frontend runs on HTTPS to communicate with HTTP-only OpenAgents networks, resolving SSL protocol errors.

Features:
- HTTP client utility with automatic proxy detection
- Conditional proxy usage: only when frontend is HTTPS and target is HTTP
- X-Target-Host header support for proxy routing
- Updated network service, event connector, and attachment display
- Seamless integration with existing code - no API changes required