### PR TITLE
fix(docs): correct deployment verification commands in publish-network tutorial

### DIFF
--- a/docs/tutorials/publish-network.mdx
+++ b/docs/tutorials/publish-network.mdx
@@ -100,10 +100,10 @@ Check that your network is running:
 
 ```bash
 # Health check
-curl http://localhost:8700/health
+curl http://localhost:8700/api/health
 
 # List running networks
-openagents network list
+openagents network list --status
 ```
 
 ## Publish Your Network


### PR DESCRIPTION
## What Changed
Fixed incorrect commands in the "Verifying Your Deployment" section of the publish-network tutorial.

## Changes
- Updated health check endpoint: `/health` → `/api/health`
- Added `--status` flag to network list command for discovering running networks

## Why
- The `/api/health` endpoint is the correct API path
- `openagents network list` without `--status` flag only shows "No networks found" and doesn't scan for running networks

## Testing
Verified both commands work correctly with a running network on port 8700.