### PR TITLE
fix: prevent Enter from sending message during IME composition

### DIFF
--- a/packages/go/components/chat/chat-input.tsx
+++ b/packages/go/components/chat/chat-input.tsx
@@ -135,6 +135,9 @@ export function ChatInput({ onSend, disabled, className, agents = [], draft, onD
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ignore Enter during IME composition (Chinese, Japanese, Korean input)
+    if (e.nativeEvent.isComposing || e.key === 'Process') return;
+
     if (showMentions && filteredAgents.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();

--- a/sdk/studio/src/pages/messaging/components/MessageInput.tsx
+++ b/sdk/studio/src/pages/messaging/components/MessageInput.tsx
@@ -715,6 +715,9 @@ const MessageInput: React.FC<MessageInputProps> = ({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Ignore Enter during IME composition (Chinese, Japanese, Korean input)
+    if (e.nativeEvent.isComposing || e.key === 'Process') return;
+
     // Handle mention navigation
     if (showMentions && filteredAgents.length > 0) {
       if (e.key === "ArrowDown") {

--- a/workspace/frontend/components/chat/chat-input.tsx
+++ b/workspace/frontend/components/chat/chat-input.tsx
@@ -135,6 +135,9 @@ export function ChatInput({ onSend, disabled, className, agents = [], draft, onD
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ignore Enter during IME composition (Chinese, Japanese, Korean input)
+    if (e.nativeEvent.isComposing || e.key === 'Process') return;
+
     if (showMentions && filteredAgents.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- When typing Chinese/Japanese/Korean using an IME, pressing Enter to confirm a character selection was incorrectly triggering message send
- Added `isComposing` guard at the top of `handleKeyDown` in all 3 chat input components: workspace frontend, packages/go, and studio MessageInput
- Uses the standard `KeyboardEvent.isComposing` property with a `Process` key fallback for legacy browsers

## Test plan
- [x] Tested locally with Chinese IME input — Enter confirms character without sending
- [ ] Verify normal Enter-to-send still works without IME active
- [ ] Verify Shift+Enter newline still works
- [ ] Verify @mention selection with Enter still works (without IME)

🤖 Generated with [Claude Code](https://claude.com/claude-code)