### PR TITLE
fix: workspace delete auth and file path traversal

### DIFF
--- a/workspace/backend/app/routers/files.py
+++ b/workspace/backend/app/routers/files.py
@@ -102,9 +102,12 @@ async def upload_file(
     file_id = str(uuid.uuid4())
     store = get_file_store()
     loop = asyncio.get_event_loop()
-    storage_key = await loop.run_in_executor(
-        None, store.save, str(workspace.id), file_id, filename, data,
-    )
+    try:
+        storage_key = await loop.run_in_executor(
+            None, store.save, str(workspace.id), file_id, filename, data,
+        )
+    except ValueError as exc:
+        return json_response(ResponseCode.BAD_REQUEST, str(exc))
 
     # Insert DB record
     record = FileRecord(
@@ -176,9 +179,12 @@ async def upload_file_base64(
     file_id = str(uuid.uuid4())
     store = get_file_store()
     loop = asyncio.get_event_loop()
-    storage_key = await loop.run_in_executor(
-        None, store.save, str(workspace.id), file_id, body.filename, data,
-    )
+    try:
+        storage_key = await loop.run_in_executor(
+            None, store.save, str(workspace.id), file_id, body.filename, data,
+        )
+    except ValueError as exc:
+        return json_response(ResponseCode.BAD_REQUEST, str(exc))
 
     record = FileRecord(
         id=file_id,

--- a/workspace/backend/app/routers/workspaces.py
+++ b/workspace/backend/app/routers/workspaces.py
@@ -271,7 +271,7 @@ async def get_workspace(
         select(Workspace).where(_workspace_filter(workspace_id))
     ).scalar_one_or_none()
 
-    if not workspace:
+    if not workspace or workspace.status == "deleted":
         return json_response(ResponseCode.NOT_FOUND, "Workspace not found")
 
     if not _verify_workspace_access(workspace, x_workspace_token, authorization):
@@ -589,14 +589,19 @@ async def update_channel(
 async def delete_workspace(
     workspace_id: str,
     db: Session = Depends(get_db),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
 ):
-    """Soft-delete a workspace (set status to 'deleted')."""
+    """Soft-delete a workspace (set status to 'deleted'). Requires workspace token or Firebase owner auth."""
     workspace = db.execute(
         select(Workspace).where(_workspace_filter(workspace_id))
     ).scalar_one_or_none()
 
-    if not workspace:
+    if not workspace or workspace.status == "deleted":
         return json_response(ResponseCode.NOT_FOUND, "Workspace not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid credentials")
 
     workspace.status = "deleted"
     db.commit()

--- a/workspace/backend/app/storage.py
+++ b/workspace/backend/app/storage.py
@@ -39,8 +39,24 @@ class LocalFileStore:
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
     def save(self, workspace_id: str, file_id: str, filename: str, data: bytes) -> str:
-        key = f"{workspace_id}/{file_id}/{filename}"
+        # Reject filenames containing any directory component.
+        # Path(x).name strips dirs, so if it differs from the input the caller
+        # passed a path (e.g. "../../etc/passwd", "/etc/passwd", "sub/file.txt").
+        safe_filename = Path(filename).name
+        if safe_filename != filename:
+            raise ValueError(f"Filename must not contain directory components: {filename!r}")
+        if not safe_filename or safe_filename in (".", ".."):
+            raise ValueError(f"Invalid filename: {filename!r}")
+
+        key = f"{workspace_id}/{file_id}/{safe_filename}"
         path = self.base_dir / key
+
+        # Belt-and-suspenders: verify the resolved path stays inside base_dir.
+        try:
+            path.resolve().relative_to(self.base_dir.resolve())
+        except ValueError:
+            raise ValueError(f"Path traversal detected for filename: {filename!r}")
+
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
         return key

--- a/workspace/backend/tests/test_file_security.py
+++ b/workspace/backend/tests/test_file_security.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""
+Security tests for file storage: path traversal prevention (CVE-6).
+
+These tests verify that LocalFileStore.save never writes outside its base_dir,
+regardless of what filename an agent supplies.
+"""
+
+import pytest
+from pathlib import Path
+
+from app.storage import LocalFileStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    """A LocalFileStore rooted at a temporary directory."""
+    return LocalFileStore(base_dir=str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Happy path — must still work after the fix
+# ---------------------------------------------------------------------------
+
+class TestLocalFileStoreNormalUsage:
+
+    def test_normal_filename_is_saved(self, store, tmp_path):
+        """Plain filenames work as before."""
+        key = store.save("ws1", "file-1", "report.pdf", b"data")
+        assert key == "ws1/file-1/report.pdf"
+        assert (tmp_path / key).exists()
+        assert (tmp_path / key).read_bytes() == b"data"
+
+    def test_filename_with_extension_is_saved(self, store, tmp_path):
+        key = store.save("ws1", "file-2", "image.png", b"\x89PNG")
+        assert (tmp_path / key).exists()
+
+    def test_filename_with_spaces_is_saved(self, store, tmp_path):
+        key = store.save("ws1", "file-3", "my report.docx", b"doc")
+        assert (tmp_path / key).exists()
+
+    def test_storage_key_uses_safe_filename(self, store):
+        """The returned key always uses the sanitized filename."""
+        key = store.save("ws-abc", "file-xyz", "notes.txt", b"hello")
+        assert key == "ws-abc/file-xyz/notes.txt"
+
+    def test_read_roundtrip(self, store):
+        """Data written by save can be read back via read."""
+        payload = b"agent output data"
+        key = store.save("ws1", "f1", "output.txt", payload)
+        assert store.read(key) == payload
+
+    def test_exists_returns_true_after_save(self, store):
+        key = store.save("ws1", "f1", "file.bin", b"x")
+        assert store.exists(key) is True
+
+    def test_exists_returns_false_for_unknown_key(self, store):
+        assert store.exists("ws1/f1/nonexistent.txt") is False
+
+
+# ---------------------------------------------------------------------------
+# Path traversal — all must raise ValueError (CVE-6)
+# ---------------------------------------------------------------------------
+
+class TestLocalFileStorePathTraversal:
+
+    def test_dotdot_slash_is_blocked(self, store):
+        """../../etc/passwd style traversal is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "../../etc/passwd", b"evil")
+
+    def test_single_dotdot_is_blocked(self, store):
+        """../escape.txt is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "../escape.txt", b"evil")
+
+    def test_absolute_unix_path_is_blocked(self, store):
+        """/etc/passwd as filename is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "/etc/passwd", b"evil")
+
+    def test_windows_absolute_path_is_blocked(self, store):
+        """C:\\Windows\\System32\\evil.dll is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "C:\\Windows\\System32\\evil.dll", b"evil")
+
+    def test_deeply_nested_traversal_is_blocked(self, store):
+        """a/b/c/../../../../etc/shadow is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "a/b/c/../../../../etc/shadow", b"evil")
+
+    def test_dot_only_filename_is_blocked(self, store):
+        """'.' as filename is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", ".", b"data")
+
+    def test_dotdot_only_filename_is_blocked(self, store):
+        """'..' as filename is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "..", b"data")
+
+    def test_empty_filename_is_blocked(self, store):
+        """Empty string filename is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "", b"data")
+
+    def test_slash_only_filename_is_blocked(self, store):
+        """'/' reduces to an empty name and is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "/", b"data")
+
+    def test_embedded_slash_is_blocked(self, store):
+        """'subdir/file.txt' contains a directory component and is rejected."""
+        with pytest.raises(ValueError):
+            store.save("ws1", "f1", "subdir/file.txt", b"data")
+
+    def test_null_byte_in_filename_is_blocked(self, store):
+        """Null byte in filename is rejected."""
+        with pytest.raises((ValueError, OSError)):
+            store.save("ws1", "f1", "file\x00.txt", b"data")
+
+
+# ---------------------------------------------------------------------------
+# Canary test — traversal attempt must never write outside base_dir
+# ---------------------------------------------------------------------------
+
+class TestNoEscapeFromBaseDir:
+    """After any traversal attempt, nothing must be written outside base_dir."""
+
+    def test_dotdot_does_not_create_file_in_parent(self, store, tmp_path):
+        canary = tmp_path.parent / "_canary_cve6_test.txt"
+        canary.unlink(missing_ok=True)
+        try:
+            store.save("ws1", "f1", "../_canary_cve6_test.txt", b"evil")
+        except (ValueError, OSError):
+            pass
+        assert not canary.exists(), "Traversal wrote a file outside base_dir"
+
+    def test_absolute_path_does_not_overwrite_existing_file(self, store, tmp_path):
+        # Create a sentinel file outside base_dir
+        sentinel = tmp_path.parent / "_sentinel_cve6.txt"
+        sentinel.write_text("original")
+        try:
+            store.save("ws1", "f1", str(sentinel), b"overwritten")
+        except (ValueError, OSError):
+            pass
+        assert sentinel.read_text() == "original", "Traversal overwrote a file outside base_dir"
+        sentinel.unlink(missing_ok=True)
+
+    def test_no_file_written_on_invalid_filename(self, store, tmp_path):
+        """A rejected filename must leave the store directory unchanged."""
+        before = set(tmp_path.rglob("*"))
+        with pytest.raises((ValueError, OSError)):
+            store.save("ws1", "f1", "../../injected.txt", b"evil")
+        after = set(tmp_path.rglob("*"))
+        assert before == after, "Files were created despite traversal rejection"

--- a/workspace/backend/tests/test_file_security.py
+++ b/workspace/backend/tests/test_file_security.py
@@ -7,7 +7,6 @@ regardless of what filename an agent supplies.
 """
 
 import pytest
-from pathlib import Path
 
 from app.storage import LocalFileStore
 

--- a/workspace/backend/tests/test_login_session_auth.py
+++ b/workspace/backend/tests/test_login_session_auth.py
@@ -681,8 +681,11 @@ class TestTokenResolveEdgeCases:
 
     def test_resolve_deleted_workspace_token(self, client, workspace):
         """Token for a deleted workspace returns 404."""
-        # Delete the workspace
-        client.delete(f"/v1/workspaces/{workspace['id']}")
+        # Delete the workspace (auth required)
+        client.delete(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
 
         # Token should no longer resolve
         resp = client.post("/v1/token/resolve", json={"token": workspace["token"]})

--- a/workspace/backend/tests/test_workspaces.py
+++ b/workspace/backend/tests/test_workspaces.py
@@ -106,16 +106,82 @@ class TestDeleteWorkspace:
 
     def test_delete_workspace(self, client, workspace):
         """Soft-delete sets status to 'deleted'."""
-        resp = client.delete(f"/v1/workspaces/{workspace['id']}")
+        resp = client.delete(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
         assert resp.status_code == 200
         assert resp.json()["data"]["status"] == "deleted"
 
     def test_deleted_workspace_hidden_from_list(self, client, workspace):
         """Deleted workspace doesn't appear in list."""
-        client.delete(f"/v1/workspaces/{workspace['id']}")
+        client.delete(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
         resp = client.get("/v1/workspaces")
         ids = [w["workspaceId"] for w in resp.json()["data"]]
         assert workspace["id"] not in ids
+
+    # ------------------------------------------------------------------
+    # Auth enforcement (CVE-1)
+    # ------------------------------------------------------------------
+
+    def test_delete_no_credentials_returns_401(self, client, workspace):
+        """Unauthenticated DELETE is rejected — workspace must not be deleted."""
+        resp = client.delete(f"/v1/workspaces/{workspace['id']}")
+        assert resp.status_code == 401
+
+        # Workspace must still exist
+        get = client.get(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+        assert get.status_code == 200
+
+    def test_delete_wrong_token_returns_401(self, client, workspace):
+        """Wrong token is rejected — workspace must not be deleted."""
+        resp = client.delete(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": "not-the-right-token"},
+        )
+        assert resp.status_code == 401
+
+    def test_delete_by_slug_with_valid_token(self, client, workspace):
+        """Deletion by slug also works with a valid token."""
+        resp = client.delete(
+            f"/v1/workspaces/{workspace['slug']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["status"] == "deleted"
+
+    def test_delete_nonexistent_workspace_returns_404(self, client):
+        """Deleting a nonexistent workspace returns 404 regardless of token."""
+        resp = client.delete(
+            "/v1/workspaces/00000000-0000-0000-0000-000000000000",
+            headers={"X-Workspace-Token": "any-token"},
+        )
+        assert resp.status_code == 404
+
+    def test_deleted_workspace_is_no_longer_accessible(self, client, workspace):
+        """After deletion the workspace returns 404 on GET."""
+        client.delete(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+        resp = client.get(
+            f"/v1/workspaces/{workspace['id']}",
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_already_deleted_workspace_returns_404(self, client, workspace):
+        """A second DELETE on an already-deleted workspace returns 404."""
+        headers = {"X-Workspace-Token": workspace["token"]}
+        client.delete(f"/v1/workspaces/{workspace['id']}", headers=headers)
+        resp = client.delete(f"/v1/workspaces/{workspace['id']}", headers=headers)
+        assert resp.status_code == 404
 
 
 class TestListWorkspaces:


### PR DESCRIPTION
# Fix: Security Gaps in Workspace Backend (Issue #337)

Addresses two confirmed vulnerabilities in the workspace backend that affect all
deployment modes, including private self-hosted instances.

---

## Fix 1: Missing Authentication on DELETE /v1/workspaces/{id}

**File:** `workspace/backend/app/routers/workspaces.py`

The `delete_workspace` endpoint accepted requests with no credentials. Any caller
that knew or could guess a workspace ID or slug could permanently soft-delete it.
Every other mutating endpoint (`PATCH`, `rotate-token`, `remove-member`) already
called `_verify_workspace_access()` -- DELETE was the only one that did not.

**Fix:** Added `x_workspace_token` and `authorization` header parameters and called
`_verify_workspace_access()` before executing the delete, consistent with the
existing pattern. Also added a `status == "deleted"` guard so that already-deleted
workspaces return 404 on both GET and DELETE instead of leaking state.

---

## Fix 2: Path Traversal in LocalFileStore.save

**File:** `workspace/backend/app/storage.py`

The `save` method built the storage path by joining `base_dir` with a
caller-supplied filename without any validation. A filename like
`../../etc/cron.d/backdoor` would resolve outside `base_dir` and write to an
arbitrary location on the host filesystem. This is a realistic attack vector
because agents upload files autonomously via the API.

**Fix:** The filename is now validated before any path is constructed:

1. `Path(filename).name` extracts the bare filename (no directory components).
2. If the result differs from the input, the filename contained a separator and
   the call is rejected with `ValueError`.
3. Dot-only names (`.`, `..`) and empty strings are also rejected.
4. A belt-and-suspenders boundary check using `path.resolve().relative_to(base_dir.resolve())`
   catches any edge case that passes the first two checks.

The router (`/v1/files` and `/v1/files/base64`) was also updated to catch
`ValueError` from `store.save()` and return a proper `400 Bad Request` instead of
propagating an unhandled 500.

---

## Tests

**`tests/test_workspaces.py`**

- Existing delete tests updated to pass the workspace token (they relied on the
  old no-auth behavior).
- Six new cases added: unauthenticated delete returns 401, wrong token returns 401,
  delete by slug with valid token, delete on nonexistent workspace returns 404,
  deleted workspace returns 404 on subsequent GET, double-delete returns 404.

**`tests/test_file_security.py`** (new file)

- Seven happy-path tests confirming normal filenames still work after the fix.
- Eleven traversal tests covering `../../etc/passwd`, `../x`, `/etc/passwd`,
  `C:\Windows\...`, deeply nested traversal, `.`, `..`, empty string, `/`,
  embedded slash, and null byte -- all must raise `ValueError`.
- Three canary tests verifying that no file is ever written outside `base_dir`
  regardless of the input, by inspecting the filesystem directly after each attempt.

---

## Scope Note

Issue #337 documents additional vulnerabilities (unauthenticated workspace enumeration,
stored XSS via inline HTML, Firebase revocation disabled, wildcard CORS default,
timing-unsafe token comparison) that are valid but only materially exploitable on
public multi-user deployments (`AUTH_MODE=firebase`, as defined in `app/config.py`).
