### PR TITLE
Plan AWS deployment for OpenAgents

### DIFF
--- a/deploy/aws-lightsail/README.md
+++ b/deploy/aws-lightsail/README.md
@@ -1,0 +1,118 @@
+# OpenAgents AWS Lightsail Deployment
+
+Deploy OpenAgents to AWS Lightsail in minutes with one-click setup.
+
+## Cost
+
+| Plan | Monthly | Specs |
+|------|---------|-------|
+| Nano | $3.50 | 512MB RAM, 1 vCPU, 20GB SSD |
+| **Micro** | **$5** | **1GB RAM, 1 vCPU, 40GB SSD** (recommended) |
+| Small | $10 | 2GB RAM, 1 vCPU, 60GB SSD |
+
+Static IP and reasonable data transfer included free.
+
+---
+
+## Deployment Steps
+
+### 1. Create Lightsail Instance
+
+1. Go to **AWS Lightsail Console**: https://lightsail.aws.amazon.com
+2. Click **"Create instance"**
+3. Choose your **region** (closest to your users)
+4. Select **Linux/Unix** → **Ubuntu 22.04 LTS**
+5. Select plan: **$5/month Micro** (recommended)
+
+### 2. Add Launch Script
+
+1. Expand the **"Launch script"** section
+2. Copy the entire contents of [`cloud-init.sh`](./cloud-init.sh) and paste it
+3. *(Optional)* For HTTPS, edit the `DOMAIN=` line before pasting:
+   ```bash
+   DOMAIN="your-domain.com"
+   ```
+
+### 3. Create Instance
+
+1. Name your instance (e.g., `openagents`)
+2. Click **"Create instance"**
+3. Wait for instance to start (~1 minute)
+
+### 4. Configure Firewall
+
+1. Click on your instance → **Networking** tab
+2. Under **IPv4 Firewall**, click **"Add rule"**:
+   - Application: Custom
+   - Protocol: TCP
+   - Port: **8700**
+3. *(Optional)* Add port **8600** for gRPC
+4. *(Optional)* Create and attach a **Static IP** for a permanent address
+
+### 5. Access OpenAgents
+
+Wait 2-3 minutes for setup to complete, then visit:
+
+```
+http://<your-instance-ip>:8700/studio
+```
+
+---
+
+## Management Commands
+
+SSH into your instance and use:
+
+```bash
+/opt/openagents/manage.sh status   # Check status
+/opt/openagents/manage.sh logs     # View logs
+/opt/openagents/manage.sh restart  # Restart OpenAgents
+/opt/openagents/manage.sh update   # Update to latest version
+/opt/openagents/manage.sh backup   # Create backup
+```
+
+---
+
+## HTTPS Setup (Optional)
+
+To enable HTTPS with automatic SSL certificates:
+
+1. **Before deploying**: Edit `DOMAIN=` in the cloud-init script
+2. **Point DNS**: Create an A record pointing your domain to the server IP
+3. **Open ports**: Add firewall rules for ports 80 and 443
+
+---
+
+## Troubleshooting
+
+### Check Setup Progress
+
+```bash
+ssh ubuntu@<your-ip>
+tail -f /var/log/openagents-setup.log
+```
+
+### Can't Access Studio
+
+1. Verify port 8700 is open in Lightsail firewall
+2. Check container status:
+   ```bash
+   /opt/openagents/manage.sh status
+   ```
+3. View logs:
+   ```bash
+   /opt/openagents/manage.sh logs
+   ```
+
+### Update OpenAgents
+
+```bash
+/opt/openagents/manage.sh update
+```
+
+---
+
+## Support
+
+- Documentation: https://openagents.org/docs
+- Issues: https://github.com/openagents-org/openagents/issues

--- a/deploy/aws-lightsail/cloud-init.sh
+++ b/deploy/aws-lightsail/cloud-init.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# =============================================================================
+# OpenAgents AWS Lightsail Cloud-Init Script
+# =============================================================================
+#
+# USAGE: Paste this entire script into the "Launch script" field when creating
+#        a new Lightsail instance, OR run it on a fresh Ubuntu instance.
+#
+# This script will:
+#   1. Install Docker
+#   2. Deploy OpenAgents with persistent storage
+#   3. Set up automatic restarts
+#   4. (Optional) Configure HTTPS with Caddy
+#
+# After running, access OpenAgents at: http://<your-ip>:8700/studio
+# =============================================================================
+
+set -e
+
+# Configuration - modify these as needed
+OPENAGENTS_VERSION="${OPENAGENTS_VERSION:-latest}"
+DATA_DIR="${DATA_DIR:-/opt/openagents/data}"
+DOMAIN="${DOMAIN:-}"  # Set this for HTTPS, e.g., "openagents.example.com"
+
+# Logging
+exec > >(tee /var/log/openagents-setup.log) 2>&1
+echo "=== OpenAgents Setup Started at $(date) ==="
+
+# Update system
+echo ">>> Updating system packages..."
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+
+# Install Docker
+echo ">>> Installing Docker..."
+if ! command -v docker &> /dev/null; then
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable docker
+    systemctl start docker
+fi
+
+# Install Docker Compose plugin
+echo ">>> Installing Docker Compose..."
+apt-get install -y docker-compose-plugin
+
+# Create OpenAgents directory structure
+echo ">>> Creating directory structure..."
+mkdir -p /opt/openagents
+mkdir -p "$DATA_DIR"
+
+# Create docker-compose.yml
+echo ">>> Creating Docker Compose configuration..."
+cat > /opt/openagents/docker-compose.yml << 'COMPOSE_EOF'
+version: '3.8'
+
+services:
+  openagents:
+    image: ghcr.io/openagents-org/openagents:${OPENAGENTS_VERSION:-latest}
+    container_name: openagents
+    ports:
+      - "8700:8700"
+      - "8600:8600"
+    environment:
+      - PYTHONUNBUFFERED=1
+      - NODE_ENV=production
+      # Add your API keys here if needed:
+      # - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      - ${DATA_DIR:-/opt/openagents/data}:/app/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8700/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+COMPOSE_EOF
+
+# Create environment file
+echo ">>> Creating environment file..."
+cat > /opt/openagents/.env << ENV_EOF
+OPENAGENTS_VERSION=${OPENAGENTS_VERSION}
+DATA_DIR=${DATA_DIR}
+# Add your API keys below (uncomment and fill in):
+# OPENAI_API_KEY=your-key-here
+# ANTHROPIC_API_KEY=your-key-here
+ENV_EOF
+
+# Create management script
+echo ">>> Creating management script..."
+cat > /opt/openagents/manage.sh << 'MANAGE_EOF'
+#!/bin/bash
+# OpenAgents Management Script
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+case "$1" in
+    start)
+        echo "Starting OpenAgents..."
+        docker compose up -d
+        ;;
+    stop)
+        echo "Stopping OpenAgents..."
+        docker compose down
+        ;;
+    restart)
+        echo "Restarting OpenAgents..."
+        docker compose restart
+        ;;
+    update)
+        echo "Updating OpenAgents to latest version..."
+        docker compose pull
+        docker compose up -d
+        ;;
+    logs)
+        docker compose logs -f
+        ;;
+    status)
+        docker compose ps
+        echo ""
+        echo "Health check:"
+        curl -s http://localhost:8700/api/health | head -c 200
+        echo ""
+        ;;
+    backup)
+        BACKUP_FILE="openagents-backup-$(date +%Y%m%d-%H%M%S).tar.gz"
+        echo "Creating backup: $BACKUP_FILE"
+        tar -czvf "$BACKUP_FILE" -C /opt/openagents data
+        echo "Backup created: $(pwd)/$BACKUP_FILE"
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|update|logs|status|backup}"
+        exit 1
+        ;;
+esac
+MANAGE_EOF
+chmod +x /opt/openagents/manage.sh
+
+# Create systemd service for auto-start on boot
+echo ">>> Creating systemd service..."
+cat > /etc/systemd/system/openagents.service << 'SERVICE_EOF'
+[Unit]
+Description=OpenAgents Network
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/openagents
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+SERVICE_EOF
+
+systemctl daemon-reload
+systemctl enable openagents.service
+
+# Pull and start OpenAgents
+echo ">>> Pulling OpenAgents image..."
+cd /opt/openagents
+docker compose pull
+
+echo ">>> Starting OpenAgents..."
+docker compose up -d
+
+# Wait for startup
+echo ">>> Waiting for OpenAgents to start..."
+sleep 15
+
+# Check health
+echo ">>> Checking health..."
+for i in {1..10}; do
+    if curl -sf http://localhost:8700/api/health > /dev/null 2>&1; then
+        echo "OpenAgents is healthy!"
+        break
+    fi
+    echo "Waiting for health check... ($i/10)"
+    sleep 5
+done
+
+# Setup HTTPS if domain is provided
+if [ -n "$DOMAIN" ]; then
+    echo ">>> Setting up HTTPS for domain: $DOMAIN"
+
+    # Install Caddy
+    apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
+    apt-get update
+    apt-get install -y caddy
+
+    # Configure Caddy
+    cat > /etc/caddy/Caddyfile << CADDY_EOF
+$DOMAIN {
+    reverse_proxy localhost:8700
+}
+CADDY_EOF
+
+    systemctl restart caddy
+    echo "HTTPS configured! Access at: https://$DOMAIN"
+fi
+
+# Print summary
+echo ""
+echo "=============================================="
+echo "  OpenAgents Installation Complete!"
+echo "=============================================="
+echo ""
+echo "Access OpenAgents Studio at:"
+if [ -n "$DOMAIN" ]; then
+    echo "  https://$DOMAIN/studio"
+else
+    echo "  http://<your-server-ip>:8700/studio"
+fi
+echo ""
+echo "Management commands:"
+echo "  /opt/openagents/manage.sh start    - Start OpenAgents"
+echo "  /opt/openagents/manage.sh stop     - Stop OpenAgents"
+echo "  /opt/openagents/manage.sh restart  - Restart OpenAgents"
+echo "  /opt/openagents/manage.sh update   - Update to latest version"
+echo "  /opt/openagents/manage.sh logs     - View logs"
+echo "  /opt/openagents/manage.sh status   - Check status"
+echo "  /opt/openagents/manage.sh backup   - Create backup"
+echo ""
+echo "Data directory: $DATA_DIR"
+echo "Logs: /var/log/openagents-setup.log"
+echo ""
+echo "=== Setup completed at $(date) ==="


### PR DESCRIPTION
Add simple one-click deployment for AWS Lightsail:

- cloud-init.sh: Paste into Lightsail launch script field
  - Installs Docker and deploys OpenAgents automatically
  - Creates systemd service for auto-start on boot
  - Includes management script (start/stop/update/backup)
  - Optional HTTPS setup with Caddy

- README.md: Step-by-step deployment guide

Users just paste the script when creating a $5/mo Lightsail instance, and OpenAgents is ready in 2-3 minutes.