### PR TITLE
fix: correct libp2p package name from py-libp2p to libp2p

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 [project.optional-dependencies]
 # P2P networking (optional, for future libp2p integration)
 p2p = [
-    "py-libp2p>=0.2.0",       # P2P networking library
+    "libp2p>=0.2.0",       # P2P networking library
 ]
 
 # WebRTC support (optional, for future WebRTC transport)


### PR DESCRIPTION
## Problem
Dependency resolution fails when installing `openagents[all]` because `py-libp2p` doesn't exist on PyPI.

## Solution
Fix package name: `py-libp2p` → `libp2p` (the actual PyPI package name)

Reference: https://github.com/libp2p/py-libp2p/blob/main/pyproject.toml and https://py-libp2p.readthedocs.io/en/stable/install.html