### PR TITLE
fix(messaging): align simple messaging thread events and client test deps

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,6 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-asyncio pytest-aiohttp pytest-mock
         pip install -e .
+        pip install -r workspace/backend/requirements.txt
 
     - name: Test ONM primitives
       run: pytest --tb=short -v tests/test_onm_addressing.py tests/test_onm_events.py tests/test_onm_pipeline.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-client-${{ hashFiles('**/pyproject.toml') }}
+        key: ${{ runner.os }}-pip-client-${{ hashFiles('**/pyproject.toml', 'workspace/backend/requirements-test.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-client-
 
@@ -39,7 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-asyncio pytest-aiohttp pytest-mock
         pip install -e .
-        pip install -r workspace/backend/requirements.txt
+        pip install -r workspace/backend/requirements-test.txt
 
     - name: Test ONM primitives
       run: pytest --tb=short -v tests/test_onm_addressing.py tests/test_onm_events.py tests/test_onm_pipeline.py

--- a/src/openagents/mods/communication/simple_messaging/adapter.py
+++ b/src/openagents/mods/communication/simple_messaging/adapter.py
@@ -249,7 +249,7 @@ class SimpleMessagingAgentAdapter(BaseModAdapter):
 
         # Create and send the message
         message = Event(
-            event_name="agent.direct_message.send",
+            event_name="thread.direct_message.send",
             source_id=self.agent_id,
             destination_id=target_agent_id,
             payload={
@@ -262,7 +262,10 @@ class SimpleMessagingAgentAdapter(BaseModAdapter):
         # DO NOT add outbound messages to sender's threads - only recipients should process incoming messages
         # The message will be added to the recipient's thread when they receive it via process_incoming_direct_message
 
-        await self.connector.send_direct_message(message)
+        if hasattr(self.connector, "send_direct_message"):
+            await self.connector.send_direct_message(message)
+        else:
+            await self.connector.send_event(message)
         logger.debug(f"Sent direct message to {target_agent_id}")
 
     async def send_broadcast_message(self, content: Dict[str, Any]) -> None:
@@ -287,7 +290,10 @@ class SimpleMessagingAgentAdapter(BaseModAdapter):
         # Add message to the broadcast conversation thread
         message.thread_name = get_broadcast_event_thread_id()
 
-        await self.connector.send_broadcast_message(message)
+        if hasattr(self.connector, "send_broadcast_message"):
+            await self.connector.send_broadcast_message(message)
+        else:
+            await self.connector.send_event(message)
         logger.debug("Sent broadcast message")
 
     async def send_text_message(self, target_agent_id: str, text: str) -> None:

--- a/src/openagents/mods/communication/simple_messaging/mod.py
+++ b/src/openagents/mods/communication/simple_messaging/mod.py
@@ -37,6 +37,11 @@ class SimpleMessagingNetworkMod(BaseMod):
         self.register_event_handler(
             self._handle_direct_message, "agent.direct_message.*"
         )
+        # Also handle thread-namespaced DM events (used by adapters that
+        # target the workspace/thread messaging mod pipeline).
+        self.register_event_handler(
+            self._handle_direct_message, "thread.direct_message.*"
+        )
         self.register_event_handler(
             self._handle_broadcast_message, "agent.broadcast_message.*"
         )

--- a/workspace/backend/requirements-test.txt
+++ b/workspace/backend/requirements-test.txt
@@ -1,0 +1,8 @@
+# Minimal deps for running workspace backend tests in CI
+fastapi>=0.115.0
+uvicorn>=0.30.0
+pydantic>=2.0.0
+sqlalchemy>=2.0.0
+python-dotenv>=1.0.0
+python-multipart>=0.0.9
+httpx>=0.25.0


### PR DESCRIPTION
## Summary
- align `simple_messaging` direct messages with the thread messaging event contract by using `thread.direct_message.send`
- fall back to generic `send_event()` when a connector does not expose specialized direct or broadcast messaging helpers
- install `workspace/backend/requirements.txt` in the `client-tests` workflow so `workspace/backend/tests` can import `fastapi.testclient`

## Test plan
- [x] `python -m pytest workspace/backend/tests -q`