### PR TITLE
Improve launcher log management and fix agent create install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ agn env openclaw --set LLM_API_KEY=sk-... # set credentials
 agn up                                    # start the daemon
 ```
 
+`agn create` only writes the agent config. Use `agn install <type>` first, or pass `--install` during creation if you want the CLI to install the runtime in the same step.
+
 **Desktop app**: [macOS](https://openagents.org/api/download/launcher/mac) · [Windows](https://openagents.org/api/download/launcher/windows) · [Linux](https://openagents.org/api/download/launcher/linux-appimage) · [All releases](https://github.com/openagents-org/openagents/releases)
 
 ### Supported Agents

--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -117,7 +117,7 @@ async function cmdStatus(connector) {
 
 async function cmdCreate(connector, flags, positional) {
   const name = positional[0];
-  if (!name) { print('Usage: agn create <name> [--type <type>]'); return; }
+  if (!name) { print('Usage: agn create <name> [--type <type>] [--install]'); return; }
   const type = flags.type || 'openclaw';
   const role = flags.role || 'worker';
 
@@ -128,8 +128,12 @@ async function cmdCreate(connector, flags, positional) {
     // Signal daemon to pick up the new agent
     try { connector.sendDaemonCommand('reload'); } catch {}
 
-    // Auto-install if not installed
     if (!connector.isInstalled(type)) {
+      if (!flags.install) {
+        print(`Runtime '${type}' is not installed. Run: agn install ${type}`);
+        return;
+      }
+
       print(`Installing ${type}...`);
       try {
         await connector.install(type);
@@ -513,6 +517,7 @@ Commands:
 
 Options:
   --config <dir>              Config directory (default: ~/.openagents)
+  --install                   Install runtime during create
 `);
 }
 

--- a/packages/agent-connector/src/config.js
+++ b/packages/agent-connector/src/config.js
@@ -213,6 +213,43 @@ class Config {
       return { lines: [], size: 0 };
     }
   }
+
+  /**
+   * Remove log entries whose leading timestamp falls within [start, end].
+   * Lines without a parseable timestamp are preserved to avoid deleting
+   * stack traces or continuation lines incorrectly.
+   * @param {Object} opts - { start, end }
+   * @param {string|number|Date} opts.start
+   * @param {string|number|Date} opts.end
+   * @returns {{ removed: number, remaining: number }}
+   */
+  clearLogsInRange(opts = {}) {
+    const start = normalizeTimeValue(opts.start);
+    const end = normalizeTimeValue(opts.end);
+
+    if (!start || !end) {
+      throw new Error('Start time and end time are required');
+    }
+    if (start.getTime() > end.getTime()) {
+      throw new Error('Start time must be before end time');
+    }
+    if (!fs.existsSync(this.logFile)) {
+      return { removed: 0, remaining: 0 };
+    }
+
+    const content = fs.readFileSync(this.logFile, 'utf-8');
+    const hasTrailingNewline = content.endsWith('\n');
+    const allLines = content.split('\n');
+    if (hasTrailingNewline) allLines.pop();
+    const { keptLines, removed } = filterLogsByTimeRange(allLines, start, end);
+
+    const nextContent = keptLines.join('\n') + (hasTrailingNewline && keptLines.length > 0 ? '\n' : '');
+    const tempFile = `${this.logFile}.tmp`;
+    fs.writeFileSync(tempFile, nextContent, 'utf-8');
+    fs.renameSync(tempFile, this.logFile);
+
+    return { removed, remaining: keptLines.length };
+  }
 }
 
 // -- YAML parser (compatible with Python SDK's daemon.yaml format) --
@@ -273,6 +310,115 @@ function parseYaml(text) {
 
   if (currentItem && currentList) result[currentList].push(currentItem);
   return result;
+}
+
+function normalizeTimeValue(value) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function filterLogsByTimeRange(lines, start, end) {
+  const headerTimes = resolveLogHeaderTimestamps(lines, end);
+  let activeRemove = false;
+  let removed = 0;
+  const keptLines = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const headerTime = headerTimes[index];
+    if (headerTime) {
+      const time = headerTime.getTime();
+      activeRemove = time >= start.getTime() && time <= end.getTime();
+    }
+
+    if (activeRemove) {
+      removed += 1;
+    } else {
+      keptLines.push(lines[index]);
+    }
+  }
+
+  return { keptLines, removed };
+}
+
+function resolveLogHeaderTimestamps(lines, referenceTime) {
+  const resolved = new Array(lines.length).fill(null);
+  let currentDay = startOfLocalDay(referenceTime);
+  let lastClockSeconds = null;
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const token = parseLogTimestampToken(lines[index]);
+    if (!token) continue;
+
+    if (token.kind === 'iso') {
+      resolved[index] = token.date;
+      currentDay = startOfLocalDay(token.date);
+      lastClockSeconds = (
+        token.date.getHours() * 3600 +
+        token.date.getMinutes() * 60 +
+        token.date.getSeconds()
+      );
+      continue;
+    }
+
+    if (lastClockSeconds !== null && token.seconds > lastClockSeconds) {
+      currentDay = addLocalDays(currentDay, -1);
+    }
+
+    resolved[index] = withLocalClock(currentDay, token.seconds);
+    lastClockSeconds = token.seconds;
+  }
+
+  return resolved;
+}
+
+function parseLogTimestampToken(line) {
+  if (!line) return null;
+
+  const isoMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2}))/);
+  if (isoMatch) {
+    const date = new Date(isoMatch[1]);
+    if (!Number.isNaN(date.getTime())) {
+      return { kind: 'iso', date };
+    }
+  }
+
+  const clockMatch = line.match(/^\[(\d{2}):(\d{2}):(\d{2})\]/);
+  if (clockMatch) {
+    return {
+      kind: 'clock',
+      seconds:
+        Number(clockMatch[1]) * 3600 +
+        Number(clockMatch[2]) * 60 +
+        Number(clockMatch[3]),
+    };
+  }
+
+  return null;
+}
+
+function startOfLocalDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addLocalDays(date, days) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+function withLocalClock(day, seconds) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  return new Date(day.getFullYear(), day.getMonth(), day.getDate(), hours, minutes, secs);
 }
 
 function parseYamlValue(val) {

--- a/packages/agent-connector/src/config.js
+++ b/packages/agent-connector/src/config.js
@@ -50,13 +50,14 @@ class Config {
     fs.writeFileSync(this.configFile, serializeYaml(config), 'utf-8');
   }
 
-  addAgent({ name, type, role, path: agentPath }) {
+  addAgent({ name, type, role, path: agentPath, env }) {
     const config = this.load();
     if (config.agents.some((a) => a.name === name)) {
       throw new Error(`Agent '${name}' already exists`);
     }
     const entry = { name, type: type || 'openclaw', role: role || 'worker' };
     if (agentPath) entry.path = agentPath;
+    if (env && Object.keys(env).length > 0) entry.env = env;
     config.agents.push(entry);
     this.save(config);
     return entry;
@@ -78,6 +79,27 @@ class Config {
     Object.assign(agent, updates);
     this.save(config);
     return agent;
+  }
+
+  updateAgentEnv(name, env) {
+    const config = this.load();
+    const agent = config.agents.find((a) => a.name === name);
+    if (!agent) throw new Error(`Agent '${name}' not found`);
+
+    const merged = { ...(agent.env || {}), ...(env || {}) };
+    const cleaned = {};
+    for (const [key, value] of Object.entries(merged)) {
+      if (value !== null && value !== undefined && value !== '') cleaned[key] = value;
+    }
+
+    if (Object.keys(cleaned).length > 0) {
+      agent.env = cleaned;
+    } else {
+      delete agent.env;
+    }
+
+    this.save(config);
+    return agent.env || {};
   }
 
   setAgentNetwork(agentName, networkSlug) {

--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -70,7 +70,7 @@ class Daemon {
     this._writeStatus();
     this._cachedAgentNames = new Set(agents.map(a => a.name));
     this._cachedAgentConfigs = {};
-    for (const a of agents) this._cachedAgentConfigs[a.name] = a.network || '';
+    for (const a of agents) this._cachedAgentConfigs[a.name] = this._agentConfigFingerprint(a);
     this._log(`Daemon started with ${agents.length} agent(s)`);
 
     // Block until shutdown
@@ -553,9 +553,17 @@ class Daemon {
   _buildAgentEnv(agentCfg) {
     const type = agentCfg.type || 'openclaw';
     const saved = this.envManager.load(type);
-    const resolved = this.envManager.resolve(type, saved, this.registry);
-    const merged = { ...saved, ...resolved, ...(agentCfg.env || {}) };
+    const mergedSaved = { ...saved, ...(agentCfg.env || {}) };
+    const resolved = this.envManager.resolve(type, mergedSaved, this.registry);
+    const merged = { ...mergedSaved, ...resolved };
     return { ...process.env, ...merged };
+  }
+
+  _agentConfigFingerprint(agentCfg) {
+    return JSON.stringify({
+      network: agentCfg.network || '',
+      env: agentCfg.env || {},
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -682,7 +690,7 @@ class Daemon {
     const newAgents = this.config.getAgents();
     const newNames = new Set(newAgents.map(a => a.name));
     const newConfigs = {};
-    for (const a of newAgents) newConfigs[a.name] = a.network || '';
+    for (const a of newAgents) newConfigs[a.name] = this._agentConfigFingerprint(a);
 
     // Stop removed agents
     for (const name of oldNames) {
@@ -698,13 +706,13 @@ class Daemon {
         await this._ensureAdapterCleared(agent.name);
         this._launchAgent(agent);
         this._log(`Reload: started new agent '${agent.name}'`);
-      } else if ((oldConfigs[agent.name] || '') !== (agent.network || '')) {
-        // Network config changed — restart agent
+      } else if ((oldConfigs[agent.name] || '') !== newConfigs[agent.name]) {
+        // Network or env config changed — restart agent
         await this.stopAgent(agent.name);
         this._stoppedAgents.delete(agent.name);
         await this._ensureAdapterCleared(agent.name);
         this._launchAgent(agent);
-        this._log(`Reload: restarted '${agent.name}' (network changed)`);
+        this._log(`Reload: restarted '${agent.name}' (config changed)`);
       }
     }
 

--- a/packages/agent-connector/src/index.js
+++ b/packages/agent-connector/src/index.js
@@ -225,6 +225,14 @@ class AgentConnector {
     return this.config.getLogs(agentName, lines);
   }
 
+  tailLogs(opts = {}) {
+    return this.config.tailLogs(opts);
+  }
+
+  clearLogsInRange(opts = {}) {
+    return this.config.clearLogsInRange(opts);
+  }
+
   // -- Workspace API --
 
   async createWorkspace(opts) {

--- a/packages/agent-connector/src/index.js
+++ b/packages/agent-connector/src/index.js
@@ -74,22 +74,24 @@ class AgentConnector {
     const agents = this.config.getAgents();
     const networks = this.config.getNetworks();
     return agents.map((a) => {
-      const agentEnv = this.env.load(a.type);
+      const type = a.type || 'openclaw';
+      const typeEnv = this.env.load(type);
       const network = networks.find((n) => n.slug === a.network || n.id === a.network);
       return {
         name: a.name,
-        type: a.type || 'openclaw',
+        type,
         role: a.role || 'worker',
         network: a.network || null,
         networkName: network ? (network.name || network.slug) : null,
         path: a.path || null,
-        env: { ...agentEnv, ...(a.env || {}) },
+        env: { ...typeEnv, ...(a.env || {}) },
+        instanceEnv: { ...(a.env || {}) },
       };
     });
   }
 
-  addAgent({ name, type, role, path }) {
-    this.config.addAgent({ name, type: type || 'openclaw', role: role || 'worker', path });
+  addAgent({ name, type, role, path, env }) {
+    this.config.addAgent({ name, type: type || 'openclaw', role: role || 'worker', path, env });
     return { success: true };
   }
 
@@ -104,6 +106,12 @@ class AgentConnector {
     return this.env.load(agentType);
   }
 
+  getAgentInstanceEnv(agentName) {
+    const agent = this.config.getAgent(agentName);
+    if (!agent) throw new Error(`Agent '${agentName}' not found`);
+    return { ...(agent.env || {}) };
+  }
+
   saveAgentEnv(agentType, env) {
     this.env.save(agentType, env);
     // Configure native auth for agents that need it (e.g. OpenClaw auth-profiles.json)
@@ -114,6 +122,24 @@ class AgentConnector {
         OpenClawAdapter.configureNativeAuth(saved);
       }
     } catch {}
+    return { success: true };
+  }
+
+  saveAgentInstanceEnv(agentName, env) {
+    const agent = this.config.getAgent(agentName);
+    if (!agent) throw new Error(`Agent '${agentName}' not found`);
+    const saved = this.config.updateAgentEnv(agentName, env);
+
+    // Preserve native auth side effects for agents that need them while
+    // keeping the model choice scoped to this individual agent.
+    try {
+      if ((agent.type || 'openclaw') === 'openclaw') {
+        const OpenClawAdapter = require('./adapters/openclaw');
+        const typeEnv = this.env.load(agent.type || 'openclaw');
+        OpenClawAdapter.configureNativeAuth({ ...typeEnv, ...saved });
+      }
+    } catch {}
+
     return { success: true };
   }
 

--- a/packages/agent-connector/test/cli.test.js
+++ b/packages/agent-connector/test/cli.test.js
@@ -70,6 +70,7 @@ describe('CLI', () => {
     try {
       const createOut = runWithConfig(tmpDir, 'create', 'test-agent', '--type', 'claude');
       assert.ok(createOut.includes("'test-agent' created"));
+      assert.ok(!createOut.includes('Installing claude...'));
 
       const listOut = runWithConfig(tmpDir, 'list');
       assert.ok(listOut.includes('test-agent'));
@@ -95,6 +96,11 @@ describe('CLI', () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it('help mentions optional create install flag', () => {
+    const out = run('help');
+    assert.ok(out.includes('--install'));
   });
 
   it('status with temp config shows no daemon', () => {

--- a/packages/agent-connector/test/config.test.js
+++ b/packages/agent-connector/test/config.test.js
@@ -51,19 +51,28 @@ networks:
     assert.equal(result.agents[0].builtin, true);
     assert.equal(result.agents[0].path, null);
   });
+
+  it('parses inline object values such as per-agent env', () => {
+    const result = parseYaml('version: 2\nagents:\n- name: a\n  type: opencode\n  env: {"LLM_MODEL":"model-a","LLM_BASE_URL":"https://openrouter.ai/api/v1"}\nnetworks: []');
+    assert.deepEqual(result.agents[0].env, {
+      LLM_MODEL: 'model-a',
+      LLM_BASE_URL: 'https://openrouter.ai/api/v1',
+    });
+  });
 });
 
 describe('serializeYaml', () => {
   it('round-trips through parse/serialize', () => {
     const config = {
       version: 2,
-      agents: [{ name: 'bot', type: 'claude', role: 'worker' }],
+      agents: [{ name: 'bot', type: 'claude', role: 'worker', env: { LLM_MODEL: 'claude-sonnet' } }],
       networks: [{ id: '1', slug: 'ws1', name: 'Workspace 1' }],
     };
     const yaml = serializeYaml(config);
     const parsed = parseYaml(yaml);
     assert.equal(parsed.agents[0].name, 'bot');
     assert.equal(parsed.agents[0].type, 'claude');
+    assert.deepEqual(parsed.agents[0].env, { LLM_MODEL: 'claude-sonnet' });
     assert.equal(parsed.networks[0].slug, 'ws1');
   });
 
@@ -100,6 +109,18 @@ describe('Config', () => {
     cfg.addAgent({ name: 'b1', type: 'claude', role: 'worker' });
     cfg.updateAgent('b1', { role: 'orchestrator' });
     assert.equal(cfg.getAgent('b1').role, 'orchestrator');
+  });
+
+  it('updateAgentEnv stores per-agent env independently', () => {
+    const cfg = new Config(tmpDir);
+    cfg.addAgent({ name: 'a1', type: 'opencode', role: 'worker' });
+    cfg.addAgent({ name: 'a2', type: 'opencode', role: 'worker' });
+
+    cfg.updateAgentEnv('a1', { LLM_MODEL: 'model-a' });
+    cfg.updateAgentEnv('a2', { LLM_MODEL: 'model-b' });
+
+    assert.equal(cfg.getAgent('a1').env.LLM_MODEL, 'model-a');
+    assert.equal(cfg.getAgent('a2').env.LLM_MODEL, 'model-b');
   });
 
   it('addNetwork / removeNetwork disconnects agents', () => {

--- a/packages/agent-connector/test/config.test.js
+++ b/packages/agent-connector/test/config.test.js
@@ -142,4 +142,61 @@ describe('Config', () => {
     const cfg2 = new Config(tmpDir);
     assert.equal(cfg2.getAgent('persist').type, 'aider');
   });
+
+  it('clearLogsInRange removes only timestamped lines in the selected window', () => {
+    const cfg = new Config(tmpDir);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(cfg.logFile, [
+      '2026-04-22T10:00:00.000Z INFO daemon boot',
+      '2026-04-22T10:05:00.000Z INFO agent-a started',
+      'stack trace line without timestamp',
+      '2026-04-22T10:10:00.000Z INFO agent-b started',
+      '',
+    ].join('\n'), 'utf-8');
+
+    const result = cfg.clearLogsInRange({
+      start: '2026-04-22T10:04:00.000Z',
+      end: '2026-04-22T10:06:00.000Z',
+    });
+
+    assert.equal(result.removed, 2);
+    assert.equal(result.remaining, 2);
+    assert.equal(fs.readFileSync(cfg.logFile, 'utf-8'), [
+      '2026-04-22T10:00:00.000Z INFO daemon boot',
+      '2026-04-22T10:10:00.000Z INFO agent-b started',
+      '',
+    ].join('\n'));
+  });
+
+  it('clearLogsInRange rejects an invalid range', () => {
+    const cfg = new Config(tmpDir);
+    assert.throws(() => cfg.clearLogsInRange({
+      start: '2026-04-22T10:06:00.000Z',
+      end: '2026-04-22T10:04:00.000Z',
+    }), /Start time must be before end time/);
+  });
+
+  it('clearLogsInRange removes rich multi-line log blocks using local time headers', () => {
+    const cfg = new Config(tmpDir);
+    fs.writeFileSync(cfg.logFile, [
+      '[15:59:58] INFO     healthy line',
+      '[16:00:10] WARNING  Poll failed: Cannot connect to host',
+      '                    workspace-endpoint.openagents.org:443 ssl:True',
+      "                    [SSLCertVerificationError: boom]",
+      '[16:01:10] INFO     recovered',
+      '',
+    ].join('\n'), 'utf-8');
+
+    const result = cfg.clearLogsInRange({
+      start: new Date(2026, 3, 22, 16, 0, 0).toISOString(),
+      end: new Date(2026, 3, 22, 16, 0, 59).toISOString(),
+    });
+
+    assert.equal(result.removed, 3);
+    assert.equal(fs.readFileSync(cfg.logFile, 'utf-8'), [
+      '[15:59:58] INFO     healthy line',
+      '[16:01:10] INFO     recovered',
+      '',
+    ].join('\n'));
+  });
 });

--- a/packages/agent-connector/test/daemon.test.js
+++ b/packages/agent-connector/test/daemon.test.js
@@ -55,6 +55,28 @@ describe('Daemon', () => {
     assert.equal(result.OPENAI_API_KEY, 'sk-test');
   });
 
+  it('_buildAgentEnv lets per-agent env override type defaults', () => {
+    const config = new Config(tmpDir);
+    const env = new EnvManager(tmpDir);
+    const reg = new Registry(tmpDir);
+    const daemon = new Daemon(config, env, reg);
+
+    env.save('opencode', {
+      LLM_BASE_URL: 'https://openrouter.ai/api/v1',
+      LLM_MODEL: 'default-model',
+    });
+
+    const result = daemon._buildAgentEnv({
+      name: 'agent-a',
+      type: 'opencode',
+      env: { LLM_MODEL: 'custom-model' },
+    });
+
+    assert.equal(result.LLM_BASE_URL, 'https://openrouter.ai/api/v1');
+    assert.equal(result.LLM_MODEL, 'custom-model');
+    assert.equal(result.OPENCODE_MODEL, 'custom-model');
+  });
+
   it('_getLaunchCommand returns command from registry', () => {
     const config = new Config(tmpDir);
     const env = new EnvManager(tmpDir);

--- a/packages/agent-connector/test/index.test.js
+++ b/packages/agent-connector/test/index.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { AgentConnector } = require('../src/index');
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-index-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('AgentConnector instance env', () => {
+  it('merges type env with instance env without cross-agent overwrite', () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.saveAgentEnv('opencode', {
+      LLM_API_KEY: 'sk-test',
+      LLM_BASE_URL: 'https://openrouter.ai/api/v1',
+      LLM_MODEL: 'default-model',
+    });
+
+    connector.addAgent({ name: 'agent-a', type: 'opencode', role: 'worker' });
+    connector.addAgent({ name: 'agent-b', type: 'opencode', role: 'worker' });
+
+    connector.saveAgentInstanceEnv('agent-a', { LLM_MODEL: 'model-a' });
+    connector.saveAgentInstanceEnv('agent-b', { LLM_MODEL: 'model-b' });
+
+    const agents = connector.listAgents();
+    const agentA = agents.find((agent) => agent.name === 'agent-a');
+    const agentB = agents.find((agent) => agent.name === 'agent-b');
+
+    assert.equal(agentA.env.LLM_MODEL, 'model-a');
+    assert.equal(agentB.env.LLM_MODEL, 'model-b');
+    assert.equal(agentA.env.LLM_BASE_URL, 'https://openrouter.ai/api/v1');
+    assert.equal(agentB.env.LLM_BASE_URL, 'https://openrouter.ai/api/v1');
+    assert.deepEqual(connector.getAgentInstanceEnv('agent-a'), { LLM_MODEL: 'model-a' });
+    assert.deepEqual(connector.getAgentInstanceEnv('agent-b'), { LLM_MODEL: 'model-b' });
+  });
+});

--- a/packages/launcher/src/main/agent-manager.js
+++ b/packages/launcher/src/main/agent-manager.js
@@ -29,6 +29,9 @@ let core = loadCore();
 class AgentManager {
   constructor(store) {
     this._store = store;
+    this._healthByType = new Map();
+    this._healthRefreshInFlight = new Set();
+    this._lastHealthRefreshAt = 0;
     if (!core) core = loadCore();
     if (core) {
       this._connector = new core.AgentConnector({ configDir: CONFIG_DIR });
@@ -92,18 +95,7 @@ class AgentManager {
     if (!this._connector) return [];
     const agents = this._connector.listAgents();
     const status = this.getAllStatus();
-    const healthByType = new Map();
-
-    for (const agent of agents) {
-      const type = agent.type || 'openclaw';
-      if (!healthByType.has(type)) {
-        try {
-          healthByType.set(type, this._connector.healthCheck(type));
-        } catch {
-          healthByType.set(type, null);
-        }
-      }
-    }
+    this._scheduleHealthRefresh(agents);
 
     const supportedTypes = new Set(this.getSupportedAgentTypes());
     return agents.map((a) => {
@@ -118,10 +110,32 @@ class AgentManager {
         state: status[a.name]?.state || 'stopped',
         restarts: status[a.name]?.restarts || 0,
         lastError: statusError || runtimeMessage,
-        health: healthByType.get(type),
+        health: this._healthByType.get(type) || null,
         runtimeMismatch,
       };
     });
+  }
+
+  _scheduleHealthRefresh(agents) {
+    const now = Date.now();
+    if (now - this._lastHealthRefreshAt < 3000) return;
+    this._lastHealthRefreshAt = now;
+
+    const types = [...new Set((agents || []).map((agent) => agent.type || 'openclaw'))];
+    for (const type of types) {
+      if (this._healthRefreshInFlight.has(type)) continue;
+      this._healthRefreshInFlight.add(type);
+      setTimeout(() => {
+        try {
+          const health = this._connector ? this._connector.healthCheck(type) : null;
+          this._healthByType.set(type, health);
+        } catch {
+          this._healthByType.set(type, null);
+        } finally {
+          this._healthRefreshInFlight.delete(type);
+        }
+      }, 0);
+    }
   }
 
   // ------------------------------------------------------------------
@@ -374,6 +388,40 @@ class AgentManager {
     return { lines: logLines };
   }
 
+  tailLogs(name, lines = 200, offset = 0) {
+    return this._connector.config.tailLogs({ agent: name || undefined, lines, offset });
+  }
+
+  clearLogsInRange(start, end) {
+    const startTime = normalizeTimeValue(start);
+    const endTime = normalizeTimeValue(end);
+
+    if (!startTime || !endTime) {
+      throw new Error('Start time and end time are required');
+    }
+    if (startTime.getTime() > endTime.getTime()) {
+      throw new Error('Start time must be before end time');
+    }
+
+    const logFile = path.join(CONFIG_DIR, 'daemon.log');
+    if (!fs.existsSync(logFile)) {
+      return { removed: 0, remaining: 0 };
+    }
+
+    const content = fs.readFileSync(logFile, 'utf-8');
+    const hasTrailingNewline = content.endsWith('\n');
+    const allLines = content.split('\n');
+    if (hasTrailingNewline) allLines.pop();
+    const { keptLines, removed } = filterLogsByTimeRange(allLines, startTime, endTime);
+
+    const nextContent = keptLines.join('\n') + (hasTrailingNewline && keptLines.length > 0 ? '\n' : '');
+    const tempFile = `${logFile}.tmp`;
+    fs.writeFileSync(tempFile, nextContent, 'utf-8');
+    fs.renameSync(tempFile, logFile);
+
+    return { removed, remaining: keptLines.length };
+  }
+
   healthCheck(type) {
     return this._connector.healthCheck(type);
   }
@@ -465,6 +513,115 @@ class AgentManager {
       return { success: false, message: `Failed to start daemon: ${e.message}` };
     }
   }
+}
+
+function normalizeTimeValue(value) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function filterLogsByTimeRange(lines, start, end) {
+  const headerTimes = resolveLogHeaderTimestamps(lines, end);
+  let activeRemove = false;
+  let removed = 0;
+  const keptLines = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const headerTime = headerTimes[index];
+    if (headerTime) {
+      const time = headerTime.getTime();
+      activeRemove = time >= start.getTime() && time <= end.getTime();
+    }
+
+    if (activeRemove) {
+      removed += 1;
+    } else {
+      keptLines.push(lines[index]);
+    }
+  }
+
+  return { keptLines, removed };
+}
+
+function resolveLogHeaderTimestamps(lines, referenceTime) {
+  const resolved = new Array(lines.length).fill(null);
+  let currentDay = startOfLocalDay(referenceTime);
+  let lastClockSeconds = null;
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const token = parseLogTimestampToken(lines[index]);
+    if (!token) continue;
+
+    if (token.kind === 'iso') {
+      resolved[index] = token.date;
+      currentDay = startOfLocalDay(token.date);
+      lastClockSeconds = (
+        token.date.getHours() * 3600 +
+        token.date.getMinutes() * 60 +
+        token.date.getSeconds()
+      );
+      continue;
+    }
+
+    if (lastClockSeconds !== null && token.seconds > lastClockSeconds) {
+      currentDay = addLocalDays(currentDay, -1);
+    }
+
+    resolved[index] = withLocalClock(currentDay, token.seconds);
+    lastClockSeconds = token.seconds;
+  }
+
+  return resolved;
+}
+
+function parseLogTimestampToken(line) {
+  if (!line) return null;
+
+  const isoMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2}))/);
+  if (isoMatch) {
+    const date = new Date(isoMatch[1]);
+    if (!Number.isNaN(date.getTime())) {
+      return { kind: 'iso', date };
+    }
+  }
+
+  const clockMatch = line.match(/^\[(\d{2}):(\d{2}):(\d{2})\]/);
+  if (clockMatch) {
+    return {
+      kind: 'clock',
+      seconds:
+        Number(clockMatch[1]) * 3600 +
+        Number(clockMatch[2]) * 60 +
+        Number(clockMatch[3]),
+    };
+  }
+
+  return null;
+}
+
+function startOfLocalDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addLocalDays(date, days) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+function withLocalClock(day, seconds) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  return new Date(day.getFullYear(), day.getMonth(), day.getDate(), hours, minutes, secs);
 }
 
 module.exports = { AgentManager };

--- a/packages/launcher/src/main/agent-manager.js
+++ b/packages/launcher/src/main/agent-manager.js
@@ -45,6 +45,15 @@ class AgentManager {
     return supported.sort();
   }
 
+  getCoreInfo() {
+    return {
+      version: this.coreVersion,
+      supportedTypes: this.getSupportedAgentTypes(),
+      globalCorePath: GLOBAL_CORE,
+      globalCorePresent: fs.existsSync(path.join(GLOBAL_CORE, 'package.json')),
+    };
+  }
+
   /** Reload core library after install/update */
   reloadCore() {
     // Clear require cache for global path
@@ -96,13 +105,23 @@ class AgentManager {
       }
     }
 
-    return agents.map((a) => ({
-      ...a,
-      state: status[a.name]?.state || 'stopped',
-      restarts: status[a.name]?.restarts || 0,
-      lastError: status[a.name]?.last_error || null,
-      health: healthByType.get(a.type || 'openclaw'),
-    }));
+    const supportedTypes = new Set(this.getSupportedAgentTypes());
+    return agents.map((a) => {
+      const type = a.type || 'openclaw';
+      const runtimeMismatch = !supportedTypes.has(type);
+      const runtimeMessage = runtimeMismatch
+        ? `Agent runtime '${type}' is not available in the currently loaded core. This usually means the Launcher core is outdated or did not reload correctly. Update Launcher and restart it.`
+        : null;
+      const statusError = status[a.name]?.last_error || null;
+      return {
+        ...a,
+        state: status[a.name]?.state || 'stopped',
+        restarts: status[a.name]?.restarts || 0,
+        lastError: statusError || runtimeMessage,
+        health: healthByType.get(type),
+        runtimeMismatch,
+      };
+    });
   }
 
   // ------------------------------------------------------------------
@@ -118,12 +137,7 @@ class AgentManager {
       throw new Error(`Agent type '${type}' is not supported in Launcher yet. Supported: ${supportedTypes.join(', ')}`);
     }
 
-    this._connector.addAgent({ name, type, role: 'worker' });
-
-    // Save env vars for the agent type
-    if (agentConfig.env && Object.keys(agentConfig.env).length > 0) {
-      this._connector.saveAgentEnv(type, agentConfig.env);
-    }
+    this._connector.addAgent({ name, type, role: 'worker', path: agentConfig.path, env: agentConfig.env });
 
     return { success: true, agent: agentConfig };
   }
@@ -136,10 +150,7 @@ class AgentManager {
 
   async updateAgent(name, updates) {
     if (updates.env) {
-      const agents = this._connector.listAgents();
-      const agent = agents.find((a) => a.name === name);
-      const type = agent ? agent.type : 'openclaw';
-      this._connector.saveAgentEnv(type, updates.env);
+      this._connector.saveAgentInstanceEnv(name, updates.env);
     }
     return { success: true };
   }
@@ -180,6 +191,10 @@ class AgentManager {
     return this._connector.getAgentEnv(agentType);
   }
 
+  getAgentInstanceEnv(agentName) {
+    return this._connector.getAgentInstanceEnv(agentName);
+  }
+
   saveAgentEnv(agentType, env) {
     this._connector.saveAgentEnv(agentType, env);
 
@@ -191,6 +206,12 @@ class AgentManager {
       }
     } catch {}
 
+    this.signalReload();
+    return { success: true };
+  }
+
+  saveAgentInstanceEnv(agentName, env) {
+    this._connector.saveAgentInstanceEnv(agentName, env);
     this.signalReload();
     return { success: true };
   }

--- a/packages/launcher/src/main/main.js
+++ b/packages/launcher/src/main/main.js
@@ -496,6 +496,7 @@ function setupIPC() {
   // Agent CRUD
   ipcMain.handle('agents:list', () => agentManager.getAgents());
   ipcMain.handle('agents:supported-types', () => agentManager.getSupportedAgentTypes());
+  ipcMain.handle('agents:core-info', () => agentManager.getCoreInfo());
   ipcMain.handle('agents:add', (_e, config) => agentManager.addAgent(config));
   ipcMain.handle('agents:remove', (_e, name) => agentManager.removeAgent(name));
   ipcMain.handle('agents:update', (_e, name, config) => agentManager.updateAgent(name, config));
@@ -536,6 +537,8 @@ function setupIPC() {
   ipcMain.handle('agents:env-fields', (_e, agentType) => agentManager.getEnvFields(agentType));
   ipcMain.handle('agents:get-env', (_e, agentType) => agentManager.getAgentEnv(agentType));
   ipcMain.handle('agents:save-env', (_e, agentType, env) => agentManager.saveAgentEnv(agentType, env));
+  ipcMain.handle('agents:get-instance-env', (_e, agentName) => agentManager.getAgentInstanceEnv(agentName));
+  ipcMain.handle('agents:save-instance-env', (_e, agentName, env) => agentManager.saveAgentInstanceEnv(agentName, env));
   ipcMain.handle('agents:test-llm', (_e, env) => agentManager.testLLM(env));
   ipcMain.handle('agents:signal-reload', () => agentManager.signalReload());
 

--- a/packages/launcher/src/main/main.js
+++ b/packages/launcher/src/main/main.js
@@ -508,6 +508,8 @@ function setupIPC() {
   ipcMain.handle('agents:stop-all', () => agentManager.stopAll());
   ipcMain.handle('agents:status', () => agentManager.getAllStatus());
   ipcMain.handle('agents:logs', (_e, name, lines) => agentManager.getLogs(name, lines));
+  ipcMain.handle('agents:tail-logs', (_e, name, lines, offset) => agentManager.tailLogs(name, lines, offset));
+  ipcMain.handle('agents:clear-logs-range', (_e, start, end) => agentManager.clearLogsInRange(start, end));
 
   // Agent install (openclaw, etc.)
   ipcMain.handle('agents:install-type', (_e, agentType) => agentManager.installAgentType(agentType));

--- a/packages/launcher/src/main/preload.js
+++ b/packages/launcher/src/main/preload.js
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('api', {
   // Agents
   listAgents: () => ipcRenderer.invoke('agents:list'),
   getSupportedAgentTypes: () => ipcRenderer.invoke('agents:supported-types'),
+  getAgentCoreInfo: () => ipcRenderer.invoke('agents:core-info'),
   addAgent: (config) => ipcRenderer.invoke('agents:add', config),
   removeAgent: (name) => ipcRenderer.invoke('agents:remove', name),
   updateAgent: (name, config) => ipcRenderer.invoke('agents:update', name, config),
@@ -34,6 +35,8 @@ contextBridge.exposeInMainWorld('api', {
   getEnvFields: (type) => ipcRenderer.invoke('agents:env-fields', type),
   getAgentEnv: (type) => ipcRenderer.invoke('agents:get-env', type),
   saveAgentEnv: (type, env) => ipcRenderer.invoke('agents:save-env', type, env),
+  getAgentInstanceEnv: (name) => ipcRenderer.invoke('agents:get-instance-env', name),
+  saveAgentInstanceEnv: (name, env) => ipcRenderer.invoke('agents:save-instance-env', name, env),
   testLLM: (env) => ipcRenderer.invoke('agents:test-llm', env),
   signalReload: () => ipcRenderer.invoke('agents:signal-reload'),
 

--- a/packages/launcher/src/main/preload.js
+++ b/packages/launcher/src/main/preload.js
@@ -20,6 +20,8 @@ contextBridge.exposeInMainWorld('api', {
   stopAll: () => ipcRenderer.invoke('agents:stop-all'),
   agentStatus: () => ipcRenderer.invoke('agents:status'),
   agentLogs: (name, lines) => ipcRenderer.invoke('agents:logs', name, lines),
+  tailAgentLogs: (name, lines, offset) => ipcRenderer.invoke('agents:tail-logs', name, lines, offset),
+  clearLogsInRange: (start, end) => ipcRenderer.invoke('agents:clear-logs-range', start, end),
 
   // Agent type install & catalog
   installAgentType: (type) => ipcRenderer.invoke('agents:install-type', type),

--- a/packages/launcher/src/renderer/index.html
+++ b/packages/launcher/src/renderer/index.html
@@ -107,6 +107,7 @@
             <option value="">All agents</option>
           </select>
           <button class="btn" id="btn-refresh-logs">Refresh</button>
+          <button class="btn" id="btn-clear-logs">Clear Logs</button>
           <button class="btn" id="btn-copy-logs">Copy Logs</button>
           <label style="font-size:12px;color:var(--text-secondary);display:flex;align-items:center;gap:4px;">
             <input type="checkbox" id="log-auto-refresh" checked> Auto-refresh

--- a/packages/launcher/src/renderer/renderer.js
+++ b/packages/launcher/src/renderer/renderer.js
@@ -137,7 +137,7 @@ async function refreshDashboard() {
 
         // Status indicators
         const configStatus = isUnsupported
-          ? '<span class="badge badge-danger-sm">Launcher unsupported</span>'
+          ? '<span class="badge badge-danger-sm">Launcher core update required</span>'
           : (health.ready
             ? `<span class="badge badge-success-sm">${esc(configLabel)}</span>`
             : `<span class="badge badge-warning-sm">${esc(configLabel)}</span>`);
@@ -272,7 +272,7 @@ function showAgentActions(name, type, state, network) {
     actions.push(`<button class="btn modal-action-btn" data-action="toggle-agent" data-name="${esc(name)}" data-state="${esc(state)}">Start</button>`);
   }
 
-  actions.push(`<button class="btn modal-action-btn" data-action="configure" data-type="${esc(type)}">Configure</button>`);
+  actions.push(`<button class="btn modal-action-btn" data-action="configure" data-name="${esc(name)}" data-type="${esc(type)}">Configure</button>`);
   actions.push(`<button class="btn modal-action-btn" data-action="agent-login" data-type="${esc(type)}">Login</button>`);
 
   if (network) {
@@ -327,14 +327,16 @@ async function openWorkspaceInBrowser(name) {
 
 // ---- Configure Agent Screen ----
 
-async function openConfigureScreen(agentType) {
+async function openConfigureScreen(agentName, agentType) {
   showModal(`<div class="loading-text">Loading configuration...</div>`);
 
   try {
-    const [fields, saved] = await Promise.all([
+    const [fields, typeSaved, instanceSaved] = await Promise.all([
       window.api.getEnvFields(agentType),
       window.api.getAgentEnv(agentType),
+      agentName ? window.api.getAgentInstanceEnv(agentName) : Promise.resolve({}),
     ]);
+    const saved = { ...(typeSaved || {}), ...(instanceSaved || {}) };
 
     if (!fields || fields.length === 0) {
       // Check if agent type requires login (e.g., Claude Code)
@@ -351,7 +353,7 @@ async function openConfigureScreen(agentType) {
         } catch {}
 
         showModal(`
-          <h3>Configure ${esc(agentType)}</h3>
+          <h3>Configure ${esc(agentName || agentType)}</h3>
           <p class="hint">This agent uses login-based authentication.</p>
           <div style="margin:16px 0;padding:12px;background:var(--bg-secondary);border-radius:var(--radius);">
             <span style="font-size:18px;">${loggedIn ? '✅' : '⚠️'}</span>
@@ -373,7 +375,7 @@ async function openConfigureScreen(agentType) {
             // Open login command in a visible terminal window
             await window.api.openTerminal(cmd);
             // Give user time to complete login, then refresh
-            setTimeout(() => openConfigureScreen(agentType), 5000);
+            setTimeout(() => openConfigureScreen(agentName, agentType), 5000);
           } catch (err) {
             showToast(`Failed to open terminal: ${err.message}`, 'error');
           }
@@ -382,7 +384,7 @@ async function openConfigureScreen(agentType) {
       }
 
       showModal(`
-        <h3>Configure ${esc(agentType)}</h3>
+        <h3>Configure ${esc(agentName || agentType)}</h3>
         <p class="hint">No configuration required for this agent type.</p>
         <button class="btn" data-action="close-modal">Close</button>
       `);
@@ -402,14 +404,14 @@ async function openConfigureScreen(agentType) {
     }).join('');
 
     showModal(`
-      <h3>Configure ${esc(agentType)}</h3>
-      <p class="hint">Settings saved to ~/.openagents/env/</p>
+      <h3>Configure ${esc(agentName || agentType)}</h3>
+      <p class="hint">${agentName ? 'Settings saved for this agent. Type defaults remain available as fallbacks.' : 'Settings saved to ~/.openagents/env/'}</p>
       <div class="configure-form">
         ${fieldsHtml}
       </div>
       <div id="test-result"></div>
       <div class="modal-button-row">
-        <button class="btn btn-primary" data-action="save-config" data-type="${esc(agentType)}">Save</button>
+        <button class="btn btn-primary" data-action="save-config" data-name="${esc(agentName || '')}" data-type="${esc(agentType)}">Save</button>
         <button class="btn" data-action="test-llm" data-type="${esc(agentType)}">Test Connection</button>
         <button class="btn" data-action="close-modal">Cancel</button>
       </div>
@@ -423,7 +425,7 @@ async function openConfigureScreen(agentType) {
   }
 }
 
-async function saveConfig(agentType) {
+async function saveConfig(agentName, agentType) {
   const fields = document.querySelectorAll('.configure-form input');
   const env = {};
   fields.forEach((input) => {
@@ -433,7 +435,11 @@ async function saveConfig(agentType) {
   });
 
   try {
-    await window.api.saveAgentEnv(agentType, env);
+    if (agentName) {
+      await window.api.saveAgentInstanceEnv(agentName, env);
+    } else {
+      await window.api.saveAgentEnv(agentType, env);
+    }
     showToast('Configuration saved', 'success');
     closeModal();
     refreshDashboard();
@@ -687,7 +693,7 @@ async function doAddAgent() {
     await window.api.addAgent({ name, type, path: agentPath || undefined });
     showToast(`Agent '${name}' created`, 'success');
     // Open configure screen for the new agent
-    openConfigureScreen(type);
+    openConfigureScreen(name, type);
     refreshAgentList();
     refreshDashboard();
   } catch (err) {
@@ -726,7 +732,7 @@ async function refreshAgentList() {
               </div>
               <span class="agent-type-label">${esc(a.type)}</span>
               <span class="agent-config-hint">
-                ${unsupported ? '<span class="text-danger">Launcher unsupported</span>' : health.ready ? `&#128273; ${esc(readyLabel)}` : `<span class="text-warning">&#9888; ${esc(readyLabel)}</span>`}
+                ${unsupported ? '<span class="text-danger">Launcher core update required</span>' : health.ready ? `&#128273; ${esc(readyLabel)}` : `<span class="text-warning">&#9888; ${esc(readyLabel)}</span>`}
                 ${envDisplay.length ? ' &middot; ' + envDisplay.map(esc).join(' &middot; ') : ''}
               </span>
               ${a.lastError ? `<span class="agent-error">${esc(a.lastError)}</span>` : ''}
@@ -742,7 +748,7 @@ async function refreshAgentList() {
               <button class="btn btn-sm${isRunning ? '' : ' btn-primary'}" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}">
                 ${isRunning ? 'Stop' : 'Start'}
               </button>
-              <button class="btn btn-sm" data-action="configure" data-type="${esc(a.type)}">Configure</button>
+              <button class="btn btn-sm" data-action="configure" data-name="${esc(a.name)}" data-type="${esc(a.type)}">Configure</button>
               ${a.network
                 ? `<button class="btn btn-sm" data-action="disconnect" data-name="${esc(a.name)}">Disconnect</button>
                    <button class="btn btn-sm" data-action="open-ws" data-name="${esc(a.name)}">Open Workspace</button>`
@@ -1175,8 +1181,7 @@ function statusClass(state) {
 }
 
 function isUnsupportedAgent(agent) {
-  const msg = String(agent?.lastError || '');
-  return msg.includes('Unknown agent type:');
+  return !!agent?.runtimeMismatch;
 }
 
 // ---- D25: Activity log ----
@@ -1360,7 +1365,7 @@ document.addEventListener('click', (e) => {
     case 'switch-tab': switchTab(tab); break;
     case 'toggle-agent': toggleAgent(name, state); break;
     case 'show-agent-actions': showAgentActions(name, type, state, network); break;
-    case 'configure': openConfigureScreen(type); break;
+    case 'configure': openConfigureScreen(name, type); break;
     case 'disconnect': disconnectAgent(name); break;
     case 'open-ws': openWorkspaceInBrowser(name); break;
     case 'remove-agent': removeAgent(name); break;
@@ -1371,7 +1376,7 @@ document.addEventListener('click', (e) => {
     case 'do-create-workspace': doCreateWorkspace(name); break;
     case 'do-join-token': doJoinWithToken(name); break;
     case 'do-add-agent': doAddAgent(); break;
-    case 'save-config': saveConfig(type); break;
+    case 'save-config': saveConfig(name, type); break;
     case 'test-llm': testLLMConfig(type); break;
     case 'close-modal': closeModal(); break;
     case 'install-catalog': installCatalogItem(name, btn.dataset.installed === 'true'); break;
@@ -1404,7 +1409,7 @@ async function agentLogin(agentType) {
   }
   if (!cmd) {
     showToast(`No login command for ${agentType}. Configure API key instead.`, 'info');
-    openConfigureScreen(agentType);
+    openConfigureScreen('', agentType);
     return;
   }
   showToast(`Opening ${agentType} login... Follow the prompts in the terminal.`, 'info');

--- a/packages/launcher/src/renderer/renderer.js
+++ b/packages/launcher/src/renderer/renderer.js
@@ -7,12 +7,6 @@ function switchTab(tabName) {
   document.querySelectorAll('.tab-content').forEach((el) => {
     el.classList.toggle('active', el.id === `tab-${tabName}`);
   });
-
-  if (tabName === 'dashboard') refreshDashboard();
-  if (tabName === 'agents') refreshAgentList();
-  if (tabName === 'install') refreshInstallStatus();
-  if (tabName === 'logs') refreshLogs();
-  if (tabName === 'settings') { refreshSettingsWorkspaces(); refreshSettingsRuntime(); }
 }
 
 document.querySelectorAll('.nav-item').forEach((el) => {
@@ -22,13 +16,31 @@ document.querySelectorAll('.nav-item').forEach((el) => {
 // Auto-refresh active tab every 5 seconds
 let _currentTab = 'dashboard';
 const _origSwitchTab = switchTab;
+let _refreshDashboardInFlight = null;
+let _refreshDashboardQueued = false;
+let _refreshAgentListInFlight = null;
+let _refreshAgentListQueued = false;
+const _pendingAgentActions = new Set();
+let _tabLoadToken = 0;
+const TAB_LOAD_DELAY_MS = 120;
+let _logsOffset = 0;
+let _logsFilter = '';
+let _clearLogsInFlight = false;
+const LOGS_INITIAL_LINES = 200;
+const LOGS_MAX_BUFFER_LINES = 400;
+
 switchTab = function(tabName) {
   _currentTab = tabName;
   _origSwitchTab(tabName);
+  showTabSkeleton(tabName);
+  const token = ++_tabLoadToken;
+  requestAnimationFrame(() => {
+    setTimeout(() => loadTabContent(tabName, token), TAB_LOAD_DELAY_MS);
+  });
 };
 setInterval(() => {
-  if (_currentTab === 'dashboard') refreshDashboard();
-  else if (_currentTab === 'agents') refreshAgentList();
+  if (_currentTab === 'dashboard') scheduleRefreshDashboard();
+  else if (_currentTab === 'agents') scheduleRefreshAgentList();
 }, 5000);
 
 // Keyboard shortcuts: Ctrl+1..5 for tabs
@@ -112,10 +124,142 @@ function formatHealthLabel(health) {
 
 // ---- Dashboard ----
 
+function scheduleRefreshDashboard() {
+  if (_refreshDashboardInFlight) {
+    _refreshDashboardQueued = true;
+    return _refreshDashboardInFlight;
+  }
+  _refreshDashboardInFlight = (async () => {
+    try {
+      await refreshDashboard();
+    } finally {
+      _refreshDashboardInFlight = null;
+      if (_refreshDashboardQueued) {
+        _refreshDashboardQueued = false;
+        scheduleRefreshDashboard();
+      }
+    }
+  })();
+  return _refreshDashboardInFlight;
+}
+
+async function loadTabContent(tabName, token) {
+  if (token !== _tabLoadToken) return;
+
+  if (tabName === 'dashboard') {
+    await scheduleRefreshDashboard();
+    return;
+  }
+
+  if (tabName === 'agents') {
+    await scheduleRefreshAgentList();
+    return;
+  }
+
+  if (tabName === 'install') {
+    if (token !== _tabLoadToken) return;
+    refreshInstallStatus();
+    return;
+  }
+
+  if (tabName === 'logs') {
+    if (token !== _tabLoadToken) return;
+    refreshLogs();
+    return;
+  }
+
+  if (tabName === 'settings') {
+    if (token !== _tabLoadToken) return;
+    refreshSettingsWorkspaces();
+    refreshSettingsRuntime();
+  }
+}
+
+function showTabSkeleton(tabName) {
+  if (tabName === 'dashboard') {
+    const el = document.getElementById('agent-cards');
+    if (el) {
+      el.innerHTML = `
+        <div class="skeleton-card">
+          <div class="skeleton-line skeleton-line-lg"></div>
+          <div class="skeleton-line skeleton-line-md"></div>
+          <div class="skeleton-line skeleton-line-sm"></div>
+        </div>
+        <div class="skeleton-card">
+          <div class="skeleton-line skeleton-line-lg"></div>
+          <div class="skeleton-line skeleton-line-md"></div>
+          <div class="skeleton-line skeleton-line-sm"></div>
+        </div>`;
+    }
+    return;
+  }
+
+  if (tabName === 'agents') {
+    const el = document.getElementById('agent-list');
+    if (el) {
+      el.innerHTML = `
+        <div class="skeleton-list">
+          <div class="skeleton-list-item">
+            <div class="skeleton-line skeleton-line-lg"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+          <div class="skeleton-list-item">
+            <div class="skeleton-line skeleton-line-lg"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+          <div class="skeleton-list-item">
+            <div class="skeleton-line skeleton-line-lg"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+        </div>`;
+    }
+    return;
+  }
+
+  if (tabName === 'install') {
+    const el = document.getElementById('catalog-table-container');
+    if (el) {
+      el.innerHTML = `
+        <div class="skeleton-list">
+          <div class="skeleton-list-item">
+            <div class="skeleton-line skeleton-line-lg"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+          <div class="skeleton-list-item">
+            <div class="skeleton-line skeleton-line-lg"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+        </div>`;
+    }
+    return;
+  }
+
+  if (tabName === 'logs') {
+    _logsOffset = 0;
+    const el = document.getElementById('log-viewer');
+    if (el) {
+      el.textContent = 'Loading logs...';
+    }
+    return;
+  }
+
+  if (tabName === 'settings') {
+    const ws = document.getElementById('settings-workspaces');
+    if (ws) ws.innerHTML = '<div class="loading-text">Loading...</div>';
+    const ids = ['settings-nodejs-version', 'settings-npm-version', 'settings-core-version', 'settings-core-latest'];
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = 'Loading...';
+    });
+  }
+}
+
 async function refreshDashboard() {
+  if (_currentTab !== 'dashboard') return;
   let agents = [];
   try {
     agents = await window.api.listAgents() || [];
+    if (_currentTab !== 'dashboard') return;
     const cardsEl = document.getElementById('agent-cards');
 
     if (agents.length === 0) {
@@ -148,12 +292,12 @@ async function refreshDashboard() {
         // Simplified buttons
         let buttons = '';
         if (isRunning) {
-          buttons += `<button class="btn btn-sm" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}">Stop</button>`;
+          buttons += `<button class="btn btn-sm" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}"${_pendingAgentActions.has(a.name) ? ' disabled' : ''}>${renderAgentActionLabel(a.name, true)}</button>`;
           if (isConnected) {
             buttons += `<button class="btn btn-sm btn-primary" data-action="open-ws" data-name="${esc(a.name)}">Open Workspace</button>`;
           }
         } else {
-          buttons += `<button class="btn btn-sm btn-primary" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}">Start</button>`;
+          buttons += `<button class="btn btn-sm btn-primary" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}"${_pendingAgentActions.has(a.name) ? ' disabled' : ''}>${renderAgentActionLabel(a.name, false)}</button>`;
         }
 
         return `
@@ -194,6 +338,25 @@ async function refreshDashboard() {
   } catch {}
 }
 
+function scheduleRefreshAgentList() {
+  if (_refreshAgentListInFlight) {
+    _refreshAgentListQueued = true;
+    return _refreshAgentListInFlight;
+  }
+  _refreshAgentListInFlight = (async () => {
+    try {
+      await refreshAgentList();
+    } finally {
+      _refreshAgentListInFlight = null;
+      if (_refreshAgentListQueued) {
+        _refreshAgentListQueued = false;
+        scheduleRefreshAgentList();
+      }
+    }
+  })();
+  return _refreshAgentListInFlight;
+}
+
 function updateDaemonStatusFromAgents(agents) {
   const el = document.getElementById('daemon-status');
   const hasOnline = agents.some((a) => a.state === 'online' || a.state === 'running' || a.state === 'idle' || a.state === 'idle');
@@ -210,6 +373,13 @@ function updateDaemonStatusFromAgents(agents) {
   }
 }
 
+function renderAgentActionLabel(name, isRunning) {
+  if (_pendingAgentActions.has(name)) {
+    return isRunning ? 'Stopping...' : 'Starting...';
+  }
+  return isRunning ? 'Stop' : 'Start';
+}
+
 async function updateDaemonStatus() {
   try {
     const agents = await window.api.listAgents() || [];
@@ -221,6 +391,11 @@ async function updateDaemonStatus() {
 }
 
 async function toggleAgent(name, currentState) {
+  if (_pendingAgentActions.has(name)) return;
+  _pendingAgentActions.add(name);
+  scheduleRefreshDashboard();
+  scheduleRefreshAgentList();
+
   try {
     if (currentState === 'online' || currentState === 'running' || currentState === 'idle') {
       await window.api.stopAgent(name);
@@ -228,14 +403,14 @@ async function toggleAgent(name, currentState) {
       // Poll until stopped (up to 15s — daemon checks commands every 5s)
       for (let i = 0; i < 5; i++) {
         await new Promise(r => setTimeout(r, 3000));
-        refreshDashboard();
-        refreshAgentList();
         const status = await window.api.agentStatus();
         const agent = status[name];
         if (!agent || agent.state === 'stopped') {
           showToast(`${name} stopped`, 'success');
           break;
         }
+        scheduleRefreshDashboard();
+        scheduleRefreshAgentList();
       }
     } else {
       await window.api.startAgent(name);
@@ -243,17 +418,22 @@ async function toggleAgent(name, currentState) {
       // Poll until running (up to 30s — daemon needs time to connect)
       for (let i = 0; i < 10; i++) {
         await new Promise(r => setTimeout(r, 3000));
-        await refreshDashboard();
         const status = await window.api.agentStatus();
         const agent = status[name];
         if (agent && (agent.state === 'running' || agent.state === 'online')) {
           showToast(`${name} is now running`, 'success');
           break;
         }
+        scheduleRefreshDashboard();
+        scheduleRefreshAgentList();
       }
     }
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
+  } finally {
+    _pendingAgentActions.delete(name);
+    scheduleRefreshDashboard();
+    scheduleRefreshAgentList();
   }
 }
 
@@ -298,8 +478,8 @@ async function disconnectAgent(name) {
     await window.api.disconnectWorkspace(name);
     showToast(`Disconnected ${name} from workspace`, 'success');
     window.api.signalReload();
-    refreshDashboard();
-    refreshAgentList();
+    scheduleRefreshDashboard();
+    scheduleRefreshAgentList();
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
@@ -442,8 +622,8 @@ async function saveConfig(agentName, agentType) {
     }
     showToast('Configuration saved', 'success');
     closeModal();
-    refreshDashboard();
-    refreshAgentList();
+    scheduleRefreshDashboard();
+    scheduleRefreshAgentList();
   } catch (err) {
     showToast(`Error saving: ${err.message}`, 'error');
   }
@@ -518,8 +698,8 @@ async function doConnectWorkspace(agentName, slug) {
     await window.api.connectWorkspace(agentName, slug);
     window.api.signalReload();
     showToast(`Connected to ${slug}`, 'success');
-    refreshDashboard();
-    refreshAgentList();
+    scheduleRefreshDashboard();
+    scheduleRefreshAgentList();
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
@@ -556,8 +736,8 @@ async function doCreateWorkspace(agentName) {
       window.api.signalReload();
       showToast(`Connected ${agentName} to ${name}`, 'success');
     }
-    refreshDashboard();
-    refreshAgentList();
+    scheduleRefreshDashboard();
+    scheduleRefreshAgentList();
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
@@ -588,8 +768,8 @@ async function doJoinWithToken(agentName) {
     await window.api.connectWorkspace(agentName, token);
     window.api.signalReload();
     showToast('Joined workspace', 'success');
-    refreshDashboard();
-    refreshAgentList();
+    scheduleRefreshDashboard();
+    scheduleRefreshAgentList();
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
@@ -694,16 +874,18 @@ async function doAddAgent() {
     showToast(`Agent '${name}' created`, 'success');
     // Open configure screen for the new agent
     openConfigureScreen(name, type);
-    refreshAgentList();
-    refreshDashboard();
+    scheduleRefreshAgentList();
+    scheduleRefreshDashboard();
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
 }
 
 async function refreshAgentList() {
+  if (_currentTab !== 'agents') return;
   try {
     const agents = await window.api.listAgents();
+    if (_currentTab !== 'agents') return;
     const listEl = document.getElementById('agent-list');
 
     if (!agents || agents.length === 0) {
@@ -745,8 +927,8 @@ async function refreshAgentList() {
           </div>
           <div class="agent-list-bottom">
             <div class="agent-list-actions">
-              <button class="btn btn-sm${isRunning ? '' : ' btn-primary'}" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}">
-                ${isRunning ? 'Stop' : 'Start'}
+              <button class="btn btn-sm${isRunning ? '' : ' btn-primary'}" data-action="toggle-agent" data-name="${esc(a.name)}" data-state="${esc(a.state)}"${_pendingAgentActions.has(a.name) ? ' disabled' : ''}>
+                ${renderAgentActionLabel(a.name, isRunning)}
               </button>
               <button class="btn btn-sm" data-action="configure" data-name="${esc(a.name)}" data-type="${esc(a.type)}">Configure</button>
               ${a.network
@@ -770,8 +952,8 @@ async function removeAgent(name) {
   try {
     await window.api.removeAgent(name);
     showToast(`Agent '${name}' removed`, 'success');
-    refreshAgentList();
-    refreshDashboard();
+    scheduleRefreshAgentList();
+    scheduleRefreshDashboard();
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
@@ -1091,15 +1273,34 @@ async function uninstallCatalogItem(name) {
 // ---- Logs tab ----
 
 async function refreshLogs() {
+  if (_currentTab !== 'logs') return;
   try {
     const filter = document.getElementById('log-agent-filter').value;
-    const result = await window.api.agentLogs(filter, 500);
     const viewer = document.getElementById('log-viewer');
-    if (result.lines && result.lines.length > 0) {
-      viewer.textContent = result.lines.join('\n');
+    const reset = filter !== _logsFilter || _logsOffset === 0;
+
+    const result = reset
+      ? await window.api.tailAgentLogs(filter, LOGS_INITIAL_LINES, 0)
+      : await window.api.tailAgentLogs(filter, LOGS_INITIAL_LINES, _logsOffset);
+    if (_currentTab !== 'logs') return;
+
+    _logsFilter = filter;
+    _logsOffset = result.size || 0;
+
+    if (reset) {
+      if (result.lines && result.lines.length > 0) {
+        viewer.textContent = result.lines.join('\n');
+      } else {
+        viewer.textContent = 'No logs available.\n\nLogs appear here after the daemon starts.';
+      }
       viewer.scrollTop = viewer.scrollHeight;
     } else {
-      viewer.textContent = 'No logs available.\n\nLogs appear here after the daemon starts.';
+      if (result.lines && result.lines.length > 0) {
+        const existing = viewer.textContent ? viewer.textContent.split('\n').filter(Boolean) : [];
+        const merged = existing.concat(result.lines).slice(-LOGS_MAX_BUFFER_LINES);
+        viewer.textContent = merged.join('\n');
+        viewer.scrollTop = viewer.scrollHeight;
+      }
     }
   } catch (err) {
     document.getElementById('log-viewer').textContent = 'Error loading logs: ' + err.message;
@@ -1108,6 +1309,7 @@ async function refreshLogs() {
   // Populate agent filter dropdown
   try {
     const agents = await window.api.listAgents();
+    if (_currentTab !== 'logs') return;
     const select = document.getElementById('log-agent-filter');
     const current = select.value;
     const existingOptions = new Set();
@@ -1125,7 +1327,97 @@ async function refreshLogs() {
   } catch {}
 }
 
-document.getElementById('btn-refresh-logs').addEventListener('click', refreshLogs);
+function toDateTimeLocalValue(date) {
+  const pad = (value) => String(value).padStart(2, '0');
+  return [
+    date.getFullYear(),
+    '-',
+    pad(date.getMonth() + 1),
+    '-',
+    pad(date.getDate()),
+    'T',
+    pad(date.getHours()),
+    ':',
+    pad(date.getMinutes()),
+  ].join('');
+}
+
+function showClearLogsModal() {
+  const now = new Date();
+  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+  showModal(`
+    <h3>Clear Logs</h3>
+    <p class="hint">Delete log entries from <code>daemon.log</code> whose timestamps fall inside the selected time range.</p>
+    <div class="form-group">
+      <label for="clear-logs-start">Start Time</label>
+      <input type="datetime-local" id="clear-logs-start" value="${toDateTimeLocalValue(oneHourAgo)}">
+    </div>
+    <div class="form-group">
+      <label for="clear-logs-end">End Time</label>
+      <input type="datetime-local" id="clear-logs-end" value="${toDateTimeLocalValue(now)}">
+    </div>
+    <div id="clear-logs-error" class="hint" style="min-height:18px;color:var(--danger-text);"></div>
+    <div class="modal-button-row">
+      <button class="btn" data-action="close-modal">Cancel</button>
+      <button class="btn btn-danger" id="confirm-clear-logs">Delete</button>
+    </div>
+  `);
+
+  const confirmBtn = document.getElementById('confirm-clear-logs');
+  confirmBtn.addEventListener('click', clearLogsInRange);
+}
+
+async function clearLogsInRange() {
+  if (_clearLogsInFlight) return;
+
+  const startEl = document.getElementById('clear-logs-start');
+  const endEl = document.getElementById('clear-logs-end');
+  const errorEl = document.getElementById('clear-logs-error');
+  const confirmBtn = document.getElementById('confirm-clear-logs');
+
+  const start = startEl?.value ? new Date(startEl.value) : null;
+  const end = endEl?.value ? new Date(endEl.value) : null;
+
+  if (!start || Number.isNaN(start.getTime()) || !end || Number.isNaN(end.getTime())) {
+    if (errorEl) errorEl.textContent = 'Please select a valid start and end time.';
+    return;
+  }
+  if (start.getTime() > end.getTime()) {
+    if (errorEl) errorEl.textContent = 'Start time must be before end time.';
+    return;
+  }
+
+  _clearLogsInFlight = true;
+  if (confirmBtn) {
+    confirmBtn.disabled = true;
+    confirmBtn.textContent = 'Deleting...';
+  }
+  if (errorEl) errorEl.textContent = '';
+
+  try {
+    const result = await window.api.clearLogsInRange(start.toISOString(), end.toISOString());
+    closeModal();
+    _logsOffset = 0;
+    await refreshLogs();
+    showToast(`Deleted ${result.removed || 0} log lines from the selected range`, 'success');
+  } catch (err) {
+    if (errorEl) errorEl.textContent = err.message || 'Failed to clear logs.';
+    if (confirmBtn) {
+      confirmBtn.disabled = false;
+      confirmBtn.textContent = 'Delete';
+    }
+  } finally {
+    _clearLogsInFlight = false;
+  }
+}
+
+document.getElementById('btn-refresh-logs').addEventListener('click', () => {
+  _logsOffset = 0;
+  refreshLogs();
+});
+document.getElementById('btn-clear-logs').addEventListener('click', () => {
+  showClearLogsModal();
+});
 document.getElementById('btn-copy-logs').addEventListener('click', () => {
   const logs = document.getElementById('log-viewer').textContent;
   navigator.clipboard.writeText(logs).then(() => {
@@ -1134,7 +1426,10 @@ document.getElementById('btn-copy-logs').addEventListener('click', () => {
     showToast('Failed to copy logs', 'error');
   });
 });
-document.getElementById('log-agent-filter').addEventListener('change', refreshLogs);
+document.getElementById('log-agent-filter').addEventListener('change', () => {
+  _logsOffset = 0;
+  refreshLogs();
+});
 document.getElementById('catalog-search-input').addEventListener('input', (e) => filterCatalog(e.target.value));
 
 // ---- Settings tab ----
@@ -1240,10 +1535,12 @@ startLogAutoRefresh();
 // ---- D29: Workspace URL display in Settings ----
 
 async function refreshSettingsWorkspaces() {
+  if (_currentTab !== 'settings') return;
   const el = document.getElementById('settings-workspaces');
   if (!el) return;
   try {
     const workspaces = await window.api.listWorkspaces();
+    if (_currentTab !== 'settings') return;
     if (!workspaces || workspaces.length === 0) {
       el.innerHTML = '<span class="hint">No workspaces configured.</span>';
       return;
@@ -1263,8 +1560,10 @@ async function refreshSettingsWorkspaces() {
 }
 
 async function refreshSettingsRuntime() {
+  if (_currentTab !== 'settings') return;
   try {
     const info = await window.api.runtimeInfo();
+    if (_currentTab !== 'settings') return;
     const set = (id, value, color) => {
       const el = document.getElementById(id);
       if (el) { el.textContent = value; el.style.color = color; }
@@ -1297,7 +1596,7 @@ setInterval(() => {
   const activeTab = document.querySelector('.nav-item.active');
   if (activeTab) {
     const tab = activeTab.dataset.tab;
-    if (tab === 'dashboard') refreshDashboard();
+    if (tab === 'dashboard') scheduleRefreshDashboard();
     if (tab === 'settings') { refreshSettingsWorkspaces(); refreshSettingsRuntime(); }
   }
   updateDaemonStatus();
@@ -1345,6 +1644,7 @@ if (window.api.onCoreUpdate) {
 document.addEventListener('click', (e) => {
   const btn = e.target.closest('[data-action]');
   if (!btn) return;
+  if (btn.disabled) return;
 
   const action = btn.dataset.action;
   const name = btn.dataset.name || '';
@@ -1434,7 +1734,7 @@ async function toggleDaemon() {
       await window.api.startAll();
       showToast('Daemon starting...', 'info');
     }
-    setTimeout(() => refreshDashboard(), 2000);
+    setTimeout(() => scheduleRefreshDashboard(), 2000);
   } catch (err) {
     showToast(`Error: ${err.message}`, 'error');
   }
@@ -1442,5 +1742,5 @@ async function toggleDaemon() {
 
 // ---- Initial load ----
 
-refreshDashboard();
+scheduleRefreshDashboard();
 renderActivity();

--- a/packages/launcher/src/renderer/styles.css
+++ b/packages/launcher/src/renderer/styles.css
@@ -855,6 +855,40 @@ h1 {
   padding: 24px 0;
 }
 
+.skeleton-card,
+.skeleton-list-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 10px;
+}
+
+.skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.skeleton-line {
+  height: 10px;
+  border-radius: 999px;
+  margin-bottom: 10px;
+  background: linear-gradient(90deg, #ececf1 25%, #f6f6f8 50%, #ececf1 75%);
+  background-size: 200% 100%;
+  animation: skeletonShimmer 1.1s linear infinite;
+}
+
+.skeleton-line-lg { width: 62%; }
+.skeleton-line-md { width: 42%; }
+.skeleton-line-sm { width: 26%; margin-bottom: 0; }
+
+@keyframes skeletonShimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
 /* ============================================
    Modal — Frosted glass
    ============================================ */
@@ -926,6 +960,10 @@ h1 {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-bg);
   background: #ffffff;
+}
+
+.modal .form-group input[type="datetime-local"] {
+  min-height: 40px;
 }
 
 .modal-button-row {


### PR DESCRIPTION
## What changed

This PR improves the Launcher and `agent-connector` CLI in three areas:

- adds incremental log tailing and time-range log cleanup
- reduces overlapping UI refreshes during tab switches and agent actions
- fixes `agn create` so it no longer auto-installs a runtime by default

It also adds loading skeletons and clearer pending states for start/stop actions.

For agent creation, the CLI now:
- creates the agent config immediately
- prints an install hint when the selected runtime is missing
- supports an explicit `--install` flag for one-step create-and-install behavior
- documents the behavior in the launcher README
- adds CLI test coverage to ensure `create` does not trigger implicit installs

## Why

The previous launcher flow reloaded too aggressively and made large logs harder to manage. This update makes the Launcher feel more responsive and gives users a safer way to clean daemon logs.

Separately, the `create / list / remove agent with temp config` test was timing out on Windows because `agn create test-agent --type claude` was triggering a real `npm install -g @anthropic-ai/claude-code` during a config CRUD test.

That made a local configuration command depend on network access and install latency, which is not appropriate for the command's default behavior and made the test flaky.

## Impact

Users can still install runtimes explicitly with `agn install <type>`.

If they want one-step create-and-install behavior, they can now run:

```bash
agn create my-agent --type openclaw --install
```

This keeps `create` fast and deterministic by default while preserving an explicit install path.

## Validation

- `npm test` in `packages/agent-connector`
- `node --test packages/agent-connector/test/*.test.js`
- Latest local result: 93 passed, 0 failed
