### PR TITLE
feat(forum): add group permission system with allowed_groups

### DIFF
--- a/src/openagents/mods/workspace/forum/adapter.py
+++ b/src/openagents/mods/workspace/forum/adapter.py
@@ -84,12 +84,15 @@ class ForumAgentAdapter(BaseModAdapter):
         else:
             logger.debug(f"Unhandled forum event: {event_name}")
 
-    async def create_forum_topic(self, title: str, content: str) -> Optional[str]:
+    async def create_forum_topic(
+        self, title: str, content: str, allowed_groups: Optional[List[str]] = None
+    ) -> Optional[str]:
         """Create a new forum topic.
 
         Args:
             title: Title of the topic
             content: Content/body of the topic
+            allowed_groups: List of group IDs that can view this topic. If None or empty, topic is visible to all
 
         Returns:
             Optional[str]: Topic ID if successful, None if failed
@@ -110,7 +113,11 @@ class ForumAgentAdapter(BaseModAdapter):
 
         # Create topic message
         topic_msg = ForumTopicMessage(
-            source_id=self.agent_id, title=title, content=content, action="create"
+            source_id=self.agent_id,
+            title=title,
+            content=content,
+            action="create",
+            allowed_groups=allowed_groups,
         )
 
         # Wrap in Event for proper transport
@@ -624,6 +631,11 @@ class ForumAgentAdapter(BaseModAdapter):
                     "content": {
                         "type": "string",
                         "description": "Content/body of the topic",
+                    },
+                    "allowed_groups": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of group IDs that can view this topic. If null or empty, topic is visible to all agents",
                     },
                 },
                 "required": ["title", "content"],

--- a/src/openagents/mods/workspace/forum/asyncapi.yaml
+++ b/src/openagents/mods/workspace/forum/asyncapi.yaml
@@ -666,6 +666,12 @@ components:
           type: string
           description: Content/body of the topic
           example: "I'd like to discuss the current state of AI safety research..."
+        allowed_groups:
+          type: array
+          items:
+            type: string
+          description: List of group IDs that can view this topic. If null or empty, topic is visible to all agents
+          example: ["group_abc", "group_xyz"]
 
     TopicEditPayload:
       type: object
@@ -1205,6 +1211,12 @@ components:
           type: string
           description: ID of the agent who created the topic
           example: "agent_alice"
+        allowed_groups:
+          type: array
+          items:
+            type: string
+          description: List of group IDs that can view this topic. If null or empty, topic is visible to all agents
+          example: ["group_abc", "group_xyz"]
         timestamp:
           type: number
           description: Creation timestamp

--- a/src/openagents/mods/workspace/forum/forum_messages.py
+++ b/src/openagents/mods/workspace/forum/forum_messages.py
@@ -1,6 +1,6 @@
 """Forum message event models."""
 
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from pydantic import BaseModel
 from openagents.models.event import Event
 
@@ -15,6 +15,7 @@ class ForumTopicMessage(Event):
         title: Optional[str] = None,
         content: Optional[str] = None,
         topic_id: Optional[str] = None,
+        allowed_groups: Optional[List[str]] = None,
         **kwargs,
     ):
         # Build event name based on action
@@ -30,6 +31,8 @@ class ForumTopicMessage(Event):
             payload["content"] = content
         if topic_id is not None:
             payload["topic_id"] = topic_id
+        if allowed_groups is not None:
+            payload["allowed_groups"] = allowed_groups
 
         # Initialize parent Event
         super().__init__(
@@ -41,6 +44,7 @@ class ForumTopicMessage(Event):
         self._content = content
         self._action = action
         self._topic_id = topic_id
+        self._allowed_groups = allowed_groups
 
     @property
     def title(self) -> Optional[str]:
@@ -57,6 +61,10 @@ class ForumTopicMessage(Event):
     @property
     def topic_id(self) -> Optional[str]:
         return self._topic_id
+
+    @property
+    def allowed_groups(self) -> Optional[List[str]]:
+        return self._allowed_groups
 
 
 class ForumCommentMessage(Event):


### PR DESCRIPTION
Implemented comprehensive group-based permission system for forum mod:

**Schema & Data Model:**
- Add allowed_groups field to Topic model (null/empty = public to all)
- Update asyncapi.yaml with allowed_groups in TopicCreatePayload and TopicInfo
- Update ForumTopicMessage to support allowed_groups parameter

**Permission Verification:**
- Add _get_agent_groups() to retrieve agent's groups from network topology
- Add _can_agent_view_topic() to check view permissions based on allowed_groups
- Implement permission filtering logic: if allowed_groups is null/empty, topic is public; otherwise only agents in those groups can view

**Access Control Enforcement:**
- Ownership checks: Only topic/comment owners can edit/delete (already in place)
- View permission checks added to:
  - Post/reply comment operations
  - Vote operations (topic and comment)
  - All query operations

**Query Filtering:**
- All topic queries now filter by agent's view permissions:
  - get_topic: Rejects if not allowed
  - list_topics, search_topics, popular_topics, recent_topics: Return only viewable topics
  - user_topics, user_comments: Filter by requester's permissions

**Agent Adapter:**
- Update create_forum_topic() to accept optional allowed_groups parameter
- Update tool schema with allowed_groups field documentation
- Add property accessor for allowed_groups in ForumTopicMessage

**Error Responses:**
- Return PERMISSION_DENIED_NOT_IN_ALLOWED_GROUPS error code for view permission failures
- Maintain existing ownership error messages for edit/delete operations