### PR TITLE
fix: SQLite default value compatibility and docker/nginx networking

### DIFF
--- a/workspace/backend/app/database.py
+++ b/workspace/backend/app/database.py
@@ -25,6 +25,22 @@ if _is_sqlite:
         SQLiteTypeCompiler.visit_JSONB = lambda self, type_, **kw: "JSON"
         SQLiteTypeCompiler.visit_UUID = lambda self, type_, **kw: "TEXT"
 
+    # Patch PostgreSQL server_defaults that SQLite can't handle.
+    # Must run before models are imported and mapper caches column metadata.
+    import sqlalchemy as _sa
+    _orig_column_init = _sa.Column.__init__
+
+    def _patched_column_init(self, *args, **kwargs):
+        _orig_column_init(self, *args, **kwargs)
+        if self.server_default is not None:
+            sd_text = str(self.server_default.arg) if hasattr(self.server_default, 'arg') else ""
+            if "gen_random_uuid" in sd_text:
+                self.server_default = None
+            elif sd_text == "NOW()":
+                self.server_default = _sa.schema.FetchedValue()
+
+    _sa.Column.__init__ = _patched_column_init
+
 _pool_kwargs = (
     {"poolclass": NullPool}
     if _is_serverless or _is_sqlite

--- a/workspace/frontend/Dockerfile
+++ b/workspace/frontend/Dockerfile
@@ -10,6 +10,8 @@ RUN npm ci
 COPY . .
 
 # Build
+ARG NEXT_PUBLIC_API_URL=http://localhost:8700
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 RUN npm run build
 
 # Run

--- a/workspace/frontend/lib/api.ts
+++ b/workspace/frontend/lib/api.ts
@@ -17,7 +17,7 @@ import type {
 } from './types';
 import { eventToMessage } from './types';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://workspace-endpoint.openagents.org';
 
 /** Map snake_case file response from backend to camelCase WorkspaceFile. */
 function mapFileResponse(raw: Record<string, unknown>): WorkspaceFile {
@@ -60,7 +60,6 @@ class WorkspaceApi {
     const url = `${API_URL}${path}`;
     const res = await fetch(url, {
       ...options,
-      cache: 'no-store',
       headers: {
         'Content-Type': 'application/json',
         ...authHeaders,

--- a/workspace/frontend/lib/auth.ts
+++ b/workspace/frontend/lib/auth.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://workspace-endpoint.openagents.org';
 
 const STORAGE_KEYS = {
   accessToken: 'oa_access_token',

--- a/workspace/frontend/lib/dashboard-api.ts
+++ b/workspace/frontend/lib/dashboard-api.ts
@@ -1,6 +1,6 @@
 import { getStoredAuth, refreshAccessToken } from './auth';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://workspace-endpoint.openagents.org';
 
 export interface WorkspaceSummary {
   workspaceId: string;

--- a/workspace/nginx.conf
+++ b/workspace/nginx.conf
@@ -1,9 +1,9 @@
 upstream backend {
-    server backend:8000;
+    server openagents-workspace:8000;
 }
 
 upstream frontend {
-    server frontend:3000;
+    server openagents-frontend:3000;
 }
 
 server {


### PR DESCRIPTION
## Summary

- **SQLite compatibility**: Patches `Column.__init__` to neutralize PostgreSQL-specific `server_default` values (`gen_random_uuid()`, `NOW()`) that SQLite can't handle, enabling local development with SQLite
- **Docker networking**: Updates `nginx.conf` upstream names from `backend`/`frontend` to `openagents-workspace`/`openagents-frontend` to match actual container names in docker-compose
- **Frontend build**: Adds `NEXT_PUBLIC_API_URL` as a build arg in the frontend Dockerfile so the API URL is baked in at build time rather than requiring runtime configuration
- **API URL fallback**: Changes `||` to `??` for `NEXT_PUBLIC_API_URL` fallback across `api.ts`, `auth.ts`, and `dashboard-api.ts` so empty string is respected (not treated as falsy)
- **Fetch caching**: Removes `cache: 'no-store'` from the base fetch wrapper to allow normal browser/CDN caching behavior

## Test plan

- [ ] Run workspace backend locally with SQLite — confirm tables create without errors
- [ ] `docker compose up` — verify nginx routes to backend and frontend correctly
- [ ] Build frontend Docker image with custom `NEXT_PUBLIC_API_URL` — confirm it's used at runtime
- [ ] Confirm API calls work with the `??` fallback change

🤖 Generated with [Claude Code](https://claude.com/claude-code)