### PR TITLE
Fix/clear messages on new project

### DIFF
--- a/studio/src/pages/messaging/components/ProjectChatRoom.tsx
+++ b/studio/src/pages/messaging/components/ProjectChatRoom.tsx
@@ -92,6 +92,16 @@ const ProjectChatRoom: React.FC<ProjectChatRoomProps> = ({
   const prevMessagesLength = useRef<number>(0)
   const prevScrollHeight = useRef<number>(0)
 
+  // Reset messages and project info when route projectId changes (including "new")
+  // Listen to routeProjectId, propProjectId, and location to catch all navigation scenarios
+  useEffect(() => {
+    // Clear messages immediately when switching projects or creating new project
+    // This handles both switching between projects and clicking "new project"
+    // location.key ensures we catch navigation even when pathname stays the same (e.g., selecting different template)
+    setMessages([])
+    setProjectInfo(null)
+  }, [routeProjectId, propProjectId, location.pathname, location.key])
+
   // Load project info and message history from backend
   useEffect(() => {
     const loadProjectInfo = async () => {

--- a/studio/src/pages/messaging/components/ProjectChatRoom.tsx
+++ b/studio/src/pages/messaging/components/ProjectChatRoom.tsx
@@ -85,6 +85,7 @@ const ProjectChatRoom: React.FC<ProjectChatRoomProps> = ({
   const [sendingMessage, setSendingMessage] = useState<boolean>(false)
   const [messagesError, setMessagesError] = useState<string | null>(null)
   const [isStartingProject, setIsStartingProject] = useState<boolean>(false)
+  const [isLoadingProject, setIsLoadingProject] = useState<boolean>(false)
 
   // Refs
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -98,6 +99,12 @@ const ProjectChatRoom: React.FC<ProjectChatRoomProps> = ({
     // Clear messages immediately when switching projects or creating new project
     // This handles both switching between projects and clicking "new project"
     // location.key ensures we catch navigation even when pathname stays the same (e.g., selecting different template)
+    
+    // Set loading state for existing projects (not for pending/new projects)
+    if (routeProjectId && routeProjectId !== 'new') {
+      setIsLoadingProject(true)
+    }
+    
     setMessages([])
     setProjectInfo(null)
   }, [routeProjectId, propProjectId, location.pathname, location.key])
@@ -219,12 +226,18 @@ const ProjectChatRoom: React.FC<ProjectChatRoomProps> = ({
             channelName: `project-${projectId}`,
           })
         }
+      } finally {
+        // Clear loading state after project info is loaded (or fails)
+        setIsLoadingProject(false)
       }
     }
 
     // Load project info when projectId changes or connection is established
     if (projectId) {
       loadProjectInfo()
+    } else {
+      // If no projectId (e.g., pending project), clear loading state
+      setIsLoadingProject(false)
     }
   }, [
     projectId,
@@ -751,7 +764,12 @@ const ProjectChatRoom: React.FC<ProjectChatRoomProps> = ({
       <div className="flex-1 flex flex-col min-h-0">
         {/* Messages */}
         <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-4">
-          {sortedMessages.length === 0 ? (
+          {isLoadingProject ? (
+            <div className="text-center text-gray-500 dark:text-gray-400 py-8">
+              <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mb-4"></div>
+              <p className="text-sm">Loading messages...</p>
+            </div>
+          ) : sortedMessages.length === 0 ? (
             <div className="text-center text-gray-500 dark:text-gray-400 py-8">
               {isPendingProject ? (
                 <>


### PR DESCRIPTION
# Fix: Clear chat messages when creating new project

## 🐛 Problem
When clicking "New Project" button, the chat messages from the previous project were not cleared, causing confusion for users.

Additionally, when switching between projects, the welcome screen briefly flashed before loading history messages, creating a poor user experience.

## ✅ Solution
1. **Message Clearing**: Added a `useEffect` hook that listens to route changes and clears messages/project info when:
   - Switching between projects
   - Creating a new project
   - Selecting different templates on the new project page

2. **Loading State**: Added `isLoadingProject` state to show a loading spinner instead of welcome screen while fetching project history, eliminating UI flicker.

## 🔧 Key Improvements
- Used `location.key` to catch navigation even when pathname stays the same
- Used `finally` block to ensure loading state is always cleared
- Only show loading state for existing projects (not for new/pending projects)

## 🧪 Testing
- ✅ Switching from project A to project B → messages cleared, loading spinner shown
- ✅ Clicking "New Project" from existing project → messages cleared immediately
- ✅ Selecting different template on new project page → messages cleared
- ✅ Switching from new project to existing project → messages cleared, loading spinner shown
- ✅ No welcome screen flicker when switching projects
