### PR TITLE
Remove category and summary from feed mod

### DIFF
--- a/src/openagents/mods/workspace/feed/adapter.py
+++ b/src/openagents/mods/workspace/feed/adapter.py
@@ -4,7 +4,7 @@ Agent-level feed mod for OpenAgents.
 This standalone mod provides one-way information broadcasting functionality with:
 - Post creation (immutable once created)
 - Full-text search with relevance scoring
-- Filtering by category, tags, author, and date
+- Filtering by tags, author, and date
 - Quick retrieval of recent posts since timestamp
 """
 
@@ -28,7 +28,7 @@ class FeedAgentAdapter(BaseModAdapter):
     This standalone mod provides:
     - Post creation (immutable once created)
     - Full-text search with relevance scoring
-    - Category and tag-based filtering
+    - Tag-based filtering
     - Quick retrieval of recent posts for polling
     """
 
@@ -81,7 +81,6 @@ class FeedAgentAdapter(BaseModAdapter):
         self,
         title: str,
         content: str,
-        category: Optional[str] = None,
         tags: Optional[List[str]] = None,
         allowed_groups: Optional[List[str]] = None,
         attachments: Optional[List[Dict[str, Any]]] = None,
@@ -93,7 +92,6 @@ class FeedAgentAdapter(BaseModAdapter):
         Args:
             title: Title of the post (max 200 chars)
             content: Content/body of the post (markdown supported)
-            category: Optional category (announcements, updates, info, alerts)
             tags: Optional list of tags for filtering
             allowed_groups: List of group IDs that can view this post. If None or empty, post is visible to all
             attachments: Optional list of attachment metadata
@@ -124,7 +122,6 @@ class FeedAgentAdapter(BaseModAdapter):
             source_id=self.agent_id,
             title=title,
             content=content,
-            category=category,
             tags=tags,
             allowed_groups=allowed_groups,
             attachments=attachments,
@@ -171,7 +168,6 @@ class FeedAgentAdapter(BaseModAdapter):
         limit: int = 50,
         offset: int = 0,
         sort_by: str = "recent",
-        category: Optional[str] = None,
         tags: Optional[List[str]] = None,
         author_id: Optional[str] = None,
         since_date: Optional[float] = None,
@@ -182,7 +178,6 @@ class FeedAgentAdapter(BaseModAdapter):
             limit: Maximum number of posts to retrieve (1-500)
             offset: Number of posts to skip for pagination
             sort_by: Sort criteria ("recent", "oldest")
-            category: Filter by category
             tags: Filter by tags (all must match)
             author_id: Filter by author ID
             since_date: Filter posts created after this timestamp
@@ -195,7 +190,6 @@ class FeedAgentAdapter(BaseModAdapter):
             limit=limit,
             offset=offset,
             sort_by=sort_by,
-            category=category,
             tags=tags,
             author_id=author_id,
             since_date=since_date,
@@ -206,7 +200,6 @@ class FeedAgentAdapter(BaseModAdapter):
         query: str,
         limit: int = 50,
         offset: int = 0,
-        category: Optional[str] = None,
         tags: Optional[List[str]] = None,
         author_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
@@ -216,7 +209,6 @@ class FeedAgentAdapter(BaseModAdapter):
             query: Search query string
             limit: Maximum number of posts to retrieve (1-500)
             offset: Number of posts to skip for pagination
-            category: Filter by category
             tags: Filter by tags (all must match)
             author_id: Filter by author ID
 
@@ -228,7 +220,6 @@ class FeedAgentAdapter(BaseModAdapter):
             query=query,
             limit=limit,
             offset=offset,
-            category=category,
             tags=tags,
             author_id=author_id,
         )
@@ -237,7 +228,6 @@ class FeedAgentAdapter(BaseModAdapter):
         self,
         since_timestamp: Optional[float] = None,
         limit: int = 100,
-        category: Optional[str] = None,
         tags: Optional[List[str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """Get posts created since a specific timestamp (for polling).
@@ -247,7 +237,6 @@ class FeedAgentAdapter(BaseModAdapter):
         Args:
             since_timestamp: Unix timestamp to get posts after
             limit: Maximum number of posts to retrieve
-            category: Filter by category
             tags: Filter by tags (all must match)
 
         Returns:
@@ -260,7 +249,6 @@ class FeedAgentAdapter(BaseModAdapter):
             "recent_posts",
             since_timestamp=since_timestamp,
             limit=limit,
-            category=category,
             tags=tags,
         )
 
@@ -418,11 +406,6 @@ class FeedAgentAdapter(BaseModAdapter):
                         "type": "string",
                         "description": "Content/body of the post (markdown supported)",
                     },
-                    "category": {
-                        "type": "string",
-                        "description": "Category of the post",
-                        "enum": ["announcements", "updates", "info", "alerts"],
-                    },
                     "tags": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -465,11 +448,6 @@ class FeedAgentAdapter(BaseModAdapter):
                         "description": "Sort criteria",
                         "enum": ["recent", "oldest"],
                         "default": "recent",
-                    },
-                    "category": {
-                        "type": "string",
-                        "description": "Filter by category",
-                        "enum": ["announcements", "updates", "info", "alerts"],
                     },
                     "tags": {
                         "type": "array",
@@ -515,11 +493,6 @@ class FeedAgentAdapter(BaseModAdapter):
                         "minimum": 0,
                         "default": 0,
                     },
-                    "category": {
-                        "type": "string",
-                        "description": "Filter by category",
-                        "enum": ["announcements", "updates", "info", "alerts"],
-                    },
                     "tags": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -553,11 +526,6 @@ class FeedAgentAdapter(BaseModAdapter):
                         "minimum": 1,
                         "maximum": 500,
                         "default": 100,
-                    },
-                    "category": {
-                        "type": "string",
-                        "description": "Filter by category",
-                        "enum": ["announcements", "updates", "info", "alerts"],
                     },
                     "tags": {
                         "type": "array",

--- a/src/openagents/mods/workspace/feed/eventdef.yaml
+++ b/src/openagents/mods/workspace/feed/eventdef.yaml
@@ -8,7 +8,7 @@ info:
     Key Features:
     - Post creation with immutability (no updates/deletes)
     - Full-text search with relevance scoring
-    - Category and tag-based filtering
+    - Tag-based filtering
     - Quick retrieval of recent posts for polling
     - Group-based access control
 
@@ -72,7 +72,7 @@ operations:
     summary: List posts with filters
     description: |
       Lists posts with pagination and filtering options.
-      Supports filtering by category, tags, author, and date.
+      Supports filtering by tags, author, and date.
 
   searchPosts:
     action: send
@@ -175,10 +175,6 @@ components:
         content:
           type: string
           description: Content/body of the post (markdown supported)
-        category:
-          type: string
-          enum: ["announcements", "updates", "info", "alerts"]
-          description: Category of the post
         tags:
           type: array
           items:
@@ -220,10 +216,6 @@ components:
           enum: ["recent", "oldest"]
           default: "recent"
           description: Sort order
-        category:
-          type: string
-          enum: ["announcements", "updates", "info", "alerts"]
-          description: Filter by category
         tags:
           type: array
           items:
@@ -260,10 +252,6 @@ components:
           minimum: 0
           default: 0
           description: Number of posts to skip for pagination
-        category:
-          type: string
-          enum: ["announcements", "updates", "info", "alerts"]
-          description: Filter by category
         tags:
           type: array
           items:
@@ -291,10 +279,6 @@ components:
           maximum: 500
           default: 100
           description: Maximum number of posts to retrieve
-        category:
-          type: string
-          enum: ["announcements", "updates", "info", "alerts"]
-          description: Filter by category
         tags:
           type: array
           items:
@@ -347,10 +331,6 @@ components:
         created_at:
           type: number
           description: Unix timestamp when post was created
-        category:
-          type: string
-          enum: ["announcements", "updates", "info", "alerts"]
-          description: Category of the post
         tags:
           type: array
           items:

--- a/src/openagents/mods/workspace/feed/feed_messages.py
+++ b/src/openagents/mods/workspace/feed/feed_messages.py
@@ -12,7 +12,6 @@ class FeedPostMessage(Event):
         source_id: str,
         title: str,
         content: str,
-        category: Optional[str] = None,
         tags: Optional[List[str]] = None,
         allowed_groups: Optional[List[str]] = None,
         attachments: Optional[List[Dict[str, Any]]] = None,
@@ -27,8 +26,6 @@ class FeedPostMessage(Event):
             "title": title,
             "content": content,
         }
-        if category is not None:
-            payload["category"] = category
         if tags is not None:
             payload["tags"] = tags
         if allowed_groups is not None:
@@ -44,7 +41,6 @@ class FeedPostMessage(Event):
         # Store values as custom attributes (avoid conflicts with Event properties)
         self._title = title
         self._content = content
-        self._category = category
         self._tags = tags or []
         self._allowed_groups = allowed_groups or []
         self._attachments = attachments or []
@@ -56,10 +52,6 @@ class FeedPostMessage(Event):
     @property
     def post_content(self) -> str:
         return self._content
-
-    @property
-    def category(self) -> Optional[str]:
-        return self._category
 
     @property
     def tags(self) -> List[str]:
@@ -86,7 +78,6 @@ class FeedQueryMessage(Event):
         offset: int = 0,
         sort_by: str = "recent",
         post_id: Optional[str] = None,
-        category: Optional[str] = None,
         tags: Optional[List[str]] = None,
         author_id: Optional[str] = None,
         since_timestamp: Optional[float] = None,
@@ -121,8 +112,6 @@ class FeedQueryMessage(Event):
             payload["query"] = query
         if post_id is not None:
             payload["post_id"] = post_id
-        if category is not None:
-            payload["category"] = category
         if tags is not None:
             payload["tags"] = tags
         if author_id is not None:
@@ -144,7 +133,6 @@ class FeedQueryMessage(Event):
         self._offset = offset
         self._sort_by = sort_by
         self._post_id = post_id
-        self._category = category
         self._tags = tags or []
         self._author_id = author_id
         self._since_timestamp = since_timestamp
@@ -173,10 +161,6 @@ class FeedQueryMessage(Event):
     @property
     def post_id(self) -> Optional[str]:
         return self._post_id
-
-    @property
-    def category(self) -> Optional[str]:
-        return self._category
 
     @property
     def tags(self) -> List[str]:

--- a/studio/src/components/feed/FeedCreateModal.tsx
+++ b/studio/src/components/feed/FeedCreateModal.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import {
-  FEED_CATEGORY_OPTIONS,
   FeedAttachment,
   FeedCreatePayload,
 } from "@/types/feed";
@@ -29,8 +28,6 @@ const FeedCreateModal: React.FC<FeedCreateModalProps> = ({
   const { t } = useTranslation('feed');
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [summary, setSummary] = useState("");
-  const [category, setCategory] = useState<string>("");
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState("");
   const [allowedGroups, setAllowedGroups] = useState<string[]>([]);
@@ -43,8 +40,6 @@ const FeedCreateModal: React.FC<FeedCreateModalProps> = ({
   const resetForm = () => {
     setTitle("");
     setContent("");
-    setSummary("");
-    setCategory("");
     setTags([]);
     setTagInput("");
     setAllowedGroups([]);
@@ -126,8 +121,6 @@ const FeedCreateModal: React.FC<FeedCreateModalProps> = ({
     const payload: FeedCreatePayload = {
       title: title.trim(),
       content: content.trim(),
-      summary: summary.trim() || undefined,
-      category: category ? (category as any) : undefined,
       tags,
       allowed_groups: allowedGroups.length > 0 ? allowedGroups : undefined,
       attachments,
@@ -203,38 +196,6 @@ const FeedCreateModal: React.FC<FeedCreateModalProps> = ({
             <p className="text-xs text-gray-500 dark:text-gray-400">
               {t('createModal.titleLength', { current: title.length })}
             </p>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {t('createModal.category')}
-              </label>
-              <select
-                value={category}
-                onChange={(e) => setCategory(e.target.value)}
-                className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 focus:ring-2 focus:ring-blue-500 outline-none"
-              >
-                <option value="">{t('createModal.categoryOptional')}</option>
-                {FEED_CATEGORY_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {t(`categories.${option.value}`)}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {t('createModal.summary')}
-              </label>
-              <input
-                type="text"
-                value={summary}
-                onChange={(e) => setSummary(e.target.value)}
-                className="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 focus:ring-2 focus:ring-blue-500 outline-none"
-                placeholder={t('createModal.summaryPlaceholder')}
-              />
-            </div>
           </div>
 
           <div className="space-y-2">

--- a/studio/src/components/feed/FeedPostDetail.tsx
+++ b/studio/src/components/feed/FeedPostDetail.tsx
@@ -83,11 +83,6 @@ const FeedPostDetail: React.FC = () => {
         {post && (
           <div className="mt-6 space-y-2">
             <div className="flex items-center gap-3">
-              {post.category && (
-                <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 text-xs font-semibold px-3 py-1">
-                  {post.category}
-                </span>
-              )}
               <span className="text-sm text-gray-500 dark:text-gray-400">
                 {createdAt} • {t('detail.postedBy', { author: post.author_id })}
               </span>

--- a/studio/src/components/feed/FeedView.tsx
+++ b/studio/src/components/feed/FeedView.tsx
@@ -5,10 +5,9 @@ import { OpenAgentsContext } from "@/context/OpenAgentsProvider";
 import { useFeedStore } from "@/stores/feedStore";
 import FeedCreateModal from "./FeedCreateModal";
 import FeedPostCard from "./components/FeedPostCard";
-import { FEED_CATEGORY_OPTIONS, FEED_SORT_FIELDS } from "@/types/feed";
+import { FEED_SORT_FIELDS } from "@/types/feed";
 
 const INITIAL_FILTER_RESET = {
-  category: "all" as const,
   author: undefined,
   tags: [] as string[],
   startDate: undefined,
@@ -159,7 +158,6 @@ const FeedView: React.FC = () => {
 
   const filtersActive = useMemo(() => {
     return (
-      filters.category !== "all" ||
       !!filters.author ||
       filters.tags.length > 0 ||
       filters.startDate ||
@@ -340,25 +338,6 @@ const FeedView: React.FC = () => {
 
             <div className="space-y-4">
               <div className="flex flex-col lg:flex-row lg:flex-wrap gap-4">
-                <div className="flex-1 min-w-[220px]">
-                  <label className="text-xs font-semibold text-gray-500 uppercase">
-                    {t('filters.category')}
-                  </label>
-                  <select
-                    value={filters.category}
-                    onChange={(e) =>
-                      applyFilters({ category: e.target.value as any })
-                    }
-                    className={`mt-1 ${fullInputClass}`}
-                  >
-                    <option value="all">{t('filters.allCategories')}</option>
-                    {FEED_CATEGORY_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
                 <div className="flex-1 min-w-[220px]">
                   <label className="text-xs font-semibold text-gray-500 uppercase">
                     {t('filters.author')}

--- a/studio/src/components/feed/components/FeedPostCard.tsx
+++ b/studio/src/components/feed/components/FeedPostCard.tsx
@@ -23,11 +23,10 @@ const FeedPostCard: React.FC<FeedPostCardProps> = ({
   const attachmentsCount = post.attachments?.length || 0;
 
   const snippet = useMemo(() => {
-    if (post.summary) return post.summary;
     const text = post.content.replace(/[#*_`>\-[\]()*~]/g, "");
     if (text.length <= 200) return text;
     return `${text.slice(0, 200)}...`;
-  }, [post.summary, post.content]);
+  }, [post.content]);
 
   return (
     <article
@@ -58,22 +57,15 @@ const FeedPostCard: React.FC<FeedPostCardProps> = ({
               )}
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            {post.category && (
-              <span className="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-900/40 px-3 py-1 text-xs font-medium text-blue-700 dark:text-blue-200">
-                {post.category}
-              </span>
-            )}
-            {isRecent && (
-              <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
-                NEW
-              </span>
-            )}
-          </div>
+          {isRecent && (
+            <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+              NEW
+            </span>
+          )}
         </div>
 
         <p className="text-sm text-gray-700 dark:text-gray-200 leading-6">
-          {snippet || "No summary available."}
+          {snippet || "No content available."}
         </p>
 
         <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">

--- a/studio/src/pages/feed/FeedSidebar.tsx
+++ b/studio/src/pages/feed/FeedSidebar.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useFeedStore } from "@/stores/feedStore";
-import { FEED_CATEGORY_OPTIONS } from "@/types/feed";
 
 const FeedSidebar: React.FC = () => {
   const { t } = useTranslation('feed');
@@ -97,35 +96,6 @@ const FeedSidebar: React.FC = () => {
               {t(newPostCount > 1 ? 'sidebar.incomingPostsPlural' : 'sidebar.incomingPosts', { count: newPostCount })}
             </div>
           )}
-        </section>
-
-        <section>
-          <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-2">
-            {t('sidebar.categoryFilters')}
-          </h3>
-          <div className="grid grid-cols-2 gap-2">
-            {FEED_CATEGORY_OPTIONS.map((category) => (
-              <button
-                key={category.value}
-                className="px-2 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800"
-                onClick={() => {
-                  applyFilters({ category: category.value });
-                  navigate("/feed");
-                }}
-              >
-                {t(`categories.${category.value}`)}
-              </button>
-            ))}
-            <button
-              className="px-2 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-xs font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800"
-              onClick={() => {
-                applyFilters({ category: "all" });
-                navigate("/feed");
-              }}
-            >
-              {t('sidebar.showAll')}
-            </button>
-          </div>
         </section>
 
         <section>

--- a/studio/src/types/feed.ts
+++ b/studio/src/types/feed.ts
@@ -1,18 +1,7 @@
-export const FEED_CATEGORY_OPTIONS = [
-  { value: "announcements", label: "Announcement" },
-  { value: "updates", label: "Update" },
-  { value: "info", label: "Information" },
-  { value: "alerts", label: "Alert" },
-] as const;
-
-export type FeedCategory =
-  (typeof FEED_CATEGORY_OPTIONS)[number]["value"];
-
 export const FEED_SORT_FIELDS = [
   { value: "recent", label: "Most Recent" },
   { value: "oldest", label: "Oldest First" },
   { value: "title", label: "Title (A-Z)" },
-  { value: "category", label: "Category" },
 ] as const;
 
 export type FeedSortField =
@@ -30,10 +19,8 @@ export interface FeedPost {
   post_id: string;
   title: string;
   content: string;
-  summary?: string;
   author_id: string;
   created_at: number;
-  category?: FeedCategory;
   tags?: string[];
   attachments?: FeedAttachment[];
   allowed_groups?: string[];
@@ -42,7 +29,6 @@ export interface FeedPost {
 }
 
 export interface FeedFilters {
-  category: FeedCategory | "all";
   author?: string;
   tags: string[];
   startDate?: string;
@@ -60,10 +46,8 @@ export interface FeedSearchPayload {
 export interface FeedCreatePayload {
   title: string;
   content: string;
-  category?: FeedCategory;
   tags?: string[];
   attachments?: FeedAttachment[];
   allowed_groups?: string[];
-  summary?: string;
 }
 


### PR DESCRIPTION
- Remove VALID_CATEGORIES and category field from FeedPost model
- Remove category from FeedPostMessage and FeedQueryMessage
- Remove category parameter from FeedAgentAdapter methods
- Update eventdef.yaml to remove category from all schemas
- Remove FEED_CATEGORY_OPTIONS and FeedCategory type from feed.ts
- Remove summary field from FeedPost and FeedCreatePayload interfaces
- Remove category dropdown and summary input from FeedCreateModal
- Remove category badge and summary logic from FeedPostCard
- Remove category display from FeedPostDetail
- Remove category filters section from FeedSidebar
- Remove category filter from FeedView and feedStore
- Update test_feed_mod.py to remove all category-related tests