### PR TITLE
fix(go): respect workspace URL host instead of always hitting hardcoded backend

### DIFF
--- a/packages/go/app/page.tsx
+++ b/packages/go/app/page.tsx
@@ -16,20 +16,31 @@ import { useOpenAgentsAuth } from '@/lib/openagents-auth-context';
 
 /**
  * Parse a workspace URL like:
- *   https://workspace.openagents.org/0048fff6?token=abc123
- *   /0048fff6?token=abc123
- *   0048fff6
+ *   https://workspace.openagents.org/0048fff6?token=abc123          → canonical, endpoint=undefined
+ *   https://agents-api.example.com/0048fff6?token=abc123            → self-hosted, endpoint=https://agents-api.example.com
+ *   /0048fff6?token=abc123                                          → endpoint=undefined
+ *   0048fff6                                                        → endpoint=undefined
+ *
+ * The canonical OpenAgents frontend host (workspace.openagents.org) is treated
+ * as endpoint=undefined so the API client falls back to its built-in default
+ * (workspace-endpoint.openagents.org). Any other origin is used as the API
+ * endpoint, which is how self-hosted workspaces opt in.
  */
-function parseWorkspaceUrl(input: string): { workspaceId: string; workspaceToken: string } | null {
+const CANONICAL_FRONTEND = 'https://workspace.openagents.org';
+
+function parseWorkspaceUrl(input: string): { workspaceId: string; workspaceToken: string; endpoint?: string } | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
 
   try {
-    const url = new URL(trimmed, 'https://workspace.openagents.org');
+    const url = new URL(trimmed, CANONICAL_FRONTEND);
     const segments = url.pathname.split('/').filter(Boolean);
     const workspaceId = segments[segments.length - 1];
     const workspaceToken = url.searchParams.get('token') || '';
-    if (workspaceId) return { workspaceId, workspaceToken };
+    if (workspaceId) {
+      const endpoint = url.origin && url.origin !== CANONICAL_FRONTEND ? url.origin : undefined;
+      return { workspaceId, workspaceToken, endpoint };
+    }
   } catch {
     // Not a URL — treat as bare workspace ID
   }
@@ -41,20 +52,23 @@ function parseWorkspaceUrl(input: string): { workspaceId: string; workspaceToken
   return null;
 }
 
-function navigateToWorkspace(workspaceId: string, workspaceToken: string) {
-  window.location.href = `/${workspaceId}?token=${workspaceToken}`;
+function navigateToWorkspace(workspaceId: string, workspaceToken: string, endpoint?: string) {
+  const params = new URLSearchParams();
+  params.set('token', workspaceToken);
+  if (endpoint) params.set('endpoint', endpoint);
+  window.location.href = `/${workspaceId}?${params.toString()}`;
 }
 
 // ---------------------------------------------------------------------------
 // Workspace View — renders when URL path has a workspace ID
 // ---------------------------------------------------------------------------
 
-function WorkspaceView({ workspaceId, token }: { workspaceId: string; token: string }) {
+function WorkspaceView({ workspaceId, token, endpoint }: { workspaceId: string; token: string; endpoint?: string }) {
   const { user, idToken, loading: authLoading, isOpenAgentsDomain, signIn } = useOpenAgentsAuth();
 
   if (token) {
     return (
-      <WorkspaceProvider workspaceId={workspaceId} token={token} bearerToken={idToken || undefined}>
+      <WorkspaceProvider workspaceId={workspaceId} token={token} bearerToken={idToken || undefined} endpoint={endpoint}>
         <LayoutProvider>
           <Wrapper />
         </LayoutProvider>
@@ -73,7 +87,7 @@ function WorkspaceView({ workspaceId, token }: { workspaceId: string; token: str
 
     if (user && idToken) {
       return (
-        <WorkspaceProvider workspaceId={workspaceId} token="" bearerToken={idToken}>
+        <WorkspaceProvider workspaceId={workspaceId} token="" bearerToken={idToken} endpoint={endpoint}>
           <LayoutProvider>
             <Wrapper />
           </LayoutProvider>
@@ -118,7 +132,7 @@ function SelectorView() {
   const [error, setError] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [history, setHistory] = useState<WorkspaceHistoryEntry[]>([]);
-  const [currentWorkspace, setCurrentWorkspace] = useState<{ id: string; token: string } | null>(null);
+  const [currentWorkspace, setCurrentWorkspace] = useState<{ id: string; token: string; endpoint?: string } | null>(null);
 
   useEffect(() => {
     async function init() {
@@ -128,14 +142,14 @@ function SelectorView() {
 
         if (isSwitching) {
           if (settings.workspaceId && settings.workspaceToken) {
-            setCurrentWorkspace({ id: settings.workspaceId, token: settings.workspaceToken });
+            setCurrentWorkspace({ id: settings.workspaceId, token: settings.workspaceToken, endpoint: settings.workspaceEndpoint });
           }
           setLoading(false);
           return;
         }
 
         if (settings.workspaceId && settings.workspaceToken) {
-          navigateToWorkspace(settings.workspaceId, settings.workspaceToken);
+          navigateToWorkspace(settings.workspaceId, settings.workspaceToken, settings.workspaceEndpoint);
           return;
         }
       }
@@ -154,11 +168,11 @@ function SelectorView() {
     init();
   }, [router, isSwitching]);
 
-  const connectToWorkspace = async (workspaceId: string, workspaceToken: string) => {
+  const connectToWorkspace = async (workspaceId: string, workspaceToken: string, endpoint?: string) => {
     if (window.electronAPI) {
-      await window.electronAPI.settings.save({ workspaceId, workspaceToken });
+      await window.electronAPI.settings.save({ workspaceId, workspaceToken, workspaceEndpoint: endpoint });
     }
-    navigateToWorkspace(workspaceId, workspaceToken);
+    navigateToWorkspace(workspaceId, workspaceToken, endpoint);
   };
 
   const handleConnect = async (e: React.FormEvent) => {
@@ -175,12 +189,12 @@ function SelectorView() {
       return;
     }
 
-    await connectToWorkspace(parsed.workspaceId, parsed.workspaceToken);
+    await connectToWorkspace(parsed.workspaceId, parsed.workspaceToken, parsed.endpoint);
   };
 
   const handleCancel = () => {
     if (currentWorkspace) {
-      navigateToWorkspace(currentWorkspace.id, currentWorkspace.token);
+      navigateToWorkspace(currentWorkspace.id, currentWorkspace.token, currentWorkspace.endpoint);
     }
   };
 
@@ -216,13 +230,14 @@ function SelectorView() {
                   const displayName = entry.name && entry.name !== entry.workspaceId
                     ? entry.name
                     : entry.workspaceId.slice(0, 8);
-                  const fullUrl = `https://workspace.openagents.org/${entry.workspaceId}?token=${entry.workspaceToken}`;
+                  const baseUrl = entry.endpoint || CANONICAL_FRONTEND;
+                  const fullUrl = `${baseUrl}/${entry.workspaceId}?token=${entry.workspaceToken}`;
 
                   return (
                     <Tooltip key={entry.workspaceId}>
                       <TooltipTrigger asChild>
                         <button
-                          onClick={() => connectToWorkspace(entry.workspaceId, entry.workspaceToken)}
+                          onClick={() => connectToWorkspace(entry.workspaceId, entry.workspaceToken, entry.endpoint)}
                           className="flex items-center gap-2 px-3 py-1.5 rounded-lg border bg-card hover:bg-accent hover:border-primary/30 transition-colors text-sm cursor-pointer"
                         >
                           <Clock className="size-3 text-muted-foreground shrink-0" />
@@ -275,7 +290,7 @@ function SelectorView() {
                           type="button"
                           onClick={() => {
                             setDropdownOpen(false);
-                            connectToWorkspace(entry.workspaceId, entry.workspaceToken);
+                            connectToWorkspace(entry.workspaceId, entry.workspaceToken, entry.endpoint);
                           }}
                           className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent transition-colors text-left cursor-pointer"
                         >
@@ -322,12 +337,13 @@ function SelectorView() {
 // ---------------------------------------------------------------------------
 
 function AppRouter() {
-  const [route, setRoute] = useState<{ type: 'loading' } | { type: 'selector' } | { type: 'workspace'; workspaceId: string; token: string }>({ type: 'loading' });
+  const [route, setRoute] = useState<{ type: 'loading' } | { type: 'selector' } | { type: 'workspace'; workspaceId: string; token: string; endpoint?: string }>({ type: 'loading' });
 
   useEffect(() => {
     const path = window.location.pathname.replace(/\/+$/, '');
     const params = new URLSearchParams(window.location.search);
     const token = params.get('token') || '';
+    const endpoint = params.get('endpoint') || undefined;
 
     // Root path or switch mode → selector
     if (!path || path === '/' || path === '') {
@@ -338,7 +354,7 @@ function AppRouter() {
     // Any other path → treat as workspace ID
     const workspaceId = path.split('/').filter(Boolean)[0];
     if (workspaceId) {
-      setRoute({ type: 'workspace', workspaceId, token });
+      setRoute({ type: 'workspace', workspaceId, token, endpoint });
     } else {
       setRoute({ type: 'selector' });
     }
@@ -354,7 +370,7 @@ function AppRouter() {
   }
 
   if (route.type === 'workspace') {
-    return <WorkspaceView workspaceId={route.workspaceId} token={route.token} />;
+    return <WorkspaceView workspaceId={route.workspaceId} token={route.token} endpoint={route.endpoint} />;
   }
 
   return <SelectorView />;

--- a/packages/go/app/page.tsx
+++ b/packages/go/app/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useState, Suspense } from 'react';
+import { useEffect, useRef, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Image from 'next/image';
-import { ArrowRight, ArrowLeft, Link2, Clock, ChevronDown } from 'lucide-react';
+import { ArrowRight, ArrowLeft, Link2, Clock, ChevronDown, ChevronRight, Server } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -14,20 +14,43 @@ import { LayoutProvider } from '@/components/layout/layout-context';
 import { Wrapper } from '@/components/layout/wrapper';
 import { useOpenAgentsAuth } from '@/lib/openagents-auth-context';
 
-/**
- * Parse a workspace URL like:
- *   https://workspace.openagents.org/0048fff6?token=abc123          → canonical, endpoint=undefined
- *   https://agents-api.example.com/0048fff6?token=abc123            → self-hosted, endpoint=https://agents-api.example.com
- *   /0048fff6?token=abc123                                          → endpoint=undefined
- *   0048fff6                                                        → endpoint=undefined
- *
- * The canonical OpenAgents frontend host (workspace.openagents.org) is treated
- * as endpoint=undefined so the API client falls back to its built-in default
- * (workspace-endpoint.openagents.org). Any other origin is used as the API
- * endpoint, which is how self-hosted workspaces opt in.
- */
 const CANONICAL_FRONTEND = 'https://workspace.openagents.org';
 
+/**
+ * Derive the API endpoint from a frontend origin using the {name}-endpoint
+ * convention. Only the first hostname label is rewritten; the rest of the
+ * domain and port are preserved.
+ *
+ *   workspace.openagents.org  →  workspace-endpoint.openagents.org
+ *   agents.caremojo.app       →  agents-endpoint.caremojo.app
+ *   localhost:3000            →  localhost:3000 (untouched, no dot)
+ *
+ * Setups that follow a different convention (e.g. agents-api.X) need the user
+ * to override via the Advanced section in the connect form.
+ */
+function deriveApiEndpoint(origin: string): string {
+  try {
+    const url = new URL(origin);
+    const hostParts = url.hostname.split('.');
+    if (hostParts.length >= 2) {
+      hostParts[0] = `${hostParts[0]}-endpoint`;
+      const port = url.port ? `:${url.port}` : '';
+      return `${url.protocol}//${hostParts.join('.')}${port}`;
+    }
+  } catch {
+    // fall through
+  }
+  return origin;
+}
+
+/**
+ * Parse a workspace URL into id + token + auto-derived API endpoint.
+ *
+ *   https://workspace.openagents.org/0048fff6?token=abc  → endpoint = workspace-endpoint.openagents.org
+ *   https://agents.caremojo.app/0048fff6?token=abc       → endpoint = agents-endpoint.caremojo.app
+ *   /0048fff6?token=abc                                  → endpoint = workspace-endpoint.openagents.org (relative resolves to canonical)
+ *   0048fff6                                             → endpoint undefined
+ */
 function parseWorkspaceUrl(input: string): { workspaceId: string; workspaceToken: string; endpoint?: string } | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -38,7 +61,7 @@ function parseWorkspaceUrl(input: string): { workspaceId: string; workspaceToken
     const workspaceId = segments[segments.length - 1];
     const workspaceToken = url.searchParams.get('token') || '';
     if (workspaceId) {
-      const endpoint = url.origin && url.origin !== CANONICAL_FRONTEND ? url.origin : undefined;
+      const endpoint = url.origin ? deriveApiEndpoint(url.origin) : undefined;
       return { workspaceId, workspaceToken, endpoint };
     }
   } catch {
@@ -133,6 +156,27 @@ function SelectorView() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [history, setHistory] = useState<WorkspaceHistoryEntry[]>([]);
   const [currentWorkspace, setCurrentWorkspace] = useState<{ id: string; token: string; endpoint?: string } | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [apiUrlOverride, setApiUrlOverride] = useState('');
+  const apiUrlEditedRef = useRef(false);
+
+  // Auto-fill the Advanced API URL field from the pasted URL using the
+  // <name>-endpoint convention, until the user manually edits it.
+  const derivedApiUrl = (() => {
+    const trimmed = urlInput.trim();
+    if (!trimmed) return '';
+    try {
+      const url = new URL(trimmed, CANONICAL_FRONTEND);
+      return url.origin ? deriveApiEndpoint(url.origin) : '';
+    } catch {
+      return '';
+    }
+  })();
+  useEffect(() => {
+    if (!apiUrlEditedRef.current) {
+      setApiUrlOverride(derivedApiUrl);
+    }
+  }, [derivedApiUrl]);
 
   useEffect(() => {
     async function init() {
@@ -189,7 +233,8 @@ function SelectorView() {
       return;
     }
 
-    await connectToWorkspace(parsed.workspaceId, parsed.workspaceToken, parsed.endpoint);
+    const endpoint = apiUrlOverride.trim() || parsed.endpoint;
+    await connectToWorkspace(parsed.workspaceId, parsed.workspaceToken, endpoint);
   };
 
   const handleCancel = () => {
@@ -309,6 +354,40 @@ function SelectorView() {
               </div>
               {error && <p className="text-xs text-destructive">{error}</p>}
             </div>
+
+            <div>
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen(!advancedOpen)}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {advancedOpen ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+                Advanced — custom API endpoint
+              </button>
+              {advancedOpen && (
+                <div className="mt-2 space-y-1.5">
+                  <div className="relative">
+                    <Server className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+                    <Input
+                      type="text"
+                      value={apiUrlOverride}
+                      onChange={(e) => {
+                        setApiUrlOverride(e.target.value);
+                        apiUrlEditedRef.current = true;
+                      }}
+                      placeholder={derivedApiUrl || 'https://workspace-endpoint.openagents.org'}
+                      className="pl-10 text-xs font-mono"
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    Default follows the <code className="bg-muted px-1 py-0.5 rounded">{'{name}-endpoint'}</code> convention
+                    {derivedApiUrl ? <> — derived <code className="bg-muted px-1 py-0.5 rounded break-all">{derivedApiUrl}</code></> : null}.
+                    Override if your backend lives at a different host.
+                  </p>
+                </div>
+              )}
+            </div>
+
             <Button type="submit" className="w-full" disabled={!urlInput.trim()}>
               Connect to Workspace
               <ArrowRight className="size-4 ml-1" />

--- a/packages/go/components/layout/electron-init.tsx
+++ b/packages/go/components/layout/electron-init.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 export interface WorkspaceHistoryEntry {
   workspaceId: string;
   workspaceToken: string;
+  endpoint?: string;
   name: string;
   lastUsed: number;
 }
@@ -13,6 +14,7 @@ export interface WorkspaceSettings {
   workspaceId: string;
   workspaceToken: string;
   workspaceName?: string;
+  workspaceEndpoint?: string;
   workspaceHistory: WorkspaceHistoryEntry[];
 }
 

--- a/packages/go/electron/storage.js
+++ b/packages/go/electron/storage.js
@@ -7,6 +7,7 @@ const SETTINGS_FILE = 'settings.json';
 const DEFAULTS = {
   workspaceId: '',
   workspaceToken: '',
+  workspaceEndpoint: '',
   workspaceHistory: [],
 };
 
@@ -44,6 +45,7 @@ function saveSettings(settings) {
     const entry = {
       workspaceId: settings.workspaceId,
       workspaceToken: settings.workspaceToken,
+      endpoint: settings.workspaceEndpoint || undefined,
       name: settings.workspaceName || settings.workspaceId,
       lastUsed: Date.now(),
     };

--- a/packages/go/lib/api.ts
+++ b/packages/go/lib/api.ts
@@ -18,7 +18,7 @@ import type {
 } from './types';
 import { eventToMessage } from './types';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+const DEFAULT_API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
 
 /** Map snake_case file response from backend to camelCase WorkspaceFile. */
 function mapFileResponse(raw: Record<string, unknown>): WorkspaceFile {
@@ -38,11 +38,13 @@ class WorkspaceApi {
   private token: string = '';
   private bearerToken: string = '';
   private workspaceId: string = '';
+  private endpoint: string = DEFAULT_API_URL;
 
-  configure(workspaceId: string, token: string, bearerToken?: string) {
+  configure(workspaceId: string, token: string, bearerToken?: string, endpoint?: string) {
     this.workspaceId = workspaceId;
     this.token = token;
     if (bearerToken !== undefined) this.bearerToken = bearerToken;
+    this.endpoint = endpoint || DEFAULT_API_URL;
   }
 
   setBearerToken(bearerToken: string) {
@@ -58,7 +60,7 @@ class WorkspaceApi {
       authHeaders['Authorization'] = `Bearer ${this.bearerToken}`;
     }
 
-    const url = `${API_URL}${path}`;
+    const url = `${this.endpoint}${path}`;
     const res = await fetch(url, {
       ...options,
       cache: 'no-store',
@@ -264,7 +266,7 @@ class WorkspaceApi {
     if (this.token) authHeaders['X-Workspace-Token'] = this.token;
     if (this.bearerToken) authHeaders['Authorization'] = `Bearer ${this.bearerToken}`;
 
-    const url = `${API_URL}/v1/files`;
+    const url = `${this.endpoint}/v1/files`;
     const res = await fetch(url, {
       method: 'POST',
       headers: authHeaders,
@@ -296,7 +298,7 @@ class WorkspaceApi {
     const params = new URLSearchParams();
     if (this.token) params.set('token', this.token);
     const qs = params.toString();
-    return `${API_URL}/v1/files/${fileId}${qs ? `?${qs}` : ''}`;
+    return `${this.endpoint}/v1/files/${fileId}${qs ? `?${qs}` : ''}`;
   }
 
   /** Delete a file. */
@@ -377,7 +379,7 @@ class WorkspaceApi {
 
   /** Get screenshot URL for a browser tab. */
   getBrowserScreenshotUrl(tabId: string): string {
-    return `${API_URL}/v1/browser/tabs/${tabId}/screenshot`;
+    return `${this.endpoint}/v1/browser/tabs/${tabId}/screenshot`;
   }
 
   /** Remove persistent state from a browser tab (revert to temporal). */

--- a/packages/go/lib/workspace-context.tsx
+++ b/packages/go/lib/workspace-context.tsx
@@ -76,11 +76,13 @@ export function WorkspaceProvider({
   workspaceId,
   token,
   bearerToken,
+  endpoint,
   children,
 }: {
   workspaceId: string;
   token: string;
   bearerToken?: string;
+  endpoint?: string;
   children: React.ReactNode;
 }) {
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
@@ -206,8 +208,8 @@ export function WorkspaceProvider({
 
   // Configure API client on mount
   useEffect(() => {
-    workspaceApi.configure(workspaceId, token, bearerToken || undefined);
-  }, [workspaceId, token, bearerToken]);
+    workspaceApi.configure(workspaceId, token, bearerToken || undefined, endpoint);
+  }, [workspaceId, token, bearerToken, endpoint]);
 
   const refreshWorkspace = useCallback(async () => {
     try {

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-go",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "electron/main.js",
   "scripts": {

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-go",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
The macOS desktop app (`packages/go`) hardcoded `https://workspace-endpoint.openagents.org` as its API host. Self-hosted users could paste any workspace URL into the connect screen — the app silently dropped the host and still hit the OpenAgents production backend, 404ing every `/v1/*` call against their workspace ID.

## What this PR does

### 1. Respect the pasted URL's host (commit `eca1f741`)
Thread an optional `endpoint` through the full chain:

```
parseWorkspaceUrl()  →  navigateToWorkspace()  →  URL query (?endpoint=…)
                                                        ↓
                                               AppRouter
                                                        ↓
                                          WorkspaceView
                                                        ↓
                                       WorkspaceProvider (endpoint prop)
                                                        ↓
                                  workspaceApi.configure(…, endpoint)
```

Persistence:
- `WorkspaceSettings.workspaceEndpoint` (top-level) and `WorkspaceHistoryEntry.endpoint` (per-history-entry) added to the electron settings shape.
- Saved on every `connectToWorkspace()`, restored on app launch and recent-workspace clicks.
- Same workspaceId pasted with a different URL → endpoint and token are both overwritten via spread merge in `electron/storage.js`.

### 2. Auto-derive API URL from the pasted host (commit `c26946f1`)
`parseWorkspaceUrl` now derives the API endpoint using the `{name}-endpoint` convention:

| Pasted URL | Derived API endpoint |
|---|---|
| `https://workspace.openagents.org/abc?token=…` | `https://workspace-endpoint.openagents.org` |
| `https://agents.caremojo.app/abc?token=…` | `https://agents-endpoint.caremojo.app` |
| `0048fff6` (bare ID) | `undefined` → falls back to `DEFAULT_API_URL` |

### 3. Advanced section in the connect form (commit `c26946f1`)
A collapsible "Advanced — custom API endpoint" toggle below the URL input. When expanded, it exposes a text field prefilled with the auto-derived URL. Self-hosted setups that don't follow the `{name}-endpoint` convention (e.g. `agents.X` frontend with `agents-api.X` backend) can override it. The override is the source of truth on submit.

The field stays in sync with the URL input via `apiUrlEditedRef` until the user manually types in it — at which point the ref flips and the field becomes user-controlled.

## Backward compatibility
- `https://workspace.openagents.org/abc?token=xyz` derives to `https://workspace-endpoint.openagents.org`, which equals `DEFAULT_API_URL`. **Zero behavior change for hosted users.**
- Bare workspace IDs continue to fall back to `DEFAULT_API_URL`.
- `NEXT_PUBLIC_API_URL` env override is still honored as the default when no per-workspace endpoint is set.
- Existing `settings.json` files without `workspaceEndpoint` / per-entry `endpoint` keep working — the field is optional everywhere.

## Out of scope
`lib/auth.ts` and `lib/dashboard-api.ts` still pin to the canonical OpenAgents host. Those handle OpenAgents account auth (Firebase) and the agent-management dashboard, which are tied to the `openagents.org` identity layer regardless of which workspace backend you're talking to. Repointing those would be a separate, larger change.

## Version
Bumped `packages/go/package.json` `0.1.0 → 0.1.2` for the patch fix + Advanced section UX.

## Test plan
- [x] Paste `https://workspace.openagents.org/<id>?token=<t>` (canonical). App talks to `workspace-endpoint.openagents.org`. Workspace loads as before.
- [x] Paste self-hosted URL with `{name}-api` convention (e.g. `https://agents.caremojo.app/...`). Auto-derived `agents-endpoint.caremojo.app` is wrong; user expands Advanced, edits to `agents-api.caremojo.app`, connects successfully.
- [x] Restart app — workspace auto-reconnects to the same custom endpoint.
- [x] Click a Recent Workspace tile that was originally connected via custom endpoint — reconnects to that endpoint.
- [x] Paste a different URL for a workspaceId already in history — token and endpoint both overwritten.
- [x] Bare workspace ID (no URL) — existing "URL must include a token parameter" error fires.