### PR TITLE
feat: implement URL-based network switching with network-id parameter

### DIFF
--- a/studio/src/components/network/ManualNetwork.tsx
+++ b/studio/src/components/network/ManualNetwork.tsx
@@ -39,8 +39,8 @@ export default function ManualNetwork() {
   const [savedAgentName, setSavedAgentName] = useState<string | null>(null);
 
   const loadSavedInfoAndSetTab = useCallback(() => {
-    // Check for network_id in URL parameters first
-    const urlNetworkId = searchParams.get("network_id");
+    // Check for network-id in URL parameters first
+    const urlNetworkId = searchParams.get("network-id");
     const tabList = []
 
     if (urlNetworkId) {

--- a/studio/src/config/routeConfig.ts
+++ b/studio/src/config/routeConfig.ts
@@ -157,7 +157,7 @@ export interface RouteConfig {
 export const dynamicRouteConfig: RouteConfig[] = [
   // 认证相关路由 - 这些页面不需要 sidebar 和完整布局
   {
-    path: "/network-selection",
+    path: "/",
     element: NetworkSelectionPage,
     title: "Network Selection",
     requiresLayout: false,
@@ -379,10 +379,7 @@ export const getAllRoutes = () => {
 
 // 特殊路由（重定向等）
 export const specialRoutes = [
-  {
-    path: "/",
-    element: () => React.createElement(Navigate, { to: "/messaging", replace: true }),
-  },
+  // No special routes needed - NetworkSelectionPage is served directly under /
 ];
 
 // 动态配置更新函数 - 可以通过接口调用来更新配置

--- a/studio/src/router/AppRouter.tsx
+++ b/studio/src/router/AppRouter.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ToastProvider } from "@/context/ToastContext";
 import { ConfirmProvider } from "@/context/ConfirmContext";
 import RouteGuard from "./RouteGuard";
-import { routes, specialRoutes } from "./routeConfig";
+import { routes } from "./routeConfig";
 import RootLayout from "@/components/layout/RootLayout";
 
 // 创建受保护路由的包装器组件
@@ -64,11 +64,6 @@ const AppRouter: React.FC = () => {
             )}
 
             <Route path="/*" element={<ProtectedRoutes />} />
-
-            {/* 特殊路由（重定向等） */}
-            {specialRoutes.map(({ path, element: Element }) => (
-              <Route key={path} path={path} element={<Element />} />
-            ))}
           </Routes>
         </ConfirmProvider>
       </ToastProvider>


### PR DESCRIPTION
- Add support for ?network-id=<id> URL parameter to pre-fill network selection
- Serve NetworkSelectionPage directly under / instead of /network-selection
- Implement network ID validation and host/port comparison for logged-in users
- Auto-switch to Network ID tab and pre-fill field when network-id parameter present
- Preserve network-id parameter across all redirects in RouteGuard
- Fix routing logic to prevent redirect loops and handle network matching
- Remove obsolete special route redirects from / to /messaging