### PR TITLE
fix: use "openai-completions" for OpenClaw provider api format

### DIFF
--- a/src/openagents/client/daemon.py
+++ b/src/openagents/client/daemon.py
@@ -421,7 +421,7 @@ class DaemonManager:
 
         # Determine API format from base URL
         is_anthropic = "anthropic" in base_url.lower() if base_url else bool(os.environ.get("ANTHROPIC_API_KEY"))
-        api_format = "anthropic-messages" if is_anthropic else "openai-chat"
+        api_format = "anthropic-messages" if is_anthropic else "openai-completions"
 
         # Build provider config
         provider_id = "openagents-llm"


### PR DESCRIPTION
## Summary

Fixes an invalid `api` value written to OpenClaw's config file (`~/.openclaw/openclaw.json`) by the OpenAgents daemon.

## Problem

`_configure_openclaw_model()` in `daemon.py` was writing `"openai-chat"` as the `api` field, which is **not a valid OpenClaw api value**. This caused OpenClaw to reject the config on startup with:

```
Error: Invalid enum value. Expected 'openai-completions' | 'openai-responses' | ... , received 'openai-chat'
```

Introduced in commit 48167e7d ("fix: configure OpenClaw model provider from OpenAgents env vars").

## Fix

One-line change: `"openai-chat"` → `"openai-completions"` in `src/openagents/client/daemon.py` line 424.

`"openai-completions"` is the standard OpenClaw api value for OpenAI-compatible endpoints (used in OpenClaw's own onboarding flow).