### PR TITLE
feat(i18n): replace hardcoded upload strings in FeedCreateModal with i18n keys

### DIFF
--- a/studio/src/components/feed/FeedCreateModal.tsx
+++ b/studio/src/components/feed/FeedCreateModal.tsx
@@ -422,14 +422,14 @@ const FeedCreateModal: React.FC<FeedCreateModalProps> = ({
                   : "bg-indigo-600 hover:bg-indigo-500"
                   }`}
                 title={
-                  connector ? "Upload attachment" : "Connect to an agent to upload"
+                  connector ? t('createModal.uploadFiles') : t('createModal.connectToUpload')
                 }
               >
                 {uploading
-                  ? "Uploading..."
+                  ? t('createModal.uploading')
                   : connector
-                    ? "Select file"
-                    : "Connect to upload"}
+                    ? t('createModal.selectFile')
+                    : t('createModal.connectToUpload')}
                 <input
                   type="file"
                   className="hidden"

--- a/studio/src/i18n/locales/en/feed.json
+++ b/studio/src/i18n/locales/en/feed.json
@@ -105,6 +105,8 @@
         "uploadFiles": "Upload files or images",
         "uploadHint": "Attach supporting materials (max 1 file per upload)",
         "selectFile": "Select file",
+        "uploading": "Uploading...",
+        "connectToUpload": "Connect to upload",
         "immutableWarning": "Posts cannot be edited or deleted once published.",
         "cancel": "Cancel",
         "create": "Create Post",

--- a/studio/src/i18n/locales/ja/feed.json
+++ b/studio/src/i18n/locales/ja/feed.json
@@ -105,6 +105,8 @@
         "uploadFiles": "ファイルや画像をアップロード",
         "uploadHint": "サポート資料を添付（アップロードごとに最大1ファイル）",
         "selectFile": "ファイルを選択",
+        "uploading": "アップロード中...",
+        "connectToUpload": "アップロードするには接続してください",
         "immutableWarning": "投稿は公開後に編集・削除できません。",
         "cancel": "キャンセル",
         "create": "投稿を作成",

--- a/studio/src/i18n/locales/ko/feed.json
+++ b/studio/src/i18n/locales/ko/feed.json
@@ -105,6 +105,8 @@
         "uploadFiles": "파일 또는 이미지 업로드",
         "uploadHint": "지원 자료 첨부 (업로드당 최대 1개 파일)",
         "selectFile": "파일 선택",
+        "uploading": "업로드 중...",
+        "connectToUpload": "업로드하려면 연결하세요",
         "immutableWarning": "게시물은 게시 후 편집하거나 삭제할 수 없습니다.",
         "cancel": "취소",
         "create": "게시물 만들기",

--- a/studio/src/i18n/locales/zh-CN/feed.json
+++ b/studio/src/i18n/locales/zh-CN/feed.json
@@ -105,6 +105,8 @@
         "uploadFiles": "上传文件或图片",
         "uploadHint": "附加支持材料 (每次最多 1 个文件)",
         "selectFile": "选择文件",
+        "uploading": "上传中...",
+        "connectToUpload": "连接以上传",
         "immutableWarning": "动态发布后无法编辑或删除。",
         "cancel": "取消",
         "create": "发布动态",


### PR DESCRIPTION

`FeedCreateModal.tsx` had three English-only hardcoded strings in the file attachment section: `"Uploading..."`, `"Select file"`, and `"Connect to upload"`
- `createModal.selectFile` already existed in all four locale files (en, zh-CN, ja, ko) but was not being used — this PR finally wires it up and is accessible for the international users 
- Added two missing keys (`uploading`, `connectToUpload`) to all four locale files with proper translations
- All three strings now go through `t()` and will automatically adapt to the user's language


 File | Change |
|------|--------|
| `FeedCreateModal.tsx` | Replace 3 hardcoded strings with `t()` calls |
| `locales/en/feed.json` | Add `uploading`, `connectToUpload` |
| `locales/zh-CN/feed.json` | Add `uploading`, `connectToUpload` |
| `locales/ja/feed.json` | Add `uploading`, `connectToUpload` |
| `locales/ko/feed.json` | Add `uploading`, `connectToUpload` |