### PR TITLE
fix: replace 27 bare excepts with except Exception

### DIFF
--- a/demos/06_elon_musk_tracker/tools/rss_fetcher.py
+++ b/demos/06_elon_musk_tracker/tools/rss_fetcher.py
@@ -233,7 +233,7 @@ def fetch_all_elon_news(count_per_source: int = 5) -> List[Dict]:
             dt = datetime.fromisoformat(item.get("published_date", ""))
             # Convert to timestamp for consistent comparison
             return dt.timestamp()
-        except:
+        except Exception:
             return 0.0
 
     all_items.sort(key=get_date, reverse=True)

--- a/examples/shared_document_network/demo_script.py
+++ b/examples/shared_document_network/demo_script.py
@@ -292,21 +292,21 @@ TBD - needs resource planning"""
             for agent in self.agents.values():
                 try:
                     await agent.close_document(self.demo_document_id)
-                except:
+                except Exception:
                     pass
         
         # Stop agents
         for agent in self.agents.values():
             try:
                 await agent.stop()
-            except:
+            except Exception:
                 pass
         
         # Stop network
         if self.network_manager:
             try:
                 await self.network_manager.stop()
-            except:
+            except Exception:
                 pass
         
         print("✅ Cleanup completed")

--- a/src/openagents/agents/runner.py
+++ b/src/openagents/agents/runner.py
@@ -469,7 +469,7 @@ class AgentRunner(ABC):
                                 msg_payload_preview = payload_str[:300] + "..."
                             else:
                                 msg_payload_preview = payload_str
-                        except:
+                        except Exception:
                             msg_payload_preview = str(unprocessed_message.payload)[:300]
 
                     event_name = getattr(unprocessed_message, 'event_name', 'unknown')
@@ -902,7 +902,7 @@ class AgentRunner(ABC):
             try:
                 self._loop_task.cancel()
                 await asyncio.sleep(0.1)  # Give the task a moment to cancel
-            except:
+            except Exception:
                 pass
         await self.client.disconnect()
 

--- a/src/openagents/core/agent_manager.py
+++ b/src/openagents/core/agent_manager.py
@@ -433,7 +433,7 @@ class AgentManager:
             if agent_info.log_file_handle:
                 try:
                     agent_info.log_file_handle.close()
-                except:
+                except Exception:
                     pass
                 agent_info.log_file_handle = None
             
@@ -507,7 +507,7 @@ class AgentManager:
                     agent_info.log_file_handle.write(f"[{timestamp}] Agent stopped\n")
                     agent_info.log_file_handle.write(f"{'='*60}\n\n")
                     agent_info.log_file_handle.close()
-                except:
+                except Exception:
                     pass
                 agent_info.log_file_handle = None
 
@@ -813,7 +813,7 @@ class AgentManager:
                 try:
                     with open(env_file, "r", encoding="utf-8") as f:
                         data = json.load(f)
-                except:
+                except Exception:
                     pass
 
             # Update env vars
@@ -941,7 +941,7 @@ class AgentManager:
                                     )
                                     agent_info.log_file_handle.write(f"{'='*60}\n\n")
                                     agent_info.log_file_handle.close()
-                                except:
+                                except Exception:
                                     pass
                                 agent_info.log_file_handle = None
                             

--- a/src/openagents/core/client.py
+++ b/src/openagents/core/client.py
@@ -535,7 +535,7 @@ class AgentClient:
                             out_payload_preview = payload_str[:500] + "..."
                         else:
                             out_payload_preview = payload_str
-                    except:
+                    except Exception:
                         out_payload_preview = str(processed_event.payload)[:500]
 
                 # Print colored box for sending event
@@ -746,7 +746,7 @@ class AgentClient:
                     payload_preview = payload_str[:500] + "..."
                 else:
                     payload_preview = payload_str
-            except:
+            except Exception:
                 payload_preview = str(event.payload)[:500]
 
         # Print colored box for received event

--- a/src/openagents/core/connectors/grpc_connector.py
+++ b/src/openagents/core/connectors/grpc_connector.py
@@ -369,7 +369,7 @@ class GRPCNetworkConnector(NetworkConnector):
                         response_data = {
                             "raw_response": response.data.value.decode("utf-8")
                         }
-                    except:
+                    except Exception:
                         response_data = {"error": "Failed to decode response data"}
 
             if response.success:
@@ -590,7 +590,7 @@ class GRPCNetworkConnector(NetworkConnector):
                 return {
                     k: self._make_json_serializable(v) for k, v in obj.__dict__.items()
                 }
-            except:
+            except Exception:
                 return str(obj)
         else:
             # Try to serialize directly, fallback to string representation

--- a/src/openagents/core/transports/http.py
+++ b/src/openagents/core/transports/http.py
@@ -1507,7 +1507,7 @@ class HttpTransport(Transport):
         if self._relay_ws and not self._relay_ws.closed:
             try:
                 await self._relay_ws.send_json({"type": "unregister"})
-            except:
+            except Exception:
                 pass
             await self._relay_ws.close()
 
@@ -1526,7 +1526,7 @@ class HttpTransport(Transport):
             try:
                 data = await request.json()
                 relay_url = data.get("relay_url", DEFAULT_RELAY_URL)
-            except:
+            except Exception:
                 relay_url = DEFAULT_RELAY_URL
 
             # Check if already connected

--- a/src/openagents/utils/cli_display.py
+++ b/src/openagents/utils/cli_display.py
@@ -14,7 +14,7 @@ def get_terminal_width() -> int:
     """
     try:
         return shutil.get_terminal_size().columns
-    except:
+    except Exception:
         return 100  # Default fallback
 
 

--- a/tests/grpc/test_basic_grpc_communication.py
+++ b/tests/grpc/test_basic_grpc_communication.py
@@ -59,7 +59,7 @@ async def test_network():
             print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
             try:
                 await network.shutdown()
-            except:
+            except Exception:
                 pass
             if attempt == max_retries - 1:
                 raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")

--- a/tests/grpc/test_basic_test_mod.py
+++ b/tests/grpc/test_basic_test_mod.py
@@ -63,7 +63,7 @@ async def test_network():
             print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
             try:
                 await network.shutdown()
-            except:
+            except Exception:
                 pass
             if attempt == max_retries - 1:
                 raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")

--- a/tests/grpc/test_mixed_grpc_http_communication.py
+++ b/tests/grpc/test_mixed_grpc_http_communication.py
@@ -60,7 +60,7 @@ async def test_network():
             print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
             try:
                 await network.shutdown()
-            except:
+            except Exception:
                 pass
             if attempt == max_retries - 1:
                 raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")

--- a/tests/http/test_basic_http_communication.py
+++ b/tests/http/test_basic_http_communication.py
@@ -56,7 +56,7 @@ async def test_network():
             print(f"❌ Network initialization failed on attempt {attempt + 1}, retrying...")
             try:
                 await network.shutdown()
-            except:
+            except Exception:
                 pass
             if attempt == max_retries - 1:
                 raise RuntimeError(f"Failed to initialize network after {max_retries} attempts")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,9 +104,9 @@ async def hello_world_network(hello_world_network_config_path) -> Tuple:
                         if resp.status == 200:
                             print(f"Network health check passed on attempt {attempt + 1}")
                             break
-                except:
+                except Exception:
                     pass
-        except:
+        except Exception:
             pass
 
         if attempt < max_retries - 1:

--- a/tests/mods/test_thread_messaging.py
+++ b/tests/mods/test_thread_messaging.py
@@ -80,9 +80,9 @@ async def thread_messaging_network():
                         if resp.status == 200:
                             print(f"✅ Network health check passed on attempt {attempt + 1}")
                             break
-                except:
+                except Exception:
                     pass
-        except:
+        except Exception:
             pass
         
         if attempt < max_retries - 1:

--- a/tests/network/test_update_network_profile.py
+++ b/tests/network/test_update_network_profile.py
@@ -101,7 +101,7 @@ async def network_with_profile():
     await network.shutdown()
     try:
         os.unlink(config_path)
-    except:
+    except Exception:
         pass
 
 

--- a/tests/utils/test_port_allocator.py
+++ b/tests/utils/test_port_allocator.py
@@ -137,7 +137,7 @@ async def test_wait_for_port_free():
     finally:
         try:
             sock.close()
-        except:
+        except Exception:
             pass
         release_port(port)
 


### PR DESCRIPTION
Replace 27 bare `except:` with `except Exception:` across 16 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.