### PR TITLE
fix(docs): remove duplicate word 'the' in start-network tutorial

### DIFF
--- a/docs/tutorials/start-network.mdx
+++ b/docs/tutorials/start-network.mdx
@@ -18,7 +18,7 @@ In this tutorial, you'll learn how to create and configure your own OpenAgents n
 - Text editor for configuration files
 
 <Banner type="important">
-**Important:** Some command and Python interface usage has changed in v0.7.0. Please read carefully even if you have read the this tutorial before.
+**Important:** Some command and Python interface usage has changed in v0.7.0. Please read carefully even if you have read this tutorial before.
 </Banner>
 
 ## Step 1: Create Network Configuration


### PR DESCRIPTION
## Summary

- Fixes a double-word typo in `docs/tutorials/start-network.mdx` line 21
- "read **the** this tutorial before" → "read this tutorial before"

## How to verify

Open https://openagents.org/docs/en/tutorials/start-network and read the important banner at the top of the page.

**Before:** `Please read carefully even if you have read the this tutorial before.`
**After:** `Please read carefully even if you have read this tutorial before.`