### PR TITLE
Bugfix/claude agent stop button

### DIFF
--- a/packages/agent-connector/src/adapters/base.js
+++ b/packages/agent-connector/src/adapters/base.js
@@ -48,6 +48,7 @@ class BaseAdapter {
     this._titledSessions = new Set();
     this._mode = 'execute';
     this._lastControlId = null;
+    this._controlWake = null;
     // Per-channel task tracking for parallel execution
     this._channelBusy = new Set();
     this._channelQueues = {};
@@ -81,7 +82,7 @@ class BaseAdapter {
     await this._skipExistingEvents();
 
     const heartbeatInterval = setInterval(() => this._heartbeat(), 30000);
-    const controlInterval = setInterval(() => this._pollControl(), 2000);
+    const controlPoller = this._controlPollerLoop();
 
     try {
       // Send initial heartbeat
@@ -92,8 +93,9 @@ class BaseAdapter {
       await this._pollLoop();
     } finally {
       this._running = false;
+      this._wakeControlPoller();
       clearInterval(heartbeatInterval);
-      clearInterval(controlInterval);
+      try { await controlPoller; } catch {}
       try {
         await this.client.disconnect(this.workspaceId, this.agentName, this.token);
       } catch {}
@@ -170,6 +172,40 @@ class BaseAdapter {
    * Handle adapter-specific control actions. Override in subclasses.
    */
   async _onControlAction(_action, _payload) {}
+
+  _hasActiveWork() {
+    return this._channelBusy.size > 0;
+  }
+
+  _controlPollDelayMs() {
+    return this._hasActiveWork() ? 250 : 2000;
+  }
+
+  _wakeControlPoller() {
+    if (this._controlWake) {
+      this._controlWake();
+      this._controlWake = null;
+    }
+  }
+
+  async _sleepUntilControlPollDue(delayMs) {
+    await new Promise((resolve) => {
+      const timeout = setTimeout(resolve, delayMs);
+      this._controlWake = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+    });
+    this._controlWake = null;
+  }
+
+  async _controlPollerLoop() {
+    while (this._running) {
+      await this._pollControl();
+      if (!this._running) break;
+      await this._sleepUntilControlPollDue(this._controlPollDelayMs());
+    }
+  }
 
   // ------------------------------------------------------------------
   // Poll loop
@@ -254,6 +290,7 @@ class BaseAdapter {
 
     // Run channel worker (don't await — parallel execution)
     this._channelWorker(channel, msg);
+    this._wakeControlPoller();
   }
 
   async _channelWorker(channel, msg) {

--- a/packages/agent-connector/src/adapters/claude.js
+++ b/packages/agent-connector/src/adapters/claude.js
@@ -33,6 +33,7 @@ class ClaudeAdapter extends BaseAdapter {
     this.disabledModules = opts.disabledModules || new Set();
     this._channelSessions = {}; // channel → Claude CLI session_id
     this._channelProcesses = {}; // channel → child process
+    this._stoppingChannels = new Set();
     this._sessionsFile = path.join(
       os.homedir(), '.openagents', 'sessions',
       `${this.workspaceId}_${this.agentName}.json`
@@ -72,19 +73,41 @@ class ClaudeAdapter extends BaseAdapter {
     if (!proc || proc.exitCode !== null) return;
     try {
       if (IS_WINDOWS) {
-        try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000 }); } catch {}
+        // Give Claude Code a Ctrl+C-like interrupt first so it can cancel
+        // shell/background tasks it manages before the forceful process-tree
+        // cleanup below. Going straight to /F can leave detached tool work
+        // alive even though the Claude CLI process itself is gone.
+        try { proc.kill('SIGINT'); } catch {}
+        const exited = await new Promise((resolve) => {
+          if (proc.exitCode !== null) {
+            resolve(true);
+            return;
+          }
+          const timeout = setTimeout(() => resolve(false), 1500);
+          proc.once('exit', () => { clearTimeout(timeout); resolve(true); });
+        });
+        if (!exited) {
+          try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000 }); } catch {}
+        }
       } else {
         try { process.kill(-proc.pid, 'SIGTERM'); } catch {
           proc.kill('SIGTERM');
         }
         await new Promise((resolve) => {
+          let done = false;
+          const finish = () => {
+            if (done) return;
+            done = true;
+            resolve();
+          };
           const timeout = setTimeout(() => {
             try { process.kill(-proc.pid, 'SIGKILL'); } catch {
               proc.kill('SIGKILL');
             }
-            resolve();
-          }, 5000);
-          proc.on('exit', () => { clearTimeout(timeout); resolve(); });
+            const reapTimeout = setTimeout(finish, 1000);
+            proc.once('exit', () => { clearTimeout(reapTimeout); finish(); });
+          }, 1500);
+          proc.once('exit', () => { clearTimeout(timeout); finish(); });
         });
       }
     } catch {}
@@ -95,6 +118,7 @@ class ClaudeAdapter extends BaseAdapter {
     if (!entries.length) return;
     this._log(`Stopping ${entries.length} running process(es)...`);
     for (const [channel, proc] of entries) {
+      this._stoppingChannels.add(channel);
       await this._stopProcess(proc);
       delete this._channelProcesses[channel];
       delete this._channelQueues[channel];
@@ -356,6 +380,7 @@ class ClaudeAdapter extends BaseAdapter {
     if (!content) return;
 
     const msgChannel = msg.sessionId || this.channelName;
+    this._stoppingChannels.delete(msgChannel);
     const sender = msg.senderName || msg.senderType || 'user';
     this._log(`Processing message from ${sender} in ${msgChannel}: ${content.slice(0, 80)}...`);
 
@@ -548,6 +573,12 @@ class ClaudeAdapter extends BaseAdapter {
           }
 
           delete this._channelProcesses[msgChannel];
+          const stoppedByUser = this._stoppingChannels.has(msgChannel);
+          if (stoppedByUser) {
+            this._stoppingChannels.delete(msgChannel);
+            resolve(false);
+            return;
+          }
 
           if (code !== 0) {
             this._log(`CLI exited with code ${code}`);

--- a/packages/agent-connector/test/stop-control.test.js
+++ b/packages/agent-connector/test/stop-control.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const EventEmitter = require('node:events');
+const { spawn } = require('node:child_process');
+
+const BaseAdapter = require('../src/adapters/base');
+const ClaudeAdapter = require('../src/adapters/claude');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readFirstLine(stream) {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const timeout = setTimeout(() => reject(new Error('Timed out waiting for child pid')), 3000);
+    stream.on('data', (chunk) => {
+      buffer += chunk.toString('utf-8');
+      const idx = buffer.indexOf('\n');
+      if (idx >= 0) {
+        clearTimeout(timeout);
+        resolve(buffer.slice(0, idx).trim());
+      }
+    });
+  });
+}
+
+describe('agent stop control', () => {
+  it('polls control events faster while work is active', () => {
+    const adapter = new BaseAdapter({
+      workspaceId: 'ws',
+      channelName: 'thread',
+      token: 'token',
+      agentName: 'agent',
+    });
+
+    assert.equal(adapter._controlPollDelayMs(), 2000);
+    adapter._channelBusy.add('thread');
+    assert.equal(adapter._controlPollDelayMs(), 250);
+  });
+
+  it('marks Claude channels as user-stopped before terminating processes', async () => {
+    const adapter = new ClaudeAdapter({
+      workspaceId: 'ws',
+      channelName: 'thread',
+      token: 'token',
+      agentName: 'claude',
+    });
+    const proc = new EventEmitter();
+    proc.pid = 99999999;
+    proc.exitCode = null;
+
+    adapter._channelProcesses.thread = proc;
+    adapter._stopProcess = async () => {};
+    const statuses = [];
+    adapter.sendStatus = async (channel, content) => statuses.push({ channel, content });
+
+    await adapter._stopAllProcesses();
+
+    assert.equal(adapter._stoppingChannels.has('thread'), true);
+    assert.deepEqual(statuses, [{ channel: 'thread', content: 'Execution stopped by user' }]);
+  });
+
+  it('Claude stop terminates the spawned process tree', async () => {
+    const adapter = new ClaudeAdapter({
+      workspaceId: 'ws',
+      channelName: 'thread',
+      token: 'token',
+      agentName: 'claude',
+    });
+    const script = [
+      "const { spawn } = require('node:child_process');",
+      "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+      'console.log(child.pid);',
+      'setInterval(() => {}, 1000);',
+    ].join('\n');
+    const proc = spawn(process.execPath, ['-e', script], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      detached: process.platform !== 'win32',
+      windowsHide: true,
+    });
+
+    try {
+      const childPid = Number(await readFirstLine(proc.stdout));
+      assert.equal(isPidAlive(proc.pid), true);
+      assert.equal(isPidAlive(childPid), true);
+
+      await adapter._stopProcess(proc);
+      await sleep(500);
+
+      assert.equal(isPidAlive(proc.pid), false);
+      assert.equal(isPidAlive(childPid), false);
+    } finally {
+      await adapter._stopProcess(proc);
+    }
+  });
+});

--- a/packages/go/components/chat/chat-messages.tsx
+++ b/packages/go/components/chat/chat-messages.tsx
@@ -46,6 +46,13 @@ function groupKey(group: MessageGroup): string {
     : `steps-${group.messages[0].messageId}`;
 }
 
+function isTerminalStatus(msg: WorkspaceMessage) {
+  return (
+    msg.messageType === 'status' &&
+    /stopped|stopping failed/i.test(msg.content)
+  );
+}
+
 // ── Component ──
 
 interface ChatMessagesProps {
@@ -140,8 +147,10 @@ export function ChatMessages({ messages, agents, showAllSteps, className, scroll
   // Group into chat messages and intermediate step clusters
   const groups = useMemo(() => groupMessages(filteredMessages), [filteredMessages]);
 
+  const hasTerminalStatus = realMessages.some(isTerminalStatus);
+
   // Loading indicator counts as a virtual row when present
-  const hasLoading = loadingMessages.length > 0;
+  const hasLoading = loadingMessages.length > 0 && !hasTerminalStatus;
   const totalCount = groups.length + (hasLoading ? 1 : 0);
 
   // ── Virtualizer ──

--- a/packages/go/components/chat/chat-view.tsx
+++ b/packages/go/components/chat/chat-view.tsx
@@ -82,7 +82,7 @@ async function refreshCachedSession(sessionId: string): Promise<void> {
 }
 
 export function ChatView() {
-  const { agents, currentSessionId, sessions, updateLastMessage, setSessionActive, agentModes, updateAgentMode, toggleAgentMode, stopAllAgents, activeSessionIds, renameSession, addParticipant, removeParticipant } = useWorkspace();
+  const { agents, currentSessionId, sessions, updateLastMessage, setSessionActive, agentModes, updateAgentMode, toggleAgentMode, stopAllAgents, activeSessionIds, stoppingSessionIds, renameSession, addParticipant, removeParticipant } = useWorkspace();
   const { isMobile, openMobileList, splitBrowser, showBrowserPreview, setShowBrowserPreview } = useLayout();
 
   // Continuously refresh message caches for top recent sessions in the background.
@@ -255,7 +255,12 @@ export function ChatView() {
     if (!currentSessionId) return;
     const lastMsg = displayMessages[displayMessages.length - 1];
     if (lastMsg) {
-      const isWorking = lastMsg.messageType === 'status' || lastMsg.messageType === 'thinking' || lastMsg.messageType === 'loading';
+      const isTerminalStatus = /stopped|stopping failed/i.test(lastMsg.content);
+      const isWorking = !isTerminalStatus && (
+        lastMsg.messageType === 'status' ||
+        lastMsg.messageType === 'thinking' ||
+        lastMsg.messageType === 'loading'
+      );
       updateLastMessage(currentSessionId, lastMsg.senderName, lastMsg.content, isWorking);
     } else {
       updateLastMessage(currentSessionId, '', '');
@@ -276,7 +281,12 @@ export function ChatView() {
       return;
     }
     const lastMsg = displayMessages[displayMessages.length - 1];
-    const isAgentWorking = lastMsg.senderType === 'agent' && (lastMsg.messageType === 'status' || lastMsg.messageType === 'thinking' || lastMsg.messageType === 'loading');
+    const isTerminalStatus = /stopped|stopping failed/i.test(lastMsg.content);
+    const isAgentWorking = lastMsg.senderType === 'agent' && !isTerminalStatus && (
+      lastMsg.messageType === 'status' ||
+      lastMsg.messageType === 'thinking' ||
+      lastMsg.messageType === 'loading'
+    );
     setSessionActive(currentSessionId, isAgentWorking);
   }, [currentSessionId, displayMessages, setSessionActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -535,13 +545,14 @@ export function ChatView() {
           })()}
 
           {/* Stop button — visible when agents are working */}
-          {currentSessionId && activeSessionIds.has(currentSessionId) && (
+          {currentSessionId && (activeSessionIds.has(currentSessionId) || stoppingSessionIds.has(currentSessionId)) && (
             <button
               onClick={stopAllAgents}
-              className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0"
+              disabled={stoppingSessionIds.has(currentSessionId)}
+              className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0 disabled:opacity-60 disabled:pointer-events-none"
             >
               <Square className="size-3 fill-current" />
-              Stop
+              {stoppingSessionIds.has(currentSessionId) ? 'Stopping...' : 'Stop'}
             </button>
           )}
 

--- a/packages/go/components/chat/intermediate-steps.tsx
+++ b/packages/go/components/chat/intermediate-steps.tsx
@@ -249,6 +249,13 @@ function ActivityIndicator() {
   );
 }
 
+function isTerminalStatus(step: WorkspaceMessage) {
+  return (
+    step.messageType === 'status' &&
+    /stopped|stopping failed/i.test(step.content)
+  );
+}
+
 // ── Intermediate Steps Group ──
 
 interface IntermediateStepsProps {
@@ -260,6 +267,7 @@ interface IntermediateStepsProps {
 export const IntermediateSteps = memo(function IntermediateSteps({ steps, agents, isActive = false }: IntermediateStepsProps) {
   const agentNames = agents?.map((a) => a.agentName) ?? [];
   if (steps.length === 0) return null;
+  const hasTerminalStatus = steps.some(isTerminalStatus);
 
   // Group consecutive steps by sender
   const hasMultipleAgents = (agents?.length ?? 0) > 1;
@@ -298,7 +306,7 @@ export const IntermediateSteps = memo(function IntermediateSteps({ steps, agents
             ))}
           </div>
         ))}
-        {isActive && <ActivityIndicator />}
+        {isActive && !hasTerminalStatus && <ActivityIndicator />}
       </div>
     </div>
   );

--- a/packages/go/components/monitor/monitor-overlay.tsx
+++ b/packages/go/components/monitor/monitor-overlay.tsx
@@ -24,7 +24,7 @@ interface MonitorOverlayProps {
 }
 
 export function MonitorOverlay({ sessionId, session, initialMessages, open, onOpenChange }: MonitorOverlayProps) {
-  const { agents, activeSessionIds, stopAllAgents, renameSession } = useWorkspace();
+  const { agents, activeSessionIds, stoppingSessionIds, stopAllAgents, renameSession } = useWorkspace();
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
   const titleInputRef = useRef<HTMLInputElement>(null);
@@ -203,14 +203,16 @@ export function MonitorOverlay({ sessionId, session, initialMessages, open, onOp
             const masterAgent = masterName ? agents.find((a) => a.agentName === masterName) : null;
             const isClaude = masterAgent?.agentType === 'claude';
             const isWorking = activeSessionIds.has(sessionId);
-            if (!isClaude || !isWorking) return null;
+            const isStopping = stoppingSessionIds.has(sessionId);
+            if (!isClaude || (!isWorking && !isStopping)) return null;
             return (
               <button
                 onClick={stopAllAgents}
-                className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0"
+                disabled={isStopping}
+                className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0 disabled:opacity-60 disabled:pointer-events-none"
               >
                 <Square className="size-3 fill-current" />
-                Stop
+                {isStopping ? 'Stopping...' : 'Stop'}
               </button>
             );
           })()}

--- a/packages/go/lib/workspace-context.tsx
+++ b/packages/go/lib/workspace-context.tsx
@@ -23,6 +23,7 @@ interface WorkspaceContextValue {
   error: string | null;
   lastMessageBySession: Record<string, LastMessageInfo>;
   activeSessionIds: Set<string>;
+  stoppingSessionIds: Set<string>;
   completedSessionIds: Set<string>;
   monitorMode: boolean;
   acknowledgeCompletion: (sessionId: string) => void;
@@ -102,6 +103,9 @@ export function WorkspaceProvider({
   const [error, setError] = useState<string | null>(null);
   const [lastMessageBySession, setLastMessageBySession] = useState<Record<string, LastMessageInfo>>({});
   const [activeSessionIds, setActiveSessionIds] = useState<Set<string>>(new Set());
+  const [stoppingSessionIds, setStoppingSessionIds] = useState<Set<string>>(new Set());
+  const stoppingSessionIdsRef = useRef(stoppingSessionIds);
+  stoppingSessionIdsRef.current = stoppingSessionIds;
   const [completedSessionIds, setCompletedSessionIds] = useState<Set<string>>(new Set());
   const [agentModes, setAgentModes] = useState<Record<string, string>>({});
   const [files, setFiles] = useState<WorkspaceFile[]>([]);
@@ -155,6 +159,14 @@ export function WorkspaceProvider({
   }, []);
 
   const updateLastMessage = useCallback((sessionId: string, senderName: string, content: string, isStatus?: boolean) => {
+    if (!isStatus || /stopped|stopping failed/i.test(content)) {
+      setStoppingSessionIds((prev) => {
+        if (!prev.has(sessionId)) return prev;
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
     setLastMessageBySession((prev) => {
       if (!content && !prev[sessionId]) return prev;
       const existing = prev[sessionId];
@@ -172,7 +184,7 @@ export function WorkspaceProvider({
   const setSessionActive = useCallback((sessionId: string, active: boolean) => {
     setActiveSessionIds((prev) => {
       const next = new Set(prev);
-      if (active) next.add(sessionId);
+      if (active && !stoppingSessionIdsRef.current.has(sessionId)) next.add(sessionId);
       else next.delete(sessionId);
       return next;
     });
@@ -199,10 +211,40 @@ export function WorkspaceProvider({
   }, [agentModes]);
 
   const stopAllAgents = useCallback(async () => {
-    await Promise.allSettled(
+    const sessionIds = Array.from(activeSessionIds);
+    if (sessionIds.length === 0) return;
+
+    setStoppingSessionIds((prev) => {
+      const next = new Set(prev);
+      sessionIds.forEach((sid) => next.add(sid));
+      return next;
+    });
+    setActiveSessionIds((prev) => {
+      const next = new Set(prev);
+      sessionIds.forEach((sid) => next.delete(sid));
+      return next;
+    });
+    setLastMessageBySession((prev) => {
+      const next = { ...prev };
+      sessionIds.forEach((sid) => {
+        next[sid] = { senderName: 'system', content: 'Stopping...', isStatus: true };
+      });
+      return next;
+    });
+
+    const sendStop = () => Promise.allSettled(
       agents.map((a) => workspaceApi.sendAgentControl(a.agentName, 'stop'))
     );
-  }, [agents]);
+    await sendStop();
+
+    window.setTimeout(() => {
+      setStoppingSessionIds((prevStopping) => {
+        const stillStopping = sessionIds.filter((sid) => prevStopping.has(sid));
+        if (stillStopping.length > 0) void sendStop();
+        return prevStopping;
+      });
+    }, 3000);
+  }, [activeSessionIds, agents]);
 
   // Configure API client on mount
   useEffect(() => {
@@ -332,9 +374,28 @@ export function WorkspaceProvider({
             const newInactive = new Set<string>();
             for (const [sid, info] of Object.entries(batch)) {
               const wasStatus = prev[sid]?.isStatus;
+              const isStopping = stoppingSessionIds.has(sid);
               if (info.isStatus) {
-                newActive.add(sid);
+                if (isStopping) {
+                  if (/stopped|stopping failed/i.test(info.content)) {
+                    setStoppingSessionIds((s) => {
+                      if (!s.has(sid)) return s;
+                      const next = new Set(s);
+                      next.delete(sid);
+                      return next;
+                    });
+                    newInactive.add(sid);
+                  }
+                } else {
+                  newActive.add(sid);
+                }
               } else if (wasStatus && !info.isStatus) {
+                setStoppingSessionIds((s) => {
+                  if (!s.has(sid)) return s;
+                  const next = new Set(s);
+                  next.delete(sid);
+                  return next;
+                });
                 newInactive.add(sid);
                 newCompleted.add(sid);
               }
@@ -367,7 +428,7 @@ export function WorkspaceProvider({
     } catch {
       // Non-critical — keep existing state
     }
-  }, [workspaceId]);
+  }, [workspaceId, stoppingSessionIds]);
 
   // Alias for backward compat
   const refreshAgents = refreshDiscovery;
@@ -731,6 +792,7 @@ export function WorkspaceProvider({
         error,
         lastMessageBySession,
         activeSessionIds,
+        stoppingSessionIds,
         completedSessionIds,
         monitorMode,
         acknowledgeCompletion,

--- a/sdk/src/openagents/adapters/base.py
+++ b/sdk/src/openagents/adapters/base.py
@@ -48,6 +48,7 @@ class BaseAdapter(ABC):
         self._titled_sessions: set = set()
         self._mode: str = "execute"
         self._last_control_id: Optional[str] = None
+        self._control_wake_event = asyncio.Event()
         # Per-channel task tracking for parallel execution
         self._channel_tasks: dict[str, asyncio.Task] = {}
         self._channel_queues: dict[str, list[dict]] = {}
@@ -155,7 +156,15 @@ class BaseAdapter(ABC):
         """Persistent background loop for control events."""
         while self._running:
             await self._poll_control()
-            await asyncio.sleep(2)
+            delay = 0.25 if self._has_active_work() else 2
+            try:
+                await asyncio.wait_for(self._control_wake_event.wait(), timeout=delay)
+            except asyncio.TimeoutError:
+                pass
+            self._control_wake_event.clear()
+
+    def _has_active_work(self) -> bool:
+        return any(task is not None and not task.done() for task in self._channel_tasks.values())
 
     # ------------------------------------------------------------------
     # Poll loop
@@ -242,6 +251,7 @@ class BaseAdapter(ABC):
 
         task = asyncio.create_task(self._channel_worker(channel, msg))
         self._channel_tasks[channel] = task
+        self._control_wake_event.set()
 
     async def _channel_worker(self, channel: str, msg: dict):
         """Process a message and then drain the channel's queue."""

--- a/sdk/src/openagents/adapters/claude.py
+++ b/sdk/src/openagents/adapters/claude.py
@@ -48,6 +48,7 @@ class ClaudeAdapter(BaseAdapter):
         self._channel_sessions: dict[str, str] = {}  # channel_name → Claude CLI session_id
         self._current_process: Optional[asyncio.subprocess.Process] = None
         self._channel_processes: dict[str, asyncio.subprocess.Process] = {}  # channel → subprocess
+        self._stopping_channels: set[str] = set()
         self._attached_file_ids: set[str] = set()  # files already attached to responses
         self._sessions_file = (
             Path.home() / ".openagents" / "sessions"
@@ -83,6 +84,36 @@ class ClaudeAdapter(BaseAdapter):
         """Kill a single Claude subprocess and its children."""
         if proc and proc.returncode is None:
             try:
+                if platform.system() == "Windows":
+                    try:
+                        proc.send_signal(signal.SIGINT)
+                    except Exception:
+                        try:
+                            proc.terminate()
+                        except Exception:
+                            pass
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=1.5)
+                        return
+                    except asyncio.TimeoutError:
+                        pass
+
+                    try:
+                        killer = await asyncio.create_subprocess_exec(
+                            "taskkill", "/F", "/T", "/PID", str(proc.pid),
+                            stdout=asyncio.subprocess.DEVNULL,
+                            stderr=asyncio.subprocess.DEVNULL,
+                        )
+                        await asyncio.wait_for(killer.wait(), timeout=5)
+                    except Exception:
+                        proc.kill()
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=1.5)
+                    except asyncio.TimeoutError:
+                        proc.kill()
+                        await proc.wait()
+                    return
+
                 # Try to kill the entire process group (catches child
                 # processes like Playwright MCP servers that may hold
                 # stdout open after the main process exits).
@@ -94,7 +125,7 @@ class ClaudeAdapter(BaseAdapter):
                 except (ProcessLookupError, PermissionError, OSError, AttributeError):
                     proc.terminate()
                 try:
-                    await asyncio.wait_for(proc.wait(), timeout=5)
+                    await asyncio.wait_for(proc.wait(), timeout=1.5)
                 except asyncio.TimeoutError:
                     try:
                         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
@@ -111,6 +142,7 @@ class ClaudeAdapter(BaseAdapter):
             return
         logger.info(f"Stopping {len(procs)} running process(es)...")
         for channel, proc in procs:
+            self._stopping_channels.add(channel)
             await self._stop_process(proc)
             self._channel_processes.pop(channel, None)
             self._channel_queues.pop(channel, None)
@@ -441,6 +473,7 @@ class ClaudeAdapter(BaseAdapter):
             )
             self._current_process = process
             self._channel_processes[msg_channel] = process
+            self._stopping_channels.discard(msg_channel)
 
             # last_response_text holds the text from the most recent
             # assistant turn.  Earlier turns are intermediate reasoning
@@ -586,6 +619,10 @@ class ClaudeAdapter(BaseAdapter):
             await process.wait()
             self._current_process = None
             self._channel_processes.pop(msg_channel, None)
+            stopped_by_user = msg_channel in self._stopping_channels
+            if stopped_by_user:
+                self._stopping_channels.discard(msg_channel)
+                return
 
             if process.returncode != 0:
                 stderr = await process.stderr.read()

--- a/workspace/frontend/components/chat/chat-messages.tsx
+++ b/workspace/frontend/components/chat/chat-messages.tsx
@@ -46,6 +46,13 @@ function groupKey(group: MessageGroup): string {
     : `steps-${group.messages[0].messageId}`;
 }
 
+function isTerminalStatus(msg: WorkspaceMessage) {
+  return (
+    msg.messageType === 'status' &&
+    /stopped|stopping failed/i.test(msg.content)
+  );
+}
+
 // ── Component ──
 
 interface ChatMessagesProps {
@@ -140,8 +147,10 @@ export function ChatMessages({ messages, agents, showAllSteps, className, scroll
   // Group into chat messages and intermediate step clusters
   const groups = useMemo(() => groupMessages(filteredMessages), [filteredMessages]);
 
+  const hasTerminalStatus = realMessages.some(isTerminalStatus);
+
   // Loading indicator counts as a virtual row when present
-  const hasLoading = loadingMessages.length > 0;
+  const hasLoading = loadingMessages.length > 0 && !hasTerminalStatus;
   const totalCount = groups.length + (hasLoading ? 1 : 0);
 
   // ── Virtualizer ──

--- a/workspace/frontend/components/chat/chat-view.tsx
+++ b/workspace/frontend/components/chat/chat-view.tsx
@@ -82,7 +82,7 @@ async function refreshCachedSession(sessionId: string): Promise<void> {
 }
 
 export function ChatView() {
-  const { agents, currentSessionId, sessions, updateLastMessage, setSessionActive, agentModes, updateAgentMode, toggleAgentMode, stopAllAgents, activeSessionIds, renameSession, addParticipant, removeParticipant } = useWorkspace();
+  const { agents, currentSessionId, sessions, updateLastMessage, setSessionActive, agentModes, updateAgentMode, toggleAgentMode, stopAllAgents, activeSessionIds, stoppingSessionIds, renameSession, addParticipant, removeParticipant } = useWorkspace();
   const { isMobile, openMobileList, splitBrowser, showBrowserPreview, setShowBrowserPreview } = useLayout();
 
   // Continuously refresh message caches for top recent sessions in the background.
@@ -255,7 +255,12 @@ export function ChatView() {
     if (!currentSessionId) return;
     const lastMsg = displayMessages[displayMessages.length - 1];
     if (lastMsg) {
-      const isWorking = lastMsg.messageType === 'status' || lastMsg.messageType === 'thinking' || lastMsg.messageType === 'loading';
+      const isTerminalStatus = /stopped|stopping failed/i.test(lastMsg.content);
+      const isWorking = !isTerminalStatus && (
+        lastMsg.messageType === 'status' ||
+        lastMsg.messageType === 'thinking' ||
+        lastMsg.messageType === 'loading'
+      );
       updateLastMessage(currentSessionId, lastMsg.senderName, lastMsg.content, isWorking);
     } else {
       updateLastMessage(currentSessionId, '', '');
@@ -276,7 +281,12 @@ export function ChatView() {
       return;
     }
     const lastMsg = displayMessages[displayMessages.length - 1];
-    const isAgentWorking = lastMsg.senderType === 'agent' && (lastMsg.messageType === 'status' || lastMsg.messageType === 'thinking' || lastMsg.messageType === 'loading');
+    const isTerminalStatus = /stopped|stopping failed/i.test(lastMsg.content);
+    const isAgentWorking = lastMsg.senderType === 'agent' && !isTerminalStatus && (
+      lastMsg.messageType === 'status' ||
+      lastMsg.messageType === 'thinking' ||
+      lastMsg.messageType === 'loading'
+    );
     setSessionActive(currentSessionId, isAgentWorking);
   }, [currentSessionId, displayMessages, setSessionActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -535,13 +545,14 @@ export function ChatView() {
           })()}
 
           {/* Stop button — visible when agents are working */}
-          {currentSessionId && activeSessionIds.has(currentSessionId) && (
+          {currentSessionId && (activeSessionIds.has(currentSessionId) || stoppingSessionIds.has(currentSessionId)) && (
             <button
               onClick={stopAllAgents}
-              className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0"
+              disabled={stoppingSessionIds.has(currentSessionId)}
+              className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0 disabled:opacity-60 disabled:pointer-events-none"
             >
               <Square className="size-3 fill-current" />
-              Stop
+              {stoppingSessionIds.has(currentSessionId) ? 'Stopping...' : 'Stop'}
             </button>
           )}
 

--- a/workspace/frontend/components/chat/intermediate-steps.tsx
+++ b/workspace/frontend/components/chat/intermediate-steps.tsx
@@ -249,6 +249,13 @@ function ActivityIndicator() {
   );
 }
 
+function isTerminalStatus(step: WorkspaceMessage) {
+  return (
+    step.messageType === 'status' &&
+    /stopped|stopping failed/i.test(step.content)
+  );
+}
+
 // ── Intermediate Steps Group ──
 
 interface IntermediateStepsProps {
@@ -260,6 +267,7 @@ interface IntermediateStepsProps {
 export const IntermediateSteps = memo(function IntermediateSteps({ steps, agents, isActive = false }: IntermediateStepsProps) {
   const agentNames = agents?.map((a) => a.agentName) ?? [];
   if (steps.length === 0) return null;
+  const hasTerminalStatus = steps.some(isTerminalStatus);
 
   // Group consecutive steps by sender
   const hasMultipleAgents = (agents?.length ?? 0) > 1;
@@ -298,7 +306,7 @@ export const IntermediateSteps = memo(function IntermediateSteps({ steps, agents
             ))}
           </div>
         ))}
-        {isActive && <ActivityIndicator />}
+        {isActive && !hasTerminalStatus && <ActivityIndicator />}
       </div>
     </div>
   );

--- a/workspace/frontend/components/monitor/monitor-overlay.tsx
+++ b/workspace/frontend/components/monitor/monitor-overlay.tsx
@@ -24,7 +24,7 @@ interface MonitorOverlayProps {
 }
 
 export function MonitorOverlay({ sessionId, session, initialMessages, open, onOpenChange }: MonitorOverlayProps) {
-  const { agents, activeSessionIds, stopAllAgents, renameSession } = useWorkspace();
+  const { agents, activeSessionIds, stoppingSessionIds, stopAllAgents, renameSession } = useWorkspace();
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
   const titleInputRef = useRef<HTMLInputElement>(null);
@@ -203,14 +203,16 @@ export function MonitorOverlay({ sessionId, session, initialMessages, open, onOp
             const masterAgent = masterName ? agents.find((a) => a.agentName === masterName) : null;
             const isClaude = masterAgent?.agentType === 'claude';
             const isWorking = activeSessionIds.has(sessionId);
-            if (!isClaude || !isWorking) return null;
+            const isStopping = stoppingSessionIds.has(sessionId);
+            if (!isClaude || (!isWorking && !isStopping)) return null;
             return (
               <button
                 onClick={stopAllAgents}
-                className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0"
+                disabled={isStopping}
+                className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors shrink-0 disabled:opacity-60 disabled:pointer-events-none"
               >
                 <Square className="size-3 fill-current" />
-                Stop
+                {isStopping ? 'Stopping...' : 'Stop'}
               </button>
             );
           })()}

--- a/workspace/frontend/lib/workspace-context.tsx
+++ b/workspace/frontend/lib/workspace-context.tsx
@@ -24,6 +24,7 @@ interface WorkspaceContextValue {
   error: string | null;
   lastMessageBySession: Record<string, LastMessageInfo>;
   activeSessionIds: Set<string>;
+  stoppingSessionIds: Set<string>;
   completedSessionIds: Set<string>;
   monitorMode: boolean;
   acknowledgeCompletion: (sessionId: string) => void;
@@ -104,6 +105,9 @@ export function WorkspaceProvider({
   const [error, setError] = useState<string | null>(null);
   const [lastMessageBySession, setLastMessageBySession] = useState<Record<string, LastMessageInfo>>({});
   const [activeSessionIds, setActiveSessionIds] = useState<Set<string>>(new Set());
+  const [stoppingSessionIds, setStoppingSessionIds] = useState<Set<string>>(new Set());
+  const stoppingSessionIdsRef = useRef(stoppingSessionIds);
+  stoppingSessionIdsRef.current = stoppingSessionIds;
   const [completedSessionIds, setCompletedSessionIds] = useState<Set<string>>(new Set());
   const [agentModes, setAgentModes] = useState<Record<string, string>>({});
   const [files, setFiles] = useState<WorkspaceFile[]>([]);
@@ -158,6 +162,14 @@ export function WorkspaceProvider({
   }, []);
 
   const updateLastMessage = useCallback((sessionId: string, senderName: string, content: string, isStatus?: boolean) => {
+    if (!isStatus || /stopped|stopping failed/i.test(content)) {
+      setStoppingSessionIds((prev) => {
+        if (!prev.has(sessionId)) return prev;
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
     setLastMessageBySession((prev) => {
       if (!content && !prev[sessionId]) return prev;
       const existing = prev[sessionId];
@@ -175,7 +187,7 @@ export function WorkspaceProvider({
   const setSessionActive = useCallback((sessionId: string, active: boolean) => {
     setActiveSessionIds((prev) => {
       const next = new Set(prev);
-      if (active) next.add(sessionId);
+      if (active && !stoppingSessionIdsRef.current.has(sessionId)) next.add(sessionId);
       else next.delete(sessionId);
       return next;
     });
@@ -202,10 +214,40 @@ export function WorkspaceProvider({
   }, [agentModes]);
 
   const stopAllAgents = useCallback(async () => {
-    await Promise.allSettled(
+    const sessionIds = Array.from(activeSessionIds);
+    if (sessionIds.length === 0) return;
+
+    setStoppingSessionIds((prev) => {
+      const next = new Set(prev);
+      sessionIds.forEach((sid) => next.add(sid));
+      return next;
+    });
+    setActiveSessionIds((prev) => {
+      const next = new Set(prev);
+      sessionIds.forEach((sid) => next.delete(sid));
+      return next;
+    });
+    setLastMessageBySession((prev) => {
+      const next = { ...prev };
+      sessionIds.forEach((sid) => {
+        next[sid] = { senderName: 'system', content: 'Stopping...', isStatus: true };
+      });
+      return next;
+    });
+
+    const sendStop = () => Promise.allSettled(
       agents.map((a) => workspaceApi.sendAgentControl(a.agentName, 'stop'))
     );
-  }, [agents]);
+    await sendStop();
+
+    window.setTimeout(() => {
+      setStoppingSessionIds((prevStopping) => {
+        const stillStopping = sessionIds.filter((sid) => prevStopping.has(sid));
+        if (stillStopping.length > 0) void sendStop();
+        return prevStopping;
+      });
+    }, 3000);
+  }, [activeSessionIds, agents]);
 
   // Configure API client on mount
   useEffect(() => {
@@ -335,9 +377,28 @@ export function WorkspaceProvider({
             const newInactive = new Set<string>();
             for (const [sid, info] of Object.entries(batch)) {
               const wasStatus = prev[sid]?.isStatus;
+              const isStopping = stoppingSessionIds.has(sid);
               if (info.isStatus) {
-                newActive.add(sid);
+                if (isStopping) {
+                  if (/stopped|stopping failed/i.test(info.content)) {
+                    setStoppingSessionIds((s) => {
+                      if (!s.has(sid)) return s;
+                      const next = new Set(s);
+                      next.delete(sid);
+                      return next;
+                    });
+                    newInactive.add(sid);
+                  }
+                } else {
+                  newActive.add(sid);
+                }
               } else {
+                setStoppingSessionIds((s) => {
+                  if (!s.has(sid)) return s;
+                  const next = new Set(s);
+                  next.delete(sid);
+                  return next;
+                });
                 // Latest event is a real message — session is not working.
                 // Always clear active so the shimmer doesn't stick when the
                 // status→chat transition happens between polls or while
@@ -374,7 +435,7 @@ export function WorkspaceProvider({
     } catch {
       // Non-critical — keep existing state
     }
-  }, [workspaceId]);
+  }, [workspaceId, stoppingSessionIds]);
 
   // Alias for backward compat
   const refreshAgents = refreshDiscovery;
@@ -738,6 +799,7 @@ export function WorkspaceProvider({
         error,
         lastMessageBySession,
         activeSessionIds,
+        stoppingSessionIds,
         completedSessionIds,
         monitorMode,
         acknowledgeCompletion,

--- a/workspace/frontend/next-env.d.ts
+++ b/workspace/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/workspace/frontend/package-lock.json
+++ b/workspace/frontend/package-lock.json
@@ -123,7 +123,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -190,7 +189,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -206,8 +204,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -658,7 +655,6 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3322,7 +3318,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3333,7 +3328,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5461,7 +5455,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5471,7 +5464,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
## Summary

Fixes Workspace Stop behavior for Claude Code agents.

- Speeds up control-event polling while an agent is actively running
- Makes Stop interrupt Claude Code more like Ctrl+C, with process cleanup fallback
- Cleans up running Claude child processes more reliably
- Adds immediate Stop UI feedback and disables repeated Stop clicks
- Retries Stop once if no stopped/idle status is observed within 3 seconds
- Stops showing active loading indicators after `Execution stopped by user`

## Validation

- Verified Claude Code agent can be stopped from Workspace UI during a long-running task
- Confirmed the agent remains connected and can receive follow-up messages after Stop
- Confirmed stopped status no longer keeps the UI in a “working” animation state
- Ran agent connector stop-control tests locally