### PR TITLE
Debug failing messaging HTTP API test

### DIFF
--- a/tests/mods/test_thread_messaging.py
+++ b/tests/mods/test_thread_messaging.py
@@ -961,9 +961,12 @@ async def test_reaction_system(alice_client, bob_client):
     channel_notification = bob_messages[0]
     assert channel_notification.event_name == "thread.channel_message.notification"
 
-    # Extract the actual message ID from the notification
-    # The event_id of the notification is the same as the original message event_id
-    actual_stored_message_id = channel_notification.event_id
+    # Extract the actual message ID from the notification payload
+    # The notification's event_id is different from the original message event_id
+    # We need to use original_event_id from payload which references the stored message
+    actual_stored_message_id = channel_notification.payload.get(
+        "original_event_id", channel_notification.event_id
+    )
     print(f"📋 Actual stored message ID from notification: {actual_stored_message_id}")
 
     # Bob adds a reaction to Alice's message using the actual stored message ID

--- a/tests/studio/test_messaging_mod_with_http_api.py
+++ b/tests/studio/test_messaging_mod_with_http_api.py
@@ -792,7 +792,9 @@ class TestMessagingFlow:
             if "content" in payload and isinstance(payload["content"], dict):
                 text = payload["content"].get("text", "")
             if text == original_message:
-                received_message_id = msg.get("event_id")
+                # Use original_event_id from payload (the actual stored message ID)
+                # NOT the notification's event_id which is a different ID
+                received_message_id = payload.get("original_event_id", msg.get("event_id"))
                 break
 
         assert (
@@ -914,7 +916,9 @@ class TestMessagingFlow:
             if "content" in payload and isinstance(payload["content"], dict):
                 text = payload["content"].get("text", "")
             if text == original_message:
-                received_message_id = msg.get("event_id")
+                # Use original_event_id from payload (the actual stored message ID)
+                # NOT the notification's event_id which is a different ID
+                received_message_id = payload.get("original_event_id", msg.get("event_id"))
                 break
 
         assert (


### PR DESCRIPTION
…ions

Tests were incorrectly using the notification's event_id instead of the original_event_id from the payload when reacting to messages.

The notification event has a different event_id than the original message. The original message's event_id is stored in the payload's original_event_id field and must be used when sending reactions or replies to ensure the message can be found in message_history.