### PR TITLE
fix(i18n): add missing English coverage for mod management and connected agents UI

### DIFF
--- a/studio/src/components/layout/ui/data-table.tsx
+++ b/studio/src/components/layout/ui/data-table.tsx
@@ -50,6 +50,8 @@ export interface DataTableProps<TData, TValue> {
   toolbar?: React.ReactNode
   className?: string
   onRowClick?: (row: TData) => void
+  paginationPageInfoLabel?: (currentPage: number, totalPages: number) => string
+  paginationTotalRecordsLabel?: (totalRecords: number) => string
 }
 
 export function DataTable<TData, TValue>({
@@ -67,6 +69,9 @@ export function DataTable<TData, TValue>({
   toolbar,
   className,
   onRowClick,
+  paginationPageInfoLabel = (currentPage, totalPages) =>
+    `Page ${currentPage} of ${totalPages}`,
+  paginationTotalRecordsLabel = (totalRecords) => `${totalRecords} records`,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
@@ -237,11 +242,17 @@ export function DataTable<TData, TValue>({
           <div className="flex items-center justify-between px-4 py-3 border-t">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span>
-                第 {table.getState().pagination.pageIndex + 1} 页，共{" "}
-                {table.getPageCount()} 页
+                {paginationPageInfoLabel(
+                  table.getState().pagination.pageIndex + 1,
+                  table.getPageCount()
+                )}
               </span>
               <span>•</span>
-              <span>共 {table.getFilteredRowModel().rows.length} 条记录</span>
+              <span>
+                {paginationTotalRecordsLabel(
+                  table.getFilteredRowModel().rows.length
+                )}
+              </span>
             </div>
             <div className="flex items-center gap-2">
               <Button

--- a/studio/src/i18n/locales/en/admin.json
+++ b/studio/src/i18n/locales/en/admin.json
@@ -435,6 +435,14 @@
       "static": "Static",
       "dynamic": "Dynamic"
     },
+    "table": {
+      "status": "Status",
+      "name": "Module Name",
+      "description": "Description",
+      "actions": "Actions",
+      "pageInfo": "Page {{current}} of {{total}}",
+      "totalRecords": "{{count}} records"
+    },
     "actions": {
       "enable": "Enable",
       "disable": "Disable",
@@ -465,6 +473,10 @@
       "maxPagesPerAgent": "Max Pages Per Agent",
       "maxPageContentLength": "Max Page Content Length",
       "configJson": "Config (JSON)",
+      "selectPlaceholder": "Please select...",
+      "addOptionPlaceholder": "Add option...",
+      "addItem": "Add item",
+      "unsupportedFieldType": "Unsupported field type",
       "noSchema": {
         "title": "No Configuration Schema",
         "description": "This mod has not defined a configuration schema. The schema will be defined in the mod's manifest.json file."

--- a/studio/src/i18n/locales/en/network.json
+++ b/studio/src/i18n/locales/en/network.json
@@ -75,6 +75,7 @@
         "refresh": "Refresh",
         "total": "Total Agents",
         "online": "Online Agents",
+        "searchPlaceholder": "Search agents...",
         "empty": "No agents connected",
         "you": "(You)",
         "kick": "Kick",

--- a/studio/src/pages/mod-management/ConfigFieldRenderer.tsx
+++ b/studio/src/pages/mod-management/ConfigFieldRenderer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ConfigField } from '@/types/modConfig';
 import { Input } from '@/components/layout/ui/input';
 import { Label } from '@/components/layout/ui/label';
@@ -29,6 +30,7 @@ const ConfigFieldRenderer: React.FC<ConfigFieldRendererProps> = ({
   errors = {},
   path = '',
 }) => {
+  const { t } = useTranslation('admin');
   const fieldPath = path ? `${path}.${field.key}` : field.key;
   const error = errors[fieldPath];
   const displayValue = value !== undefined && value !== null ? value : field.default;
@@ -100,7 +102,12 @@ const ConfigFieldRenderer: React.FC<ConfigFieldRendererProps> = ({
             }}
           >
             <SelectTrigger size="lg" className={error ? 'border-red-500' : ''}>
-              <SelectValue placeholder={field.placeholder || '请选择...'} />
+              <SelectValue
+                placeholder={
+                  field.placeholder ||
+                  t('modManagement.settings.selectPlaceholder', '请选择...')
+                }
+              />
             </SelectTrigger>
             <SelectContent>
               {field.options?.map((option) => (
@@ -126,7 +133,12 @@ const ConfigFieldRenderer: React.FC<ConfigFieldRendererProps> = ({
               }}
             >
               <SelectTrigger size="lg" className={error ? 'border-red-500' : ''}>
-                <SelectValue placeholder={field.placeholder || '添加选项...'} />
+                <SelectValue
+                  placeholder={
+                    field.placeholder ||
+                    t('modManagement.settings.addOptionPlaceholder', '添加选项...')
+                  }
+                />
               </SelectTrigger>
               <SelectContent>
                 {field.options?.map((option) => (
@@ -248,7 +260,7 @@ const ConfigFieldRenderer: React.FC<ConfigFieldRendererProps> = ({
               className="text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-900/20"
             >
               <Plus className="w-4 h-4 mr-2" />
-              添加项
+              {t('modManagement.settings.addItem', '添加项')}
             </Button>
           </div>
         );
@@ -277,7 +289,7 @@ const ConfigFieldRenderer: React.FC<ConfigFieldRendererProps> = ({
       default:
         return (
           <div className="text-sm text-gray-500 dark:text-gray-400">
-            不支持的字段类型: {field.type}
+            {t('modManagement.settings.unsupportedFieldType', '不支持的字段类型')}: {field.type}
           </div>
         );
     }

--- a/studio/src/pages/mod-management/ModManagementPage.tsx
+++ b/studio/src/pages/mod-management/ModManagementPage.tsx
@@ -411,6 +411,17 @@ const ModManagementPage: React.FC = () => {
           searchColumn={["id", "name", "displayName", "description"]}
           pagination={true}
           pageSize={10}
+          paginationPageInfoLabel={(currentPage, totalPages) =>
+            t("modManagement.table.pageInfo", "第 {{current}} 页，共 {{total}} 页", {
+              current: currentPage,
+              total: totalPages,
+            })
+          }
+          paginationTotalRecordsLabel={(totalRecords) =>
+            t("modManagement.table.totalRecords", "共 {{count}} 条记录", {
+              count: totalRecords,
+            })
+          }
           emptyMessage={t(
             "modManagement.enabledMods.empty",
             "No mods configured"


### PR DESCRIPTION
## Summary

Adds missing English i18n coverage in Studio where Chinese strings were still visible under English locale.

### Changes

- Add missing `modManagement.table.*` and config-field English keys in `studio/src/i18n/locales/en/admin.json`
- Add missing `agents.searchPlaceholder` in `studio/src/i18n/locales/en/network.json`
- Replace hardcoded Chinese literals in `studio/src/pages/mod-management/ConfigFieldRenderer.tsx` with i18n keys
- Make `studio/src/components/layout/ui/data-table.tsx` pagination/count labels customizable with English defaults
- Wire i18n pagination labels in `studio/src/pages/mod-management/ModManagementPage.tsx`

## Validation

- Confirmed affected mod-management and connected-agents UI paths resolve to English under English locale
- Lint check passed for touched files

## Scope

Focused i18n coverage fix only; no broader translation refactor.