### PR TITLE
feat(studio): Agent-to-agent DM visibility, DM history fixes & dark mode improvements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,6 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-asyncio pytest-aiohttp pytest-mock
         pip install -e .
+        pip install -r workspace/backend/requirements.txt
 
     - name: Test ONM primitives
       run: pytest --tb=short -v tests/test_onm_addressing.py tests/test_onm_events.py tests/test_onm_pipeline.py

--- a/src/openagents/mods/workspace/messaging/mod.py
+++ b/src/openagents/mods/workspace/messaging/mod.py
@@ -39,6 +39,11 @@ from .thread_messages import (
 logger = logging.getLogger(__name__)
 
 
+def _bare_agent_id(aid: str) -> str:
+    """Strip the ``agent:`` prefix so prefixed and bare IDs compare equally."""
+    return aid[len("agent:"):] if aid.startswith("agent:") else aid
+
+
 class MessageThread:
     """Represents a conversation thread with Reddit-like nesting."""
 
@@ -907,10 +912,12 @@ class ThreadMessagingNetworkMod(BaseMod):
                 if not is_direct_message:
                     continue
 
-                source = msg.source_id
+                source = msg.source_id or ""
                 target = msg.payload["target_agent_id"]
+                bare_source = _bare_agent_id(source)
+                bare_target = _bare_agent_id(target)
                 # Normalize the pair so (A,B) and (B,A) are the same
-                pair = (min(source, target), max(source, target))
+                pair = (min(bare_source, bare_target), max(bare_source, bare_target))
 
                 content_text = ""
                 if msg.payload and "content" in msg.payload:
@@ -1895,14 +1902,10 @@ class ThreadMessagingNetworkMod(BaseMod):
 
             if is_direct_message:
                 payload_target = msg.payload["target_agent_id"]
-                # Normalize agent IDs by stripping "agent:" prefix for comparison
-                def _bare(aid: str) -> str:
-                    return aid[len("agent:"):] if aid.startswith("agent:") else aid
-
-                bare_agent = _bare(agent_id) if agent_id else ""
-                bare_target = _bare(target_agent_id) if target_agent_id else ""
-                bare_source = _bare(msg.source_id) if msg.source_id else ""
-                bare_payload_target = _bare(payload_target)
+                bare_agent = _bare_agent_id(agent_id) if agent_id else ""
+                bare_target = _bare_agent_id(target_agent_id) if target_agent_id else ""
+                bare_source = _bare_agent_id(msg.source_id) if msg.source_id else ""
+                bare_payload_target = _bare_agent_id(payload_target)
 
                 # Check if this message is between the requesting agents
                 is_direct_msg_between_agents = (

--- a/src/openagents/mods/workspace/messaging/mod.py
+++ b/src/openagents/mods/workspace/messaging/mod.py
@@ -878,6 +878,88 @@ class ThreadMessagingNetworkMod(BaseMod):
             "Direct message retrieval completed successfully",
         )
 
+    @mod_event_handler("thread.conversations.list")
+    async def _handle_thread_conversations_list(
+        self, event: Event
+    ) -> Optional[EventResponse]:
+        """Handle listing all agent-to-agent DM conversations.
+
+        Scans message_history for direct messages and groups them by
+        conversation pair, returning metadata for each pair.
+        """
+        # Prevent infinite loops
+        if (
+            self.network
+            and event.source_id == self.network.network_id
+            and event.relevant_mod == "openagents.mods.workspace.messaging"
+        ):
+            return None
+
+        try:
+            conversations: Dict[tuple, Dict[str, Any]] = {}
+
+            for msg_id, msg in self.message_history.items():
+                is_direct_message = (
+                    msg.payload
+                    and "target_agent_id" in msg.payload
+                    and msg.destination_id
+                )
+                if not is_direct_message:
+                    continue
+
+                source = msg.source_id
+                target = msg.payload["target_agent_id"]
+                # Normalize the pair so (A,B) and (B,A) are the same
+                pair = (min(source, target), max(source, target))
+
+                content_text = ""
+                if msg.payload and "content" in msg.payload:
+                    content = msg.payload["content"]
+                    if isinstance(content, dict):
+                        content_text = content.get("text", "")
+                    elif isinstance(content, str):
+                        content_text = content
+
+                ts = msg.timestamp or 0
+
+                if pair not in conversations:
+                    conversations[pair] = {
+                        "agents": list(pair),
+                        "last_message": {
+                            "content": content_text[:200],
+                            "sender": source,
+                            "timestamp": ts,
+                        },
+                        "message_count": 1,
+                    }
+                else:
+                    conversations[pair]["message_count"] += 1
+                    if ts > conversations[pair]["last_message"]["timestamp"]:
+                        conversations[pair]["last_message"] = {
+                            "content": content_text[:200],
+                            "sender": source,
+                            "timestamp": ts,
+                        }
+
+            # Sort by most recent activity
+            result = sorted(
+                conversations.values(),
+                key=lambda c: c["last_message"]["timestamp"],
+                reverse=True,
+            )
+
+            return self._create_event_response(
+                success=True,
+                message="Conversations listed successfully",
+                data={"conversations": result},
+            )
+        except Exception as e:
+            logger.error(f"Error listing conversations: {e}")
+            return self._create_event_response(
+                success=False,
+                message=f"Error listing conversations: {str(e)}",
+            )
+
     @mod_event_handler("thread.reaction.add")
     async def _handle_thread_reaction_add(
         self, event: Event
@@ -1809,15 +1891,23 @@ class ThreadMessagingNetworkMod(BaseMod):
                 msg.payload
                 and "target_agent_id" in msg.payload
                 and msg.destination_id
-                and msg.destination_id.startswith("agent:")
             )
 
             if is_direct_message:
                 payload_target = msg.payload["target_agent_id"]
+                # Normalize agent IDs by stripping "agent:" prefix for comparison
+                def _bare(aid: str) -> str:
+                    return aid[len("agent:"):] if aid.startswith("agent:") else aid
+
+                bare_agent = _bare(agent_id) if agent_id else ""
+                bare_target = _bare(target_agent_id) if target_agent_id else ""
+                bare_source = _bare(msg.source_id) if msg.source_id else ""
+                bare_payload_target = _bare(payload_target)
+
                 # Check if this message is between the requesting agents
                 is_direct_msg_between_agents = (
-                    msg.source_id == agent_id and payload_target == target_agent_id
-                ) or (msg.source_id == target_agent_id and payload_target == agent_id)
+                    bare_source == bare_agent and bare_payload_target == bare_target
+                ) or (bare_source == bare_target and bare_payload_target == bare_agent)
                 if is_direct_msg_between_agents:
                     logger.debug(
                         f"Found direct message: {msg_id} from {msg.source_id} to {payload_target}"

--- a/studio/src/pages/messaging/MessagingSidebar.tsx
+++ b/studio/src/pages/messaging/MessagingSidebar.tsx
@@ -231,6 +231,7 @@ const MessagingSidebar: React.FC = () => {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
+     <div className="flex-1 overflow-y-auto">
       {/* Channels Section */}
       <SectionHeader title={t('sidebar.channels')} />
       <div className="px-3">
@@ -289,7 +290,7 @@ const MessagingSidebar: React.FC = () => {
       {agentConversations.length > 0 && (
         <>
           <SectionHeader title="Agent DMs" />
-          <div className="flex-1 overflow-y-auto px-3 custom-scrollbar">
+          <div className="px-3">
             <ul className="flex flex-col gap-1">
               {agentConversations.map((convo) => {
                 const key = `${convo.agents[0]},${convo.agents[1]}`;
@@ -328,6 +329,7 @@ const MessagingSidebar: React.FC = () => {
           </div>
         </>
       )}
+     </div>
     </div>
   );
 };

--- a/studio/src/pages/messaging/MessagingSidebar.tsx
+++ b/studio/src/pages/messaging/MessagingSidebar.tsx
@@ -111,16 +111,21 @@ const MessagingSidebar: React.FC = () => {
   const {
     currentChannel,
     currentDirectMessage,
+    currentAgentConversation,
     selectChannel,
     selectDirectMessage,
+    selectAgentConversation,
     channels,
     channelsLoading,
     channelsLoaded,
     agents,
     agentsLoading,
     agentsLoaded,
+    agentConversations,
+    agentConversationsLoaded,
     loadChannels,
     loadAgents,
+    loadAgentConversations,
     restorePersistedSelection,
     initializeWithDefaultSelection,
   } = useChatStore();
@@ -136,8 +141,11 @@ const MessagingSidebar: React.FC = () => {
         console.log('MessagingSidebar: Loading agents...');
         loadAgents();
       }
+      if (!agentConversationsLoaded) {
+        loadAgentConversations();
+      }
     }
-  }, [isConnected, channelsLoaded, channelsLoading, agentsLoaded, agentsLoading, loadChannels, loadAgents]);
+  }, [isConnected, channelsLoaded, channelsLoading, agentsLoaded, agentsLoading, agentConversationsLoaded, loadChannels, loadAgents, loadAgentConversations]);
 
   // Handle selection restoration and default selection - execute after data loading completes
   React.useEffect(() => {
@@ -176,6 +184,15 @@ const MessagingSidebar: React.FC = () => {
 
     handleSelectionInitialization();
   }, [channelsLoaded, agentsLoaded, currentChannel, currentDirectMessage, restorePersistedSelection, initializeWithDefaultSelection]);
+
+  // Periodically refresh agent conversations
+  React.useEffect(() => {
+    if (!isConnected) return;
+    const interval = setInterval(() => {
+      loadAgentConversations();
+    }, 15_000);
+    return () => clearInterval(interval);
+  }, [isConnected, loadAgentConversations]);
 
   // Filter out current user
   const filteredAgents = React.useMemo(() => {
@@ -243,7 +260,7 @@ const MessagingSidebar: React.FC = () => {
 
       {/* Direct Messages Section */}
       <SectionHeader title={t('sidebar.directMessages')} />
-      <div className="flex-1 overflow-y-auto px-3 custom-scrollbar">
+      <div className="px-3">
         {agentsLoading && filteredAgents.length === 0 ? (
           <div className="text-gray-500 text-sm px-2 py-2 text-center">
             {t('sidebar.loadingAgents')}
@@ -267,6 +284,50 @@ const MessagingSidebar: React.FC = () => {
           </ul>
         )}
       </div>
+
+      {/* Agent-to-Agent Conversations Section */}
+      {agentConversations.length > 0 && (
+        <>
+          <SectionHeader title="Agent DMs" />
+          <div className="flex-1 overflow-y-auto px-3 custom-scrollbar">
+            <ul className="flex flex-col gap-1">
+              {agentConversations.map((convo) => {
+                const key = `${convo.agents[0]},${convo.agents[1]}`;
+                const isActive = currentAgentConversation === key;
+                const preview = convo.lastMessage.content
+                  ? `${convo.lastMessage.sender}: ${convo.lastMessage.content}`.slice(0, 60)
+                  : '';
+                return (
+                  <li key={key}>
+                    <button
+                      onClick={() => selectAgentConversation(key)}
+                      className={`w-full text-left text-sm px-2 py-2 font-medium rounded transition-colors
+                        ${isActive
+                          ? "bg-[#F4F4F5] text-gray-900 dark:bg-[#F4F4F5] dark:text-gray-900 pl-2"
+                          : "text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-zinc-900 pl-2.5"
+                        }
+                      `}
+                      title={`${convo.agents[0]} ↔ ${convo.agents[1]} (${convo.messageCount} messages)`}
+                    >
+                      <div className="flex items-center min-w-0">
+                        <span className="mr-2 text-gray-400 text-xs">↔</span>
+                        <span className="truncate text-xs">
+                          {convo.agents[0]} ↔ {convo.agents[1]}
+                        </span>
+                      </div>
+                      {preview && (
+                        <div className="text-xs text-gray-400 truncate mt-0.5 pl-5">
+                          {preview}
+                        </div>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/studio/src/pages/messaging/MessagingView.tsx
+++ b/studio/src/pages/messaging/MessagingView.tsx
@@ -30,7 +30,7 @@ const ThreadMessagingViewEventBased: React.FC = () => {
   const { theme: currentTheme } = useThemeStore()
 
   // Get current selection state and selection methods from chatStore
-  const { currentChannel, currentDirectMessage, selectChannel } = useChatStore()
+  const { currentChannel, currentDirectMessage, currentAgentConversation, selectChannel } = useChatStore()
 
   // Check if current channel is project channel
   const isProjectChannelActive = useMemo(() => {
@@ -111,9 +111,13 @@ const ThreadMessagingViewEventBased: React.FC = () => {
   const prevMessagesLength = useRef<number>(0)
   const prevScrollHeight = useRef<number>(0)
 
-  // Get messages for current channel or DM
+  // Get messages for current channel, DM, or agent conversation
   const messages = useMemo(() => {
-    if (currentChannel) {
+    if (currentAgentConversation) {
+      // Agent-to-agent conversation — stored in directMessages under conversation key
+      const msgs = directMessages.get(currentAgentConversation) || []
+      return msgs
+    } else if (currentChannel) {
       // Get data directly from Map
       const msgs = channelMessages.get(currentChannel) || []
       console.log(
@@ -143,6 +147,7 @@ const ThreadMessagingViewEventBased: React.FC = () => {
   }, [
     currentChannel,
     currentDirectMessage,
+    currentAgentConversation,
     channelMessages,
     directMessages,
     connectionStatus.agentId,
@@ -653,10 +658,14 @@ const ThreadMessagingViewEventBased: React.FC = () => {
 
   // Get current view title
   const getCurrentViewTitle = useMemo(() => {
+    if (currentAgentConversation) {
+      const [a, b] = currentAgentConversation.split(",", 2)
+      return `${a} ↔ ${b}`
+    }
     if (currentChannel) return `#${currentChannel}`
     if (currentDirectMessage) return `@${currentDirectMessage}`
     return t("header.selectChannel")
-  }, [currentChannel, currentDirectMessage, t])
+  }, [currentChannel, currentDirectMessage, currentAgentConversation, t])
 
   // Check if its a project channel, if so use ProjectChatRoom component
   const projectId = useMemo(() => {
@@ -768,7 +777,10 @@ const ThreadMessagingViewEventBased: React.FC = () => {
                 //   currentDirectMessage
                 // });
 
-                if (currentChannel) {
+                if (currentAgentConversation) {
+                  // Agent conversation — show all messages (already filtered by store)
+                  return true
+                } else if (currentChannel) {
                   // For channel messages, match the channel
                   return (
                     (message.type === "channel_message" &&
@@ -891,8 +903,15 @@ const ThreadMessagingViewEventBased: React.FC = () => {
             <div ref={messagesEndRef} />
           </div>
 
-          {/* Message Input */}
-          {(currentChannel || currentDirectMessage) && (
+          {/* Read-only banner for agent conversations */}
+          {currentAgentConversation && (
+            <div className="px-4 py-2 text-xs text-center text-gray-400 bg-gray-50 dark:bg-zinc-900 border-t border-gray-200 dark:border-zinc-700">
+              Read-only — agent-to-agent conversation ({currentAgentConversation.replace(",", " ↔ ")})
+            </div>
+          )}
+
+          {/* Message Input — hidden for agent conversation (read-only) */}
+          {(currentChannel || currentDirectMessage) && !currentAgentConversation && (
             <MessageInput
               agents={currentDirectMessage ? [] : filteredAgents}
               onSendMessage={(

--- a/studio/src/pages/messaging/components/MarkdownContent.tsx
+++ b/studio/src/pages/messaging/components/MarkdownContent.tsx
@@ -19,7 +19,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         h1: ({ children }) => (
           <h1
             className={`text-2xl font-bold mb-2 ${
-              currentTheme === "dark" ? "text-gray-100" : "text-gray-900"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -28,7 +28,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         h2: ({ children }) => (
           <h2
             className={`text-xl font-semibold mb-2 ${
-              currentTheme === "dark" ? "text-gray-100" : "text-gray-900"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -37,7 +37,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         h3: ({ children }) => (
           <h3
             className={`text-lg font-medium mb-2 ${
-              currentTheme === "dark" ? "text-gray-200" : "text-gray-800"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -47,7 +47,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         p: ({ children }) => (
           <p
             className={`mb-2 ${
-              currentTheme === "dark" ? "text-gray-300" : "text-gray-700"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -99,7 +99,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
             <code
               className={`px-1 py-0.5 rounded text-sm font-mono ${
                 currentTheme === "dark"
-                  ? "bg-gray-700 text-gray-200"
+                  ? "bg-gray-700 text-white"
                   : "bg-gray-100 text-gray-800"
               }`}
               {...props}
@@ -113,8 +113,8 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
           <blockquote
             className={`border-l-4 pl-4 my-2 italic ${
               currentTheme === "dark"
-                ? "border-gray-600 text-gray-400"
-                : "border-gray-300 text-gray-600"
+                ? "border-gray-500 text-gray-200"
+                : "border-gray-300 text-gray-800"
             }`}
           >
             {children}
@@ -124,7 +124,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         ul: ({ children }) => (
           <ul
             className={`list-disc pl-6 mb-2 ${
-              currentTheme === "dark" ? "text-gray-300" : "text-gray-700"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -133,7 +133,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         ol: ({ children }) => (
           <ol
             className={`list-decimal pl-6 mb-2 ${
-              currentTheme === "dark" ? "text-gray-300" : "text-gray-700"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -144,7 +144,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         strong: ({ children }) => (
           <strong
             className={`font-semibold ${
-              currentTheme === "dark" ? "text-gray-100" : "text-gray-900"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -154,7 +154,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
         em: ({ children }) => (
           <em
             className={`italic ${
-              currentTheme === "dark" ? "text-gray-300" : "text-gray-700"
+              currentTheme === "dark" ? "text-white" : "text-gray-900"
             }`}
           >
             {children}
@@ -193,8 +193,8 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({ content }) => {
           <td
             className={`border p-2 ${
               currentTheme === "dark"
-                ? "border-gray-600 text-gray-300"
-                : "border-gray-300 text-gray-700"
+                ? "border-gray-600 text-gray-100"
+                : "border-gray-300 text-gray-900"
             }`}
           >
             {children}

--- a/studio/src/pages/messaging/components/MessageRenderer.tsx
+++ b/studio/src/pages/messaging/components/MessageRenderer.tsx
@@ -282,7 +282,7 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
         >
           {/* Message header */}
           <div className="flex items-center gap-2 mb-2 text-sm">
-            <span className="font-semibold text-slate-800 dark:text-slate-100">
+            <span className="font-semibold text-slate-800 dark:text-white">
               {isOwnMessage ? "You" : formatUsername(messageProps.senderId)}
             </span>
             <span className="text-xs text-slate-500 dark:text-slate-400">
@@ -294,7 +294,7 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
           </div>
 
           {/* Message content */}
-          <div className="message-content leading-6 break-words">
+          <div className="message-content leading-6 break-words text-gray-900 dark:text-white">
             {messageProps.content ? (
               <MarkdownContent content={messageProps.content} />
             ) : (
@@ -481,7 +481,7 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
         >
           {/* Message header */}
           <div className="flex items-center gap-2 mb-2 text-sm">
-            <span className="font-semibold text-slate-800 dark:text-slate-100">
+            <span className="font-semibold text-slate-800 dark:text-white">
               {isOwnMessage ? "You" : formatUsername(message.senderId)}
             </span>
             <span className="text-xs text-slate-500 dark:text-slate-400">
@@ -493,7 +493,7 @@ const MessageRenderer: React.FC<MessageRendererProps> = ({
           </div>
 
           {/* Message content */}
-          <div className="message-content leading-6 break-words">
+          <div className="message-content leading-6 break-words text-gray-900 dark:text-white">
             {message.content ? (
               <MarkdownContent content={message.content} />
             ) : (

--- a/studio/src/services/eventConnector.ts
+++ b/studio/src/services/eventConnector.ts
@@ -615,6 +615,15 @@ export class HttpEventConnector {
     });
   }
 
+  async getConversationsList(): Promise<EventResponse> {
+    return this.sendEvent({
+      event_name: EventNames.THREAD_CONVERSATIONS_LIST,
+      source_id: this.agentId,
+      destination_id: "mod:openagents.mods.workspace.messaging",
+      payload: {},
+    });
+  }
+
   async getChannelAnnouncement(channel: string): Promise<EventResponse> {
     return this.sendEvent({
       event_name: "thread.announcement.get",

--- a/studio/src/stores/chatStore.ts
+++ b/studio/src/stores/chatStore.ts
@@ -54,6 +54,15 @@ interface ChatState {
   agentsError: string | null;
   agentsLoaded: boolean;
 
+  // Agent-to-agent DM conversations (observability)
+  agentConversations: Array<{
+    agents: [string, string];
+    lastMessage: { content: string; sender: string; timestamp: number };
+    messageCount: number;
+  }>;
+  agentConversationsLoaded: boolean;
+  currentAgentConversation: string | null; // "agentA,agentB" format
+
   // Connection helpers
   getConnection: () => any | null;
   isConnected: () => boolean;
@@ -61,8 +70,12 @@ interface ChatState {
   // Actions - Selection
   selectChannel: (channel: string) => void;
   selectDirectMessage: (targetAgentId: string) => void;
+  selectAgentConversation: (conversationKey: string) => void;
   clearSelection: () => void;
   clearAllChatData: () => void;
+
+  // Actions - Agent conversations
+  loadAgentConversations: () => Promise<void>;
 
   // Persistence actions
   restorePersistedSelection: () => Promise<void>;
@@ -259,6 +272,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
   agentsError: null,
   agentsLoaded: false,
 
+  // Agent-to-agent conversations
+  agentConversations: [],
+  agentConversationsLoaded: false,
+  currentAgentConversation: null,
+
   // Event handler reference
   eventHandler: null,
 
@@ -276,7 +294,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
     console.log(`ChatStore: Selecting channel #${channel}`);
     set({
       currentChannel: channel,
-      currentDirectMessage: null, // Clear direct message selection when switching to channel
+      currentDirectMessage: null,
+      currentAgentConversation: null,
       persistedSelectionType: "channel",
       persistedSelectionId: channel,
     });
@@ -289,7 +308,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
     console.log(`ChatStore: Selecting direct message with ${targetAgentId}`);
     set({
       currentDirectMessage: targetAgentId,
-      currentChannel: null, // Clear channel selection when switching to direct message
+      currentChannel: null,
+      currentAgentConversation: null,
       persistedSelectionType: "agent",
       persistedSelectionId: targetAgentId,
     });
@@ -298,11 +318,58 @@ export const useChatStore = create<ChatState>((set, get) => ({
     get().saveSelectionToStorage("agent", targetAgentId);
   },
 
+  selectAgentConversation: (conversationKey: string) => {
+    console.log(`ChatStore: Selecting agent conversation ${conversationKey}`);
+    // Parse "agentA,agentB" format and load DMs between them
+    const [agentA, agentB] = conversationKey.split(",", 2);
+    set({
+      currentAgentConversation: conversationKey,
+      currentChannel: null,
+      currentDirectMessage: null,
+    });
+    // Load the conversation messages using existing DM retrieval
+    // We set source_id to agentA and target to agentB — the handler matches bidirectionally
+    const connection = get().getConnection();
+    if (connection && agentA && agentB) {
+      set({ messagesLoading: true, messagesError: null });
+      connection
+        .sendEvent({
+          event_name: EventNames.THREAD_DIRECT_MESSAGES_RETRIEVE,
+          source_id: agentA,
+          destination_id: "mod:openagents.mods.workspace.messaging",
+          payload: {
+            target_agent_id: agentB,
+            limit: 200,
+            offset: 0,
+            include_threads: true,
+            message_type: "message_retrieval",
+          },
+        })
+        .then((response: any) => {
+          if (response.success && response.data?.messages) {
+            const messages = response.data.messages.map((msg: any) =>
+              MessageAdapter.fromRaw(msg)
+            );
+            // Store in directMessages under the conversation key
+            const currentMessages = new Map(get().directMessages);
+            currentMessages.set(conversationKey, messages);
+            set({ directMessages: currentMessages, messagesLoading: false });
+          } else {
+            set({ messagesLoading: false });
+          }
+        })
+        .catch(() => {
+          set({ messagesLoading: false });
+        });
+    }
+  },
+
   clearSelection: () => {
     console.log("ChatStore: Clearing selection");
     set({
       currentChannel: null,
       currentDirectMessage: null,
+      currentAgentConversation: null,
       persistedSelectionType: null,
       persistedSelectionId: null,
     });
@@ -317,6 +384,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Reset selection
       currentChannel: null,
       currentDirectMessage: null,
+      currentAgentConversation: null,
       persistedSelectionType: null,
       persistedSelectionId: null,
 
@@ -340,6 +408,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       agentsLoading: false,
       agentsError: null,
       agentsLoaded: false,
+
+      // Reset agent conversations
+      agentConversations: [],
+      agentConversationsLoaded: false,
     });
 
     // Clear localStorage
@@ -914,6 +986,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
         agentsError: "Failed to load connected agents",
         agentsLoading: false,
       });
+    }
+  },
+
+  loadAgentConversations: async () => {
+    const connection = get().getConnection();
+    if (!connection) return;
+
+    try {
+      const response = await connection.getConversationsList();
+      if (response.success && response.data?.conversations) {
+        set({
+          agentConversations: response.data.conversations.map((c: any) => ({
+            agents: c.agents,
+            lastMessage: c.last_message,
+            messageCount: c.message_count,
+          })),
+          agentConversationsLoaded: true,
+        });
+      }
+    } catch (error) {
+      console.error("ChatStore: Failed to load agent conversations:", error);
     }
   },
 

--- a/studio/src/stores/chatStore.ts
+++ b/studio/src/stores/chatStore.ts
@@ -1007,6 +1007,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
     } catch (error) {
       console.error("ChatStore: Failed to load agent conversations:", error);
+      set({ agentConversationsLoaded: true });
     }
   },
 

--- a/studio/src/styles/index.css
+++ b/studio/src/styles/index.css
@@ -1,6 +1,9 @@
 /* Tailwind CSS v4 */
 @import "tailwindcss";
 
+/* Use .dark class selector instead of prefers-color-scheme media query */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /** Colors - https://tailwindcss.com/docs/colors **/
 :root {
   --background: #ffffff;

--- a/studio/src/types/events.ts
+++ b/studio/src/types/events.ts
@@ -47,6 +47,7 @@ export enum EventNames {
   THREAD_CHANNEL_MESSAGES_RETRIEVE_RESPONSE = 'thread.channel_messages.retrieve_response',
   THREAD_DIRECT_MESSAGES_RETRIEVE = 'thread.direct_messages.retrieve',
   THREAD_DIRECT_MESSAGES_RETRIEVE_RESPONSE = 'thread.direct_messages.retrieve_response',
+  THREAD_CONVERSATIONS_LIST = 'thread.conversations.list',
   
   // System events
   SYSTEM_REGISTER_AGENT = 'system.register_agent',

--- a/studio/src/utils/messageDisplayUtils.ts
+++ b/studio/src/utils/messageDisplayUtils.ts
@@ -69,8 +69,8 @@ export function getThreadStyleClass(level: number): string {
  */
 export function getMessageBackgroundClass(isOwnMessage: boolean): string {
   return isOwnMessage
-    ? "bg-blue-50 border-blue-200 hover:bg-slate-100 hover:border-slate-300 dark:bg-blue-900 dark:border-blue-500 dark:hover:bg-slate-700 dark:hover:border-slate-600"
-    : "bg-slate-50 border-slate-200 hover:bg-slate-100 hover:border-slate-300 dark:bg-slate-900 dark:border-slate-600 dark:hover:bg-slate-700 dark:hover:border-slate-500";
+    ? "bg-blue-50 border-blue-200 hover:bg-slate-100 hover:border-slate-300 dark:bg-blue-950/60 dark:border-blue-700 dark:hover:bg-slate-700 dark:hover:border-slate-600 dark:text-white"
+    : "bg-slate-50 border-slate-200 hover:bg-slate-100 hover:border-slate-300 dark:bg-slate-800 dark:border-slate-600 dark:hover:bg-slate-700 dark:hover:border-slate-500 dark:text-white";
 }
 
 /**

--- a/workspace/backend/app/routers/events.py
+++ b/workspace/backend/app/routers/events.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, Query
 from pydantic import BaseModel
-from sqlalchemy import cast, select, Text
+from sqlalchemy import and_, cast, func, or_, select, Text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -123,9 +123,11 @@ async def send_event(
 async def poll_events(
     network: str = Query(..., description="Network (workspace) ID or slug"),
     after: Optional[str] = Query(None, description="Return events after this event ID"),
+    before: Optional[str] = Query(None, description="Return events before this event ID"),
     target: Optional[str] = Query(None, description="Filter by target address"),
     channel: Optional[str] = Query(None, description="Filter by channel name"),
     type: Optional[str] = Query(None, description="Filter by event type prefix"),
+    conversation: Optional[str] = Query(None, description="Filter to DM conversation between two agents (comma-separated addresses)"),
     search: Optional[str] = Query(None, description="Search message content (case-insensitive)"),
     member: Optional[str] = Query(None, description="Filter to channels where this agent is a member"),
     sort: Optional[str] = Query(None, description="Sort order: 'asc' (default) or 'desc'"),
@@ -170,12 +172,30 @@ async def poll_events(
             # Agent is not a member of any channel — return empty
             return success_response({"events": [], "has_more": False})
 
+    if conversation:
+        parts = [p.strip() for p in conversation.split(",", 1)]
+        if len(parts) == 2:
+            a, b = parts
+            query = query.where(
+                or_(
+                    and_(EventRecord.source == a, EventRecord.target == b),
+                    and_(EventRecord.source == b, EventRecord.target == a),
+                )
+            )
+
     if after:
         cursor_event = db.execute(
             select(EventRecord.timestamp).where(EventRecord.id == after)
         ).scalar_one_or_none()
         if cursor_event is not None:
             query = query.where(EventRecord.timestamp > cursor_event)
+
+    if before:
+        cursor_event = db.execute(
+            select(EventRecord.timestamp).where(EventRecord.id == before)
+        ).scalar_one_or_none()
+        if cursor_event is not None:
+            query = query.where(EventRecord.timestamp < cursor_event)
 
     if target:
         query = query.where(EventRecord.target == target)
@@ -216,4 +236,163 @@ async def poll_events(
             for e in events
         ],
         "has_more": has_more,
+        "oldest_id": (events[-1].id if sort == "desc" else events[0].id) if events else None,
+        "newest_id": (events[0].id if sort == "desc" else events[-1].id) if events else None,
     })
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/events/conversations — discover agent-to-agent DM conversations
+# ---------------------------------------------------------------------------
+
+@router.get("/events/conversations")
+async def list_conversations(
+    network: str = Query(..., description="Network (workspace) ID or slug"),
+    agent: Optional[str] = Query(None, description="Filter to conversations involving this agent"),
+    limit: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+):
+    """
+    List active agent-to-agent DM conversations.
+
+    Returns distinct conversation pairs with their latest message,
+    ordered by most recent activity.
+    """
+    workspace = db.execute(
+        select(Workspace).where(_workspace_filter(network))
+    ).scalar_one_or_none()
+
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    # Build a subquery to find the latest event per conversation pair.
+    # Normalize pairs so (A→B) and (B→A) are the same conversation.
+    lesser = func.least(EventRecord.source, EventRecord.target)
+    greater = func.greatest(EventRecord.source, EventRecord.target)
+
+    base = (
+        select(
+            lesser.label("agent_a"),
+            greater.label("agent_b"),
+            func.max(EventRecord.timestamp).label("last_ts"),
+            func.count().label("msg_count"),
+        )
+        .where(
+            EventRecord.network_id == workspace.id,
+            EventRecord.visibility == "direct",
+            # Exclude channel targets — those are not DMs
+            ~EventRecord.target.startswith("channel/"),
+        )
+    )
+
+    if agent:
+        base = base.where(
+            or_(EventRecord.source == agent, EventRecord.target == agent)
+        )
+
+    base = base.group_by("agent_a", "agent_b").order_by(func.max(EventRecord.timestamp).desc()).limit(limit)
+
+    pairs = db.execute(base).all()
+
+    # For each pair, fetch the actual latest event
+    conversations = []
+    for row in pairs:
+        latest_event = db.execute(
+            select(EventRecord)
+            .where(
+                EventRecord.network_id == workspace.id,
+                EventRecord.timestamp == row.last_ts,
+                or_(
+                    and_(EventRecord.source == row.agent_a, EventRecord.target == row.agent_b),
+                    and_(EventRecord.source == row.agent_b, EventRecord.target == row.agent_a),
+                ),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if latest_event:
+            payload = latest_event.payload or {}
+            conversations.append({
+                "agents": [row.agent_a, row.agent_b],
+                "last_message": {
+                    "content": payload.get("content", ""),
+                    "sender": latest_event.source,
+                    "timestamp": latest_event.timestamp,
+                },
+                "message_count": row.msg_count,
+            })
+
+    return success_response({"conversations": conversations})
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/events/latest-per-channel — bulk thread preview endpoint
+# ---------------------------------------------------------------------------
+
+@router.get("/events/latest-per-channel")
+async def latest_per_channel(
+    network: str = Query(..., description="Network (workspace) ID or slug"),
+    type: Optional[str] = Query("workspace.message", description="Event type prefix to filter"),
+    db: Session = Depends(get_db),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+):
+    """
+    Return the most recent event per channel in a single query.
+
+    Replaces N separate pollEvents calls for thread list previews.
+    Uses a SQL window function to efficiently pick the latest event per target.
+    """
+    workspace = db.execute(
+        select(Workspace).where(_workspace_filter(network))
+    ).scalar_one_or_none()
+
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    # Window function: ROW_NUMBER() OVER (PARTITION BY target ORDER BY timestamp DESC)
+    row_num = func.row_number().over(
+        partition_by=EventRecord.target,
+        order_by=EventRecord.timestamp.desc(),
+    ).label("rn")
+
+    inner = (
+        select(EventRecord, row_num)
+        .where(
+            EventRecord.network_id == workspace.id,
+            EventRecord.target.startswith("channel/"),
+        )
+    )
+
+    if type:
+        inner = inner.where(EventRecord.type.startswith(type))
+
+    inner = inner.subquery()
+
+    # Select only the first row per partition
+    query = select(inner).where(inner.c.rn == 1)
+    rows = db.execute(query).all()
+
+    channels = {}
+    for row in rows:
+        channel_name = row.target.replace("channel/", "", 1)
+        channels[channel_name] = {
+            "id": row.id,
+            "type": row.type,
+            "source": row.source,
+            "target": row.target,
+            "payload": row.payload,
+            "metadata": row.metadata,
+            "timestamp": row.timestamp,
+            "visibility": row.visibility,
+        }
+
+    return success_response({"channels": channels})

--- a/workspace/backend/app/routers/events.py
+++ b/workspace/backend/app/routers/events.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, Query
 from pydantic import BaseModel
-from sqlalchemy import and_, cast, func, or_, select, Text
+from sqlalchemy import and_, case, cast, func, or_, select, Text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -174,28 +174,42 @@ async def poll_events(
 
     if conversation:
         parts = [p.strip() for p in conversation.split(",", 1)]
-        if len(parts) == 2:
-            a, b = parts
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            return json_response(ResponseCode.BAD_REQUEST, "conversation must be two comma-separated addresses")
+        a, b = parts
+        query = query.where(
+            EventRecord.visibility == "direct",
+            ~EventRecord.target.startswith("channel/"),
+            or_(
+                and_(EventRecord.source == a, EventRecord.target == b),
+                and_(EventRecord.source == b, EventRecord.target == a),
+            ),
+        )
+
+    if after:
+        cursor_row = db.execute(
+            select(EventRecord.timestamp, EventRecord.id).where(EventRecord.id == after)
+        ).one_or_none()
+        if cursor_row is not None:
+            # Use (timestamp, id) tuple to avoid skipping/duplicating events with the same timestamp
             query = query.where(
                 or_(
-                    and_(EventRecord.source == a, EventRecord.target == b),
-                    and_(EventRecord.source == b, EventRecord.target == a),
+                    EventRecord.timestamp > cursor_row.timestamp,
+                    and_(EventRecord.timestamp == cursor_row.timestamp, EventRecord.id > cursor_row.id),
                 )
             )
 
-    if after:
-        cursor_event = db.execute(
-            select(EventRecord.timestamp).where(EventRecord.id == after)
-        ).scalar_one_or_none()
-        if cursor_event is not None:
-            query = query.where(EventRecord.timestamp > cursor_event)
-
     if before:
-        cursor_event = db.execute(
-            select(EventRecord.timestamp).where(EventRecord.id == before)
-        ).scalar_one_or_none()
-        if cursor_event is not None:
-            query = query.where(EventRecord.timestamp < cursor_event)
+        cursor_row = db.execute(
+            select(EventRecord.timestamp, EventRecord.id).where(EventRecord.id == before)
+        ).one_or_none()
+        if cursor_row is not None:
+            query = query.where(
+                or_(
+                    EventRecord.timestamp < cursor_row.timestamp,
+                    and_(EventRecord.timestamp == cursor_row.timestamp, EventRecord.id < cursor_row.id),
+                )
+            )
 
     if target:
         query = query.where(EventRecord.target == target)
@@ -213,9 +227,9 @@ async def poll_events(
         )
 
     if sort == "desc":
-        query = query.order_by(EventRecord.timestamp.desc()).limit(limit + 1)
+        query = query.order_by(EventRecord.timestamp.desc(), EventRecord.id.desc()).limit(limit + 1)
     else:
-        query = query.order_by(EventRecord.timestamp.asc()).limit(limit + 1)
+        query = query.order_by(EventRecord.timestamp.asc(), EventRecord.id.asc()).limit(limit + 1)
     rows = db.execute(query).scalars().all()
 
     has_more = len(rows) > limit
@@ -272,8 +286,15 @@ async def list_conversations(
 
     # Build a subquery to find the latest event per conversation pair.
     # Normalize pairs so (A→B) and (B→A) are the same conversation.
-    lesser = func.least(EventRecord.source, EventRecord.target)
-    greater = func.greatest(EventRecord.source, EventRecord.target)
+    # Use case() instead of func.least/greatest for SQLite compatibility.
+    lesser = case(
+        (EventRecord.source <= EventRecord.target, EventRecord.source),
+        else_=EventRecord.target,
+    )
+    greater = case(
+        (EventRecord.source > EventRecord.target, EventRecord.source),
+        else_=EventRecord.target,
+    )
 
     base = (
         select(

--- a/workspace/frontend/components/chat/chat-messages.tsx
+++ b/workspace/frontend/components/chat/chat-messages.tsx
@@ -5,7 +5,7 @@ import { ChatMessage } from './chat-message';
 import { IntermediateSteps } from './intermediate-steps';
 import { Button } from '@/components/ui/button';
 import { ArrowDown } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { WorkspaceMessage, WorkspaceAgent } from '@/lib/types';
 
 // ── Message Grouping ──

--- a/workspace/frontend/components/chat/chat-messages.tsx
+++ b/workspace/frontend/components/chat/chat-messages.tsx
@@ -5,7 +5,7 @@ import { ChatMessage } from './chat-message';
 import { IntermediateSteps } from './intermediate-steps';
 import { Button } from '@/components/ui/button';
 import { ArrowDown } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { WorkspaceMessage, WorkspaceAgent } from '@/lib/types';
 
 // ── Message Grouping ──
@@ -47,9 +47,15 @@ interface ChatMessagesProps {
   className?: string;
   /** Increment to force scroll to bottom (e.g. after user sends a message). */
   scrollKey?: number;
+  /** Callback to load older messages (infinite scroll upward). */
+  loadOlder?: () => Promise<void>;
+  /** Whether there are older messages available to load. */
+  hasOlder?: boolean;
+  /** Whether older messages are currently being loaded. */
+  loadingOlder?: boolean;
 }
 
-export function ChatMessages({ messages, agents, showAllSteps, className, scrollKey }: ChatMessagesProps) {
+export function ChatMessages({ messages, agents, showAllSteps, className, scrollKey, loadOlder, hasOlder, loadingOlder }: ChatMessagesProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
 
@@ -162,19 +168,39 @@ export function ChatMessages({ messages, agents, showAllSteps, className, scroll
     }
   }, [scrollKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Track scroll position for "scroll to bottom" button
+  // Track scroll position for "scroll to bottom" button + infinite scroll upward
+  const loadingOlderInternalRef = useRef(false);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
-    const onScroll = () => {
+    const onScroll = async () => {
       const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
       setShowScrollBtn(!isNearBottom);
+
+      // Infinite scroll: load older messages when near the top
+      if (
+        el.scrollTop < 100 &&
+        hasOlder &&
+        !loadingOlder &&
+        !loadingOlderInternalRef.current &&
+        loadOlder
+      ) {
+        loadingOlderInternalRef.current = true;
+        const prevScrollHeight = el.scrollHeight;
+        await loadOlder();
+        // Maintain scroll position after prepending older messages
+        requestAnimationFrame(() => {
+          const newScrollHeight = el.scrollHeight;
+          el.scrollTop = newScrollHeight - prevScrollHeight;
+          loadingOlderInternalRef.current = false;
+        });
+      }
     };
 
     el.addEventListener('scroll', onScroll);
     return () => el.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [hasOlder, loadingOlder, loadOlder]);
 
   return (
     <div className="relative flex-1 min-h-0">
@@ -182,6 +208,27 @@ export function ChatMessages({ messages, agents, showAllSteps, className, scroll
         ref={containerRef}
         className={cn('flex flex-col h-full overflow-y-auto space-y-1', className)}
       >
+        {loadingOlder && (
+          <div className="flex items-center justify-center py-3">
+            <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+        {hasOlder && !loadingOlder && loadOlder && (
+          <button
+            onClick={async () => {
+              const el = containerRef.current;
+              if (!el) return;
+              const prevScrollHeight = el.scrollHeight;
+              await loadOlder();
+              requestAnimationFrame(() => {
+                el.scrollTop = el.scrollHeight - prevScrollHeight;
+              });
+            }}
+            className="flex items-center justify-center py-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Load older messages
+          </button>
+        )}
         {groups.map((group, gi) => {
           if (group.type === 'chat') {
             return (

--- a/workspace/frontend/components/chat/chat-view.tsx
+++ b/workspace/frontend/components/chat/chat-view.tsx
@@ -46,16 +46,12 @@ function cacheMessages(sessionId: string, msgs: WorkspaceMessage[]) {
 const PREFETCH_COUNT = 6;
 const CACHE_REFRESH_INTERVAL = 5_000; // refresh caches every 5s
 
-/** Fetch all messages for a session (initial load). */
+/** Fetch recent messages for a session (cache prefetch). */
 async function fetchSessionMessages(sessionId: string): Promise<WorkspaceMessage[]> {
   try {
-    const result = await workspaceApi.pollEvents({
-      channel: sessionId,
-      type: 'workspace.message',
-      sort: 'asc',
-      limit: 200,
-    });
-    return result.events.map(eventToMessage);
+    const result = await workspaceApi.loadMessageHistory(sessionId, { limit: 50 });
+    // Events come newest-first from sort=desc, reverse for chronological display
+    return result.events.map(eventToMessage).reverse();
   } catch {
     return [];
   }
@@ -136,7 +132,7 @@ export function ChatView() {
     initialMessagesRef.current = currentSessionId ? messageCache.get(currentSessionId) : undefined;
   }
 
-  const { messages, loading, forceRefresh, generation } = useMessagePolling({
+  const { messages, loading, forceRefresh, generation, loadOlder, hasOlder, loadingOlder } = useMessagePolling({
     sessionId: currentSessionId,
     initialMessages: initialMessagesRef.current,
   });
@@ -208,6 +204,7 @@ export function ChatView() {
     }
   }, [currentSessionId]);
 
+  const isDM = currentSessionId?.startsWith('dm:') ?? false;
   const currentSession = sessions.find((s) => s.sessionId === currentSessionId);
   const agentNames = agents.map((a) => a.agentName);
 
@@ -365,7 +362,15 @@ export function ChatView() {
               <ChevronLeft className="size-5" />
             </button>
           )}
-          {editingTitle ? (
+          {isDM ? (
+            <h2 className="text-sm font-semibold truncate flex items-center gap-1.5">
+              <MessageSquare className="size-3.5 text-muted-foreground" />
+              {currentSessionId!.slice(3).split(',').map((a) => a.replace(/^openagents:/, '')).join(' ↔ ')}
+              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 font-medium">
+                read-only
+              </span>
+            </h2>
+          ) : editingTitle ? (
             <input
               ref={titleInputRef}
               value={titleDraft}
@@ -404,8 +409,8 @@ export function ChatView() {
           })()}
         </div>
         <div className="flex items-center gap-1 lg:gap-1.5">
-          {/* Participant chips — hidden on mobile, shown on desktop */}
-          <div className="hidden lg:flex items-center gap-1 overflow-x-auto">
+          {/* Participant chips — hidden on mobile, shown on desktop, not shown for DMs */}
+          {!isDM && <div className="hidden lg:flex items-center gap-1 overflow-x-auto">
             {(() => {
               const participants = currentSession?.participants || [];
               const sessionAgents = participants.length > 0
@@ -435,7 +440,7 @@ export function ChatView() {
                 );
               });
             })()}
-          </div>
+          </div>}
 
           {/* Compact avatar stack on mobile */}
           {isMobile && (() => {
@@ -630,22 +635,27 @@ export function ChatView() {
             agents={agents}
             showAllSteps={showAllSteps}
             scrollKey={scrollKey}
+            loadOlder={loadOlder}
+            hasOlder={hasOlder}
+            loadingOlder={loadingOlder}
             className="flex-1 overflow-y-auto px-3 lg:px-5 py-3"
           />
         )}
 
-        {/* Input */}
-        <div className="px-3 lg:px-4 py-2 lg:py-3">
-          <div className="max-w-3xl mx-auto w-full">
-            <ChatInput
-              onSend={handleSend}
-              agents={agents}
-              draft={currentDraft}
-              onDraftChange={handleDraftChange}
-              focusKey={focusKey}
-            />
+        {/* Input — hidden for read-only DM views */}
+        {!isDM && (
+          <div className="px-3 lg:px-4 py-2 lg:py-3">
+            <div className="max-w-3xl mx-auto w-full">
+              <ChatInput
+                onSend={handleSend}
+                agents={agents}
+                draft={currentDraft}
+                onDraftChange={handleDraftChange}
+                focusKey={focusKey}
+              />
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/workspace/frontend/components/threads/thread-list.tsx
+++ b/workspace/frontend/components/threads/thread-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { PanelLeft, RefreshCw, Search, Star, Archive, Trash2, MoreVertical, ArchiveRestore, Wrench, Loader2, CheckCircle2 } from 'lucide-react';
+import { PanelLeft, RefreshCw, Search, Star, Archive, Trash2, MoreVertical, ArchiveRestore, Wrench, Loader2, CheckCircle2, MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWorkspace } from '@/lib/workspace-context';
 import { useLayout } from '@/components/layout/layout-context';
@@ -65,8 +65,80 @@ function highlightMatch(text: string, query: string): React.ReactNode {
   );
 }
 
+function DMSection({
+  conversations,
+  currentSessionId,
+  onSelect,
+}: {
+  conversations: { agents: [string, string]; lastMessage: { content: string; sender: string; timestamp: number }; messageCount: number }[];
+  currentSessionId: string | null;
+  onSelect: (sessionId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="mt-3 pt-3 border-t border-zinc-200 dark:border-zinc-700">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1.5 px-1 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-full"
+      >
+        <MessageCircle className="size-3" />
+        <span>Agent DMs ({conversations.length})</span>
+        <svg
+          className={cn('size-3 ml-auto transition-transform', expanded && 'rotate-180')}
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M3 5l3 3 3-3" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="mt-1 space-y-1">
+          {conversations.map((convo) => {
+            const dmId = `dm:${convo.agents[0]},${convo.agents[1]}`;
+            const isSelected = currentSessionId === dmId;
+            const agentA = convo.agents[0].replace(/^openagents:/, '');
+            const agentB = convo.agents[1].replace(/^openagents:/, '');
+            const sender = convo.lastMessage.sender.replace(/^openagents:/, '');
+            const preview = `${sender}: ${convo.lastMessage.content}`;
+            const displayTime = convo.lastMessage.timestamp
+              ? timeAgo(new Date(convo.lastMessage.timestamp).toISOString())
+              : '';
+
+            return (
+              <div
+                key={dmId}
+                onClick={() => onSelect(dmId)}
+                className={cn(
+                  'w-full flex items-center gap-2.5 p-2 rounded-lg text-left transition-colors cursor-pointer',
+                  isSelected ? 'bg-zinc-100 dark:bg-zinc-800 ring-2 ring-indigo-500 dark:ring-indigo-400' : 'hover:bg-zinc-50 dark:hover:bg-zinc-800/50'
+                )}
+              >
+                <div className="shrink-0 flex items-center justify-center border border-zinc-200 dark:border-zinc-700 rounded-full size-[30px] bg-white dark:bg-zinc-900">
+                  <MessageCircle className="size-3.5 text-muted-foreground" />
+                </div>
+                <div className="flex-1 min-w-0 space-y-0.5">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-sm flex-1 min-w-0 truncate font-normal text-foreground">
+                      {agentA} ↔ {agentB}
+                    </span>
+                    <span className="text-xs text-muted-foreground shrink-0">{displayTime}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground truncate">{preview}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function ThreadList() {
-  const { sessions, currentSessionId, setCurrentSessionId, agents, lastMessageBySession, activeSessionIds, completedSessionIds, updateSession } = useWorkspace();
+  const { sessions, currentSessionId, setCurrentSessionId, agents, lastMessageBySession, activeSessionIds, completedSessionIds, updateSession, dmConversations } = useWorkspace();
   const { sidebarToggle, isMobile, openMobileDetail } = useLayout();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchHit[]>([]);
@@ -341,6 +413,18 @@ export function ThreadList() {
                 </>
               )}
             </div>
+          )}
+
+          {/* Agent DMs section */}
+          {!isSearching && dmConversations.length > 0 && (
+            <DMSection
+              conversations={dmConversations}
+              currentSessionId={currentSessionId}
+              onSelect={(id) => {
+                setCurrentSessionId(id);
+                if (isMobile) openMobileDetail();
+              }}
+            />
           )}
 
           {/* Archived section */}

--- a/workspace/frontend/hooks/use-polling.ts
+++ b/workspace/frontend/hooks/use-polling.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { workspaceApi } from '@/lib/api';
+import { eventToMessage } from '@/lib/types';
 import type { WorkspaceMessage } from '@/lib/types';
 
 interface UsePollingOptions {
@@ -11,33 +12,48 @@ interface UsePollingOptions {
   initialMessages?: WorkspaceMessage[];
 }
 
+/** Parse a DM session ID like "dm:agentA,agentB" into agent addresses. */
+function parseDMSession(sessionId: string | null): [string, string] | null {
+  if (!sessionId?.startsWith('dm:')) return null;
+  const parts = sessionId.slice(3).split(',', 2);
+  if (parts.length === 2) return [parts[0], parts[1]];
+  return null;
+}
+
 export function useMessagePolling({ sessionId, enabled = true, initialMessages }: UsePollingOptions) {
   const [messages, setMessages] = useState<WorkspaceMessage[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [hasOlder, setHasOlder] = useState(false);
   // Increments when messages are bulk-replaced (backfill/session switch) to signal scroll-to-bottom
   const [generation, setGeneration] = useState(0);
-  const lastSeenIdRef = useRef<string | null>(null);
+
+  // Refs for cursor tracking
+  const newestIdRef = useRef<string | null>(null);
+  const oldestIdRef = useRef<string | null>(null);
   const lastActivityRef = useRef<number>(Date.now());
-  const initialLoadDoneRef = useRef(false);
-  const needsBackfillRef = useRef(false);
-  // Track current session to discard stale poll responses
+  const historyLoadedRef = useRef(false);
+  // Track current session to discard stale responses
   const currentSessionRef = useRef<string | null>(sessionId);
 
   // Reset when session changes
   useEffect(() => {
     currentSessionRef.current = sessionId;
-    // Seed with initial messages if provided (instant display, no loading)
+
     if (initialMessages && initialMessages.length > 0) {
+      // Seed with cached messages for instant display
       setMessages(initialMessages);
-      lastSeenIdRef.current = initialMessages[initialMessages.length - 1].messageId;
-      initialLoadDoneRef.current = true;
-      needsBackfillRef.current = true; // backfill full history in background
+      newestIdRef.current = initialMessages[initialMessages.length - 1].messageId;
+      oldestIdRef.current = initialMessages[0].messageId;
+      historyLoadedRef.current = true;
+      setHasOlder(true); // assume there may be older until proven otherwise
       setLoading(false);
     } else {
       setMessages([]);
-      lastSeenIdRef.current = null;
-      initialLoadDoneRef.current = false;
-      needsBackfillRef.current = false;
+      newestIdRef.current = null;
+      oldestIdRef.current = null;
+      historyLoadedRef.current = false;
+      setHasOlder(false);
       setLoading(false);
     }
   }, [sessionId]); // intentionally omit initialMessages — only seed on session change
@@ -55,23 +71,62 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
     };
   }, []);
 
-  const poll = useCallback(async () => {
+  // Load recent history (newest messages first, then reverse for display)
+  const dmPair = useMemo(() => parseDMSession(sessionId), [sessionId]);
+
+  const loadHistory = useCallback(async () => {
     if (!sessionId) return;
 
+    setLoading(true);
     try {
-      const isInitial = !initialLoadDoneRef.current;
+      const result = dmPair
+        ? await workspaceApi.pollConversation(dmPair[0], dmPair[1], { sort: 'desc', limit: 50 })
+        : await workspaceApi.loadMessageHistory(sessionId, { limit: 50 });
 
-      if (isInitial) {
-        setLoading(true);
+      // Discard if session changed
+      if (sessionId !== currentSessionRef.current) return;
+
+      if (result.events.length > 0) {
+        // Events come newest-first from sort=desc, reverse for chronological display
+        const historicMessages = result.events.map(eventToMessage).reverse();
+        setMessages(historicMessages);
+        // newest_id is the most recent event (first in desc order)
+        newestIdRef.current = result.newest_id || historicMessages[historicMessages.length - 1].messageId;
+        // oldest_id for loading older messages
+        oldestIdRef.current = result.oldest_id || historicMessages[0].messageId;
+        setHasOlder(result.has_more);
+        setGeneration((g) => g + 1);
+      } else {
+        setHasOlder(false);
       }
 
+      historyLoadedRef.current = true;
+    } catch {
+      historyLoadedRef.current = true;
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, dmPair]);
+
+  // Forward poll: fetch new messages since the newest known
+  const poll = useCallback(async () => {
+    if (!sessionId || !historyLoadedRef.current) return;
+
+    try {
       // Keep fetching while there are more events (handles bursts of status messages)
       let hasMore = true;
       while (hasMore) {
-        const result = await workspaceApi.pollMessages(
-          sessionId,
-          isInitial && !lastSeenIdRef.current ? undefined : (lastSeenIdRef.current ?? undefined),
-        );
+        const result = dmPair
+          ? await (async () => {
+              const r = await workspaceApi.pollConversation(dmPair[0], dmPair[1], {
+                after: newestIdRef.current ?? undefined,
+              });
+              return { messages: r.events.map(eventToMessage), hasMore: r.has_more };
+            })()
+          : await workspaceApi.pollMessages(
+              sessionId,
+              newestIdRef.current ?? undefined,
+            );
 
         // Discard response if session changed while request was in flight
         if (sessionId !== currentSessionRef.current) return;
@@ -81,7 +136,7 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
 
         if (newMessages.length > 0) {
           const lastMsg = newMessages[newMessages.length - 1];
-          lastSeenIdRef.current = lastMsg.messageId;
+          newestIdRef.current = lastMsg.messageId;
 
           setMessages((prev) => {
             const existingIds = new Set(prev.map((m) => m.messageId));
@@ -90,59 +145,57 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
           });
         }
       }
-
-      if (isInitial) {
-        initialLoadDoneRef.current = true;
-        setLoading(false);
-      }
     } catch {
-      if (!initialLoadDoneRef.current) {
-        setLoading(false);
-      }
+      // Polling error — will retry on next interval
     }
-  }, [sessionId]);
+  }, [sessionId, dmPair]);
 
-  // Background backfill: when seeded with partial cache, fetch full history once
-  const backfill = useCallback(async () => {
-    if (!sessionId || !needsBackfillRef.current) return;
-    needsBackfillRef.current = false;
+  // Load older messages (infinite scroll upward)
+  const loadOlder = useCallback(async () => {
+    if (!sessionId || !hasOlder || loadingOlder) return;
 
+    setLoadingOlder(true);
     try {
-      // Fetch all messages from the beginning (no cursor)
-      let allMessages: WorkspaceMessage[] = [];
-      let cursor: string | undefined;
-      let hasMore = true;
-      while (hasMore) {
-        const result = await workspaceApi.pollMessages(sessionId, cursor);
-        if (sessionId !== currentSessionRef.current) return;
-        allMessages = [...allMessages, ...result.messages];
-        hasMore = result.hasMore && result.messages.length > 0;
-        if (result.messages.length > 0) {
-          cursor = result.messages[result.messages.length - 1].messageId;
-        }
-      }
+      const result = dmPair
+        ? await workspaceApi.pollConversation(dmPair[0], dmPair[1], {
+            before: oldestIdRef.current ?? undefined,
+            sort: 'desc',
+            limit: 30,
+          })
+        : await workspaceApi.loadMessageHistory(sessionId, {
+            before: oldestIdRef.current ?? undefined,
+            limit: 30,
+          });
 
       if (sessionId !== currentSessionRef.current) return;
 
-      if (allMessages.length > 0) {
-        lastSeenIdRef.current = allMessages[allMessages.length - 1].messageId;
-        setMessages(allMessages);
-        setGeneration((g) => g + 1);
+      if (result.events.length > 0) {
+        const olderMessages = result.events.map(eventToMessage).reverse();
+        oldestIdRef.current = result.oldest_id || olderMessages[0].messageId;
+        setHasOlder(result.has_more);
+
+        setMessages((prev) => {
+          const existingIds = new Set(prev.map((m) => m.messageId));
+          const unique = olderMessages.filter((m) => !existingIds.has(m.messageId));
+          return unique.length > 0 ? [...unique, ...prev] : prev;
+        });
+      } else {
+        setHasOlder(false);
       }
     } catch {
-      // Backfill failed — seeded messages still work fine
+      // Best-effort
+    } finally {
+      setLoadingOlder(false);
     }
-  }, [sessionId]);
+  }, [sessionId, hasOlder, loadingOlder, dmPair]);
 
-  // Polling loop
+  // Initial load + polling loop
   useEffect(() => {
     if (!sessionId || !enabled) return;
 
-    // Initial load (or backfill if seeded)
-    if (needsBackfillRef.current) {
-      backfill();
-    } else {
-      poll();
+    // Load history if not seeded from cache
+    if (!historyLoadedRef.current) {
+      loadHistory();
     }
 
     const getDelay = () => {
@@ -160,7 +213,16 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
     schedule();
 
     return () => clearTimeout(timeout);
-  }, [sessionId, enabled, poll, backfill]);
+  }, [sessionId, enabled, poll, loadHistory]);
+
+  // If seeded with cache, do a background refresh to catch any new messages
+  useEffect(() => {
+    if (!sessionId || !enabled) return;
+    if (initialMessages && initialMessages.length > 0) {
+      // Immediately poll for new messages after cache display
+      poll();
+    }
+  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Force immediate poll (after sending a message)
   const forceRefresh = useCallback(() => {
@@ -168,5 +230,5 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
     poll();
   }, [poll]);
 
-  return { messages, loading, forceRefresh, generation };
+  return { messages, loading, forceRefresh, generation, loadOlder, hasOlder, loadingOlder };
 }

--- a/workspace/frontend/hooks/use-polling.ts
+++ b/workspace/frontend/hooks/use-polling.ts
@@ -88,7 +88,13 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
 
       if (result.events.length > 0) {
         // Events come newest-first from sort=desc, reverse for chronological display
-        const historicMessages = result.events.map(eventToMessage).reverse();
+        const historicMessages = result.events.map((e) => {
+          const msg = eventToMessage(e);
+          // For DM sessions, override sessionId so all messages share the dm: sessionId
+          // (eventToMessage derives sessionId from event.target which differs per message)
+          if (dmPair && sessionId) msg.sessionId = sessionId;
+          return msg;
+        }).reverse();
         setMessages(historicMessages);
         // newest_id is the most recent event (first in desc order)
         newestIdRef.current = result.newest_id || historicMessages[historicMessages.length - 1].messageId;
@@ -121,7 +127,14 @@ export function useMessagePolling({ sessionId, enabled = true, initialMessages }
               const r = await workspaceApi.pollConversation(dmPair[0], dmPair[1], {
                 after: newestIdRef.current ?? undefined,
               });
-              return { messages: r.events.map(eventToMessage), hasMore: r.has_more };
+              return {
+                messages: r.events.map((e) => {
+                  const msg = eventToMessage(e);
+                  if (sessionId) msg.sessionId = sessionId;
+                  return msg;
+                }),
+                hasMore: r.has_more,
+              };
             })()
           : await workspaceApi.pollMessages(
               sessionId,

--- a/workspace/frontend/lib/api.ts
+++ b/workspace/frontend/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AgentCatalogEntry,
   ApiResponse,
   BrowserTab,
+  DMConversation,
   EventPollResponse,
   MessagePollResponse,
   NetworkDiscovery,
@@ -452,6 +453,7 @@ class WorkspaceApi {
   /** Poll events from the network. */
   async pollEvents(opts: {
     after?: string;
+    before?: string;
     target?: string;
     channel?: string;
     type?: string;
@@ -461,6 +463,7 @@ class WorkspaceApi {
   } = {}): Promise<EventPollResponse> {
     const params = new URLSearchParams({ network: this.workspaceId });
     if (opts.after) params.set('after', opts.after);
+    if (opts.before) params.set('before', opts.before);
     if (opts.target) params.set('target', opts.target);
     if (opts.channel) params.set('channel', opts.channel);
     if (opts.type) params.set('type', opts.type);
@@ -468,6 +471,23 @@ class WorkspaceApi {
     if (opts.sort) params.set('sort', opts.sort);
     if (opts.limit) params.set('limit', String(opts.limit));
     return this.request<EventPollResponse>(`/v1/events?${params}`);
+  }
+
+  /**
+   * Load message history for a channel (most recent first).
+   * Used for initial load and infinite scroll (loading older messages).
+   */
+  async loadMessageHistory(
+    channelName: string,
+    options?: { before?: string; limit?: number },
+  ): Promise<EventPollResponse> {
+    return this.pollEvents({
+      channel: channelName,
+      type: 'workspace.message',
+      before: options?.before,
+      sort: 'desc',
+      limit: options?.limit ?? 50,
+    });
   }
 
   /** Search messages across all channels. Returns events grouped by channel. */
@@ -482,6 +502,52 @@ class WorkspaceApi {
       snippet: (e.payload as Record<string, string>)?.content || '',
       messageId: e.id,
     }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Agent DM conversations
+  // ---------------------------------------------------------------------------
+
+  /** List active agent-to-agent DM conversations. */
+  async listConversations(agentFilter?: string): Promise<DMConversation[]> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    if (agentFilter) params.set('agent', agentFilter);
+    const result = await this.request<{ conversations: Array<{
+      agents: [string, string];
+      last_message: { content: string; sender: string; timestamp: number };
+      message_count: number;
+    }> }>(`/v1/events/conversations?${params}`);
+    return result.conversations.map((c) => ({
+      agents: c.agents,
+      lastMessage: c.last_message,
+      messageCount: c.message_count,
+    }));
+  }
+
+  /** Poll messages for a DM conversation between two agents. */
+  async pollConversation(
+    agentA: string,
+    agentB: string,
+    opts?: { after?: string; before?: string; sort?: 'asc' | 'desc'; limit?: number },
+  ): Promise<EventPollResponse> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    params.set('conversation', `${agentA},${agentB}`);
+    params.set('type', 'workspace.message');
+    if (opts?.after) params.set('after', opts.after);
+    if (opts?.before) params.set('before', opts.before);
+    if (opts?.sort) params.set('sort', opts.sort);
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    return this.request<EventPollResponse>(`/v1/events?${params}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulk thread previews
+  // ---------------------------------------------------------------------------
+
+  /** Fetch the latest message event per channel in a single request. */
+  async latestPerChannel(): Promise<{ channels: Record<string, ONMEvent> }> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    return this.request<{ channels: Record<string, ONMEvent> }>(`/v1/events/latest-per-channel?${params}`);
   }
 }
 

--- a/workspace/frontend/lib/types.ts
+++ b/workspace/frontend/lib/types.ts
@@ -122,6 +122,8 @@ export interface ONMEvent {
 export interface EventPollResponse {
   events: ONMEvent[];
   has_more: boolean;
+  oldest_id: string | null;
+  newest_id: string | null;
 }
 
 export interface NetworkAgent {
@@ -191,6 +193,12 @@ export interface PaginatedResponse<T> {
 export interface MessagePollResponse {
   messages: WorkspaceMessage[];
   hasMore: boolean;
+}
+
+export interface DMConversation {
+  agents: [string, string];
+  lastMessage: { content: string; sender: string; timestamp: number };
+  messageCount: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/workspace/frontend/lib/workspace-context.tsx
+++ b/workspace/frontend/lib/workspace-context.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useCallback, useEffect, useState } from 'react';
 import { workspaceApi } from './api';
 import { networkAgentToWorkspaceAgent, networkChannelToSession } from './types';
-import type { BrowserTab, Workspace, WorkspaceAgent, WorkspaceFile, WorkspaceSession } from './types';
+import type { BrowserTab, DMConversation, ONMEvent, Workspace, WorkspaceAgent, WorkspaceFile, WorkspaceSession } from './types';
 
 interface LastMessageInfo {
   content: string;
@@ -51,6 +51,8 @@ interface WorkspaceContextValue {
   refreshBrowserTabs: () => Promise<void>;
   openBrowserTab: (url?: string) => Promise<BrowserTab>;
   closeBrowserTab: (tabId: string) => Promise<void>;
+  dmConversations: DMConversation[];
+  refreshDMConversations: () => Promise<void>;
 }
 
 const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
@@ -97,6 +99,7 @@ export function WorkspaceProvider({
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
   const [browserTabs, setBrowserTabs] = useState<BrowserTab[]>([]);
   const [selectedBrowserTabId, setSelectedBrowserTabId] = useState<string | null>(null);
+  const [dmConversations, setDMConversations] = useState<DMConversation[]>([]);
   const [manuallyRenamedSessions, setManuallyRenamedSessions] = useState<Set<string>>(new Set());
 
   const updateLastMessage = useCallback((sessionId: string, senderName: string, content: string, isStatus?: boolean) => {
@@ -304,9 +307,10 @@ export function WorkspaceProvider({
         }
       }
 
-      // Also refresh files and browser tabs so sidebar counts stay current
+      // Also refresh files, browser tabs, and DM conversations so sidebar counts stay current
       workspaceApi.listFiles().then((r) => setFiles(r.files)).catch(() => {});
       workspaceApi.listBrowserTabs().then((r) => setBrowserTabs(r.tabs)).catch(() => {});
+      workspaceApi.listConversations().then((c) => setDMConversations(c)).catch(() => {});
     } catch {
       // Non-critical — keep existing state
     }
@@ -357,6 +361,15 @@ export function WorkspaceProvider({
     if (selectedBrowserTabId === tabId) setSelectedBrowserTabId(null);
   }, [selectedBrowserTabId]);
 
+  const refreshDMConversations = useCallback(async () => {
+    try {
+      const convos = await workspaceApi.listConversations();
+      setDMConversations(convos);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
   // Initial load: workspace metadata + discover for channels
   useEffect(() => {
     let cancelled = false;
@@ -389,49 +402,41 @@ export function WorkspaceProvider({
           setCurrentSessionId(channelSessions[0].sessionId);
         }
 
-        // Fetch last message preview for each channel (newest first)
-        const previews = await Promise.all(
-          channelSessions.map(async (s) => {
-            try {
-              const result = await workspaceApi.pollEvents({
-                channel: s.sessionId,
-                type: 'workspace.message',
-                sort: 'desc',
-                limit: 10,
-              });
-              if (result.events.length === 0) return null;
-              const latest = result.events[0];
-              const latestPayload = latest.payload as Record<string, string>;
-              const latestType = latestPayload?.message_type || 'chat';
-              const isAgentWorking = latestType === 'status' || latestType === 'thinking';
-              // Find the latest chat message for preview
-              const lastChat = result.events.find((e) => {
-                const mt = (e.payload as Record<string, string>)?.message_type || 'chat';
-                return mt !== 'status' && mt !== 'thinking';
-              });
-              // If agent is actively working, show the status; otherwise show last chat
-              const pick = isAgentWorking ? latest : (lastChat || latest);
-              const payload = pick.payload as Record<string, string>;
-              {
-                const sender = pick.source.replace(/^(openagents:|human:)/, '');
-                const content = payload?.content || '';
-                const msgType = payload?.message_type || 'chat';
-                const isStatus = msgType === 'status' || msgType === 'thinking';
-                return { sessionId: s.sessionId, senderName: sender, content, isStatus };
-              }
-            } catch { /* ignore */ }
-            return null;
-          })
-        );
-        if (!cancelled) {
-          const batch: Record<string, LastMessageInfo> = {};
-          for (const p of previews) {
-            if (p && p.content) {
-              batch[p.sessionId] = { senderName: p.senderName, content: p.content.slice(0, 100), isStatus: p.isStatus };
-            }
+        // Seed previews from localStorage for instant display
+        const cacheKey = `previews:${workspaceId}`;
+        try {
+          const cached = localStorage.getItem(cacheKey);
+          if (cached && !cancelled) {
+            setLastMessageBySession((prev) => ({ ...JSON.parse(cached), ...prev }));
           }
-          setLastMessageBySession((prev) => ({ ...prev, ...batch }));
-        }
+        } catch { /* ignore corrupt cache */ }
+
+        // Bulk fetch latest message per channel (1 request instead of N)
+        try {
+          const bulk = await workspaceApi.latestPerChannel();
+          if (!cancelled) {
+            const batch: Record<string, LastMessageInfo> = {};
+            for (const [channelName, event] of Object.entries(bulk.channels)) {
+              const payload = event.payload as Record<string, string>;
+              const sender = event.source.replace(/^(openagents:|human:)/, '');
+              const content = payload?.content || '';
+              const msgType = payload?.message_type || 'chat';
+              const isStatus = msgType === 'status' || msgType === 'thinking';
+              if (content) {
+                batch[channelName] = { senderName: sender, content: content.slice(0, 100), isStatus };
+              }
+            }
+            setLastMessageBySession((prev) => ({ ...prev, ...batch }));
+            try {
+              localStorage.setItem(cacheKey, JSON.stringify(batch));
+            } catch { /* storage full */ }
+          }
+        } catch { /* non-critical */ }
+
+        // Also fetch DM conversations
+        workspaceApi.listConversations().then((c) => {
+          if (!cancelled) setDMConversations(c);
+        }).catch(() => {});
       } catch (e) {
         if (!cancelled) {
           setError(e instanceof Error ? e.message : 'Failed to load workspace');
@@ -442,6 +447,14 @@ export function WorkspaceProvider({
     })();
     return () => { cancelled = true; };
   }, [workspaceId, token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Persist previews to localStorage for instant rendering on reload
+  useEffect(() => {
+    if (Object.keys(lastMessageBySession).length === 0) return;
+    try {
+      localStorage.setItem(`previews:${workspaceId}`, JSON.stringify(lastMessageBySession));
+    } catch { /* storage full */ }
+  }, [lastMessageBySession, workspaceId]);
 
   // Discovery polling — adaptive: 5s when agents are active, 15s when idle
   const hasActiveAgentsRef = React.useRef(false);
@@ -625,6 +638,8 @@ export function WorkspaceProvider({
         refreshBrowserTabs,
         openBrowserTab,
         closeBrowserTab,
+        dmConversations,
+        refreshDMConversations,
       }}
     >
       {children}

--- a/workspace/frontend/lib/workspace-context.tsx
+++ b/workspace/frontend/lib/workspace-context.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useCallback, useEffect, useState } from 'react';
 import { workspaceApi } from './api';
 import { networkAgentToWorkspaceAgent, networkChannelToSession } from './types';
-import type { BrowserPersistentContext, BrowserTab, DMConversation, ONMEvent, Workspace, WorkspaceAgent, WorkspaceFile, WorkspaceSession } from './types';
+import type { BrowserPersistentContext, BrowserTab, DMConversation, Workspace, WorkspaceAgent, WorkspaceFile, WorkspaceSession } from './types';
 
 interface LastMessageInfo {
   content: string;


### PR DESCRIPTION
# feat(studio): Agent-to-agent DM visibility, DM history fixes & dark mode improvements

## Summary

This PR adds visibility into agent-to-agent direct message conversations, fixes a bug where DM responses were invisible, and resolves dark mode readability issues in the Studio UI.

### Agent-to-Agent DM Visibility

When agents communicate via direct messages (e.g. through `WorkerAgent.send_direct()`), those conversations are persisted in the messaging mod but invisible in the Studio UI. This PR surfaces them:

- **Backend:** New `thread.conversations.list` event handler in the messaging mod that scans message history and returns grouped DM conversation pairs with metadata (participants, last message, message count)
- **Frontend:** New "Agent DMs" section in the messaging sidebar showing active agent-to-agent conversations with last message preview and periodic refresh
- **Frontend:** Read-only chat view for agent conversations — users can observe but not inject messages into agent-to-agent DMs

### DM Response Visibility Fix

Fixed a bug where agent responses to DMs were invisible in the Studio chat view. The DM retrieval filter required `destination_id` to have an `agent:` prefix, but `WorkerAgent.send_direct()` sets `destination_id` to the bare agent ID. The filter now normalizes both formats when matching conversations.

### Dark Mode Readability Fix

- **Root cause:** Tailwind CSS v4 defaults to `@media (prefers-color-scheme: dark)` for the `dark:` variant, but the Studio uses a `.dark` class on `<html>`. All `dark:` utility classes were silently ignored.
- **Fix:** Added `@custom-variant dark (&:where(.dark, .dark *))` to align Tailwind v4 with class-based dark mode
- Improved message text contrast across all markdown elements (paragraphs, lists, headings, code, blockquotes, tables)
- Adjusted message bubble backgrounds for better visual distinction in dark mode

### Workspace Backend Endpoints

Added REST API endpoints to the workspace backend for future use:

- `GET /v1/events?conversation=agentA,agentB` — bidirectional DM filtering
- `GET /v1/events/conversations` — DM conversation discovery with latest message per pair
- `GET /v1/events/latest-per-channel` — bulk latest-message-per-channel using SQL window functions (replaces N+1 queries)

## Test plan

- [ ] Open Studio in dark mode — all message text should be white and clearly readable
- [ ] Send a DM to an agent — both your message and the agent's response should be visible
- [ ] Connect multiple agents that exchange DMs — "Agent DMs" section should appear in the sidebar
- [ ] Click an agent DM conversation — should open a read-only chat view with conversation history
- [ ] Verify light mode styling is unaffected
- [ ] Verify channel messaging still works as before