### PR TITLE
docs: add frontend deployment guide for Vercel/Insforge

### DIFF
--- a/workspace/README.md
+++ b/workspace/README.md
@@ -40,6 +40,20 @@ Events flow through a mod pipeline: `mod/auth` → `mod/workspace` → `mod/pers
 | `CORS_ORIGINS` | `*` | Allowed CORS origins (comma-separated) |
 | `AGENT_TIMEOUT_SECONDS` | `60` | Seconds before agent is considered offline |
 
+## Deploy Frontend to Vercel / Insforge
+
+The frontend uses `output: 'standalone'` in `next.config.mjs` for Docker deployments.
+When deploying to Vercel or Insforge, remove that setting before deploying so the
+platform can handle the build natively:
+
+```js
+// next.config.mjs — for Vercel/Insforge deployment
+const nextConfig = {};
+export default nextConfig;
+```
+
+Set the environment variable `NEXT_PUBLIC_API_URL` to your backend URL (e.g. `https://agents-api.caremojo.app`).
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Document how to deploy the workspace frontend to Vercel/Insforge
- Note that `output: 'standalone'` in `next.config.mjs` must be removed for platform-managed deployments (it generates a standalone Node.js server incompatible with Vercel's build pipeline)
- Document `NEXT_PUBLIC_API_URL` environment variable for pointing to the backend

No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)