### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ sdk = [
     "structlog>=23.0.0",
 ]
 
+# Exa AI-powered search tool
+exa = [
+    "exa-py>=2.0.0",
+]
+
 # P2P networking (optional, for future libp2p integration)
 p2p = [
     "libp2p>=0.2.0",       # P2P networking library
@@ -119,7 +124,7 @@ docs = [
 
 # All optional dependencies
 all = [
-    "openagents[sdk,p2p,webrtc,langchain,autogen,dev,docs]",
+    "openagents[sdk,exa,p2p,webrtc,langchain,autogen,dev,docs]",
 ]
 
 [project.urls]

--- a/sdk/demos/03_research_team/agents/web_searcher.yaml
+++ b/sdk/demos/03_research_team/agents/web_searcher.yaml
@@ -57,6 +57,36 @@ config:
         required:
           - query
 
+    - name: "search_exa"
+      description: "AI-powered web search using Exa. Supports neural/fast/deep search types, content extraction (highlights/text/summary), and filtering by domain, category, text, and date. Requires EXA_API_KEY."
+      implementation: "tools.exa_search.search_exa"
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+            description: "The search query"
+          num_results:
+            type: integer
+            description: "Number of results (default 5, max 100)"
+          search_type:
+            type: string
+            description: "Search type: 'auto', 'neural', 'fast', 'instant', 'deep-lite', 'deep', or 'deep-reasoning'"
+          content_mode:
+            type: string
+            description: "Content mode: 'highlights', 'text', 'summary', or 'none'"
+          category:
+            type: string
+            description: "Category filter: 'company', 'research paper', 'news', 'personal site', 'financial report', 'people'"
+          include_domains:
+            type: string
+            description: "Comma-separated domains to include (e.g. 'arxiv.org,github.com')"
+          exclude_domains:
+            type: string
+            description: "Comma-separated domains to exclude"
+        required:
+          - query
+
   instruction: |
     You are the WEB SEARCHER. When you get a task, search and report results.
 

--- a/sdk/demos/03_research_team/tools/exa_search.py
+++ b/sdk/demos/03_research_team/tools/exa_search.py
@@ -1,0 +1,8 @@
+"""
+Exa AI-powered web search tool.
+
+Requires: EXA_API_KEY environment variable.
+Install: pip install exa-py>=2.0.0
+"""
+
+from openagents.tools.exa_search import search_exa  # noqa: F401

--- a/sdk/src/openagents/tools/exa_search.py
+++ b/sdk/src/openagents/tools/exa_search.py
@@ -1,0 +1,160 @@
+"""
+Exa AI-powered web search tool for OpenAgents.
+
+This module provides web search and content retrieval capabilities using
+the Exa API. It supports multiple search types, content extraction modes,
+and filtering options.
+
+Requires: EXA_API_KEY environment variable.
+Install: pip install exa-py>=2.0.0
+"""
+
+import logging
+import os
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def _get_client():
+    """Create and return an Exa client with integration tracking header."""
+    api_key = os.environ.get("EXA_API_KEY", "")
+    if not api_key:
+        raise ValueError(
+            "EXA_API_KEY environment variable is required. "
+            "Get your key from: https://dashboard.exa.ai/api-keys"
+        )
+
+    from exa_py import Exa
+
+    client = Exa(api_key=api_key)
+    client.headers["x-exa-integration"] = "openagents"
+    return client
+
+
+def _extract_snippet(result, content_mode: str = "highlights") -> str:
+    """Extract content snippet from an Exa result, cascading through available fields."""
+    # Try highlights first
+    highlights = getattr(result, "highlights", None)
+    if highlights:
+        return "\n".join(highlights)
+
+    # Try summary
+    summary = getattr(result, "summary", None)
+    if summary:
+        return summary
+
+    # Try text (truncated)
+    text = getattr(result, "text", None)
+    if text:
+        return text[:500] + ("..." if len(text) > 500 else "")
+
+    return ""
+
+
+def search_exa(
+    query: str,
+    num_results: int = 5,
+    search_type: str = "auto",
+    content_mode: str = "highlights",
+    category: str = None,
+    include_domains: str = None,
+    exclude_domains: str = None,
+    include_text: str = None,
+    exclude_text: str = None,
+    start_published_date: str = None,
+    end_published_date: str = None,
+) -> str:
+    """
+    Search the web using Exa's AI-powered search engine.
+
+    Supports multiple search types and content extraction modes with
+    advanced filtering by domain, text, category, and date range.
+
+    Args:
+        query: The search query to execute
+        num_results: Number of results to return (default 5, max 100)
+        search_type: Search algorithm - 'auto' (default), 'neural', 'fast',
+                     'instant', 'deep-lite', 'deep', or 'deep-reasoning'
+        content_mode: Content retrieval - 'highlights' (default), 'text',
+                      'summary', or 'none'
+        category: Filter by category - 'company', 'research paper', 'news',
+                  'personal site', 'financial report', 'people'
+        include_domains: Comma-separated domains to include (e.g. 'arxiv.org,github.com')
+        exclude_domains: Comma-separated domains to exclude
+        include_text: Text that must appear in page content
+        exclude_text: Text to exclude from results
+        start_published_date: ISO 8601 date; only results after this (e.g. '2024-01-01T00:00:00.000Z')
+        end_published_date: ISO 8601 date; only results before this
+
+    Returns:
+        Formatted string with search results including titles, URLs, and content snippets
+    """
+    try:
+        client = _get_client()
+    except ValueError as e:
+        return str(e)
+
+    # Build search kwargs
+    search_kwargs: Dict[str, Any] = {
+        "query": query,
+        "num_results": min(num_results, 100),
+        "type": search_type,
+    }
+
+    # Build contents parameter
+    if content_mode == "highlights":
+        search_kwargs["contents"] = {"highlights": {"max_characters": 4000}}
+    elif content_mode == "text":
+        search_kwargs["contents"] = {"text": {"max_characters": 10000}}
+    elif content_mode == "summary":
+        search_kwargs["contents"] = {"summary": True}
+    # 'none' omits contents entirely
+
+    # Add optional filters
+    if category:
+        search_kwargs["category"] = category
+    if include_domains:
+        search_kwargs["include_domains"] = [d.strip() for d in include_domains.split(",")]
+    if exclude_domains:
+        search_kwargs["exclude_domains"] = [d.strip() for d in exclude_domains.split(",")]
+    if include_text:
+        search_kwargs["include_text"] = [include_text]
+    if exclude_text:
+        search_kwargs["exclude_text"] = [exclude_text]
+    if start_published_date:
+        search_kwargs["start_published_date"] = start_published_date
+    if end_published_date:
+        search_kwargs["end_published_date"] = end_published_date
+
+    try:
+        logger.info(f"Exa search: query={query!r}, type={search_type}, num_results={num_results}")
+        response = client.search(**search_kwargs)
+    except Exception as e:
+        logger.error(f"Exa search failed: {e}")
+        return f"Exa search error: {e}"
+
+    if not response.results:
+        return f"No results found for: {query}"
+
+    # Format results matching the repo's existing web_search output style
+    output = f"Search results for '{query}':\n\n"
+    for i, result in enumerate(response.results, 1):
+        title = getattr(result, "title", "No Title") or "No Title"
+        url = getattr(result, "url", "") or ""
+        published_date = getattr(result, "published_date", None)
+
+        output += f"{i}. {title}\n"
+        output += f"   URL: {url}\n"
+
+        if published_date:
+            output += f"   Published: {published_date}\n"
+
+        snippet = _extract_snippet(result, content_mode)
+        if snippet:
+            output += f"   {snippet}\n"
+
+        output += "\n"
+
+    logger.info(f"Exa search returned {len(response.results)} results")
+    return output.strip()

--- a/tests/agents/test_exa_search.py
+++ b/tests/agents/test_exa_search.py
@@ -1,0 +1,285 @@
+"""
+Test cases for Exa search tool.
+
+Tests cover API response parsing, content snippet fallback logic,
+and disabled state when EXA_API_KEY is unset.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openagents.tools.exa_search import _extract_snippet, _get_client, search_exa
+
+# --- Fixtures ---
+
+SAMPLE_RESULT_HIGHLIGHTS = MagicMock(
+    title="Exa: AI-Powered Search",
+    url="https://exa.ai",
+    published_date="2024-06-15",
+    highlights=["Exa provides AI-powered web search.", "Built for developers."],
+    summary="Exa is a search engine for AI.",
+    text="Full page text content here.",
+)
+
+SAMPLE_RESULT_SUMMARY_ONLY = MagicMock(
+    title="Neural Search Guide",
+    url="https://example.com/neural-search",
+    published_date=None,
+    highlights=None,
+    summary="A comprehensive guide to neural search techniques.",
+    text=None,
+)
+
+SAMPLE_RESULT_TEXT_ONLY = MagicMock(
+    title="Deep Learning Paper",
+    url="https://arxiv.org/abs/1234",
+    published_date="2024-01-10",
+    highlights=None,
+    summary=None,
+    text="This paper explores deep learning approaches to information retrieval...",
+)
+
+SAMPLE_RESULT_EMPTY = MagicMock(
+    title=None,
+    url="",
+    published_date=None,
+    highlights=None,
+    summary=None,
+    text=None,
+)
+
+SAMPLE_RESPONSE = MagicMock(results=[SAMPLE_RESULT_HIGHLIGHTS, SAMPLE_RESULT_SUMMARY_ONLY])
+EMPTY_RESPONSE = MagicMock(results=[])
+
+
+# --- Tests ---
+
+
+class TestExtractSnippet:
+    """Tests for content snippet extraction with fallback logic."""
+
+    def test_highlights_preferred(self):
+        """Highlights should be used when available."""
+        snippet = _extract_snippet(SAMPLE_RESULT_HIGHLIGHTS)
+        assert "Exa provides AI-powered web search." in snippet
+        assert "Built for developers." in snippet
+
+    def test_fallback_to_summary(self):
+        """Summary should be used when highlights are missing."""
+        snippet = _extract_snippet(SAMPLE_RESULT_SUMMARY_ONLY)
+        assert snippet == "A comprehensive guide to neural search techniques."
+
+    def test_fallback_to_text(self):
+        """Text should be used when both highlights and summary are missing."""
+        snippet = _extract_snippet(SAMPLE_RESULT_TEXT_ONLY)
+        assert "deep learning approaches" in snippet
+
+    def test_text_truncation(self):
+        """Long text should be truncated to 500 characters."""
+        long_result = MagicMock(
+            highlights=None,
+            summary=None,
+            text="x" * 600,
+        )
+        snippet = _extract_snippet(long_result)
+        assert len(snippet) == 503  # 500 + "..."
+        assert snippet.endswith("...")
+
+    def test_empty_result(self):
+        """Empty result should return empty string."""
+        snippet = _extract_snippet(SAMPLE_RESULT_EMPTY)
+        assert snippet == ""
+
+
+class TestSearchExa:
+    """Tests for the main search_exa function."""
+
+    def test_missing_api_key(self):
+        """Should return error message when EXA_API_KEY is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove EXA_API_KEY if present
+            env = os.environ.copy()
+            env.pop("EXA_API_KEY", None)
+            with patch.dict(os.environ, env, clear=True):
+                result = search_exa("test query")
+                assert "EXA_API_KEY" in result
+                assert "required" in result.lower() or "environment variable" in result.lower()
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_basic_search(self, mock_get_client):
+        """Should format results correctly from a basic search."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        result = search_exa("AI search engines")
+
+        assert "Exa: AI-Powered Search" in result
+        assert "https://exa.ai" in result
+        assert "Neural Search Guide" in result
+        assert "Published: 2024-06-15" in result
+
+        # Verify search was called with correct defaults
+        mock_client.search.assert_called_once()
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["query"] == "AI search engines"
+        assert call_kwargs["num_results"] == 5
+        assert call_kwargs["type"] == "auto"
+        assert "highlights" in call_kwargs["contents"]
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_search_with_text_content_mode(self, mock_get_client):
+        """Should request text content when content_mode is 'text'."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa("test", content_mode="text")
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert "text" in call_kwargs["contents"]
+        assert call_kwargs["contents"]["text"]["max_characters"] == 10000
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_search_with_summary_content_mode(self, mock_get_client):
+        """Should request summary content when content_mode is 'summary'."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa("test", content_mode="summary")
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["contents"] == {"summary": True}
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_search_with_no_content(self, mock_get_client):
+        """Should omit contents when content_mode is 'none'."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa("test", content_mode="none")
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert "contents" not in call_kwargs
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_empty_results(self, mock_get_client):
+        """Should return 'no results' message when search returns empty."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = EMPTY_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        result = search_exa("nonexistent query xyz")
+        assert "No results found" in result
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_domain_filtering(self, mock_get_client):
+        """Should pass domain filters to the API."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa(
+            "test",
+            include_domains="arxiv.org, github.com",
+            exclude_domains="twitter.com",
+        )
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["include_domains"] == ["arxiv.org", "github.com"]
+        assert call_kwargs["exclude_domains"] == ["twitter.com"]
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_category_and_date_filtering(self, mock_get_client):
+        """Should pass category and date filters to the API."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa(
+            "AI research",
+            category="research paper",
+            start_published_date="2024-01-01T00:00:00.000Z",
+            end_published_date="2024-12-31T23:59:59.000Z",
+        )
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["category"] == "research paper"
+        assert call_kwargs["start_published_date"] == "2024-01-01T00:00:00.000Z"
+        assert call_kwargs["end_published_date"] == "2024-12-31T23:59:59.000Z"
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_text_filtering(self, mock_get_client):
+        """Should pass text include/exclude filters to the API."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa("test", include_text="python", exclude_text="java")
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["include_text"] == ["python"]
+        assert call_kwargs["exclude_text"] == ["java"]
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_num_results_capped_at_100(self, mock_get_client):
+        """Should cap num_results at 100."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = SAMPLE_RESPONSE
+        mock_get_client.return_value = mock_client
+
+        search_exa("test", num_results=200)
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["num_results"] == 100
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_api_error_handling(self, mock_get_client):
+        """Should return error message when API call fails."""
+        mock_client = MagicMock()
+        mock_client.search.side_effect = Exception("API rate limit exceeded")
+        mock_get_client.return_value = mock_client
+
+        result = search_exa("test query")
+        assert "Exa search error" in result
+        assert "rate limit" in result
+
+    @patch("openagents.tools.exa_search._get_client")
+    def test_null_title_handling(self, mock_get_client):
+        """Should handle results with null titles gracefully."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = MagicMock(results=[SAMPLE_RESULT_EMPTY])
+        mock_get_client.return_value = mock_client
+
+        result = search_exa("test")
+        assert "No Title" in result
+
+
+class TestGetClient:
+    """Tests for client initialization."""
+
+    def test_client_requires_api_key(self):
+        """Should raise ValueError when EXA_API_KEY is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="EXA_API_KEY"):
+                _get_client()
+
+    def test_client_sets_tracking_header(self):
+        """Should set x-exa-integration tracking header."""
+        mock_client = MagicMock()
+        mock_client.headers = {}
+
+        # Create a fake exa_py module so the local import resolves
+        fake_exa_py = types.ModuleType("exa_py")
+        fake_exa_py.Exa = MagicMock(return_value=mock_client)
+
+        with patch.dict(os.environ, {"EXA_API_KEY": "test-key"}):
+            with patch.dict(sys.modules, {"exa_py": fake_exa_py}):
+                client = _get_client()
+                assert client.headers["x-exa-integration"] == "openagents"


### PR DESCRIPTION
## Summary

- Adds Exa as a new AI-powered search provider for OpenAgents, supporting multiple search types (`auto`, `neural`, `fast`, `instant`, `deep-lite`, `deep`, `deep-reasoning`), content extraction modes (`highlights`, `text`, `summary`), and filtering by domain, category, text, and date range
- Includes 19 unit tests covering API response parsing, content fallback logic, all filtering options, error handling, and disabled state when `EXA_API_KEY` is unset
- Integrates into the existing research team demo alongside DuckDuckGo and Brave Search

## Usage

Set `EXA_API_KEY` in your environment, then reference the tool in an agent YAML config:

```yaml
tools:
  - name: "search_exa"
    description: "AI-powered web search using Exa"
    implementation: "tools.exa_search.search_exa"
    input_schema:
      type: object
      properties:
        query:
          type: string
          description: "The search query"
        search_type:
          type: string
          description: "'auto', 'neural', 'fast', 'instant', 'deep-lite', 'deep', or 'deep-reasoning'"
        content_mode:
          type: string
          description: "'highlights', 'text', 'summary', or 'none'"
        category:
          type: string
          description: "'company', 'research paper', 'news', 'personal site', 'financial report', 'people'"
      required:
        - query
```

Or use it directly in Python:

```python
from openagents.tools.exa_search import search_exa

results = search_exa(
    "latest AI agent frameworks",
    search_type="auto",
    content_mode="highlights",
    category="news",
    num_results=5,
)
print(results)
```

## Files changed

- `sdk/src/openagents/tools/exa_search.py` -- new Exa search tool module
- `tests/agents/test_exa_search.py` -- 19 unit tests
- `sdk/demos/03_research_team/agents/web_searcher.yaml` -- added Exa tool to demo agent
- `sdk/demos/03_research_team/tools/exa_search.py` -- re-export for demo usage
- `pyproject.toml` -- added `exa-py>=2.0.0` as optional `[exa]` dependency

## Test plan

- [x] All 19 unit tests pass (`pytest tests/agents/test_exa_search.py`)
- [x] `ruff check` passes on all new/modified files
- [x] API response parsing with highlights, summary, and text content modes
- [x] Content snippet fallback logic (highlights -> summary -> text -> empty)
- [x] Domain, category, text, and date range filtering passed correctly to API
- [x] Graceful error handling (missing API key, API errors, empty results, null titles)
- [x] `num_results` capped at 100
- [x] Integration tracking header `x-exa-integration: openagents` set on client