### PR TITLE
Fix sequential test execution configuration

### DIFF
--- a/src/openagents/mods/workspace/feed/__init__.py
+++ b/src/openagents/mods/workspace/feed/__init__.py
@@ -17,7 +17,7 @@ Key Differentiators from Forum:
 - Feed emphasizes quick retrieval and search
 """
 
-from .mod import FeedNetworkMod, FeedPost, Attachment, VALID_CATEGORIES
+from .mod import FeedNetworkMod, FeedPost, Attachment
 from .adapter import FeedAgentAdapter
 from .feed_messages import FeedPostMessage, FeedQueryMessage
 
@@ -32,6 +32,4 @@ __all__ = [
     # Messages
     "FeedPostMessage",
     "FeedQueryMessage",
-    # Constants
-    "VALID_CATEGORIES",
 ]


### PR DESCRIPTION
The VALID_CATEGORIES constant was removed from mod.py but the import statement in __init__.py was not updated, causing an ImportError when running tests.