### PR TITLE
fix: correct broken Network Configuration links in docs

### DIFF
--- a/docs/concepts/agent-connection.mdx
+++ b/docs/concepts/agent-connection.mdx
@@ -616,4 +616,4 @@ print(f"Authentication: {auth_result.status}")
 - **[OpenAgents Studio](/concepts/openagents-studio)** - Learn about the web interface
 - **[Connect Agents Tutorial](/tutorials/connect-agents)** - Hands-on agent connection
 - **[Python Interface](/python-interface/connect-using-client)** - Programmatic connection
-- **[Network Configuration](/network-configuration)** - Configure network connectivity
+- **[Network Configuration](/network-configuration/network-configuration)** - Configure network connectivity

--- a/docs/concepts/agent-networks.mdx
+++ b/docs/concepts/agent-networks.mdx
@@ -260,4 +260,4 @@ Networks provide metrics on:
 - **[Open Collaboration](/concepts/open-collaboration)** - Learn about collaborative patterns
 - **[Architecture](/concepts/architecture)** - Understand system architecture
 - **[Start a Network](/tutorials/start-network)** - Create your first network
-- **[Network Configuration](/network-configuration)** - Complete configuration reference
+- **[Network Configuration](/network-configuration/network-configuration)** - Complete configuration reference

--- a/docs/concepts/core-concepts.mdx
+++ b/docs/concepts/core-concepts.mdx
@@ -151,7 +151,7 @@ network_profile:
   capacity: 500
 ```
 
-For comprehensive configuration options including security, performance tuning, and production deployment settings, see the **[Network Configuration Reference](/network-configuration)**.
+For comprehensive configuration options including security, performance tuning, and production deployment settings, see the **[Network Configuration Reference](/network-configuration/network-configuration)**.
 
 ## Event System
 

--- a/docs/concepts/network-mods.mdx
+++ b/docs/concepts/network-mods.mdx
@@ -574,5 +574,5 @@ for mod_name, mod_metrics in metrics.items():
 
 - **[Agent Connection](/concepts/agent-connection)** - Learn how agents connect to networks
 - **[OpenAgents Studio](/concepts/openagents-studio)** - Explore the web interface
-- **[Network Configuration](/network-configuration)** - Complete mod configuration reference
+- **[Network Configuration](/network-configuration/network-configuration)** - Complete mod configuration reference
 - **[Python Interface](/python-interface/workspace-interface)** - Use workspace features programmatically

--- a/docs/concepts/openagents-studio.mdx
+++ b/docs/concepts/openagents-studio.mdx
@@ -502,4 +502,4 @@ Studio supports modern browsers:
 - **[Using Studio Tutorial](/tutorials/using-studio)** - Hands-on Studio walkthrough
 - **[Studio Reference](/studio-reference/studio-reference)** - Complete Studio documentation
 - **[Connect Agents](/tutorials/connect-agents)** - Learn to work with agents
-- **[Network Configuration](/network-configuration)** - Configure Studio access
+- **[Network Configuration](/network-configuration/network-configuration)** - Configure Studio access

--- a/docs/concepts/transports.mdx
+++ b/docs/concepts/transports.mdx
@@ -447,5 +447,5 @@ Common transport issues and solutions:
 
 - **[Network Mods](/concepts/network-mods)** - Learn about extensible functionality
 - **[Agent Connection](/concepts/agent-connection)** - Understand agent connectivity
-- **[Network Configuration](/network-configuration)** - Complete transport configuration
+- **[Network Configuration](/network-configuration/network-configuration)** - Complete transport configuration
 - **[Python Interface](/python-interface/connect-using-client)** - Connect agents programmatically

--- a/docs/python-interface/launching-a-network.mdx
+++ b/docs/python-interface/launching-a-network.mdx
@@ -782,5 +782,5 @@ async def resilient_network_example():
 
 - **[Connect using Client](/python-interface/connect-using-client)** - Connect agents to your network
 - **[Workspace Interface](/python-interface/workspace-interface)** - Use workspace features
-- **[Network Configuration](/network-configuration)** - Complete configuration reference
+- **[Network Configuration](/network-configuration/network-configuration)** - Complete configuration reference
 - **[Start a Network Tutorial](/tutorials/start-network)** - Step-by-step network creation

--- a/docs/tutorials/start-network.mdx
+++ b/docs/tutorials/start-network.mdx
@@ -50,7 +50,7 @@ You should see output similar to:
 
 ## Step 3: Understanding the Configuration
 
-Let's break down what each part of your configuration does. For complete configuration options, see the **[Network Configuration Reference](/network-configuration)**.
+Let's break down what each part of your configuration does. For complete configuration options, see the **[Network Configuration Reference](/network-configuration/network-configuration)**.
 
 ### Network Basics
 ```yaml

--- a/docs/tutorials/tutorials.mdx
+++ b/docs/tutorials/tutorials.mdx
@@ -22,7 +22,7 @@ Learn how to launch your own agent network with custom configuration, mods, and 
 - Setting up security and transport options
 - Publishing your network for others to join
 
-**See Also:** [Network Configuration Reference](/network-configuration) - Complete configuration guide
+**See Also:** [Network Configuration Reference](/network-configuration/network-configuration) - Complete configuration guide
 
 **Prerequisites:** Basic understanding of YAML and command line
 


### PR DESCRIPTION
## Problem

Multiple documentation pages contain broken links to the Network Configuration 
reference. Clicking these links results in a 404 error.

## Steps to Reproduce

1. Go to https://openagents.org/docs/en/concepts/agent-networks
2. Scroll to the bottom "Next Steps" section
3. Click the **Network Configuration** hyperlink

**Before:** Routes to `/network-configuration` → 404 This page could not be found.

**After:** Routes to `/network-configuration/network-configuration` → Page loads correctly.

## Fix

Replace all broken `/network-configuration` links with the correct path 
`/network-configuration/network-configuration` to match the actual file location 
at `docs/network-configuration/network-configuration.mdx`.

The correct link format was already used in `docs/deployment/docker.mdx` and 
`docs/deployment/aws-lightsail.mdx`, which served as reference.

## Affected Files

- `docs/tutorials/tutorials.mdx`
- `docs/tutorials/start-network.mdx`
- `docs/concepts/agent-connection.mdx`
- `docs/concepts/openagents-studio.mdx`
- `docs/concepts/network-mods.mdx`
- `docs/concepts/agent-networks.mdx`
- `docs/concepts/transports.mdx`
- `docs/concepts/core-concepts.mdx`
- `docs/python-interface/launching-a-network.mdx`