### PR TITLE
fix: route all @mentions in messages, not just leading mention

### DIFF
--- a/workspace/backend/app/mods/workspace_mod.py
+++ b/workspace/backend/app/mods/workspace_mod.py
@@ -590,6 +590,23 @@ async def _handle_message_posted(event: Event, ctx: PipelineContext) -> Optional
 
     # Agent messages: use LLM router for multi-agent threads
     if event.source.startswith("openagents:"):
+        # Explicit @mentions take priority over the LLM router.
+        if mentions:
+            sender = event.source[len("openagents:"):]
+            targets = [m for m in mentions if m != sender]
+            if targets:
+                event.metadata["target_agents"] = targets
+                # Auto-add mentioned agents as channel participants
+                from app.models import ChannelMember
+                if channel:
+                    existing = {p.agent_name for p in (channel.participants or [])}
+                    for t in targets:
+                        if t not in existing:
+                            db.add(ChannelMember(channel_id=channel.id, agent_name=t))
+                    db.flush()
+                return event
+            # All mentions were self → fall through to LLM router / master
+
         if channel and len(channel.participants or []) >= 2:
             # Multi-agent thread → LLM router decides next speaker
             from app.config import config
@@ -618,11 +635,9 @@ async def _handle_message_posted(event: Event, ctx: PipelineContext) -> Optional
     # Auto-name channel from first human message if title is default/empty
     _auto_title_channel(channel, content, db)
 
-    # If message starts with @agent-name, route directly to that agent.
-    # Other @mentions in the body are just references, not routing targets.
-    leading = _extract_leading_mention(content, known_agents)
-    if leading:
-        event.metadata["target_agents"] = [leading]
+    # Route to all @mentioned agents in the message.
+    if mentions:
+        event.metadata["target_agents"] = mentions
     elif channel.master_agent:
         # Default: route to channel master
         event.metadata["target_agents"] = [channel.master_agent]

--- a/workspace/backend/tests/test_events.py
+++ b/workspace/backend/tests/test_events.py
@@ -176,13 +176,13 @@ class TestSendEvent:
         # Member's response should be routed back to the master
         assert data["metadata"]["target_agents"] == ["agent-alpha"]
 
-    def test_member_message_routes_to_master_in_fallback(self, client, workspace):
-        """Member agent messages in single-agent channels route to master (fallback).
+    def test_agent_message_with_mention_routes_to_mentioned(self, client, workspace):
+        """Agent messages with @mentions route to the mentioned agent(s).
 
-        With the LLM router disabled (no API key in tests), member messages
-        always route back to the channel master regardless of @mentions.
+        Explicit @mentions in agent messages take priority over the LLM
+        router and the master-fallback.
         """
-        # Add member agents to workspace (not to channel — so channel stays single-participant)
+        # Add member agents to workspace
         for name in ["agent-beta", "agent-gamma"]:
             client.post("/v1/join", json={
                 "agent_name": name,
@@ -201,8 +201,101 @@ class TestSendEvent:
 
         assert resp.status_code == 200
         data = resp.json()["data"]
-        # Fallback: member messages route to master
-        assert data["metadata"]["target_agents"] == ["agent-alpha"]
+        # @mention routing: agent-gamma is targeted
+        assert data["metadata"]["target_agents"] == ["agent-gamma"]
+
+    def test_agent_message_with_mid_text_mention(self, client, workspace):
+        """@mentions in the middle of an agent message also route correctly."""
+        for name in ["agent-beta", "agent-gamma"]:
+            client.post("/v1/join", json={
+                "agent_name": name,
+                "token": workspace["token"],
+                "network": workspace["id"],
+            })
+
+        channel_name = workspace["channel"]["name"]
+        resp = client.post("/v1/events", json={
+            "type": "workspace.message.posted",
+            "source": "openagents:agent-beta",
+            "target": f"channel/{channel_name}",
+            "payload": {"content": "Hey, I think @agent-gamma should look at this"},
+            "network": workspace["id"],
+        }, headers={"X-Workspace-Token": workspace["token"]})
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["metadata"]["target_agents"] == ["agent-gamma"]
+
+    def test_agent_message_with_multiple_mentions(self, client, workspace):
+        """Agent messages with multiple @mentions route to all mentioned agents."""
+        for name in ["agent-beta", "agent-gamma", "agent-delta"]:
+            client.post("/v1/join", json={
+                "agent_name": name,
+                "token": workspace["token"],
+                "network": workspace["id"],
+            })
+
+        channel_name = workspace["channel"]["name"]
+        resp = client.post("/v1/events", json={
+            "type": "workspace.message.posted",
+            "source": "openagents:agent-alpha",
+            "target": f"channel/{channel_name}",
+            "payload": {"content": "@agent-beta and @agent-gamma please collaborate"},
+            "network": workspace["id"],
+        }, headers={"X-Workspace-Token": workspace["token"]})
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        targets = data["metadata"]["target_agents"]
+        assert "agent-beta" in targets
+        assert "agent-gamma" in targets
+        assert len(targets) == 2
+
+    def test_human_message_with_multiple_mentions(self, client, workspace):
+        """Human messages with multiple @mentions route to all mentioned agents."""
+        for name in ["agent-beta", "agent-gamma"]:
+            client.post("/v1/join", json={
+                "agent_name": name,
+                "token": workspace["token"],
+                "network": workspace["id"],
+            })
+
+        channel_name = workspace["channel"]["name"]
+        resp = client.post("/v1/events", json={
+            "type": "workspace.message.posted",
+            "source": "human:user1",
+            "target": f"channel/{channel_name}",
+            "payload": {"content": "@agent-alpha and @agent-beta please help"},
+            "network": workspace["id"],
+        }, headers={"X-Workspace-Token": workspace["token"]})
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        targets = data["metadata"]["target_agents"]
+        assert "agent-alpha" in targets
+        assert "agent-beta" in targets
+        assert len(targets) == 2
+
+    def test_human_message_mid_text_mention(self, client, workspace):
+        """Human @mentions in the middle of text also trigger routing."""
+        client.post("/v1/join", json={
+            "agent_name": "agent-beta",
+            "token": workspace["token"],
+            "network": workspace["id"],
+        })
+
+        channel_name = workspace["channel"]["name"]
+        resp = client.post("/v1/events", json={
+            "type": "workspace.message.posted",
+            "source": "human:user1",
+            "target": f"channel/{channel_name}",
+            "payload": {"content": "I think @agent-beta should handle this"},
+            "network": workspace["id"],
+        }, headers={"X-Workspace-Token": workspace["token"]})
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["metadata"]["target_agents"] == ["agent-beta"]
 
 
 class TestPollEvents:


### PR DESCRIPTION
## Summary

- **Agent messages**: @mentions now take priority over the LLM router — `@agent-name` anywhere in the text routes directly to that agent (self-mentions excluded)
- **Human messages**: all @mentions route, not just the leading one — `"please ask @alice and @bob"` routes to both

## Changes

- `workspace_mod.py`: 20 insertions, 5 deletions (zero formatting changes)
- `test_events.py`: replaced 1 outdated test + added 5 new tests covering mid-text mentions, multiple mentions, and both agent/human paths

## Test results

```
21 passed in 0.44s
```