### PR TITLE
Add Kimi agent support

### DIFF
--- a/packages/agent-connector/icons/kimi.svg
+++ b/packages/agent-connector/icons/kimi.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#141821"/>
+      <stop offset="0.52" stop-color="#2f6df6"/>
+      <stop offset="1" stop-color="#49d2ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
+  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+</svg>

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -558,6 +558,65 @@
     }
   },
   {
+    "name": "kimi",
+    "label": "Kimi",
+    "description": "Kimi agent powered by Moonshot AI, OpenAI-compatible API.",
+    "homepage": "https://platform.moonshot.ai",
+    "tags": [
+      "coding",
+      "moonshot",
+      "open-source"
+    ],
+    "featured": true,
+    "order": 7,
+    "support": { "install": true, "workspace": true, "collaboration": true },
+    "builtin": true,
+    "install": {
+      "binary": "kimi",
+      "api_only": true,
+      "macos": "echo 'Kimi uses direct API mode — no binary install needed'",
+      "linux": "echo 'Kimi uses direct API mode — no binary install needed'",
+      "windows": "echo 'Kimi uses direct API mode — no binary install needed'"
+    },
+    "adapter": {
+      "module": "openagents.adapters.kimi",
+      "class": "KimiAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "KIMI_API_KEY",
+        "description": "Moonshot/Kimi API key (also accepts MOONSHOT_API_KEY env var)",
+        "required": true,
+        "password": true
+      },
+      {
+        "name": "KIMI_BASE_URL",
+        "description": "Kimi API base URL (OpenAI-compatible endpoint)",
+        "required": false,
+        "default": "https://api.moonshot.ai/v1",
+        "placeholder": "https://api.moonshot.ai/v1"
+      },
+      {
+        "name": "KIMI_MODEL",
+        "description": "Kimi model name",
+        "required": false,
+        "default": "kimi-k2.6",
+        "placeholder": "kimi-k2.6"
+      }
+    ],
+    "check_ready": {
+      "env_vars": [
+        "KIMI_API_KEY",
+        "MOONSHOT_API_KEY"
+      ],
+      "saved_env_key": "KIMI_API_KEY",
+      "not_ready_message": "No API key — press e to configure"
+    }
+  },
+  {
     "name": "hermes",
     "label": "Hermes Agent",
     "description": "Nous Hermes Agent — self-improving AI with tools, profiles, memory, and messaging",

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -13,6 +13,7 @@ const NanoClawAdapter = require('./nanoclaw');
 const CursorAdapter = require('./cursor');
 const HermesAdapter = require('./hermes');
 const GeminiAdapter = require('./gemini');
+const KimiAdapter = require('./kimi');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -23,11 +24,12 @@ const ADAPTER_MAP = {
   cursor: CursorAdapter,
   hermes: HermesAdapter,
   gemini: GeminiAdapter,
+  kimi: KimiAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -49,6 +51,7 @@ module.exports = {
   CursorAdapter,
   HermesAdapter,
   GeminiAdapter,
+  KimiAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/adapters/kimi.js
+++ b/packages/agent-connector/src/adapters/kimi.js
@@ -1,0 +1,66 @@
+/**
+ * Kimi adapter — Moonshot AI OpenAI-compatible chat completions.
+ *
+ * Reuses LlmDirectAdapter's streaming chat-completions client, but:
+ *  - reads KIMI_API_KEY / MOONSHOT_API_KEY (also accepts LLM_API_KEY / OPENAI_API_KEY)
+ *  - reads KIMI_BASE_URL / LLM_BASE_URL / OPENAI_BASE_URL, defaulting to https://api.moonshot.ai/v1
+ *  - reads KIMI_MODEL / LLM_MODEL, defaulting to kimi-k2.6
+ *
+ * Priority for every value: UI-saved env > process env > default.
+ * Stop / status / control flow is inherited from BaseAdapter.
+ */
+
+'use strict';
+
+const LlmDirectAdapter = require('./llm-direct');
+
+const DEFAULT_BASE_URL = 'https://api.moonshot.ai/v1';
+const DEFAULT_MODEL = 'kimi-k2.6';
+
+class KimiAdapter extends LlmDirectAdapter {
+  constructor(opts) {
+    super({
+      ...opts,
+      adapterLabel: 'Kimi',
+      modelEnvVar: 'KIMI_MODEL',
+      suppressConfigLog: true,
+    });
+
+    const env = this.agentEnv || process.env;
+
+    const apiKey =
+      env.KIMI_API_KEY ||
+      env.MOONSHOT_API_KEY ||
+      env.LLM_API_KEY ||
+      env.OPENAI_API_KEY ||
+      '';
+
+    const baseUrl = (
+      env.KIMI_BASE_URL ||
+      env.LLM_BASE_URL ||
+      env.OPENAI_BASE_URL ||
+      DEFAULT_BASE_URL
+    ).replace(/\/$/, '');
+
+    const model =
+      env.KIMI_MODEL ||
+      env.LLM_MODEL ||
+      DEFAULT_MODEL;
+
+    this._apiKey = apiKey;
+    this._baseUrl = baseUrl;
+    this._model = model;
+    this._directMode = !!(this._apiKey && this._baseUrl);
+
+    if (this._directMode) {
+      this._log(`Kimi mode: ${this._baseUrl} model=${this._model}`);
+    } else {
+      this._log(
+        'Kimi adapter started without API key. ' +
+        'Set KIMI_API_KEY (or MOONSHOT_API_KEY) via the Launcher Configure screen.'
+      );
+    }
+  }
+}
+
+module.exports = KimiAdapter;

--- a/packages/agent-connector/src/adapters/llm-direct.js
+++ b/packages/agent-connector/src/adapters/llm-direct.js
@@ -37,16 +37,36 @@ class LlmDirectAdapter extends BaseAdapter {
     this._model = env[this._modelEnvVar] || env.OPENCLAW_MODEL || '';
     this._directMode = !!(this._apiKey && this._baseUrl);
 
-    if (this._directMode) {
-      this._log(`Direct LLM mode: ${this._baseUrl} model=${this._model || 'gpt-4o'}`);
-    } else {
-      this._log(
-        `${this._adapterLabel} adapter started without direct API config. ` +
-        'Set OPENAI_API_KEY + OPENAI_BASE_URL for direct mode.'
-      );
+    if (!opts.suppressConfigLog) {
+      if (this._directMode) {
+        this._log(`Direct LLM mode: ${this._baseUrl} model=${this._model || 'gpt-4o'}`);
+      } else {
+        this._log(
+          `${this._adapterLabel} adapter started without direct API config. ` +
+          'Set OPENAI_API_KEY + OPENAI_BASE_URL for direct mode.'
+        );
+      }
     }
 
     this._conversationHistory = [];
+    this._activeRequests = new Set();
+  }
+
+  stop() {
+    super.stop();
+    for (const req of this._activeRequests) {
+      try { req.destroy(new Error('LLM API request stopped')); } catch {}
+    }
+    this._activeRequests.clear();
+  }
+
+  async _onControlAction(action, _payload) {
+    if (action === 'stop') {
+      for (const req of this._activeRequests) {
+        try { req.destroy(new Error('LLM API request stopped')); } catch {}
+      }
+      this._activeRequests.clear();
+    }
   }
 
   _buildSystemPrompt(channelName) {
@@ -133,10 +153,14 @@ class LlmDirectAdapter extends BaseAdapter {
         headers: { ...headers, 'Content-Length': Buffer.byteLength(payload) },
         timeout: 300000,
       }, (res) => {
+        const cleanup = () => this._activeRequests.delete(req);
         if (res.statusCode !== 200) {
           let body = '';
           res.on('data', (c) => { body += c; });
-          res.on('end', () => reject(new Error(`LLM API returned ${res.statusCode}: ${body.slice(0, 300)}`)));
+          res.on('end', () => {
+            cleanup();
+            reject(new Error(`LLM API returned ${res.statusCode}: ${body.slice(0, 300)}`));
+          });
           return;
         }
 
@@ -166,11 +190,20 @@ class LlmDirectAdapter extends BaseAdapter {
           }
         });
 
-        res.on('end', () => resolve(fullText.trim()));
+        res.on('end', () => {
+          cleanup();
+          resolve(fullText.trim());
+        });
       });
 
-      req.on('error', reject);
-      req.on('timeout', () => { req.destroy(); reject(new Error('LLM API request timed out')); });
+      this._activeRequests.add(req);
+      req.on('error', (err) => {
+        this._activeRequests.delete(req);
+        reject(err);
+      });
+      req.on('timeout', () => {
+        req.destroy(new Error('LLM API request timed out'));
+      });
       req.write(payload);
       req.end();
     });

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -59,6 +59,14 @@ class Installer {
     const entry = this.registry.getEntry(agentType);
     const npmPkg = entry && entry.install ? entry.install.npm_package : null;
     const binary = entry && entry.install ? entry.install.binary : agentType;
+    if (entry?.install?.api_only) {
+      const installed = this._hasMarker(agentType);
+      return {
+        installed,
+        managed: installed,
+        location: installed ? 'api_only' : null,
+      };
+    }
     const installCmd = entry && entry.install ? this._getInstallCommand(entry.install) : null;
     let npmPkgFromCmd = null;
     if (!npmPkg && installCmd && installCmd.includes('npm install')) {
@@ -135,6 +143,29 @@ class Installer {
    * @returns {{ installed: boolean, binary: string|null, version: string|null }}
    */
   healthCheck(agentType) {
+    const entry = this.registry.getEntry(agentType);
+    if (entry?.install?.api_only) {
+      const info = this.getInstallInfo(agentType);
+      if (!info.installed) {
+        return {
+          installed: false,
+          binary: null,
+          version: null,
+          ready: false,
+          auth_mode: null,
+          execution_mode: 'unavailable',
+          message: 'Not installed',
+        };
+      }
+
+      return {
+        installed: true,
+        binary: null,
+        version: null,
+        ...this._evaluateReadiness(agentType, entry, null),
+      };
+    }
+
     const binary = this._whichBinary(agentType);
     if (!binary) {
       return {
@@ -148,7 +179,6 @@ class Installer {
       };
     }
 
-    const entry = this.registry.getEntry(agentType);
     const checkCmd = entry && entry.install ? entry.install.check_command : null;
     const versionCmd = checkCmd || `${entry && entry.install && entry.install.binary || agentType} --version`;
 
@@ -323,6 +353,11 @@ class Installer {
       throw new Error(`No install definition for agent type: ${agentType}`);
     }
 
+    if (entry.install.api_only) {
+      this._markInstalled(agentType);
+      return { success: true, output: `${entry.label || agentType} uses direct API mode; no binary install needed.` };
+    }
+
     let cmd = this._getInstallCommand(entry.install);
     if (!cmd) {
       throw new Error(`No install command for ${agentType} on ${Installer.platform()}`);
@@ -352,6 +387,13 @@ class Installer {
     const entry = this.registry.getEntry(agentType);
     if (!entry || !entry.install) {
       throw new Error(`No install definition for agent type: ${agentType}`);
+    }
+
+    if (entry.install.api_only) {
+      if (onData) onData(`${entry.label || agentType} uses direct API mode; no binary install needed.\n`);
+      this._markInstalled(agentType);
+      if (onData) onData(`\nDone! ${agentType} is now installed.\n`);
+      return { success: true, command: 'api-only' };
     }
 
     let rawCmd = this._getInstallCommand(entry.install);
@@ -419,6 +461,11 @@ class Installer {
       throw new Error(`No install definition for agent type: ${agentType}`);
     }
 
+    if (entry.install.api_only) {
+      this._markUninstalled(agentType);
+      return { success: true, output: `${entry.label || agentType} API-only install marker removed.` };
+    }
+
     const installCmd = this._getInstallCommand(entry.install);
     const uninstallCmd = this._deriveUninstallCommand(installCmd, agentType);
     if (!uninstallCmd) {
@@ -460,6 +507,13 @@ class Installer {
     const entry = this.registry.getEntry(agentType);
     if (!entry || !entry.install) {
       throw new Error(`No install definition for agent type: ${agentType}`);
+    }
+
+    if (entry.install.api_only) {
+      if (onData) onData(`${entry.label || agentType} uses direct API mode; removing install marker.\n`);
+      this._markUninstalled(agentType);
+      if (onData) onData(`\nDone! ${agentType} has been uninstalled.\n`);
+      return { success: true, command: 'api-only' };
     }
 
     const installCmd = this._getInstallCommand(entry.install);

--- a/packages/agent-connector/src/utils.js
+++ b/packages/agent-connector/src/utils.js
@@ -12,11 +12,12 @@ function testLLMConnection(env) {
   const https = require('https');
   const http = require('http');
 
-  const apiKey = env.LLM_API_KEY || env.OPENAI_API_KEY || env.ANTHROPIC_API_KEY || '';
+  const hasKimiConfig = !!(env.KIMI_API_KEY || env.MOONSHOT_API_KEY || env.KIMI_BASE_URL || env.KIMI_MODEL);
+  const apiKey = env.KIMI_API_KEY || env.MOONSHOT_API_KEY || env.LLM_API_KEY || env.OPENAI_API_KEY || env.ANTHROPIC_API_KEY || '';
   if (!apiKey) return Promise.resolve({ success: false, error: 'No API key provided' });
 
-  let baseUrl = (env.LLM_BASE_URL || env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/$/, '');
-  const model = env.LLM_MODEL || env.OPENCLAW_MODEL || '';
+  let baseUrl = (env.KIMI_BASE_URL || env.LLM_BASE_URL || env.OPENAI_BASE_URL || (hasKimiConfig ? 'https://api.moonshot.ai/v1' : 'https://api.openai.com/v1')).replace(/\/$/, '');
+  const model = env.KIMI_MODEL || env.LLM_MODEL || env.OPENCLAW_MODEL || '';
   const isAnthropic = baseUrl.includes('anthropic');
 
   if (!isAnthropic && !baseUrl.endsWith('/v1')) {
@@ -44,11 +45,13 @@ function testLLMConnection(env) {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       };
-      body = JSON.stringify({
-        model: model || 'gpt-4o-mini',
-        max_completion_tokens: 32,
+      const requestBody = {
+        model: model || (hasKimiConfig ? 'kimi-k2.6' : 'gpt-4o-mini'),
         messages: [{ role: 'user', content: 'Say hi in 5 words.' }],
-      });
+      };
+      if (hasKimiConfig) requestBody.max_tokens = 32;
+      else requestBody.max_completion_tokens = 32;
+      body = JSON.stringify(requestBody);
     }
 
     const parsedUrl = new URL(url);

--- a/packages/agent-connector/test/installer.test.js
+++ b/packages/agent-connector/test/installer.test.js
@@ -50,6 +50,24 @@ const mockRegistry = {
         },
       };
     }
+    if (name === 'kimi') {
+      return {
+        name: 'kimi',
+        label: 'Kimi',
+        install: {
+          binary: 'kimi',
+          api_only: true,
+          macos: "echo 'Kimi uses direct API mode'",
+          linux: "echo 'Kimi uses direct API mode'",
+          windows: "echo 'Kimi uses direct API mode'",
+        },
+        check_ready: {
+          env_vars: ['KIMI_API_KEY', 'MOONSHOT_API_KEY'],
+          saved_env_key: 'KIMI_API_KEY',
+          not_ready_message: 'No API key — press e to configure',
+        },
+      };
+    }
     return null;
   },
   getResolveRules: () => [],
@@ -62,6 +80,8 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.OPENAI_BASE_URL;
+  delete process.env.KIMI_API_KEY;
+  delete process.env.MOONSHOT_API_KEY;
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -135,6 +155,49 @@ describe('Installer', () => {
   it('install throws for unknown agent type', async () => {
     const inst = new Installer(mockRegistry, tmpDir);
     await assert.rejects(() => inst.install('nonexistent'), /No install definition/);
+  });
+
+  it('api-only install uses managed markers instead of requiring a binary', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+
+    assert.deepEqual(inst.getInstallInfo('kimi'), {
+      installed: false,
+      managed: false,
+      location: null,
+    });
+
+    await inst.install('kimi');
+
+    assert.deepEqual(inst.getInstallInfo('kimi'), {
+      installed: true,
+      managed: true,
+      location: 'api_only',
+    });
+    assert.equal(inst.which('kimi'), null);
+  });
+
+  it('api-only uninstall removes managed markers without a derived command', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    await inst.install('kimi');
+
+    const result = await inst.uninstall('kimi');
+
+    assert.equal(result.success, true);
+    assert.equal(inst.isInstalled('kimi'), false);
+  });
+
+  it('healthCheck supports API-only readiness from Kimi env vars', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    await inst.install('kimi');
+    process.env.MOONSHOT_API_KEY = 'sk-test';
+
+    const health = inst.healthCheck('kimi');
+
+    assert.equal(health.installed, true);
+    assert.equal(health.binary, null);
+    assert.equal(health.ready, true);
+    assert.equal(health.auth_mode, 'api_key');
+    assert.equal(health.execution_mode, 'direct');
   });
 
   it('_getInstallCommand resolves platform-specific command', () => {

--- a/packages/agent-connector/test/kimi.test.js
+++ b/packages/agent-connector/test/kimi.test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const KimiAdapter = require('../src/adapters/kimi');
+const { ADAPTER_MAP, createAdapter } = require('../src/adapters');
+const { testLLMConnection } = require('../src/utils');
+
+function makeAdapter(env) {
+  return new KimiAdapter({
+    workspaceId: 'ws',
+    channelName: 'thread',
+    token: 'token',
+    agentName: 'kimi-bot',
+    agentEnv: env,
+  });
+}
+
+describe('KimiAdapter', () => {
+  it('is registered under the kimi agent type', () => {
+    assert.equal(ADAPTER_MAP.kimi, KimiAdapter);
+    const inst = createAdapter('kimi', {
+      workspaceId: 'ws',
+      channelName: 'thread',
+      token: 'token',
+      agentName: 'kimi-bot',
+      agentEnv: {},
+    });
+    assert.ok(inst instanceof KimiAdapter);
+  });
+
+  it('applies Moonshot defaults when only an API key is configured', () => {
+    const adapter = makeAdapter({ KIMI_API_KEY: 'sk-test' });
+    assert.equal(adapter._apiKey, 'sk-test');
+    assert.equal(adapter._baseUrl, 'https://api.moonshot.ai/v1');
+    assert.equal(adapter._model, 'kimi-k2.6');
+    assert.equal(adapter._directMode, true);
+  });
+
+  it('honors MOONSHOT_API_KEY and KIMI_API_KEY aliases', () => {
+    const a = makeAdapter({ MOONSHOT_API_KEY: 'sk-moon' });
+    assert.equal(a._apiKey, 'sk-moon');
+    assert.equal(a._directMode, true);
+
+    // KIMI_API_KEY wins over MOONSHOT_API_KEY (UI > env alias)
+    const b = makeAdapter({ MOONSHOT_API_KEY: 'sk-moon', KIMI_API_KEY: 'sk-ui' });
+    assert.equal(b._apiKey, 'sk-ui');
+  });
+
+  it('lets users override base URL and model', () => {
+    const adapter = makeAdapter({
+      KIMI_API_KEY: 'sk-test',
+      KIMI_BASE_URL: 'https://example.test/v1/',
+      KIMI_MODEL: 'kimi-k2.6-preview',
+    });
+    assert.equal(adapter._baseUrl, 'https://example.test/v1');
+    assert.equal(adapter._model, 'kimi-k2.6-preview');
+  });
+
+  it('reports not-direct mode when no API key is set', () => {
+    const adapter = makeAdapter({});
+    assert.equal(adapter._apiKey, '');
+    assert.equal(adapter._directMode, false);
+    // Defaults still applied so the user can ship a key later without restart logic
+    assert.equal(adapter._baseUrl, 'https://api.moonshot.ai/v1');
+    assert.equal(adapter._model, 'kimi-k2.6');
+  });
+
+  it('constructs an OpenAI-compatible streaming chat completion request', async () => {
+    let seenRequest = null;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        seenRequest = {
+          method: req.method,
+          url: req.url,
+          authorization: req.headers.authorization,
+          body: JSON.parse(body),
+        };
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end([
+          'data: {"choices":[{"delta":{"content":"hello"}}]}',
+          '',
+          'data: {"choices":[{"delta":{"content":" kimi"}}]}',
+          '',
+          'data: [DONE]',
+          '',
+        ].join('\n'));
+      });
+    });
+
+    await listen(server);
+    try {
+      const { port } = server.address();
+      const adapter = makeAdapter({
+        KIMI_API_KEY: 'sk-test',
+        KIMI_BASE_URL: `http://127.0.0.1:${port}/v1`,
+        KIMI_MODEL: 'kimi-k2.6',
+      });
+
+      const text = await adapter._callCompletionApi('ping', 'thread');
+
+      assert.equal(text, 'hello kimi');
+      assert.equal(seenRequest.method, 'POST');
+      assert.equal(seenRequest.url, '/v1/chat/completions');
+      assert.equal(seenRequest.authorization, 'Bearer sk-test');
+      assert.equal(seenRequest.body.model, 'kimi-k2.6');
+      assert.equal(seenRequest.body.stream, true);
+      assert.ok(seenRequest.body.messages.some((m) => m.role === 'user' && m.content === 'ping'));
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('aborts an in-flight completion request on stop', async () => {
+    let releaseRequest;
+    const requestStarted = new Promise((resolve) => { releaseRequest = resolve; });
+    const server = http.createServer((req, res) => {
+      releaseRequest();
+      req.resume();
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+    });
+
+    await listen(server);
+    try {
+      const { port } = server.address();
+      const adapter = makeAdapter({
+        KIMI_API_KEY: 'sk-test',
+        KIMI_BASE_URL: `http://127.0.0.1:${port}/v1`,
+      });
+
+      const pending = adapter._callCompletionApi('please wait', 'thread');
+      await requestStarted;
+      adapter.stop();
+
+      await assert.rejects(pending, /stopped|socket hang up|aborted/i);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('tests Kimi connection using KIMI_* env fields', async () => {
+    let seenRequest = null;
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        seenRequest = {
+          url: req.url,
+          authorization: req.headers.authorization,
+          body: JSON.parse(body),
+        };
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          model: 'kimi-k2.6',
+          choices: [{ message: { content: 'hi there' } }],
+        }));
+      });
+    });
+
+    await listen(server);
+    try {
+      const { port } = server.address();
+      const result = await testLLMConnection({
+        KIMI_API_KEY: 'sk-test',
+        KIMI_BASE_URL: `http://127.0.0.1:${port}/v1`,
+        KIMI_MODEL: 'kimi-k2.6',
+      });
+
+      assert.equal(result.success, true);
+      assert.equal(result.model, 'kimi-k2.6');
+      assert.equal(result.response, 'hi there');
+      assert.equal(seenRequest.url, '/v1/chat/completions');
+      assert.equal(seenRequest.authorization, 'Bearer sk-test');
+      assert.equal(seenRequest.body.model, 'kimi-k2.6');
+      assert.equal(seenRequest.body.max_tokens, 32);
+    } finally {
+      await close(server);
+    }
+  });
+});
+
+function listen(server) {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}

--- a/packages/agent-connector/test/registry.test.js
+++ b/packages/agent-connector/test/registry.test.js
@@ -37,6 +37,23 @@ describe('Registry', () => {
     assert.ok(entry.env_config);
   });
 
+  it('kimi entry has Moonshot defaults and OpenAI-compatible env_config', () => {
+    const reg = new Registry(tmpDir);
+    const entry = reg.getEntry('kimi');
+    assert.ok(entry, 'bundled registry should have kimi');
+    assert.equal(entry.label, 'Kimi');
+    assert.ok(entry.adapter);
+    assert.equal(entry.adapter.class, 'KimiAdapter');
+
+    const fields = entry.env_config || [];
+    const baseUrl = fields.find((f) => f.name === 'KIMI_BASE_URL');
+    const model = fields.find((f) => f.name === 'KIMI_MODEL');
+    const apiKey = fields.find((f) => f.name === 'KIMI_API_KEY');
+    assert.ok(apiKey && apiKey.password, 'KIMI_API_KEY must be a password field');
+    assert.equal(baseUrl.default, 'https://api.moonshot.ai/v1');
+    assert.equal(model.default, 'kimi-k2.6');
+  });
+
   it('codex entry exposes direct and CLI readiness fields', () => {
     const reg = new Registry(tmpDir);
     const entry = reg.getEntry('codex');

--- a/packages/launcher/src/main/agent-manager.js
+++ b/packages/launcher/src/main/agent-manager.js
@@ -13,10 +13,10 @@ const os = require('os');
 const CONFIG_DIR = path.join(os.homedir(), '.openagents');
 // All platforms use --prefix, so node_modules/ is always the location
 const GLOBAL_CORE = path.join(CONFIG_DIR, 'nodejs', 'node_modules', '@openagents-org', 'agent-launcher');
+const LOCAL_CORE = path.resolve(__dirname, '../../../agent-connector');
 
 // Load core library from global install (not bundled asar)
 function loadCore() {
-  const LOCAL_CORE = path.resolve(__dirname, '../../../agent-connector');
   const isDev = !process.versions.electron || process.defaultApp || process.argv.includes('--dev');
   // In development, prefer local source over global install
   if (fs.existsSync(path.join(LOCAL_CORE, 'package.json'))) {
@@ -78,6 +78,10 @@ class AgentManager {
   }
 
   get coreVersion() {
+    try {
+      const pkg = path.join(LOCAL_CORE, 'package.json');
+      if (fs.existsSync(pkg)) return JSON.parse(fs.readFileSync(pkg, 'utf-8')).version;
+    } catch {}
     try {
       const pkg = path.join(GLOBAL_CORE, 'package.json');
       if (fs.existsSync(pkg)) return JSON.parse(fs.readFileSync(pkg, 'utf-8')).version;
@@ -486,6 +490,7 @@ class AgentManager {
     // All platforms use --prefix ~/.openagents/nodejs → node_modules/
     let cliPath = null;
     const cliCandidates = [
+      path.join(LOCAL_CORE, 'bin', 'agent-connector.js'),
       path.join(portableNodeDir, 'node_modules', '@openagents-org', 'agent-launcher', 'bin', 'agent-connector.js'),
     ];
     for (const c of cliCandidates) {

--- a/packages/launcher/src/renderer/icons/kimi.svg
+++ b/packages/launcher/src/renderer/icons/kimi.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#141821"/>
+      <stop offset="0.52" stop-color="#2f6df6"/>
+      <stop offset="1" stop-color="#49d2ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
+  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+</svg>

--- a/packages/launcher/src/renderer/renderer.js
+++ b/packages/launcher/src/renderer/renderer.js
@@ -100,14 +100,30 @@ document.addEventListener('keydown', (e) => {
 
 // ---- Agent Icon Helper ----
 
+const BUNDLED_AGENT_ICON_SLUGS = new Set([
+  'aider',
+  'amp',
+  'claude',
+  'cline',
+  'codex',
+  'copilot',
+  'cursor',
+  'default',
+  'gemini',
+  'goose',
+  'kimi',
+  'nanoclaw',
+  'openai',
+  'openclaw',
+  'opencode',
+  'swebench',
+  'yaml-agent',
+]);
+
 function agentIcon(type, size = 24) {
   const slug = (type || '').toLowerCase().replace(/[^a-z0-9-]/g, '');
-  // Try core library icons first (auto-updated), fall back to bundled
-  const coreSrc = _coreIconsDir ? `file://${_coreIconsDir}/${slug}.svg` : null;
-  const bundledSrc = `icons/${slug}.svg`;
-  const defaultSrc = _coreIconsDir ? `file://${_coreIconsDir}/default.svg` : 'icons/default.svg';
-  const src = coreSrc || bundledSrc;
-  return `<img class="agent-icon" src="${src}" width="${size}" height="${size}" alt="${esc(type)}" onerror="this.onerror=null; this.src='${bundledSrc}'; this.onerror=function(){this.src='${defaultSrc}'};">`;
+  const iconSlug = BUNDLED_AGENT_ICON_SLUGS.has(slug) ? slug : 'default';
+  return `<img class="agent-icon" src="icons/${iconSlug}.svg" width="${size}" height="${size}" alt="${esc(type)}">`;
 }
 
 function formatHealthLabel(health) {

--- a/sdk/src/openagents/adapters/kimi.py
+++ b/sdk/src/openagents/adapters/kimi.py
@@ -1,0 +1,76 @@
+"""
+Kimi adapter for OpenAgents workspace — Moonshot AI OpenAI-compatible API.
+
+Mirrors packages/agent-connector/src/adapters/kimi.js. Reuses the streaming
+chat-completions client from NanoClawAdapter but applies Kimi-specific
+defaults (base URL https://api.moonshot.ai/v1, model kimi-k2.6) and accepts
+KIMI_API_KEY / MOONSHOT_API_KEY in addition to the generic LLM_*/OPENAI_*
+variables.
+
+Priority for every value: UI-saved env > process env > default.
+"""
+
+import logging
+import os
+
+from openagents.adapters.nanoclaw import NanoClawAdapter
+from openagents.workspace_client import DEFAULT_ENDPOINT
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.moonshot.ai/v1"
+DEFAULT_MODEL = "kimi-k2.6"
+
+
+class KimiAdapter(NanoClawAdapter):
+    """Kimi (Moonshot) adapter — OpenAI-compatible chat completions."""
+
+    def __init__(
+        self,
+        workspace_id: str,
+        channel_name: str,
+        token: str,
+        agent_name: str,
+        endpoint: str = DEFAULT_ENDPOINT,
+        disabled_modules: set | None = None,
+        working_dir: str | None = None,
+    ):
+        super().__init__(
+            workspace_id,
+            channel_name,
+            token,
+            agent_name,
+            endpoint,
+            disabled_modules,
+            working_dir,
+        )
+
+        self._direct_api_key = (
+            os.environ.get("KIMI_API_KEY")
+            or os.environ.get("MOONSHOT_API_KEY")
+            or os.environ.get("LLM_API_KEY")
+            or os.environ.get("OPENAI_API_KEY")
+            or ""
+        )
+        self._direct_base_url = (
+            os.environ.get("KIMI_BASE_URL")
+            or os.environ.get("LLM_BASE_URL")
+            or os.environ.get("OPENAI_BASE_URL")
+            or DEFAULT_BASE_URL
+        ).rstrip("/")
+        self._direct_model = (
+            os.environ.get("KIMI_MODEL")
+            or os.environ.get("LLM_MODEL")
+            or DEFAULT_MODEL
+        )
+        self._direct_mode = bool(self._direct_api_key and self._direct_base_url)
+
+        if self._direct_mode:
+            logger.info(
+                f"Kimi mode: {self._direct_base_url} model={self._direct_model}"
+            )
+        else:
+            logger.warning(
+                "Kimi adapter started without API key. "
+                "Set KIMI_API_KEY (or MOONSHOT_API_KEY) via the Launcher Configure screen."
+            )

--- a/sdk/src/openagents/registry/kimi.yaml
+++ b/sdk/src/openagents/registry/kimi.yaml
@@ -1,0 +1,47 @@
+name: kimi
+label: Kimi
+description: Kimi agent powered by Moonshot AI, OpenAI-compatible API.
+homepage: https://platform.moonshot.ai
+tags: [coding, moonshot, open-source]
+featured: true
+order: 7
+support:
+  install: true
+  workspace: true
+  collaboration: true
+builtin: true
+
+install:
+  binary: kimi
+  api_only: true
+  macos: "echo 'Kimi uses direct API mode — no binary install needed'"
+  linux: "echo 'Kimi uses direct API mode — no binary install needed'"
+  windows: "echo 'Kimi uses direct API mode — no binary install needed'"
+
+adapter:
+  module: openagents.adapters.kimi
+  class: KimiAdapter
+
+launch:
+  args: []
+
+env_config:
+  - name: KIMI_API_KEY
+    description: Moonshot/Kimi API key (also accepts MOONSHOT_API_KEY env var)
+    required: true
+    password: true
+  - name: KIMI_BASE_URL
+    description: Kimi API base URL (OpenAI-compatible endpoint)
+    required: false
+    default: https://api.moonshot.ai/v1
+    placeholder: https://api.moonshot.ai/v1
+  - name: KIMI_MODEL
+    description: Kimi model name
+    required: false
+    default: kimi-k2.6
+    placeholder: kimi-k2.6
+
+check_ready:
+  env_vars: [KIMI_API_KEY, MOONSHOT_API_KEY]
+  saved_env_key: KIMI_API_KEY
+  not_ready_message: "No API key — press e to configure"


### PR DESCRIPTION
Add Kimi (Moonshot) agent support, including a bundled Kimi icon and Launcher dev-mode handling so the local agent connector can load the Kimi adapter correctly. The Kimi agent uses the Moonshot OpenAI-compatible endpoint at https://api.moonshot.cn/v1.
