### PR TITLE
fix(cli): resolve NameError for show_banner in cli_network (#323)

### DIFF
--- a/src/openagents/client/cli.py
+++ b/src/openagents/client/cli.py
@@ -25,7 +25,7 @@ from rich.table import Table
 from rich import box
 
 # -- Shared state (re-export for backward compatibility) ----------------------
-from openagents.client.cli_shared import app, console
+from openagents.client.cli_shared import app, console, show_banner
 
 VERBOSE_MODE = False  # mutable global, updated by verbose_callback
 
@@ -196,25 +196,6 @@ def verbose_callback(value: bool):
     VERBOSE_MODE = value
     return value
 
-
-def show_banner():
-    """Show a beautiful startup banner"""
-    banner_text = """
-[bold blue]   ___                              ___                          _       [/bold blue]
-[bold blue]  / _ \\ _ __    ___  _ __           /   \\  __ _   ___  _ __   | |_  ___ [/bold blue]
-[bold blue] | | | | '_ \\  / _ \\| '_ \\         / /\\ / / _` | / _ \\| '_ \\  | __|/ __[/bold blue]
-[bold blue] | |_| | |_) ||  __/| | | |       / /_// | (_| ||  __/| | | | | |_\\__ \\ [/bold blue]
-[bold blue]  \\___/| .__/  \\___||_| |_|      /___,'   \\__, | \\___||_| |_|  \\__|___/[/bold blue]
-[bold blue]       |_|                              |___/                        [/bold blue]
-
-[bold cyan]AI Agent Networks for Open Collaboration[/bold cyan]
-[dim]   Create and manage distributed AI agent networks with ease[/dim]
-"""
-    console.print(Panel(
-        banner_text.strip(),
-        border_style="blue",
-        expand=False
-    ))
 
 
 @app.callback()

--- a/src/openagents/client/cli_network.py
+++ b/src/openagents/client/cli_network.py
@@ -20,7 +20,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 from rich import box
 
-from openagents.client.cli_shared import app, console, OPENAGENTS_API_BASE
+from openagents.client.cli_shared import app, console, OPENAGENTS_API_BASE, show_banner
 from openagents.client.cli_helpers import (
     connect_to_relay,
     initialize_workspace,

--- a/src/openagents/client/cli_shared.py
+++ b/src/openagents/client/cli_shared.py
@@ -9,6 +9,7 @@ import sys
 
 import typer
 from rich.console import Console
+from rich.panel import Panel
 
 # Ensure UTF-8 output on Windows (avoids charmap codec errors with emoji)
 if sys.platform == "win32" and not os.environ.get("PYTHONIOENCODING"):
@@ -38,3 +39,23 @@ VERBOSE_MODE = False
 OPENAGENTS_API_BASE = "https://endpoint.openagents.org/v1"
 OPENAGENTS_RELAY_URL = "wss://relay.openagents.org"
 LOCALHOST_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0", "::1", "local"]
+
+
+def show_banner():
+    """Show a beautiful startup banner"""
+    banner_text = """
+[bold blue]   ___                              ___                          _       [/bold blue]
+[bold blue]  / _ \\ _ __    ___  _ __           /   \\  __ _   ___  _ __   | |_  ___ [/bold blue]
+[bold blue] | | | | '_ \\  / _ \\| '_ \\         / /\\ / / _` | / _ \\| '_ \\  | __|/ __[/bold blue]
+[bold blue] | |_| | |_) ||  __/| | | |       / /_// | (_| ||  __/| | | | | |_\\__ \\ [/bold blue]
+[bold blue]  \\___/| .__/  \\___||_| |_|      /___,'   \\__, | \\___||_| |_|  \\__|___/[/bold blue]
+[bold blue]       |_|                              |___/                        [/bold blue]
+
+[bold cyan]AI Agent Networks for Open Collaboration[/bold cyan]
+[dim]   Create and manage distributed AI agent networks with ease[/dim]
+"""
+    console.print(Panel(
+        banner_text.strip(),
+        border_style="blue",
+        expand=False
+    ))


### PR DESCRIPTION
## Summary

Fixes #323 — `name 'show_banner' is not defined` error when using project-hub template in Studio.

## Root Cause

In commit `39a8325e` (2026-03-09, "split 6,154-line cli.py into 9 domain modules"), `show_banner()` was left in `cli.py` while its call site was moved to `cli_network.py` without an import. A direct import from `cli.py` into `cli_network.py` is impossible because `cli.py` already imports `cli_network` (circular dependency).

## Fix

- Move `show_banner()` from `cli.py` to `cli_shared.py` (the shared utilities module designed to break circular deps)
- Both `cli.py` and `cli_network.py` now import `show_banner` from `cli_shared`

## Changes

- `src/openagents/client/cli_shared.py` — Add `Panel` import + `show_banner()` function
- `src/openagents/client/cli.py` — Import `show_banner` from `cli_shared`, remove local definition
- `src/openagents/client/cli_network.py` — Add `show_banner` to existing `cli_shared` import

3 files changed, 23 insertions, 21 deletions.