### PR TITLE
Fix spelling typos across codebase

### DIFF
--- a/docs/getting-started/quick-start-guide.mdx
+++ b/docs/getting-started/quick-start-guide.mdx
@@ -26,7 +26,7 @@ Before starting, make sure you have:
 openagents network init ./my_first_network
 ```
 
-Afer executing the command, you should see a new directory created called `my_first_network` with a `network.yaml` file inside.
+After executing the command, you should see a new directory created called `my_first_network` with a `network.yaml` file inside.
 
 ### Start Your Network
 
@@ -48,7 +48,7 @@ You should see output like:
 
 ### Launch OpenAgents Studio for visualization
 
-<Banner type="importan">
+<Banner type="important">
 After version 0.7.0, OpenAgents no longer requires npm and Node.js to be installed for launching the studio.
 </Banner>
 
@@ -163,7 +163,7 @@ curl http://localhost:8700/
 
 ### Studio Won't Load
 
-Try a differen port:
+Try a different port:
 
 ```bash
 # Check Studio is running

--- a/src/openagents/config/globals.py
+++ b/src/openagents/config/globals.py
@@ -82,8 +82,8 @@ SYSTEM_EVENT_UPDATE_NETWORK_PROFILE = "system.update_network_profile"
 SYSTEM_EVENT_UPDATE_AGENT_GROUPS = "system.update_agent_groups"
 SYSTEM_EVENT_UPDATE_EXTERNAL_ACCESS = "system.update_external_access"
 
-SYSTEM_NOTIFICAITON_REGISTER_AGENT = "system.notification.register_agent"
-SYSTEM_NOTIFICAITON_UNREGISTER_AGENT = "system.notification.unregister_agent"
+SYSTEM_NOTIFICATION_REGISTER_AGENT = "system.notification.register_agent"
+SYSTEM_NOTIFICATION_UNREGISTER_AGENT = "system.notification.unregister_agent"
 SYSTEM_NOTIFICATION_AGENT_KICKED = "system.agent_kicked"
 
 AGENT_EVENT_MESSAGE = "agent.message"

--- a/src/openagents/core/network.py
+++ b/src/openagents/core/network.py
@@ -26,8 +26,8 @@ from openagents.config.globals import (
     SYSTEM_EVENT_REGISTER_AGENT,
     SYSTEM_EVENT_UNREGISTER_AGENT,
     SYSTEM_EVENT_POLL_MESSAGES,
-    SYSTEM_NOTIFICAITON_REGISTER_AGENT,
-    SYSTEM_NOTIFICAITON_UNREGISTER_AGENT,
+    SYSTEM_NOTIFICATION_REGISTER_AGENT,
+    SYSTEM_NOTIFICATION_UNREGISTER_AGENT,
     WORKSPACE_DEFAULT_MOD_NAME,
 )
 from openagents.core.base_mod import BaseMod
@@ -538,7 +538,7 @@ class AgentNetwork:
 
             # Notify mods about agent registration
             registration_notification = Event(
-                event_name=SYSTEM_NOTIFICAITON_REGISTER_AGENT,
+                event_name=SYSTEM_NOTIFICATION_REGISTER_AGENT,
                 source_id=SYSTEM_AGENT_ID,
                 payload={"agent_id": agent_id, "metadata": metadata},
             )
@@ -586,7 +586,7 @@ class AgentNetwork:
             logger.info(f"Unregistered agent {agent_id} from network")
             await self.process_external_event(
                 Event(
-                    event_name=SYSTEM_NOTIFICAITON_UNREGISTER_AGENT,
+                    event_name=SYSTEM_NOTIFICATION_UNREGISTER_AGENT,
                     source_id=SYSTEM_AGENT_ID,
                     payload={"agent_id": agent_id},
                 )

--- a/studio/src/components/layout/ui/menubar.tsx
+++ b/studio/src/components/layout/ui/menubar.tsx
@@ -58,7 +58,7 @@ function MenubarSubTrigger({
 }) {
   return (
     <MenubarPrimitive.SubTrigger
-      data-slot="menubar-sub-tirgger"
+      data-slot="menubar-sub-trigger"
       className={cn(
         'flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-hidden',
         'focus:bg-accent focus:text-accent-foreground',

--- a/studio/src/components/layout/ui/sheet.tsx
+++ b/studio/src/components/layout/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({ className, ...props }: React.ComponentProps<typeof Sheet
 }
 
 const sheetVariants = cva(
-  'flex flex-col items-strech fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-400',
+  'flex flex-col items-stretch fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-400',
   {
     variants: {
       side: {

--- a/studio/src/components/ui/menubar.tsx
+++ b/studio/src/components/ui/menubar.tsx
@@ -58,7 +58,7 @@ function MenubarSubTrigger({
 }) {
   return (
     <MenubarPrimitive.SubTrigger
-      data-slot="menubar-sub-tirgger"
+      data-slot="menubar-sub-trigger"
       className={cn(
         'flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-hidden',
         'focus:bg-accent focus:text-accent-foreground',

--- a/studio/src/components/ui/sheet.tsx
+++ b/studio/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({ className, ...props }: React.ComponentProps<typeof Sheet
 }
 
 const sheetVariants = cva(
-  'flex flex-col items-strech fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-400',
+  'flex flex-col items-stretch fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-400',
   {
     variants: {
       side: {


### PR DESCRIPTION
Fixes #274

This PR fixes multiple spelling typos found in the codebase.

## Code Constants
- Fixed \`NOTIFICAITON\` → \`NOTIFICATION\` in:
  - \`src/openagents/config/globals.py\`
  - \`src/openagents/core/network.py\`

## Documentation
- Fixed typos in:
  - \`README.md\`: "havn" → "haven"
  - \`docs/getting-started/quick-start-guide.mdx\`: "Afer" → "After", "importan" → "important", "differen" → "different"
  - \`docs/tutorials/demo-grammar-check-forum.mdx\`: "utlities" → "utilities", "becuase" → "because"

## Changelogs
- Fixed typos in:
  - \`changelogs/blogs/2025-11-27-demo-showcase.md\`
  - \`changelogs/docs/2025-11-27-demo-showcase.md\`
  - \`changelogs/docs/2025-12-20-grammar-forum-bedrock.md\`

## Studio UI Components
- Fixed typos in sheet.tsx and menubar.tsx

## Notes
The following were intentionally **NOT** changed:
- \`network_discovey.py\` - filename typo (requires file rename)
- \`desitnation_id\` - attribute name (API breaking change)
- Grammar checker demo files - intentional typos for demonstration