### PR TITLE
fix(launcher): pass path to addAgent so new agent workdir takes effect 

### DIFF
--- a/packages/launcher/src/main/agent-manager.js
+++ b/packages/launcher/src/main/agent-manager.js
@@ -118,7 +118,7 @@ class AgentManager {
       throw new Error(`Agent type '${type}' is not supported in Launcher yet. Supported: ${supportedTypes.join(', ')}`);
     }
 
-    this._connector.addAgent({ name, type, role: 'worker' });
+    this._connector.addAgent({ name, type, role: 'worker', path: agentConfig.path });
 
     // Save env vars for the agent type
     if (agentConfig.env && Object.keys(agentConfig.env).length > 0) {


### PR DESCRIPTION
PR 标题：                                                                                                                                                   
  fix(launcher): pass path to addAgent so new agent workdir takes effect                                                                                      
   
  PR 描述：                                                                                                                                                   
  ## Summary      
                                                                                                                                                              
  When creating a new agent via the Launcher UI, the `path` field from `agentConfig` was not being forwarded to `connector.addAgent()`, causing the agent's   
  working directory to always fall back to the default and never reflect the user-specified path.

  ## Root Cause

  ```js
  // before
  this._connector.addAgent({ name, type, role: 'worker' });

  // after
  this._connector.addAgent({ name, type, role: 'worker', path: agentConfig.path });

  Test Plan

  - Create a new agent via Launcher with a custom work path configured
  - Verify the agent process starts in the specified directory
  - Verify existing agents without an explicit path are unaffected

  🤖 Generated with Claude Code