### PR TITLE
docs: add AWS Lightsail deployment guide

### DIFF
--- a/docs/deployment/aws-lightsail.mdx
+++ b/docs/deployment/aws-lightsail.mdx
@@ -1,0 +1,300 @@
+---
+title: "AWS Lightsail Deployment"
+summary: "Deploy OpenAgents to AWS Lightsail with one-click setup - the easiest way to run OpenAgents in the cloud."
+topicTitle: "Deployment"
+topicSlug: "deployment"
+---
+
+## AWS Lightsail Deployment
+
+Deploy OpenAgents to AWS Lightsail in minutes. This is the easiest and most cost-effective way to run OpenAgents in the cloud.
+
+## Cost
+
+| Plan | Monthly | Specs |
+|------|---------|-------|
+| Nano | $3.50 | 512MB RAM, 1 vCPU, 20GB SSD |
+| **Micro** | **$5** | **1GB RAM, 1 vCPU, 40GB SSD** (recommended) |
+| Small | $10 | 2GB RAM, 1 vCPU, 60GB SSD |
+
+Static IP and reasonable data transfer are included free.
+
+## One-Click Deployment
+
+### Step 1: Create Lightsail Instance
+
+1. Go to **AWS Lightsail Console**: [lightsail.aws.amazon.com](https://lightsail.aws.amazon.com)
+2. Click **"Create instance"**
+3. Choose your **region** (closest to your users)
+4. Select **Linux/Unix** → **Ubuntu 22.04 LTS**
+5. Select plan: **$5/month Micro** (recommended)
+
+### Step 2: Add Launch Script
+
+1. Expand the **"Launch script"** section
+2. Copy the entire script below and paste it:
+
+```bash
+#!/bin/bash
+set -e
+
+OPENAGENTS_VERSION="${OPENAGENTS_VERSION:-latest}"
+DATA_DIR="${DATA_DIR:-/opt/openagents/data}"
+DOMAIN="${DOMAIN:-}"  # Set this for HTTPS, e.g., "openagents.example.com"
+
+exec > >(tee /var/log/openagents-setup.log) 2>&1
+echo "=== OpenAgents Setup Started at $(date) ==="
+
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
+
+if ! command -v docker &> /dev/null; then
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable docker
+    systemctl start docker
+fi
+
+apt-get install -y docker-compose-plugin
+
+mkdir -p /opt/openagents
+mkdir -p "$DATA_DIR"
+
+cat > /opt/openagents/docker-compose.yml << 'COMPOSE_EOF'
+version: '3.8'
+services:
+  openagents:
+    image: ghcr.io/openagents-org/openagents:${OPENAGENTS_VERSION:-latest}
+    container_name: openagents
+    ports:
+      - "8700:8700"
+      - "8600:8600"
+    environment:
+      - PYTHONUNBUFFERED=1
+      - NODE_ENV=production
+    volumes:
+      - ${DATA_DIR:-/opt/openagents/data}:/app/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8700/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+COMPOSE_EOF
+
+cat > /opt/openagents/.env << ENV_EOF
+OPENAGENTS_VERSION=${OPENAGENTS_VERSION}
+DATA_DIR=${DATA_DIR}
+ENV_EOF
+
+cat > /opt/openagents/manage.sh << 'MANAGE_EOF'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+case "$1" in
+    start) docker compose up -d ;;
+    stop) docker compose down ;;
+    restart) docker compose restart ;;
+    update) docker compose pull && docker compose up -d ;;
+    logs) docker compose logs -f ;;
+    status) docker compose ps && echo "" && curl -s http://localhost:8700/api/health | head -c 200 && echo "" ;;
+    backup) tar -czvf "openagents-backup-$(date +%Y%m%d-%H%M%S).tar.gz" -C /opt/openagents data ;;
+    *) echo "Usage: $0 {start|stop|restart|update|logs|status|backup}" && exit 1 ;;
+esac
+MANAGE_EOF
+chmod +x /opt/openagents/manage.sh
+
+cat > /etc/systemd/system/openagents.service << 'SERVICE_EOF'
+[Unit]
+Description=OpenAgents Network
+Requires=docker.service
+After=docker.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/openagents
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+TimeoutStartSec=0
+[Install]
+WantedBy=multi-user.target
+SERVICE_EOF
+
+systemctl daemon-reload
+systemctl enable openagents.service
+
+cd /opt/openagents
+docker compose pull
+docker compose up -d
+
+sleep 15
+for i in {1..10}; do
+    curl -sf http://localhost:8700/api/health > /dev/null 2>&1 && echo "OpenAgents is healthy!" && break
+    echo "Waiting for health check... ($i/10)"
+    sleep 5
+done
+
+if [ -n "$DOMAIN" ]; then
+    apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
+    apt-get update && apt-get install -y caddy
+    cat > /etc/caddy/Caddyfile << CADDY_EOF
+$DOMAIN {
+    reverse_proxy localhost:8700
+}
+CADDY_EOF
+    systemctl restart caddy
+fi
+
+echo "=== Setup completed at $(date) ==="
+```
+
+<Banner type="info">
+**For HTTPS:** Before pasting, edit the `DOMAIN=` line at the top of the script to set your domain, e.g., `DOMAIN="openagents.example.com"`
+</Banner>
+
+### Step 3: Create Instance
+
+1. Name your instance (e.g., `openagents`)
+2. Click **"Create instance"**
+3. Wait for instance to start (~1 minute)
+
+### Step 4: Configure Firewall
+
+1. Click on your instance → **Networking** tab
+2. Under **IPv4 Firewall**, click **"Add rule"**:
+   - Application: Custom
+   - Protocol: TCP
+   - Port: **8700**
+3. *(Optional)* Add port **8600** for gRPC
+4. *(Optional)* Create and attach a **Static IP** for a permanent address
+
+### Step 5: Access OpenAgents
+
+Wait 2-3 minutes for setup to complete, then visit:
+
+```
+http://<your-instance-ip>:8700/studio
+```
+
+<Banner type="success">
+**Deployment Complete!** Your OpenAgents instance is now running on AWS Lightsail.
+</Banner>
+
+## Management Commands
+
+SSH into your instance and use the management script:
+
+```bash
+/opt/openagents/manage.sh status   # Check status
+/opt/openagents/manage.sh logs     # View logs
+/opt/openagents/manage.sh restart  # Restart OpenAgents
+/opt/openagents/manage.sh update   # Update to latest version
+/opt/openagents/manage.sh backup   # Create backup
+/opt/openagents/manage.sh stop     # Stop OpenAgents
+/opt/openagents/manage.sh start    # Start OpenAgents
+```
+
+## HTTPS Setup (Optional)
+
+To enable HTTPS with automatic SSL certificates:
+
+1. **Before deploying**: Edit `DOMAIN=` in the launch script to your domain
+2. **Point DNS**: Create an A record pointing your domain to the server IP
+3. **Open ports**: Add firewall rules for ports **80** and **443**
+
+The script will automatically install Caddy and configure SSL certificates via Let's Encrypt.
+
+## Updating OpenAgents
+
+To update to the latest version:
+
+```bash
+ssh ubuntu@<your-ip>
+/opt/openagents/manage.sh update
+```
+
+## Backup and Restore
+
+### Create Backup
+
+```bash
+/opt/openagents/manage.sh backup
+```
+
+This creates a timestamped backup file in `/opt/openagents/`.
+
+### Restore Backup
+
+```bash
+cd /opt/openagents
+/opt/openagents/manage.sh stop
+tar -xzvf openagents-backup-YYYYMMDD-HHMMSS.tar.gz
+/opt/openagents/manage.sh start
+```
+
+## Troubleshooting
+
+### Check Setup Progress
+
+```bash
+ssh ubuntu@<your-ip>
+tail -f /var/log/openagents-setup.log
+```
+
+### Can't Access Studio
+
+1. Verify port 8700 is open in Lightsail firewall
+2. Check container status:
+   ```bash
+   /opt/openagents/manage.sh status
+   ```
+3. View logs:
+   ```bash
+   /opt/openagents/manage.sh logs
+   ```
+
+### Container Not Starting
+
+```bash
+# Check Docker status
+sudo systemctl status docker
+
+# View container logs
+docker logs openagents
+
+# Restart the service
+sudo systemctl restart openagents
+```
+
+### HTTPS Not Working
+
+1. Verify DNS is pointing to your server:
+   ```bash
+   nslookup your-domain.com
+   ```
+2. Check Caddy logs:
+   ```bash
+   sudo journalctl -u caddy -f
+   ```
+3. Ensure ports 80 and 443 are open in Lightsail firewall
+
+## Security Recommendations
+
+1. **Keep Updated**: Regularly run `/opt/openagents/manage.sh update`
+2. **Use HTTPS**: Configure a domain with SSL for production use
+3. **Firewall**: Only open necessary ports (8700, and 443 if using HTTPS)
+4. **Backups**: Create regular backups with `/opt/openagents/manage.sh backup`
+5. **Monitoring**: Set up Lightsail alarms for CPU and memory usage
+
+## Next Steps
+
+- **[Connect Agents](/tutorials/connect-agents)** - Connect your agents to the network
+- **[Using Studio](/tutorials/using-studio)** - Learn to use the OpenAgents Studio interface
+- **[Network Configuration](/network-configuration/network-configuration)** - Customize your network settings


### PR DESCRIPTION
Add deployment documentation section with AWS Lightsail guide:
- Step-by-step one-click deployment instructions
- Inline cloud-init script for easy copy-paste
- Management commands reference
- HTTPS setup instructions
- Backup and restore procedures
- Troubleshooting guide