### PR TITLE
feat: add agent group authentication with password_hash parameter

### DIFF
--- a/examples/workspace_test.yaml
+++ b/examples/workspace_test.yaml
@@ -51,7 +51,42 @@ network:
   message_queue_size: 1000
   message_timeout: 30.0
   message_routing_enabled: true
-  
+
+  # Agent groups configuration with password-based authentication
+  # Agents join groups by providing a password_hash as a direct parameter during registration
+  # (not in metadata - passed directly in the registration event payload)
+  # Use openagents.utils.password_utils.hash_password() to generate hashes
+
+  # Default group for agents without valid credentials
+  default_agent_group: "guests"
+
+  agent_groups:
+    moderators:
+      password_hash: "$2b$12$p7CBrw9kLCB8LC0snzyFOeIAXSzrEK6Zw.IBXp9GYVtb75k5F/o7O"
+      description: "Forum moderators with elevated permissions"
+      metadata:
+        permissions: ["delete_posts", "ban_users", "manage_channels"]
+        # Password for this group: "ModSecure2024!" (do not store plaintext in production!)
+    ai-bots:
+      password_hash: "$2b$12$fN4XSArA6AmrXOZ6wtoKeO5vmUHuCUUzhFXEGulT2.GCi7VaPD2em"
+      description: "AI assistant and automation agents"
+      metadata:
+        permissions: ["post_messages", "read_channels"]
+        # Password: "AiBotKey2024!"
+    researchers:
+      password_hash: "$2b$12$U2x0T4obqhhTCVRvdnQxUu0deCEsOTC3kKf.BJr3kCqgN9hD3C1QK"
+      description: "Research agents and knowledge contributors"
+      metadata:
+        permissions: ["post_messages", "create_wiki_pages", "edit_documents"]
+        # Password: "ResearchAccess2024!"
+    users:
+      password_hash: "$2b$12$Mkk6zsut18qVjGNIUkDPjuswDtUqjaW/arJumrVTEcVmpA3gJhh/i"
+      description: "Regular user agents"
+      metadata:
+        permissions: ["post_messages", "read_channels"]
+        # Password: "UserStandard2024!"
+  # Note: Agents without valid credentials are assigned to the configured 'default_agent_group' (in this case: "guests")
+
   # Mod configuration - Thread messaging, workspace functionality, and shared documents
   mods:
     # Thread Messaging for Discord/Slack-like communication

--- a/examples/workspace_test.yaml
+++ b/examples/workspace_test.yaml
@@ -60,6 +60,11 @@ network:
   # Default group for agents without valid credentials
   default_agent_group: "guests"
 
+  # Password requirement setting
+  # When True: Password authentication is mandatory - agents must provide valid password_hash
+  # When False: Agents without password_hash are assigned to default_agent_group
+  requires_password: false
+
   agent_groups:
     moderators:
       password_hash: "$2b$12$p7CBrw9kLCB8LC0snzyFOeIAXSzrEK6Zw.IBXp9GYVtb75k5F/o7O"

--- a/src/openagents/agents/runner.py
+++ b/src/openagents/agents/runner.py
@@ -391,6 +391,7 @@ class AgentRunner(ABC):
         port: Optional[int] = None,
         network_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        password_hash: Optional[str] = None,
     ):
         """Async implementation of starting the agent runner.
 
@@ -398,8 +399,12 @@ class AgentRunner(ABC):
         """
         # verbose_print(f"🚀 Agent {self._agent_id} starting...")
         try:
-            connected = await self.client.connect_to_server(
-                host, port, network_id, metadata
+            connected = await self.client.connect(
+                network_host=host,
+                network_port=port,
+                network_id=network_id,
+                metadata=metadata,
+                password_hash=password_hash,
             )
             if not connected:
                 raise Exception("Failed to connect to server")
@@ -619,6 +624,7 @@ class AgentRunner(ABC):
         network_port: Optional[int] = None,
         network_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        password_hash: Optional[str] = None,
     ):
         """Start the agent runner.
 
@@ -630,6 +636,7 @@ class AgentRunner(ABC):
             port: Server port
             network_id: Network ID
             metadata: Additional metadata
+            password_hash: Password hash for agent group authentication
         """
         # Create a new event loop if one doesn't exist
         try:
@@ -641,7 +648,7 @@ class AgentRunner(ABC):
 
         # Run the async start method in the event loop
         try:
-            loop.run_until_complete(self._async_start(network_host, network_port, network_id, metadata))
+            loop.run_until_complete(self._async_start(network_host, network_port, network_id, metadata, password_hash))
         except Exception as e:
             raise Exception(f"Failed to start agent: {str(e)}")
 

--- a/src/openagents/config/globals.py
+++ b/src/openagents/config/globals.py
@@ -88,3 +88,6 @@ BROADCAST_AGENT_ID = "agent:broadcast"
 
 # ===== THREAD IDS =====
 THREAD_ID_UNCATEGORIZED = "uncategorized"
+
+# ===== SYSTEM METADATA =====
+DEFAULT_AGENT_GROUP = "guest"

--- a/src/openagents/core/client.py
+++ b/src/openagents/core/client.py
@@ -152,6 +152,7 @@ class AgentClient:
         enforce_transport_type: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         max_message_size: int = 104857600,
+        password_hash: Optional[str] = None,
     ) -> bool:
         """Connect to a network server.
 
@@ -162,6 +163,7 @@ class AgentClient:
             enforce_transport_type: Enforce a specific transport type (grpc, http, websocket)
             metadata: Metadata to send to the server
             max_message_size: Maximum WebSocket message size in bytes (default 10MB)
+            password_hash: Password hash for agent group authentication
 
         Returns:
             bool: True if connection successful
@@ -258,13 +260,14 @@ class AgentClient:
                 self.agent_id,
                 metadata,
                 max_message_size,
+                password_hash,
             )
         elif transport_type == "http":
             logger.info(f"Creating HTTP connector for agent {self.agent_id}")
             from openagents.core.connectors.http_connector import HTTPNetworkConnector
 
             self.connector = HTTPNetworkConnector(
-                optimal_transport_host, optimal_transport_port, self.agent_id, metadata
+                optimal_transport_host, optimal_transport_port, self.agent_id, metadata, password_hash
             )
         elif transport_type == "websocket":
             raise NotImplementedError("WebSocket transport is not supported yet")
@@ -313,6 +316,7 @@ class AgentClient:
         enforce_transport_type: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         max_message_size: int = 104857600,
+        password_hash: Optional[str] = None,
     ) -> bool:
         """Connect to a network server (alias for connect_to_server).
 
@@ -325,12 +329,13 @@ class AgentClient:
             enforce_transport_type: Enforce a specific transport type (grpc, http, websocket)
             metadata: Metadata to send to the server
             max_message_size: Maximum WebSocket message size in bytes (default 10MB)
+            password_hash: Password hash for agent group authentication
 
         Returns:
             bool: True if connection successful
         """
         return await self.connect_to_server(
-            network_host, network_port, network_id, enforce_transport_type, metadata, max_message_size
+            network_host, network_port, network_id, enforce_transport_type, metadata, max_message_size, password_hash
         )
 
     async def disconnect(self) -> bool:

--- a/src/openagents/core/connectors/grpc_connector.py
+++ b/src/openagents/core/connectors/grpc_connector.py
@@ -34,6 +34,7 @@ class GRPCNetworkConnector(NetworkConnector):
         agent_id: str,
         metadata: Optional[Dict[str, Any]] = None,
         max_message_size: int = 104857600,
+        password_hash: Optional[str] = None,
     ):
         """Initialize a gRPC network connector.
 
@@ -43,11 +44,13 @@ class GRPCNetworkConnector(NetworkConnector):
             agent_id: Agent identifier
             metadata: Agent metadata to send during registration
             max_message_size: Maximum message size in bytes (default 100MB)
+            password_hash: Password hash for agent group authentication
         """
         # Initialize base connector
         super().__init__(host, port, agent_id, metadata)
 
         self.max_message_size = max_message_size
+        self.password_hash = password_hash
         self.is_polling = True  # gRPC uses polling for message retrieval
 
         # gRPC components
@@ -139,6 +142,7 @@ class GRPCNetworkConnector(NetworkConnector):
                 agent_id=self.agent_id,
                 metadata=self.metadata,
                 capabilities=[],  # TODO: Add capabilities if needed
+                password_hash=self.password_hash or "",
             )
 
             register_response = await self.stub.RegisterAgent(register_request)

--- a/src/openagents/core/connectors/http_connector.py
+++ b/src/openagents/core/connectors/http_connector.py
@@ -32,6 +32,7 @@ class HTTPNetworkConnector(NetworkConnector):
         port: int,
         agent_id: str,
         metadata: Optional[Dict[str, Any]] = None,
+        password_hash: Optional[str] = None,
         timeout: int = 30,
     ):
         """Initialize an HTTP network connector.
@@ -41,12 +42,14 @@ class HTTPNetworkConnector(NetworkConnector):
             port: Server port
             agent_id: Agent identifier
             metadata: Agent metadata to send during registration
+            password_hash: Password hash for agent group authentication
             timeout: Request timeout in seconds (default 30)
         """
         # Initialize base connector
         super().__init__(host, port, agent_id, metadata)
 
         self.timeout = timeout
+        self.password_hash = password_hash
         self.is_polling = True  # HTTP uses polling for message retrieval
 
         # HTTP client session
@@ -115,7 +118,11 @@ class HTTPNetworkConnector(NetworkConnector):
                 return False
 
             # Register with server
-            register_data = {"agent_id": self.agent_id, "metadata": self.metadata}
+            register_data = {
+                "agent_id": self.agent_id,
+                "metadata": self.metadata,
+                "password_hash": self.password_hash or "",
+            }
 
             try:
                 async with self.session.post(

--- a/src/openagents/core/network.py
+++ b/src/openagents/core/network.py
@@ -352,6 +352,7 @@ class AgentNetwork:
         metadata: Dict[str, Any],
         certificate: str,
         force_reconnect: bool = False,
+        password_hash: Optional[str] = None,
     ) -> EventResponse:
         """Register an agent with the network.
 
@@ -361,6 +362,7 @@ class AgentNetwork:
             metadata: Agent metadata including capabilities
             certificate: Agent certificate
             force_reconnect: Whether to force reconnect
+            password_hash: Password hash for group authentication (direct parameter, not in metadata)
 
         Returns:
             bool: True if registration successful
@@ -393,11 +395,13 @@ class AgentNetwork:
                     message=f"Agent {agent_id} already registered with network",
                 )
 
-        success = await self.topology.register_agent(agent_info)
+        success = await self.topology.register_agent(agent_info, password_hash=password_hash)
 
         if success:
             # Generate and store authentication secret
             secret = self.secret_manager.generate_secret(agent_id)
+
+            # Group assignment is now handled by topology layer
 
             # Register agent with event gateway to create event queue
             self.event_gateway.register_agent(agent_id)
@@ -409,7 +413,11 @@ class AgentNetwork:
                 payload={"agent_id": agent_id, "metadata": metadata},
             )
             await self.process_external_event(registration_notification)
-            logger.info(f"Registered agent {agent_id} with network")
+
+            # Get assigned group from topology
+            assigned_group = self.topology.agent_group_membership.get(agent_id, "default")
+            logger.info(f"Registered agent {agent_id} with network in group '{assigned_group}'")
+
             return EventResponse(
                 success=True,
                 message=f"Registered agent {agent_id} with network",
@@ -478,10 +486,41 @@ class AgentNetwork:
         """Get network statistics.
 
         Returns:
-            Dict[str, Any]: Network statistics
+            Dict[str, Any]: Network statistics including group information
         """
         uptime = time.time() - self.start_time if self.start_time else 0
         agent_registry = self.get_agent_registry()
+
+        # Build groups dictionary: group_name -> list of agent_ids
+        # Use topology's agent_group_membership
+        groups: Dict[str, List[str]] = {}
+        for agent_id, group_name in self.topology.agent_group_membership.items():
+            if group_name not in groups:
+                groups[group_name] = []
+            groups[group_name].append(agent_id)
+
+        # Build group config info (without tokens for security)
+        group_config = []
+        added_group_names = set()
+        for group_name, group_cfg in self.config.agent_groups.items():
+            added_group_names.add(group_name)
+            group_config.append({
+                "name": group_name,
+                "description": group_cfg.description,
+                "agent_count": len(groups.get(group_name, [])),
+                "metadata": group_cfg.metadata,
+            })
+
+        # Add default group info if it has agents
+        default_group_name = self.config.default_agent_group
+        if default_group_name not in added_group_names:
+            added_group_names.add(default_group_name)
+            group_config.append({
+                "name": default_group_name,
+                "description": "Agents without valid credentials",
+                "agent_count": len(groups.get(default_group_name, [])),
+                "metadata": {},
+            })
 
         return {
             "network_id": self.network_id,
@@ -495,9 +534,12 @@ class AgentNetwork:
                     "last_seen": info.last_seen,
                     "transport_type": info.transport_type,
                     "address": info.address,
+                    "group": self.topology.agent_group_membership.get(agent_id, self.config.default_agent_group),
                 }
                 for agent_id, info in agent_registry.items()
             },
+            "groups": groups,
+            "group_config": group_config,
             "mods": [mod.model_dump() for mod in self.config.mods],
             "topology_mode": (
                 self.config.mode

--- a/src/openagents/core/network.py
+++ b/src/openagents/core/network.py
@@ -424,10 +424,15 @@ class AgentNetwork:
                 data={"secret": secret},
             )
         else:
+            # Check if rejection was due to password requirement
+            error_message = f"Failed to register agent {agent_id} with network"
+            if self.config.requires_password:
+                error_message = "Password authentication required for network registration"
+
             logger.error(f"Failed to register agent {agent_id} with network")
             return EventResponse(
                 success=False,
-                message=f"Failed to register agent {agent_id} with network",
+                message=error_message,
             )
 
     async def unregister_agent(self, agent_id: str) -> EventResponse:

--- a/src/openagents/core/system_commands.py
+++ b/src/openagents/core/system_commands.py
@@ -149,9 +149,10 @@ class SystemCommandProcessor:
         metadata = event.payload.get("metadata", {})
         certificate = event.payload.get("certificate", None)
         force_reconnect = event.payload.get("force_reconnect", False)
+        password_hash = event.payload.get("password_hash", None)
 
         return await self.network.register_agent(
-            agent_id, transport_type, metadata, certificate, force_reconnect
+            agent_id, transport_type, metadata, certificate, force_reconnect, password_hash
         )
 
     async def handle_unregister_agent(self, event: Event) -> EventResponse:

--- a/src/openagents/core/transports/grpc.py
+++ b/src/openagents/core/transports/grpc.py
@@ -134,6 +134,7 @@ class OpenAgentsGRPCServicer(agent_service_pb2_grpc.AgentServiceServicer):
                 "transport_type": TransportType.GRPC,
                 "certificate": getattr(request, "certificate", None),
                 "force_reconnect": getattr(request, "force_reconnect", True),
+                "password_hash": getattr(request, "password_hash", None),
             },
         )
         try:

--- a/src/openagents/core/transports/http.py
+++ b/src/openagents/core/transports/http.py
@@ -161,6 +161,7 @@ class HttpTransport(Transport):
                     "transport_type": TransportType.HTTP,
                     "certificate": data.get("certificate", None),
                     "force_reconnect": True,
+                    "password_hash": data.get("password_hash", None),
                 },
             )
             # Process the registration event through the event handler

--- a/src/openagents/models/network_config.py
+++ b/src/openagents/models/network_config.py
@@ -154,6 +154,11 @@ class NetworkConfig(BaseModel):
         "default",
         description="Name of the default group for agents without valid credentials",
     )
+    requires_password: bool = Field(
+        False,
+        description="When True, password authentication is mandatory for all agents (including default group). "
+                    "When False, agents without password_hash are assigned to default_agent_group.",
+    )
 
     @field_validator("name")
     @classmethod

--- a/src/openagents/models/network_config.py
+++ b/src/openagents/models/network_config.py
@@ -35,6 +35,27 @@ class ModConfig(BaseModel):
     )
 
 
+class AgentGroupConfig(BaseModel):
+    """Configuration for an agent group.
+
+    Uses password-based authentication where agents provide plain password
+    as 'password_hash' parameter during registration (not in metadata -
+    passed directly in the registration event payload).
+    """
+
+    password_hash: Optional[str] = Field(
+        None,
+        description="Bcrypt password hash for group authentication. "
+                    "Agents send plain password directly in registration payload, server verifies against this hash."
+    )
+    description: str = Field(
+        default="", description="Human-readable description of this group"
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Additional group metadata (e.g., permissions)"
+    )
+
+
 class AgentConfig(BaseModel):
     """Configuration for an agent."""
 
@@ -124,11 +145,37 @@ class NetworkConfig(BaseModel):
     message_queue_size: int = Field(1000, description="Maximum message queue size")
     message_timeout: float = Field(30.0, description="Message timeout in seconds")
 
+    # Agent groups configuration
+    agent_groups: Dict[str, AgentGroupConfig] = Field(
+        default_factory=dict,
+        description="Agent groups with registration tokens for group-based organization and permissions",
+    )
+    default_agent_group: str = Field(
+        "default",
+        description="Name of the default group for agents without valid credentials",
+    )
+
     @field_validator("name")
     @classmethod
     def name_must_be_valid(cls, v):
         if not v or not isinstance(v, str):
             raise ValueError("Network name must be a non-empty string")
+        return v
+
+    @field_validator("agent_groups")
+    @classmethod
+    def validate_agent_groups(cls, v):
+        """Validate agent groups configuration."""
+        if not v:
+            return v
+
+        # Check that each group has password_hash defined
+        for group_name, group_config in v.items():
+            if not group_config.password_hash:
+                raise ValueError(
+                    f"Group '{group_name}' must have 'password_hash' defined"
+                )
+
         return v
 
 

--- a/src/openagents/proto/agent_service.proto
+++ b/src/openagents/proto/agent_service.proto
@@ -54,6 +54,7 @@ message RegisterAgentRequest {
   repeated string capabilities = 3;
   bool force_reconnect = 4;
   string certificate = 5;
+  string password_hash = 6;
 }
 
 message RegisterAgentResponse {

--- a/src/openagents/proto/agent_service_pb2.py
+++ b/src/openagents/proto/agent_service_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x61gent_service.proto\x12\nopenagents\x1a\x19google/protobuf/any.proto\"\xb1\x02\n\x05\x45vent\x12\x10\n\x08\x65vent_id\x18\x01 \x01(\t\x12\x12\n\nevent_name\x18\x02 \x01(\t\x12\x11\n\tsource_id\x18\x03 \x01(\t\x12\x17\n\x0ftarget_agent_id\x18\x04 \x01(\t\x12%\n\x07payload\x18\x05 \x01(\x0b\x32\x14.google.protobuf.Any\x12\x11\n\ttimestamp\x18\x06 \x01(\x03\x12\x31\n\x08metadata\x18\x07 \x03(\x0b\x32\x1f.openagents.Event.MetadataEntry\x12\x12\n\nvisibility\x18\x08 \x01(\t\x12\x14\n\x0crelevant_mod\x18\t \x01(\t\x12\x0e\n\x06secret\x18\n \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"i\n\rEventResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\"\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\x12\x12\n\nevent_name\x18\x04 \x01(\t\"\xdf\x01\n\x14RegisterAgentRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12@\n\x08metadata\x18\x02 \x03(\x0b\x32..openagents.RegisterAgentRequest.MetadataEntry\x12\x14\n\x0c\x63\x61pabilities\x18\x03 \x03(\t\x12\x17\n\x0f\x66orce_reconnect\x18\x04 \x01(\x08\x12\x13\n\x0b\x63\x65rtificate\x18\x05 \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"O\n\x15RegisterAgentResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0e\n\x06secret\x18\x03 \x01(\t\":\n\x16UnregisterAgentRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\"A\n\x17UnregisterAgentResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x15\n\rerror_message\x18\x02 \x01(\t\"6\n\x15\x44iscoverAgentsRequest\x12\x1d\n\x15required_capabilities\x18\x01 \x03(\t\"?\n\x16\x44iscoverAgentsResponse\x12%\n\x06\x61gents\x18\x01 \x03(\x0b\x32\x15.openagents.AgentInfo\"\'\n\x13GetAgentInfoRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\"K\n\x14GetAgentInfoResponse\x12$\n\x05\x61gent\x18\x01 \x01(\x0b\x32\x15.openagents.AgentInfo\x12\r\n\x05\x66ound\x18\x02 \x01(\x08\"\xd7\x01\n\tAgentInfo\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x35\n\x08metadata\x18\x02 \x03(\x0b\x32#.openagents.AgentInfo.MetadataEntry\x12\x14\n\x0c\x63\x61pabilities\x18\x03 \x03(\t\x12\x11\n\tlast_seen\x18\x04 \x01(\x03\x12\x16\n\x0etransport_type\x18\x05 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x06 \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"7\n\x10HeartbeatRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\"7\n\x11HeartbeatResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\"\x14\n\x12NetworkInfoRequest\"\xf2\x01\n\x13NetworkInfoResponse\x12\x12\n\nnetwork_id\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_name\x18\x02 \x01(\t\x12\x12\n\nis_running\x18\x03 \x01(\x08\x12\x16\n\x0euptime_seconds\x18\x04 \x01(\x03\x12\x13\n\x0b\x61gent_count\x18\x05 \x01(\x05\x12%\n\x06\x61gents\x18\x06 \x03(\x0b\x32\x15.openagents.AgentInfo\x12\x15\n\rtopology_mode\x18\x07 \x01(\t\x12\x16\n\x0etransport_type\x18\x08 \x01(\t\x12\x0c\n\x04host\x18\t \x01(\t\x12\x0c\n\x04port\x18\n \x01(\x05\x32\xfe\x04\n\x0c\x41gentService\x12\x39\n\tSendEvent\x12\x11.openagents.Event\x1a\x19.openagents.EventResponse\x12\x38\n\x0cStreamEvents\x12\x11.openagents.Event\x1a\x11.openagents.Event(\x01\x30\x01\x12T\n\rRegisterAgent\x12 .openagents.RegisterAgentRequest\x1a!.openagents.RegisterAgentResponse\x12Z\n\x0fUnregisterAgent\x12\".openagents.UnregisterAgentRequest\x1a#.openagents.UnregisterAgentResponse\x12W\n\x0e\x44iscoverAgents\x12!.openagents.DiscoverAgentsRequest\x1a\".openagents.DiscoverAgentsResponse\x12Q\n\x0cGetAgentInfo\x12\x1f.openagents.GetAgentInfoRequest\x1a .openagents.GetAgentInfoResponse\x12H\n\tHeartbeat\x12\x1c.openagents.HeartbeatRequest\x1a\x1d.openagents.HeartbeatResponse\x12Q\n\x0eGetNetworkInfo\x12\x1e.openagents.NetworkInfoRequest\x1a\x1f.openagents.NetworkInfoResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x61gent_service.proto\x12\nopenagents\x1a\x19google/protobuf/any.proto\"\xb1\x02\n\x05\x45vent\x12\x10\n\x08\x65vent_id\x18\x01 \x01(\t\x12\x12\n\nevent_name\x18\x02 \x01(\t\x12\x11\n\tsource_id\x18\x03 \x01(\t\x12\x17\n\x0ftarget_agent_id\x18\x04 \x01(\t\x12%\n\x07payload\x18\x05 \x01(\x0b\x32\x14.google.protobuf.Any\x12\x11\n\ttimestamp\x18\x06 \x01(\x03\x12\x31\n\x08metadata\x18\x07 \x03(\x0b\x32\x1f.openagents.Event.MetadataEntry\x12\x12\n\nvisibility\x18\x08 \x01(\t\x12\x14\n\x0crelevant_mod\x18\t \x01(\t\x12\x0e\n\x06secret\x18\n \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"i\n\rEventResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\"\n\x04\x64\x61ta\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\x12\x12\n\nevent_name\x18\x04 \x01(\t\"\xf6\x01\n\x14RegisterAgentRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12@\n\x08metadata\x18\x02 \x03(\x0b\x32..openagents.RegisterAgentRequest.MetadataEntry\x12\x14\n\x0c\x63\x61pabilities\x18\x03 \x03(\t\x12\x17\n\x0f\x66orce_reconnect\x18\x04 \x01(\x08\x12\x13\n\x0b\x63\x65rtificate\x18\x05 \x01(\t\x12\x15\n\rpassword_hash\x18\x06 \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"O\n\x15RegisterAgentResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x0e\n\x06secret\x18\x03 \x01(\t\":\n\x16UnregisterAgentRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0e\n\x06secret\x18\x02 \x01(\t\"A\n\x17UnregisterAgentResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x15\n\rerror_message\x18\x02 \x01(\t\"6\n\x15\x44iscoverAgentsRequest\x12\x1d\n\x15required_capabilities\x18\x01 \x03(\t\"?\n\x16\x44iscoverAgentsResponse\x12%\n\x06\x61gents\x18\x01 \x03(\x0b\x32\x15.openagents.AgentInfo\"\'\n\x13GetAgentInfoRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\"K\n\x14GetAgentInfoResponse\x12$\n\x05\x61gent\x18\x01 \x01(\x0b\x32\x15.openagents.AgentInfo\x12\r\n\x05\x66ound\x18\x02 \x01(\x08\"\xd7\x01\n\tAgentInfo\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x35\n\x08metadata\x18\x02 \x03(\x0b\x32#.openagents.AgentInfo.MetadataEntry\x12\x14\n\x0c\x63\x61pabilities\x18\x03 \x03(\t\x12\x11\n\tlast_seen\x18\x04 \x01(\x03\x12\x16\n\x0etransport_type\x18\x05 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x06 \x01(\t\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"7\n\x10HeartbeatRequest\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\"7\n\x11HeartbeatResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\"\x14\n\x12NetworkInfoRequest\"\xf2\x01\n\x13NetworkInfoResponse\x12\x12\n\nnetwork_id\x18\x01 \x01(\t\x12\x14\n\x0cnetwork_name\x18\x02 \x01(\t\x12\x12\n\nis_running\x18\x03 \x01(\x08\x12\x16\n\x0euptime_seconds\x18\x04 \x01(\x03\x12\x13\n\x0b\x61gent_count\x18\x05 \x01(\x05\x12%\n\x06\x61gents\x18\x06 \x03(\x0b\x32\x15.openagents.AgentInfo\x12\x15\n\rtopology_mode\x18\x07 \x01(\t\x12\x16\n\x0etransport_type\x18\x08 \x01(\t\x12\x0c\n\x04host\x18\t \x01(\t\x12\x0c\n\x04port\x18\n \x01(\x05\x32\xfe\x04\n\x0c\x41gentService\x12\x39\n\tSendEvent\x12\x11.openagents.Event\x1a\x19.openagents.EventResponse\x12\x38\n\x0cStreamEvents\x12\x11.openagents.Event\x1a\x11.openagents.Event(\x01\x30\x01\x12T\n\rRegisterAgent\x12 .openagents.RegisterAgentRequest\x1a!.openagents.RegisterAgentResponse\x12Z\n\x0fUnregisterAgent\x12\".openagents.UnregisterAgentRequest\x1a#.openagents.UnregisterAgentResponse\x12W\n\x0e\x44iscoverAgents\x12!.openagents.DiscoverAgentsRequest\x1a\".openagents.DiscoverAgentsResponse\x12Q\n\x0cGetAgentInfo\x12\x1f.openagents.GetAgentInfoRequest\x1a .openagents.GetAgentInfoResponse\x12H\n\tHeartbeat\x12\x1c.openagents.HeartbeatRequest\x1a\x1d.openagents.HeartbeatResponse\x12Q\n\x0eGetNetworkInfo\x12\x1e.openagents.NetworkInfoRequest\x1a\x1f.openagents.NetworkInfoResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -45,35 +45,35 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_EVENTRESPONSE']._serialized_start=370
   _globals['_EVENTRESPONSE']._serialized_end=475
   _globals['_REGISTERAGENTREQUEST']._serialized_start=478
-  _globals['_REGISTERAGENTREQUEST']._serialized_end=701
+  _globals['_REGISTERAGENTREQUEST']._serialized_end=724
   _globals['_REGISTERAGENTREQUEST_METADATAENTRY']._serialized_start=321
   _globals['_REGISTERAGENTREQUEST_METADATAENTRY']._serialized_end=368
-  _globals['_REGISTERAGENTRESPONSE']._serialized_start=703
-  _globals['_REGISTERAGENTRESPONSE']._serialized_end=782
-  _globals['_UNREGISTERAGENTREQUEST']._serialized_start=784
-  _globals['_UNREGISTERAGENTREQUEST']._serialized_end=842
-  _globals['_UNREGISTERAGENTRESPONSE']._serialized_start=844
-  _globals['_UNREGISTERAGENTRESPONSE']._serialized_end=909
-  _globals['_DISCOVERAGENTSREQUEST']._serialized_start=911
-  _globals['_DISCOVERAGENTSREQUEST']._serialized_end=965
-  _globals['_DISCOVERAGENTSRESPONSE']._serialized_start=967
-  _globals['_DISCOVERAGENTSRESPONSE']._serialized_end=1030
-  _globals['_GETAGENTINFOREQUEST']._serialized_start=1032
-  _globals['_GETAGENTINFOREQUEST']._serialized_end=1071
-  _globals['_GETAGENTINFORESPONSE']._serialized_start=1073
-  _globals['_GETAGENTINFORESPONSE']._serialized_end=1148
-  _globals['_AGENTINFO']._serialized_start=1151
-  _globals['_AGENTINFO']._serialized_end=1366
+  _globals['_REGISTERAGENTRESPONSE']._serialized_start=726
+  _globals['_REGISTERAGENTRESPONSE']._serialized_end=805
+  _globals['_UNREGISTERAGENTREQUEST']._serialized_start=807
+  _globals['_UNREGISTERAGENTREQUEST']._serialized_end=865
+  _globals['_UNREGISTERAGENTRESPONSE']._serialized_start=867
+  _globals['_UNREGISTERAGENTRESPONSE']._serialized_end=932
+  _globals['_DISCOVERAGENTSREQUEST']._serialized_start=934
+  _globals['_DISCOVERAGENTSREQUEST']._serialized_end=988
+  _globals['_DISCOVERAGENTSRESPONSE']._serialized_start=990
+  _globals['_DISCOVERAGENTSRESPONSE']._serialized_end=1053
+  _globals['_GETAGENTINFOREQUEST']._serialized_start=1055
+  _globals['_GETAGENTINFOREQUEST']._serialized_end=1094
+  _globals['_GETAGENTINFORESPONSE']._serialized_start=1096
+  _globals['_GETAGENTINFORESPONSE']._serialized_end=1171
+  _globals['_AGENTINFO']._serialized_start=1174
+  _globals['_AGENTINFO']._serialized_end=1389
   _globals['_AGENTINFO_METADATAENTRY']._serialized_start=321
   _globals['_AGENTINFO_METADATAENTRY']._serialized_end=368
-  _globals['_HEARTBEATREQUEST']._serialized_start=1368
-  _globals['_HEARTBEATREQUEST']._serialized_end=1423
-  _globals['_HEARTBEATRESPONSE']._serialized_start=1425
-  _globals['_HEARTBEATRESPONSE']._serialized_end=1480
-  _globals['_NETWORKINFOREQUEST']._serialized_start=1482
-  _globals['_NETWORKINFOREQUEST']._serialized_end=1502
-  _globals['_NETWORKINFORESPONSE']._serialized_start=1505
-  _globals['_NETWORKINFORESPONSE']._serialized_end=1747
-  _globals['_AGENTSERVICE']._serialized_start=1750
-  _globals['_AGENTSERVICE']._serialized_end=2388
+  _globals['_HEARTBEATREQUEST']._serialized_start=1391
+  _globals['_HEARTBEATREQUEST']._serialized_end=1446
+  _globals['_HEARTBEATRESPONSE']._serialized_start=1448
+  _globals['_HEARTBEATRESPONSE']._serialized_end=1503
+  _globals['_NETWORKINFOREQUEST']._serialized_start=1505
+  _globals['_NETWORKINFOREQUEST']._serialized_end=1525
+  _globals['_NETWORKINFORESPONSE']._serialized_start=1528
+  _globals['_NETWORKINFORESPONSE']._serialized_end=1770
+  _globals['_AGENTSERVICE']._serialized_start=1773
+  _globals['_AGENTSERVICE']._serialized_end=2411
 # @@protoc_insertion_point(module_scope)

--- a/src/openagents/utils/password_utils.py
+++ b/src/openagents/utils/password_utils.py
@@ -1,0 +1,101 @@
+"""
+Password utilities for OpenAgents network security.
+
+This module provides secure password hashing and verification using bcrypt.
+"""
+
+import bcrypt
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def hash_password(password: str) -> str:
+    """
+    Hash a password using bcrypt.
+    
+    Args:
+        password: Plain text password to hash
+        
+    Returns:
+        str: Bcrypt hash of the password
+        
+    Raises:
+        ValueError: If password is empty or None
+    """
+    if not password:
+        raise ValueError("Password cannot be empty")
+        
+    # Generate salt and hash the password
+    salt = bcrypt.gensalt()
+    password_bytes = password.encode('utf-8')
+    hashed = bcrypt.hashpw(password_bytes, salt)
+    
+    # Return as string for storage
+    return hashed.decode('utf-8')
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """
+    Verify a password against a bcrypt hash.
+    
+    Args:
+        password: Plain text password to verify
+        password_hash: Bcrypt hash to verify against
+        
+    Returns:
+        bool: True if password matches hash, False otherwise
+    """
+    if not password or not password_hash:
+        return False
+        
+    try:
+        password_bytes = password.encode('utf-8')
+        hash_bytes = password_hash.encode('utf-8')
+        return bcrypt.checkpw(password_bytes, hash_bytes)
+    except Exception as e:
+        logger.warning(f"Password verification failed: {e}")
+        return False
+
+
+def generate_password_hash_for_config(password: str) -> str:
+    """
+    Generate a password hash for use in network configuration.
+    
+    This is a convenience function for creating password hashes
+    that can be stored in network configuration files.
+    
+    Args:
+        password: Plain text password
+        
+    Returns:
+        str: Bcrypt hash suitable for configuration storage
+        
+    Example:
+        >>> hash_value = generate_password_hash_for_config("my_secure_password")
+        >>> # Store hash_value in network config's password_hash field
+    """
+    return hash_password(password)
+
+
+def validate_password_strength(password: str) -> tuple[bool, str]:
+    """
+    Validate password strength requirements.
+    
+    Args:
+        password: Password to validate
+        
+    Returns:
+        tuple: (is_valid, error_message)
+    """
+    if not password:
+        return False, "Password cannot be empty"
+        
+    if len(password) < 8:
+        return False, "Password must be at least 8 characters long"
+        
+    # Add more strength requirements as needed
+    # For now, just check minimum length
+    
+    return True, ""

--- a/tests/grpc/test_basic_grpc_communication.py
+++ b/tests/grpc/test_basic_grpc_communication.py
@@ -32,19 +32,34 @@ async def test_network():
     # Load config and use random port to avoid conflicts
     config = load_network_config(str(config_path))
 
-    # Update the gRPC transport port to avoid conflicts
-    grpc_port = random.randint(47000, 48000)
-    http_port = grpc_port + 100  # HTTP port should be different
+    # Retry network initialization with different ports if there's a conflict
+    network = None
+    max_retries = 5
+    for attempt in range(max_retries):
+        grpc_port = random.randint(47000, 48000)
+        http_port = grpc_port + 100  # HTTP port should be different
 
-    for transport in config.network.transports:
-        if transport.type == "grpc":
-            transport.config["port"] = grpc_port
-        elif transport.type == "http":
-            transport.config["port"] = http_port
+        for transport in config.network.transports:
+            if transport.type == "grpc":
+                transport.config["port"] = grpc_port
+            elif transport.type == "http":
+                transport.config["port"] = http_port
 
-    # Create and initialize network
-    network = create_network(config.network)
-    await network.initialize()
+        # Create and initialize network
+        network = create_network(config.network)
+        success = await network.initialize()
+
+        if success:
+            print(f"✅ Network initialized successfully on attempt {attempt + 1} (ports: gRPC={grpc_port}, HTTP={http_port})")
+            break
+        else:
+            print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
+            try:
+                await network.shutdown()
+            except:
+                pass
+            if attempt == max_retries - 1:
+                raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")
 
     # Give network time to start up
     await asyncio.sleep(1.0)

--- a/tests/grpc/test_basic_test_mod.py
+++ b/tests/grpc/test_basic_test_mod.py
@@ -36,19 +36,34 @@ async def test_network():
     # Load config and use random port to avoid conflicts
     config = load_network_config(str(config_path))
 
-    # Update the gRPC transport port to avoid conflicts
-    grpc_port = random.randint(47000, 48000)
-    http_port = grpc_port + 100  # HTTP port should be different
+    # Retry network initialization with different ports if there's a conflict
+    network = None
+    max_retries = 5
+    for attempt in range(max_retries):
+        grpc_port = random.randint(47000, 48000)
+        http_port = grpc_port + 100  # HTTP port should be different
 
-    for transport in config.network.transports:
-        if transport.type == "grpc":
-            transport.config["port"] = grpc_port
-        elif transport.type == "http":
-            transport.config["port"] = http_port
+        for transport in config.network.transports:
+            if transport.type == "grpc":
+                transport.config["port"] = grpc_port
+            elif transport.type == "http":
+                transport.config["port"] = http_port
 
-    # Create and initialize network
-    network = create_network(config.network)
-    await network.initialize()
+        # Create and initialize network
+        network = create_network(config.network)
+        success = await network.initialize()
+
+        if success:
+            print(f"✅ Network initialized successfully on attempt {attempt + 1} (ports: gRPC={grpc_port}, HTTP={http_port})")
+            break
+        else:
+            print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
+            try:
+                await network.shutdown()
+            except:
+                pass
+            if attempt == max_retries - 1:
+                raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")
 
     # Give network time to start up
     await asyncio.sleep(1.0)

--- a/tests/http/test_basic_http_communication.py
+++ b/tests/http/test_basic_http_communication.py
@@ -32,19 +32,34 @@ async def test_network():
     # Load config and use random port to avoid conflicts
     config = load_network_config(str(config_path))
 
-    # Update the gRPC and HTTP transport ports to avoid conflicts
-    grpc_port = random.randint(47000, 48000)
-    http_port = grpc_port + 100  # HTTP port should be different
+    # Retry network initialization with different ports if there's a conflict
+    network = None
+    max_retries = 5
+    for attempt in range(max_retries):
+        grpc_port = random.randint(47000, 48000)
+        http_port = grpc_port + 100  # HTTP port should be different
 
-    for transport in config.network.transports:
-        if transport.type == "grpc":
-            transport.config["port"] = grpc_port
-        elif transport.type == "http":
-            transport.config["port"] = http_port
+        for transport in config.network.transports:
+            if transport.type == "grpc":
+                transport.config["port"] = grpc_port
+            elif transport.type == "http":
+                transport.config["port"] = http_port
 
-    # Create and initialize network
-    network = create_network(config.network)
-    await network.initialize()
+        # Create and initialize network
+        network = create_network(config.network)
+        success = await network.initialize()
+
+        if success:
+            print(f"✅ Network initialized successfully on attempt {attempt + 1} (ports: gRPC={grpc_port}, HTTP={http_port})")
+            break
+        else:
+            print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
+            try:
+                await network.shutdown()
+            except:
+                pass
+            if attempt == max_retries - 1:
+                raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")
 
     # Give network time to start up
     await asyncio.sleep(1.0)

--- a/tests/integration/test_agent_group_auth.py
+++ b/tests/integration/test_agent_group_auth.py
@@ -1,0 +1,319 @@
+"""
+Integration tests for agent group authentication with gRPC and HTTP clients.
+
+This module tests end-to-end agent group authentication using both
+gRPC and HTTP transports.
+"""
+
+import pytest
+import asyncio
+
+from openagents.core.network import AgentNetwork
+from openagents.core.client import AgentClient
+from openagents.models.network_config import NetworkConfig, AgentGroupConfig, NetworkMode, TransportConfigItem
+from openagents.models.transport import TransportType
+
+
+# Test hashes for groups
+ADMIN_HASH = "admin_secret_hash_123"
+USER_HASH = "user_secret_hash_456"
+
+
+@pytest.fixture
+async def network_with_groups():
+    """Create a test network with agent groups and both gRPC and HTTP transports."""
+    config = NetworkConfig(
+        name="TestNetwork",
+        mode=NetworkMode.CENTRALIZED,
+        host="localhost",
+        port=8571,  # Use different port to avoid conflicts
+        default_agent_group="guests",
+        transports=[
+            TransportConfigItem(
+                type=TransportType.GRPC,
+                config={"host": "localhost", "port": 8571}
+            ),
+            TransportConfigItem(
+                type=TransportType.HTTP,
+                config={"host": "localhost", "port": 8572}
+            ),
+        ],
+        agent_groups={
+            "admins": AgentGroupConfig(
+                password_hash=ADMIN_HASH,
+                description="Administrator agents",
+                metadata={"permissions": ["all"]},
+            ),
+            "users": AgentGroupConfig(
+                password_hash=USER_HASH,
+                description="Regular user agents",
+                metadata={"permissions": ["read", "write"]},
+            ),
+        },
+    )
+
+    network = AgentNetwork.create_from_config(config)
+    await network.initialize()
+
+    yield network
+
+    # Cleanup
+    await network.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_grpc_client_with_valid_password_hash(network_with_groups):
+    """Test gRPC client connecting with valid password hash."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="grpc-admin-1")
+
+    try:
+        # Connect with valid admin password hash
+        # Use HTTP port for auto-detection, it will choose the right transport
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,  # HTTP port for auto-detection
+            password_hash=ADMIN_HASH,
+        )
+
+        assert connected, "Client should connect successfully"
+
+        # Verify agent was assigned to admins group
+        group = network.topology.agent_group_membership.get("grpc-admin-1")
+        assert group == "admins", f"Expected 'admins', got '{group}'"
+
+        # Verify agent appears in network stats
+        stats = network.get_network_stats()
+        assert "grpc-admin-1" in stats["agents"]
+        assert stats["agents"]["grpc-admin-1"]["group"] == "admins"
+        assert "grpc-admin-1" in stats["groups"]["admins"]
+
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_grpc_client_with_invalid_password_hash(network_with_groups):
+    """Test gRPC client connecting with invalid password hash goes to default group."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="grpc-guest-1")
+
+    try:
+        # Connect with invalid password hash
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,
+            
+            password_hash="wrong_hash_999",
+        )
+
+        assert connected, "gRPC client should connect successfully"
+
+        # Verify agent was assigned to default guests group
+        group = network.topology.agent_group_membership.get("grpc-guest-1")
+        assert group == "guests", f"Expected 'guests', got '{group}'"
+
+        # Verify agent appears in network stats
+        stats = network.get_network_stats()
+        assert "grpc-guest-1" in stats["agents"]
+        assert stats["agents"]["grpc-guest-1"]["group"] == "guests"
+
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_grpc_client_without_password_hash(network_with_groups):
+    """Test gRPC client connecting without password hash goes to default group."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="grpc-no-password-1")
+
+    try:
+        # Connect without password hash
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,
+            
+        )
+
+        assert connected, "gRPC client should connect successfully"
+
+        # Verify agent was assigned to default guests group
+        group = network.topology.agent_group_membership.get("grpc-no-password-1")
+        assert group == "guests", f"Expected 'guests', got '{group}'"
+
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_http_client_with_valid_password_hash(network_with_groups):
+    """Test HTTP client connecting with valid password hash."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="http-admin-1")
+
+    try:
+        # Connect with valid admin password hash
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,
+            enforce_transport_type="http",
+            password_hash=ADMIN_HASH,
+        )
+
+        assert connected, "HTTP client should connect successfully"
+
+        # Verify agent was assigned to admins group
+        group = network.topology.agent_group_membership.get("http-admin-1")
+        assert group == "admins", f"Expected 'admins', got '{group}'"
+
+        # Verify agent appears in network stats
+        stats = network.get_network_stats()
+        assert "http-admin-1" in stats["agents"]
+        assert stats["agents"]["http-admin-1"]["group"] == "admins"
+        assert "http-admin-1" in stats["groups"]["admins"]
+
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_http_client_with_invalid_password_hash(network_with_groups):
+    """Test HTTP client connecting with invalid password hash goes to default group."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="http-guest-1")
+
+    try:
+        # Connect with invalid password hash
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,
+            enforce_transport_type="http",
+            password_hash="wrong_hash_999",
+        )
+
+        assert connected, "HTTP client should connect successfully"
+
+        # Verify agent was assigned to default guests group
+        group = network.topology.agent_group_membership.get("http-guest-1")
+        assert group == "guests", f"Expected 'guests', got '{group}'"
+
+        # Verify agent appears in network stats
+        stats = network.get_network_stats()
+        assert "http-guest-1" in stats["agents"]
+        assert stats["agents"]["http-guest-1"]["group"] == "guests"
+
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_http_client_without_password_hash(network_with_groups):
+    """Test HTTP client connecting without password hash goes to default group."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="http-no-password-1")
+
+    try:
+        # Connect without password hash
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,
+            enforce_transport_type="http",
+        )
+
+        assert connected, "HTTP client should connect successfully"
+
+        # Verify agent was assigned to default guests group
+        group = network.topology.agent_group_membership.get("http-no-password-1")
+        assert group == "guests", f"Expected 'guests', got '{group}'"
+
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_multiple_clients_different_transports_same_group(network_with_groups):
+    """Test multiple clients using different transports can join the same group."""
+    network = network_with_groups
+
+    grpc_client = AgentClient(agent_id="grpc-user-1")
+    http_client = AgentClient(agent_id="http-user-1")
+
+    try:
+        # Connect both clients with user password hash
+        grpc_connected = await grpc_client.connect(
+            network_host="localhost",
+            network_port=8572,
+            
+            password_hash=USER_HASH,
+        )
+
+        http_connected = await http_client.connect(
+            network_host="localhost",
+            network_port=8572,
+            enforce_transport_type="http",
+            password_hash=USER_HASH,
+        )
+
+        assert grpc_connected and http_connected, "Both clients should connect"
+
+        # Verify both agents assigned to users group
+        grpc_group = network.topology.agent_group_membership.get("grpc-user-1")
+        http_group = network.topology.agent_group_membership.get("http-user-1")
+
+        assert grpc_group == "users", f"gRPC client expected 'users', got '{grpc_group}'"
+        assert http_group == "users", f"HTTP client expected 'users', got '{http_group}'"
+
+        # Verify both appear in same group in network stats
+        stats = network.get_network_stats()
+        assert "grpc-user-1" in stats["groups"]["users"]
+        assert "http-user-1" in stats["groups"]["users"]
+        assert len(stats["groups"]["users"]) == 2
+
+    finally:
+        await grpc_client.disconnect()
+        await http_client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_group_cleanup_on_disconnect(network_with_groups):
+    """Test that group membership is cleaned up when client disconnects."""
+    network = network_with_groups
+
+    client = AgentClient(agent_id="temp-admin")
+
+    try:
+        # Connect with admin password
+        connected = await client.connect(
+            network_host="localhost",
+            network_port=8572,
+            
+            password_hash=ADMIN_HASH,
+        )
+
+        assert connected, "Client should connect"
+
+        # Verify agent in admins group
+        group = network.topology.agent_group_membership.get("temp-admin")
+        assert group == "admins"
+
+        # Disconnect
+        await client.disconnect()
+
+        # Verify agent removed from group membership
+        assert "temp-admin" not in network.topology.agent_group_membership
+
+        # Verify agent not in network stats
+        stats = network.get_network_stats()
+        assert "temp-admin" not in stats["agents"]
+
+    except Exception:
+        # Ensure cleanup even if test fails
+        await client.disconnect()
+        raise

--- a/tests/network/test_agent_groups.py
+++ b/tests/network/test_agent_groups.py
@@ -1,0 +1,301 @@
+"""
+Test cases for the agent groups system.
+
+This module contains tests for agent group configuration, authentication,
+and permission management.
+"""
+
+import pytest
+import asyncio
+
+from openagents.core.network import AgentNetwork
+from openagents.models.network_config import NetworkConfig, AgentGroupConfig, NetworkMode
+from openagents.models.transport import TransportType
+
+# Predefined password hashes for testing
+MODERATOR_HASH = "mod_hash_12345"
+USER_HASH = "user_hash_67890"
+
+
+@pytest.fixture
+async def network_with_groups():
+    """Create a test network with agent groups configured."""
+    config = NetworkConfig(
+        name="TestNetwork",
+        mode=NetworkMode.CENTRALIZED,
+        default_agent_group="guests",
+        agent_groups={
+            "moderators": AgentGroupConfig(
+                password_hash=MODERATOR_HASH,
+                description="Forum moderators with elevated permissions",
+                metadata={"permissions": ["delete_posts", "ban_users", "manage_channels"]},
+            ),
+            "users": AgentGroupConfig(
+                password_hash=USER_HASH,
+                description="Regular user agents",
+                metadata={"permissions": ["post_messages", "read_channels"]},
+            ),
+        },
+    )
+
+    network = AgentNetwork.create_from_config(config)
+    await network.initialize()
+
+    yield network
+
+    # Cleanup
+    await network.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_password_based_authentication(network_with_groups):
+    """Test password-based group authentication."""
+    network = network_with_groups
+
+    # Register agent with valid moderator password hash
+    response = await network.register_agent(
+        agent_id="mod-agent-1",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "Moderator Agent"},
+        certificate=None,
+        force_reconnect=False,
+        password_hash=MODERATOR_HASH,
+    )
+
+    assert response.success, f"Registration failed: {response.message}"
+
+    # Verify agent was assigned to moderators group
+    group = network.topology.agent_group_membership.get("mod-agent-1")
+    assert group == "moderators", f"Expected 'moderators', got '{group}'"
+
+    # Verify group metadata is preserved
+    stats = network.get_network_stats()
+    mod_group_config = next(
+        (g for g in stats["group_config"] if g["name"] == "moderators"), None
+    )
+    assert mod_group_config is not None
+    assert mod_group_config["description"] == "Forum moderators with elevated permissions"
+    assert mod_group_config["metadata"]["permissions"] == [
+        "delete_posts",
+        "ban_users",
+        "manage_channels",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_invalid_password_authentication(network_with_groups):
+    """Test that invalid passwords assign agents to default group."""
+    network = network_with_groups
+
+    # Register agent with invalid password
+    response = await network.register_agent(
+        agent_id="invalid-agent-1",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "Invalid Agent"},
+        certificate=None,
+        force_reconnect=False,
+        password_hash="WrongPassword123!",
+    )
+
+    assert response.success, f"Registration failed: {response.message}"
+
+    # Verify agent was assigned to default group (guests)
+    group = network.topology.agent_group_membership.get("invalid-agent-1")
+    assert group == "guests", f"Expected 'guests', got '{group}'"
+
+
+@pytest.mark.asyncio
+async def test_no_credentials_authentication(network_with_groups):
+    """Test that agents without credentials go to default group."""
+    network = network_with_groups
+
+    # Register agent without any credentials
+    response = await network.register_agent(
+        agent_id="guest-agent-1",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "Guest Agent"},
+        certificate=None,
+        force_reconnect=False,
+        password_hash=None,
+    )
+
+    assert response.success, f"Registration failed: {response.message}"
+
+    # Verify agent was assigned to default group (guests)
+    group = network.topology.agent_group_membership.get("guest-agent-1")
+    assert group == "guests", f"Expected 'guests', got '{group}'"
+
+
+@pytest.mark.asyncio
+async def test_multiple_agents_same_group(network_with_groups):
+    """Test multiple agents can join the same group."""
+    network = network_with_groups
+
+    # Register multiple users with same password
+    for i in range(3):
+        response = await network.register_agent(
+            agent_id=f"user-agent-{i}",
+            transport_type=TransportType.HTTP,
+            metadata={"name": f"User Agent {i}"},
+            certificate=None,
+            force_reconnect=False,
+            password_hash=USER_HASH,
+        )
+        assert response.success
+
+    # Verify all were assigned to users group
+    for i in range(3):
+        group = network.topology.agent_group_membership.get(f"user-agent-{i}")
+        assert group == "users", f"Agent {i} expected 'users', got '{group}'"
+
+    # Verify network stats show correct counts
+    stats = network.get_network_stats()
+    assert "users" in stats["groups"]
+    assert len(stats["groups"]["users"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_configurable_default_group():
+    """Test that default_agent_group configuration is respected."""
+    config = NetworkConfig(
+        name="TestNetwork",
+        mode=NetworkMode.CENTRALIZED,
+        default_agent_group="anonymous",  # Custom default group name
+        agent_groups={},
+    )
+
+    network = AgentNetwork.create_from_config(config)
+    await network.initialize()
+
+    try:
+        # Register agent without credentials
+        response = await network.register_agent(
+            agent_id="test-agent",
+            transport_type=TransportType.HTTP,
+            metadata={"name": "Test Agent"},
+            certificate=None,
+            force_reconnect=False,
+            password_hash=None,
+        )
+
+        assert response.success
+
+        # Verify agent was assigned to custom default group
+        group = network.topology.agent_group_membership.get("test-agent")
+        assert group == "anonymous", f"Expected 'anonymous', got '{group}'"
+
+        # Verify network stats use custom default group name
+        stats = network.get_network_stats()
+        assert "anonymous" in stats["groups"]
+        assert "default" not in stats["groups"]
+
+    finally:
+        await network.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_group_cleanup_on_unregister(network_with_groups):
+    """Test that group membership is cleaned up when agent unregisters."""
+    network = network_with_groups
+
+    # Register agent
+    response = await network.register_agent(
+        agent_id="temp-agent",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "Temporary Agent"},
+        certificate=None,
+        force_reconnect=False,
+        password_hash=MODERATOR_HASH,
+    )
+
+    assert response.success
+
+    # Verify agent is in moderators group
+    group = network.topology.agent_group_membership.get("temp-agent")
+    assert group == "moderators"
+
+    # Unregister agent
+    unregister_response = await network.unregister_agent("temp-agent")
+    assert unregister_response.success
+
+    # Verify agent is removed from group membership
+    assert "temp-agent" not in network.topology.agent_group_membership
+
+    # Verify network stats don't include the agent
+    stats = network.get_network_stats()
+    assert "temp-agent" not in stats["agents"]
+
+
+@pytest.mark.asyncio
+async def test_network_stats_group_info(network_with_groups):
+    """Test that network stats correctly report group information."""
+    network = network_with_groups
+
+    # Register agents in different groups
+    await network.register_agent(
+        agent_id="mod-1",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "Moderator 1"},
+        certificate=None,
+        password_hash=MODERATOR_HASH,
+    )
+
+    await network.register_agent(
+        agent_id="user-1",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "User 1"},
+        certificate=None,
+        password_hash=USER_HASH,
+    )
+
+    await network.register_agent(
+        agent_id="guest-1",
+        transport_type=TransportType.HTTP,
+        metadata={"name": "Guest 1"},
+        certificate=None,
+        password_hash=None,
+    )
+
+    # Get network stats
+    stats = network.get_network_stats()
+
+    # Verify groups dictionary is populated correctly
+    assert "moderators" in stats["groups"]
+    assert "users" in stats["groups"]
+    assert "guests" in stats["groups"]
+
+    assert "mod-1" in stats["groups"]["moderators"]
+    assert "user-1" in stats["groups"]["users"]
+    assert "guest-1" in stats["groups"]["guests"]
+
+    # Verify group_config array includes all groups
+    group_names = [g["name"] for g in stats["group_config"]]
+    assert "moderators" in group_names
+    assert "users" in group_names
+    assert "guests" in group_names  # Default group should be included
+
+    # Verify agent count is correct in group_config
+    mod_config = next(g for g in stats["group_config"] if g["name"] == "moderators")
+    assert mod_config["agent_count"] == 1
+
+    # Verify each agent has group info
+    assert stats["agents"]["mod-1"]["group"] == "moderators"
+    assert stats["agents"]["user-1"]["group"] == "users"
+    assert stats["agents"]["guest-1"]["group"] == "guests"
+
+
+@pytest.mark.asyncio
+async def test_group_metadata_not_exposed_in_stats(network_with_groups):
+    """Test that sensitive group data (tokens, passwords) is not exposed in stats."""
+    network = network_with_groups
+
+    stats = network.get_network_stats()
+
+    # Verify group_config doesn't include password_hashes
+    for group_cfg in stats["group_config"]:
+        assert "password_hash" not in group_cfg
+
+        # But metadata should be included
+        if group_cfg["name"] == "moderators":
+            assert "metadata" in group_cfg
+            assert "permissions" in group_cfg["metadata"]

--- a/tests/studio/test_messaging_mod_with_http_api.py
+++ b/tests/studio/test_messaging_mod_with_http_api.py
@@ -527,6 +527,9 @@ class TestMessagingFlow:
         print("\n🧪 Test: Direct Message Flow")
         print("-" * 40)
 
+        # Add extra delay to ensure network is fully ready
+        await asyncio.sleep(5)
+
         # Register both clients
         assert await client_a.register(), "Client A registration should succeed"
         assert await client_b.register(), "Client B registration should succeed"
@@ -609,6 +612,9 @@ class TestMessagingFlow:
         """
         print("\n🧪 Test: Self Reply Flow")
         print("-" * 40)
+
+        # Add extra delay to ensure network is fully ready
+        await asyncio.sleep(5)
 
         # Register both clients
         assert await client_a.register(), "Client A registration should succeed"
@@ -710,6 +716,9 @@ class TestMessagingFlow:
         """
         print("\n🧪 Test: Cross-Client Reply Flow")
         print("-" * 40)
+
+        # Add extra delay to ensure network is fully ready
+        await asyncio.sleep(5)
 
         # Register both clients
         assert await client_a.register(), "Client A registration should succeed"
@@ -832,6 +841,9 @@ class TestMessagingFlow:
         print("\n🧪 Test: Reaction Flow")
         print("-" * 40)
 
+        # Add extra delay to ensure network is fully ready
+        await asyncio.sleep(5)
+
         # Register both clients
         assert await client_a.register(), "Client A registration should succeed"
         assert await client_b.register(), "Client B registration should succeed"
@@ -941,6 +953,9 @@ class TestMessagingFlow:
         """
         print("\n🧪 Test: File Operations Flow")
         print("-" * 40)
+
+        # Add extra delay to ensure network is fully ready
+        await asyncio.sleep(5)
 
         # Register both clients
         assert await client_a.register(), "Client A registration should succeed"

--- a/tests/workspace/test_grpc_workspace.py
+++ b/tests/workspace/test_grpc_workspace.py
@@ -301,9 +301,9 @@ async def test_workspace_channel_message_retrieval(
     # Give time for messages to be processed
     await asyncio.sleep(2.0)
 
-    # Test message retrieval (now synchronous!)
-    print("📥 Testing synchronous message retrieval...")
-    messages = general_channel.get_messages(limit=10)
+    # Test message retrieval
+    print("📥 Testing message retrieval...")
+    messages = await general_channel.get_messages(limit=10)
 
     print(f"📥 Retrieved {len(messages)} messages from channel")
 
@@ -313,7 +313,7 @@ async def test_workspace_channel_message_retrieval(
     for i, message in enumerate(messages[:5]):  # Show first 5 messages
         print(f"   Message {i+1}: {message}")
 
-    print("✅ Workspace channel message retrieval test PASSED (synchronous!)")
+    print("✅ Workspace channel message retrieval test PASSED")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implemented comprehensive agent group authentication system with password_hash parameter support across all layers of the stack.

## Features Added

### 1. Agent Group Configuration
- Added `AgentGroupConfig` model with password_hash field
- Added `agent_groups` dict to NetworkConfig for group definitions
- Added `default_agent_group` config for agents without credentials
- Added validator to ensure all groups have password_hash defined

### 2. Group Assignment & Management
- Moved group logic to topology layer (alongside agent_register)
- Implemented `_assign_agent_to_group()` for password hash matching
- Track group membership in `agent_group_membership` dict
- Clean up group membership on agent unregister/disconnect

### 3. Password Parameter Flow
- Added `password_hash` parameter to AgentRunner.start()
- Added `password_hash` parameter to AgentClient.connect()
- Added `password_hash` to GRPCNetworkConnector and HTTPNetworkConnector
- Updated proto file RegisterAgentRequest with password_hash field
- Updated gRPC and HTTP transports to extract and pass password_hash

### 4. Network Stats Enhancement
- Added `groups` dict mapping group names to agent IDs
- Added `group_config` array with group info (excluding sensitive data)
- Added `group` field to each agent in stats

### 5. Security
- Password hashes stored in config, never exposed in network stats
- Agents send password_hash directly in registration payload
- Server compares hash with configured group hashes
- Invalid credentials assign to configurable default_agent_group

## Testing
- 8 unit tests in tests/network/test_agent_groups.py (all passing)
- 8 integration tests in tests/integration/test_agent_group_auth.py (all passing)
- Tests cover gRPC and HTTP transports
- Tests cover valid/invalid passwords and default group assignment

## Example Usage
```python
# Using AgentRunner
runner = AgentRunner(agent_id="my-agent")
runner.start(
    network_host="localhost",
    network_port=8570,
    password_hash="my_secret_hash_123"
)

# Using AgentClient
client = AgentClient(agent_id="my-client")
await client.connect(
    network_host="localhost",
    network_port=8570,
    password_hash="my_secret_hash_123"
)
```