### PR TITLE
fix: Windows encoding in setup.py and missing imports in CLI modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """
 Setup script for OpenAgents.
 This is a minimal setup.py that defers to pyproject.toml for configuration.
@@ -6,8 +7,17 @@ This is a minimal setup.py that defers to pyproject.toml for configuration.
 
 import os
 import shutil
+import sys
 from pathlib import Path
 from setuptools import setup, find_packages
+
+def safe_print(message):
+    """Print with fallback for Windows encoding issues."""
+    try:
+        print(message)
+    except UnicodeEncodeError:
+        # Fallback: remove non-ASCII characters
+        print(message.encode('ascii', 'replace').decode('ascii'))
 
 def copy_studio_build():
     """Copy studio build files to package directory if they exist."""
@@ -25,11 +35,11 @@ def copy_studio_build():
         
         # Copy build directory
         shutil.copytree(studio_build_src, studio_build_dst)
-        print(f"✅ Copied studio build files from {studio_build_src} to {studio_build_dst}")
+        safe_print(f"✅ Copied studio build files from {studio_build_src} to {studio_build_dst}")
     else:
-        print(f"⚠️  Studio build directory not found at {studio_build_src}")
-        print("   The package will work, but users will need Node.js to run the studio.")
-        print("   To include the built frontend, run 'npm run build' in the studio directory first.")
+        safe_print(f"⚠️  Studio build directory not found at {studio_build_src}")
+        safe_print("   The package will work, but users will need Node.js to run the studio.")
+        safe_print("   To include the built frontend, run 'npm run build' in the studio directory first.")
 
 if __name__ == "__main__":
     # Copy studio build files before setup

--- a/src/openagents/client/cli_agent.py
+++ b/src/openagents/client/cli_agent.py
@@ -6,11 +6,14 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+import yaml
 from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 from rich import box
 
 from openagents.client.cli_shared import app, console
+from openagents.client.cli_helpers import configure_workspace_logging
 
 agent_app = typer.Typer(
     name="agent",


### PR DESCRIPTION
## Summary

Fix Unicode encoding errors on Windows and missing imports in CLI modules.

## Problem

- `setup.py` uses emoji characters (✅, ⚠️) in print statements that fail 
  on Windows terminals using cp1252 encoding, breaking `pip install -e .` and `pip install .`
- `cli_agent.py` is missing imports for `Progress`, `SpinnerColumn`, `TextColumn`, 
  `yaml`, and `configure_workspace_logging`
- `cli_network.py` is missing the `show_banner` import

## Changes

- `setup.py`: Added `safe_print()` function that catches `UnicodeEncodeError` 
  and falls back to ASCII-safe output
- `cli_agent.py`: Added missing imports from `rich.progress`, `yaml`, 
  and `configure_workspace_logging` from `cli_helpers`
- `cli_network.py`: Added `show_banner` import from `cli`
