### PR TITLE
feat(agentid): remove org layer - globally unique agent names

### DIFF
--- a/src/openagents/agentid/__init__.py
+++ b/src/openagents/agentid/__init__.py
@@ -2,11 +2,12 @@
 OpenAgents AgentID - Cryptographic Identity for AI Agents.
 
 This module provides tools for verifying and authenticating AI agents
-using the OpenAgents AgentID system.
+using the OpenAgents AgentID system. Agent names are globally unique
+(like Twitter handles) — no organization scope required.
 
 Two identifier formats are supported:
-- Level 2: openagents:agent-name[@org] - For JWT-based authentication
-- Level 3: did:openagents:agent-name[@org] - For W3C DID verification
+- Level 2: openagents:agent-name - For JWT-based authentication
+- Level 3: did:openagents:agent-name - For W3C DID verification
 
 Quick Start:
 
@@ -22,7 +23,6 @@ Quick Start:
 
     auth = AgentIDAuth(
         agent_name="my-agent",
-        org="my-org",
         private_key_path="agent_private.pem"
     )
     token = auth.get_token()

--- a/src/openagents/agentid/client.py
+++ b/src/openagents/agentid/client.py
@@ -62,7 +62,7 @@ class AgentIDVerifier:
         result = client.validate("openagents:my-agent")
 
         # Get agent info
-        info = client.get_agent_info("my-agent", org="my-org")
+        info = client.get_agent_info("my-agent")
 
         # Resolve DID
         did_doc = client.resolve_did("did:openagents:my-agent")
@@ -166,8 +166,8 @@ class AgentIDVerifier:
         """Get agent information from the registry.
 
         Args:
-            agent_name: Agent name
-            org: Optional organization scope
+            agent_name: Agent name (globally unique)
+            org: Deprecated. Legacy organization scope, ignored for new agents.
 
         Returns:
             AgentInfo with agent details
@@ -304,8 +304,8 @@ class AgentIDVerifier:
         """Request an authentication challenge.
 
         Args:
-            agent_name: Agent name
-            org: Optional organization scope
+            agent_name: Agent name (globally unique)
+            org: Deprecated. Legacy organization scope, kept for backward compat.
             algorithm: Signing algorithm (RS256 or Ed25519)
 
         Returns:
@@ -362,10 +362,10 @@ class AgentIDVerifier:
         """Exchange a signature for a JWT token.
 
         Args:
-            agent_name: Agent name
+            agent_name: Agent name (globally unique)
             nonce: Challenge nonce
             signature: Base64-encoded signature of the challenge
-            org: Optional organization scope
+            org: Deprecated. Legacy organization scope, kept for backward compat.
 
         Returns:
             TokenResponse with JWT token
@@ -421,16 +421,19 @@ class AgentIDVerifier:
         public_key_pem: str,
         org: str = None,
         api_key: str = None,
-        namespace_type: str = "org",
+        namespace_type: str = "global",
     ) -> ClaimResponse:
         """Claim/register a new agent ID.
 
+        Agent names are globally unique (like Twitter handles). The org parameter
+        is deprecated and only kept for backward compatibility with legacy agents.
+
         Args:
-            agent_name: Desired agent name
+            agent_name: Desired agent name (must be globally unique)
             public_key_pem: Public key in PEM format
-            org: Organization scope (required if using org namespace)
+            org: Deprecated. Legacy organization scope, kept for backward compat.
             api_key: API key for authentication
-            namespace_type: Namespace type ("org" or "global")
+            namespace_type: Namespace type (default "global")
 
         Returns:
             ClaimResponse with the claimed agent details and certificate
@@ -524,7 +527,12 @@ class AgentIDVerifier:
         return self._run_async(self.validate_async(agent_id))
 
     def get_agent_info(self, agent_name: str, org: str = None) -> AgentInfo:
-        """Get agent information (sync version)."""
+        """Get agent information (sync version).
+
+        Args:
+            agent_name: Agent name (globally unique)
+            org: Deprecated. Legacy organization scope.
+        """
         return self._run_async(self.get_agent_info_async(agent_name, org=org))
 
     def resolve_did(self, did: str) -> DIDDocument:
@@ -564,7 +572,7 @@ class AgentIDVerifier:
         public_key_pem: str,
         org: str = None,
         api_key: str = None,
-        namespace_type: str = "org",
+        namespace_type: str = "global",
     ) -> ClaimResponse:
         """Claim/register a new agent ID (sync version)."""
         return self._run_async(
@@ -587,7 +595,6 @@ class AgentIDAuth:
     Usage:
         auth = AgentIDAuth(
             agent_name="my-agent",
-            org="my-org",
             private_key_path="agent_private.pem"
         )
 
@@ -610,8 +617,8 @@ class AgentIDAuth:
         """Initialize the authentication helper.
 
         Args:
-            agent_name: Agent name
-            org: Optional organization scope
+            agent_name: Agent name (globally unique)
+            org: Deprecated. Legacy organization scope, kept for backward compat.
             private_key_path: Path to private key PEM file
             private_key_pem: Private key in PEM format (alternative to path)
             algorithm: Signing algorithm (RS256 or Ed25519)

--- a/src/openagents/agentid/models.py
+++ b/src/openagents/agentid/models.py
@@ -22,16 +22,16 @@ class AgentIDLevel(str, Enum):
 class AgentIDFormat(str, Enum):
     """Format type of an Agent ID string."""
 
-    SIMPLE = "simple"  # Just the name: my-agent or my-agent@org
-    LEVEL_2 = "level_2"  # openagents:my-agent or openagents:my-agent@org
-    LEVEL_3 = "level_3"  # did:openagents:my-agent or did:openagents:my-agent@org
+    SIMPLE = "simple"  # Just the name: my-agent (or legacy my-agent@org)
+    LEVEL_2 = "level_2"  # openagents:my-agent (or legacy openagents:my-agent@org)
+    LEVEL_3 = "level_3"  # did:openagents:my-agent (or legacy did:openagents:my-agent@org)
 
 
 class ParsedAgentID(BaseModel):
     """Parsed components of an Agent ID."""
 
-    agent_name: str = Field(..., description="The agent's unique name")
-    org: Optional[str] = Field(None, description="Organization scope (optional)")
+    agent_name: str = Field(..., description="The agent's globally unique name")
+    org: Optional[str] = Field(None, description="Legacy organization scope (deprecated, kept for backward compat)")
     format: AgentIDFormat = Field(..., description="The format of the original ID")
 
     @property
@@ -55,8 +55,8 @@ class ParsedAgentID(BaseModel):
 class AgentInfo(BaseModel):
     """Agent information from the registry."""
 
-    agent_name: str = Field(..., description="The agent's name")
-    org: Optional[str] = Field(None, description="Organization scope")
+    agent_name: str = Field(..., description="The agent's globally unique name")
+    org: Optional[str] = Field(None, description="Legacy organization scope (deprecated)")
     status: str = Field(..., description="Agent status (active, inactive, etc.)")
     created_at: Optional[datetime] = Field(None, description="When the agent was created")
     public_key_pem: Optional[str] = Field(
@@ -77,8 +77,8 @@ class VerificationResult(BaseModel):
 
     verified: bool = Field(..., description="Whether the agent was verified")
     level: AgentIDLevel = Field(..., description="Verification level achieved")
-    agent_name: str = Field(..., description="The agent's name")
-    org: Optional[str] = Field(None, description="Organization scope")
+    agent_name: str = Field(..., description="The agent's globally unique name")
+    org: Optional[str] = Field(None, description="Legacy organization scope (deprecated)")
     status: Optional[str] = Field(None, description="Agent status")
     message: Optional[str] = Field(None, description="Additional verification message")
 
@@ -130,7 +130,7 @@ class TokenValidationResult(BaseModel):
     agent_name: Optional[str] = Field(
         None, alias="agentName", description="Agent name from token"
     )
-    org: Optional[str] = Field(None, description="Organization from token")
+    org: Optional[str] = Field(None, description="Legacy organization from token (deprecated)")
     expires_at: Optional[datetime] = Field(
         None, alias="expiresAt", description="Token expiration time"
     )
@@ -174,7 +174,7 @@ class ClaimResponse(BaseModel):
     """Response from claiming/registering an agent ID."""
 
     agent_name: str = Field(..., alias="agentName", description="The claimed agent name")
-    org: Optional[str] = Field(None, description="Organization scope")
+    org: Optional[str] = Field(None, description="Legacy organization scope (deprecated)")
     cert_pem: Optional[str] = Field(
         None, alias="certPem", description="Issued certificate in PEM format"
     )

--- a/src/openagents/agentid/parser.py
+++ b/src/openagents/agentid/parser.py
@@ -4,10 +4,13 @@ Agent ID format parsing utilities.
 This module provides functions for parsing, validating, and normalizing
 Agent ID strings in different formats (Level 2 and Level 3).
 
+Agent names are globally unique. The @org suffix is supported for
+backward compatibility with legacy agents but is not required.
+
 Supported formats:
-- Simple: my-agent, my-agent@org
-- Level 2: openagents:my-agent, openagents:my-agent@org
-- Level 3: did:openagents:my-agent, did:openagents:my-agent@org
+- Simple: my-agent (or legacy my-agent@org)
+- Level 2: openagents:my-agent (or legacy openagents:my-agent@org)
+- Level 3: did:openagents:my-agent (or legacy did:openagents:my-agent@org)
 """
 
 import re

--- a/src/openagents/cli.py
+++ b/src/openagents/cli.py
@@ -3387,7 +3387,7 @@ def agentid_verify(
 @agentid_app.command("info")
 def agentid_info(
     agent_name: str = typer.Argument(..., help="Agent name to look up"),
-    org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization scope")
+    org: Optional[str] = typer.Option(None, "--org", "-o", help="Legacy organization scope (deprecated)")
 ):
     """📋 Get detailed agent information"""
     from openagents.agentid import AgentIDVerifier, AgentIDNotFoundError, AgentIDConnectionError
@@ -3538,7 +3538,7 @@ def agentid_verify_token(
 @agentid_app.command("challenge")
 def agentid_challenge(
     agent_name: str = typer.Argument(..., help="Agent name to request challenge for"),
-    org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization scope"),
+    org: Optional[str] = typer.Option(None, "--org", "-o", help="Legacy organization scope (deprecated)"),
     algorithm: str = typer.Option("RS256", "--algorithm", "-a", help="Signing algorithm (RS256 or Ed25519)")
 ):
     """🎯 Request an authentication challenge"""
@@ -3585,7 +3585,7 @@ def agentid_token(
     agent_name: str = typer.Argument(..., help="Agent name"),
     nonce: str = typer.Option(..., "--nonce", "-n", help="Challenge nonce"),
     signature: str = typer.Option(..., "--signature", "-s", help="Base64-encoded signature"),
-    org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization scope"),
+    org: Optional[str] = typer.Option(None, "--org", "-o", help="Legacy organization scope (deprecated)"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Output only the token")
 ):
     """🎫 Exchange a signature for a JWT token"""
@@ -3633,7 +3633,7 @@ Use with: [cyan]Authorization: Bearer <token>[/cyan]""",
 def agentid_auth(
     agent_name: str = typer.Argument(..., help="Agent name"),
     key: str = typer.Option(..., "--key", "-k", help="Path to private key PEM file"),
-    org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization scope"),
+    org: Optional[str] = typer.Option(None, "--org", "-o", help="Legacy organization scope (deprecated)"),
     algorithm: str = typer.Option("RS256", "--algorithm", "-a", help="Signing algorithm"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Output only the token")
 ):
@@ -3702,7 +3702,7 @@ Use with: [cyan]Authorization: Bearer <token>[/cyan]""",
 def agentid_claim(
     agent_name: str = typer.Argument(..., help="Agent name to claim"),
     key: str = typer.Option(..., "--key", "-k", help="Path to public key PEM file"),
-    org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization scope"),
+    org: Optional[str] = typer.Option(None, "--org", "-o", help="Legacy organization scope (deprecated)"),
     api_key: Optional[str] = typer.Option(None, "--api-key", "-a", help="API key for authentication"),
     save_cert: Optional[str] = typer.Option(None, "--save-cert", "-c", help="Path to save the issued certificate"),
 ):
@@ -3774,7 +3774,7 @@ def agentid_claim(
 
     except AgentIDAuthenticationError as e:
         console.print(f"[red]❌ Authentication failed: {e.message}[/red]")
-        console.print("[dim]Make sure your API key is valid and belongs to the specified organization.[/dim]")
+        console.print("[dim]Make sure your API key is valid.[/dim]")
         raise typer.Exit(1)
     except AgentIDConnectionError as e:
         if "already exists" in str(e.message).lower():


### PR DESCRIPTION
## Summary
- **Agent names become globally unique** (like Twitter handles) instead of scoped to an org
- `namespace_type` default changed from `"org"` to `"global"` in the SDK client
- All `org` parameters marked as deprecated across models, client, parser, and CLI
- CLI `--org` options flagged as deprecated in help text

## Changes
- `agentid/__init__.py` — Updated module docstring, removed org from examples
- `agentid/client.py` — Default `namespace_type="global"`, deprecated org in docstrings  
- `agentid/models.py` — All org fields marked "Legacy (deprecated)"
- `agentid/parser.py` — `@org` shown as legacy format in docstring
- `cli.py` — All `--org` CLI options marked deprecated

## Context
This is Phase 0 of the identity infrastructure simplification. The corresponding backend/frontend changes are in the openagents-web repo.

## Test plan
- [ ] Verify `openagents agentid register <name>` works without `--org`
- [ ] Verify `openagents agentid claim <name>` works without `--org`
- [ ] Verify backward compatibility: `--org` still accepted but ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)