### PR TITLE
feat(studio): replace native window.confirm with styled useConfirm dialog

### DIFF
--- a/studio/src/components/artifact/ArtifactTopicDetail.tsx
+++ b/studio/src/components/artifact/ArtifactTopicDetail.tsx
@@ -4,9 +4,11 @@ import { useArtifactStore } from "@/stores/artifactStore";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { OpenAgentsContext } from "@/context/OpenAgentsProvider";
+import { useConfirm } from "@/context/ConfirmContext";
 
 const ArtifactTopicDetail: React.FC = () => {
   const { t } = useTranslation('artifact');
+  const { confirm } = useConfirm();
   const context = useContext(OpenAgentsContext);
   const { artifactId } = useParams<{ artifactId: string }>();
   const navigate = useNavigate();
@@ -107,14 +109,22 @@ const ArtifactTopicDetail: React.FC = () => {
   const handleDelete = async () => {
     if (!selectedArtifact) return;
 
-    if (window.confirm(t('detail.deleteConfirm', { name: selectedArtifact.name }))) {
-      const success = await deleteArtifact(selectedArtifact.artifact_id);
-      if (success) {
-        toast.success(t('detail.deleteSuccess'));
-        navigate("/artifact");
-      } else {
-        toast.error(t('detail.deleteFailed'));
+    const confirmed = await confirm(
+      t('detail.delete'),
+      t('detail.deleteConfirm', { name: selectedArtifact.name }),
+      {
+        confirmText: t('detail.delete'),
+        type: "danger",
       }
+    );
+    if (!confirmed) return;
+
+    const success = await deleteArtifact(selectedArtifact.artifact_id);
+    if (success) {
+      toast.success(t('detail.deleteSuccess'));
+      navigate("/artifact");
+    } else {
+      toast.error(t('detail.deleteFailed'));
     }
   };
 

--- a/studio/src/pages/profile/EventLogs.tsx
+++ b/studio/src/pages/profile/EventLogs.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react"
 import { useTranslation } from "react-i18next"
+import { useConfirm } from "@/context/ConfirmContext"
 import { ColumnDef } from "@tanstack/react-table"
 import {
   eventLogService,
@@ -27,6 +28,7 @@ type TabType = "events" | "http"
 
 const EventLogs: React.FC = () => {
   const { t } = useTranslation("admin")
+  const { confirm } = useConfirm()
   const [logs, setLogs] = useState<LogEntry[]>([])
   const [activeTab, setActiveTab] = useState<TabType>("events")
   const [refreshing, setRefreshing] = useState(false)
@@ -73,11 +75,18 @@ const EventLogs: React.FC = () => {
   }, [loadLogs])
 
   // Clear logs
-  const handleClearLogs = () => {
-    if (window.confirm(t("eventLogs.clearConfirm"))) {
-      eventLogService.clearLogs()
-      setSelectedLog(null)
-    }
+  const handleClearLogs = async () => {
+    const confirmed = await confirm(
+      t("eventLogs.clearLogs"),
+      t("eventLogs.clearConfirm"),
+      {
+        confirmText: t("eventLogs.clearLogs"),
+        type: "warning",
+      }
+    )
+    if (!confirmed) return
+    eventLogService.clearLogs()
+    setSelectedLog(null)
   }
 
   // Format time


### PR DESCRIPTION
## Context
Replace browser-native window.confirm() calls with the app's existing useConfirm() hook in two places:

- EventLogs.tsx: "Clear Logs" confirmation now uses the styled dialog
- ArtifactTopicDetail.tsx: "Delete Artifact" confirmation uses styled dialog with type="danger" for the destructive action

This makes the confirmation dialogs consistent with the rest of the app (TransportConfig, AdminDashboard, AgentManagement, etc.) which all use useConfirm(). No new i18n keys needed — all strings use existing translations in admin.json and artifact.json.


## Test plan
- [X] Go to Profile → Event Logs, click "Clear Logs" → 
1) styled confirmation dialog appears, 
2) After clicking Cancel button, the dialog disappeared 
3) After Clicking Button "Clear Logs", the logs indeed got deleted
(Test Scenario: http://localhost:8050/profile/event-logs)
* Before the change, browser-native window.confirm() will be called and the following are screenshot:
<img width="1639" height="256" alt="Screenshot 2026-03-06 at 10 30 31 PM" src="https://github.com/user-attachments/assets/6a4479c1-2b31-42fd-accc-e85cb74c9807" />

* After the change, useConfirm() hook will be used and the following are screenshot :
<img width="1496" height="1402" alt="Screenshot 2026-03-06 at 10 34 09 PM" src="https://github.com/user-attachments/assets/82c3460b-a5ee-4630-aaf2-16af3c9d78b0" />
