### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ sdk = [
     "jinja2>=3.1.0",
     "mcp>=1.15.0",
     "openai>=1.98",
+    "litellm>=1.55.0,<1.85",
     "prometheus-client>=0.16.0",
     "structlog>=23.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ sdk = [
     "jinja2>=3.1.0",
     "mcp>=1.15.0",
     "openai>=1.98",
-    "litellm>=1.67.0,<1.90",
+    "litellm>=1.80.0,<1.87",
     "prometheus-client>=0.16.0",
     "structlog>=23.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ sdk = [
     "jinja2>=3.1.0",
     "mcp>=1.15.0",
     "openai>=1.98",
-    "litellm>=1.55.0,<1.85",
+    "litellm>=1.67.0,<1.90",
     "prometheus-client>=0.16.0",
     "structlog>=23.0.0",
 ]

--- a/sdk/src/openagents/config/llm_configs.py
+++ b/sdk/src/openagents/config/llm_configs.py
@@ -28,6 +28,7 @@ class LLMProviderType(str, Enum):
     GROQ = "groq"
     OPENROUTER = "openrouter"
     MINIMAX = "minimax"
+    LITELLM = "litellm"
     CUSTOM = "custom"  # Custom OpenAI-compatible endpoint
     OPENAI_COMPATIBLE = "openai-compatible"  # Alias for custom
 
@@ -194,6 +195,12 @@ MODEL_CONFIGS: Dict[str, Dict[str, Any]] = {
             "MiniMax-M2.7-highspeed",
         ],
         "API_KEY_ENV_VAR": "MINIMAX_API_KEY",
+    },
+    # LiteLLM (unified SDK for 100+ providers)
+    "litellm": {
+        "provider": "litellm",
+        "models": [],  # User specifies model with provider prefix (e.g., "anthropic/claude-sonnet-4-5")
+        "API_KEY_ENV_VAR": None,  # LiteLLM reads provider-specific env vars automatically
     },
     # Custom OpenAI-compatible endpoint (e.g., Ollama, vLLM, local models)
     "custom": {
@@ -439,6 +446,7 @@ def create_model_provider(
         AnthropicProvider,
         BedrockProvider,
         GeminiProvider,
+        LiteLLMProvider,
         MiniMaxProvider,
         SimpleGenericProvider,
     )
@@ -464,6 +472,8 @@ def create_model_provider(
         return MiniMaxProvider(
             model_name=model_name, api_base=effective_api_base, api_key=api_key, **kwargs
         )
+    elif provider == "litellm":
+        return LiteLLMProvider(model_name=model_name, **kwargs)
     elif provider == "custom" or provider == "openai-compatible":
         # Custom OpenAI-compatible endpoint requires api_base
         if not api_base:

--- a/sdk/src/openagents/lms/__init__.py
+++ b/sdk/src/openagents/lms/__init__.py
@@ -10,6 +10,7 @@ from .providers import (
     AnthropicProvider,
     BedrockProvider,
     GeminiProvider,
+    LiteLLMProvider,
     MiniMaxProvider,
     SimpleGenericProvider,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "AnthropicProvider",
     "BedrockProvider",
     "GeminiProvider",
+    "LiteLLMProvider",
     "MiniMaxProvider",
     "SimpleGenericProvider",
     # LLM logging

--- a/sdk/src/openagents/lms/providers.py
+++ b/sdk/src/openagents/lms/providers.py
@@ -713,7 +713,18 @@ class LiteLLMProvider(BaseModelProvider):
             call_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             call_kwargs["tool_choice"] = "auto"
 
-        response = await litellm.acompletion(**call_kwargs)
+        try:
+            response = await litellm.acompletion(**call_kwargs)
+        except litellm.AuthenticationError:
+            raise
+        except litellm.BadRequestError:
+            raise
+        except litellm.RateLimitError as e:
+            logger.warning(f"LiteLLM rate limited: {e}")
+            raise
+        except (litellm.APIConnectionError, litellm.Timeout) as e:
+            logger.error(f"LiteLLM connection error: {e}")
+            raise
 
         # Standardize response format
         message = response.choices[0].message

--- a/sdk/src/openagents/lms/providers.py
+++ b/sdk/src/openagents/lms/providers.py
@@ -658,6 +658,77 @@ class MiniMaxProvider(BaseModelProvider):
         return [tool.to_openai_function() for tool in tools]
 
 
+class LiteLLMProvider(BaseModelProvider):
+    """LiteLLM provider supporting 100+ LLM providers through a unified interface.
+
+    LiteLLM routes requests to the correct provider based on the model string.
+    For example, ``anthropic/claude-sonnet-4-5`` routes to Anthropic,
+    ``bedrock/anthropic.claude-v2`` routes to AWS Bedrock, and
+    ``vertex_ai/gemini-pro`` routes to Google Vertex AI.
+
+    Authentication is handled via provider-specific environment variables
+    (e.g. ``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``AWS_ACCESS_KEY_ID``).
+    LiteLLM reads these automatically based on the model prefix.
+
+    For a full list of supported providers, see: https://docs.litellm.ai/docs/providers
+    """
+
+    def __init__(self, model_name: str, **kwargs):
+        self.model_name = model_name
+
+        try:
+            import litellm  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "litellm package is required for LiteLLM provider. "
+                "Install with: pip install litellm"
+            )
+
+    async def chat_completion(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Generate chat completion using LiteLLM SDK."""
+        import litellm
+
+        kwargs: Dict[str, Any] = {"model": self.model_name, "messages": messages}
+
+        if tools:
+            kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
+            kwargs["tool_choice"] = "auto"
+
+        response = await litellm.acompletion(**kwargs)
+
+        # Standardize response format
+        message = response.choices[0].message
+        result: Dict[str, Any] = {"content": message.content, "tool_calls": []}
+
+        if hasattr(message, "tool_calls") and message.tool_calls:
+            for tool_call in message.tool_calls:
+                result["tool_calls"].append(
+                    {
+                        "id": tool_call.id,
+                        "name": tool_call.function.name,
+                        "arguments": tool_call.function.arguments,
+                    }
+                )
+
+        # Extract token usage
+        if hasattr(response, "usage") and response.usage:
+            result["usage"] = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        return result
+
+    def format_tools(self, tools: List[Any]) -> List[Dict[str, Any]]:
+        """Format tools for LiteLLM (OpenAI-compatible format)."""
+        return [tool.to_openai_function() for tool in tools]
+
+
 class SimpleGenericProvider(BaseModelProvider):
     """Generic provider for OpenAI-compatible APIs (DeepSeek, Qwen, Grok, etc.)."""
 

--- a/sdk/src/openagents/lms/providers.py
+++ b/sdk/src/openagents/lms/providers.py
@@ -6,6 +6,8 @@ import logging
 from typing import Dict, List, Any, Optional
 from abc import ABC, abstractmethod
 
+import litellm
+
 logger = logging.getLogger(__name__)
 
 
@@ -676,21 +678,12 @@ class LiteLLMProvider(BaseModelProvider):
     def __init__(self, model_name: str, **kwargs):
         self.model_name = model_name
 
-        try:
-            import litellm  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "litellm package is required for LiteLLM provider. "
-                "Install with: pip install litellm"
-            )
-
     async def chat_completion(
         self,
         messages: List[Dict[str, Any]],
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """Generate chat completion using LiteLLM SDK."""
-        import litellm
 
         kwargs: Dict[str, Any] = {"model": self.model_name, "messages": messages}
 

--- a/sdk/src/openagents/lms/providers.py
+++ b/sdk/src/openagents/lms/providers.py
@@ -6,8 +6,6 @@ import logging
 from typing import Dict, List, Any, Optional
 from abc import ABC, abstractmethod
 
-import litellm
-
 logger = logging.getLogger(__name__)
 
 
@@ -675,8 +673,23 @@ class LiteLLMProvider(BaseModelProvider):
     For a full list of supported providers, see: https://docs.litellm.ai/docs/providers
     """
 
-    def __init__(self, model_name: str, **kwargs):
+    def __init__(
+        self,
+        model_name: str,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ):
+        try:
+            import litellm  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "litellm package is required for LiteLLMProvider. "
+                "Install with: pip install litellm"
+            )
         self.model_name = model_name
+        self._api_key = api_key
+        self._api_base = api_base
 
     async def chat_completion(
         self,
@@ -684,14 +697,23 @@ class LiteLLMProvider(BaseModelProvider):
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """Generate chat completion using LiteLLM SDK."""
+        import litellm
 
-        kwargs: Dict[str, Any] = {"model": self.model_name, "messages": messages}
+        call_kwargs: Dict[str, Any] = {
+            "model": self.model_name,
+            "messages": messages,
+            "drop_params": True,
+        }
+        if self._api_key:
+            call_kwargs["api_key"] = self._api_key
+        if self._api_base:
+            call_kwargs["api_base"] = self._api_base
 
         if tools:
-            kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
-            kwargs["tool_choice"] = "auto"
+            call_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
+            call_kwargs["tool_choice"] = "auto"
 
-        response = await litellm.acompletion(**kwargs)
+        response = await litellm.acompletion(**call_kwargs)
 
         # Standardize response format
         message = response.choices[0].message

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,153 @@
+"""Tests for LiteLLM provider."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestLiteLLMProviderInit:
+    def test_requires_litellm_installed(self):
+        with patch.dict("sys.modules", {"litellm": None}):
+            from openagents.lms.providers import LiteLLMProvider
+
+            with pytest.raises(ImportError, match="litellm"):
+                LiteLLMProvider(model_name="openai/gpt-4o")
+
+    def test_stores_model_name(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="anthropic/claude-sonnet-4-6")
+        assert provider.model_name == "anthropic/claude-sonnet-4-6"
+
+    def test_stores_api_key(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o", api_key="sk-test")
+        assert provider._api_key == "sk-test"
+
+    def test_stores_api_base(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o", api_base="http://localhost:4000")
+        assert provider._api_base == "http://localhost:4000"
+
+    def test_api_key_none_by_default(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o")
+        assert provider._api_key is None
+
+    def test_api_base_none_by_default(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o")
+        assert provider._api_base is None
+
+
+class TestLiteLLMProviderChatCompletion:
+    @pytest.mark.asyncio
+    async def test_chat_completion_basic(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o-mini")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello!"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response) as mock:
+            result = await provider.chat_completion([{"role": "user", "content": "Hi"}])
+
+            assert result["content"] == "Hello!"
+            assert result["usage"]["prompt_tokens"] == 10
+            call_kwargs = mock.call_args.kwargs
+            assert call_kwargs["model"] == "openai/gpt-4o-mini"
+            assert call_kwargs["drop_params"] is True
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_forwards_api_key(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o", api_key="sk-test")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = None
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response) as mock:
+            await provider.chat_completion([{"role": "user", "content": "test"}])
+            assert mock.call_args.kwargs["api_key"] == "sk-test"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_forwards_api_base(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o", api_base="http://proxy:4000")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = None
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response) as mock:
+            await provider.chat_completion([{"role": "user", "content": "test"}])
+            assert mock.call_args.kwargs["api_base"] == "http://proxy:4000"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_omits_api_key_when_none(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = None
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response) as mock:
+            await provider.chat_completion([{"role": "user", "content": "test"}])
+            assert "api_key" not in mock.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_with_tools(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o")
+
+        mock_tc = MagicMock()
+        mock_tc.id = "call_123"
+        mock_tc.function.name = "get_weather"
+        mock_tc.function.arguments = '{"city": "Paris"}'
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+        mock_response.choices[0].message.tool_calls = [mock_tc]
+        mock_response.usage = None
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_response):
+            result = await provider.chat_completion(
+                [{"role": "user", "content": "Weather?"}],
+                tools=[{"name": "get_weather", "parameters": {}}],
+            )
+            assert len(result["tool_calls"]) == 1
+            assert result["tool_calls"][0]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_format_tools(self):
+        from openagents.lms.providers import LiteLLMProvider
+
+        provider = LiteLLMProvider(model_name="openai/gpt-4o")
+
+        mock_tool = MagicMock()
+        mock_tool.to_openai_function.return_value = {"name": "test", "parameters": {}}
+
+        result = provider.format_tools([mock_tool])
+        assert result == [{"name": "test", "parameters": {}}]


### PR DESCRIPTION
## Summary

Adds LiteLLM as a new model provider, giving users access to 100+ LLM providers through a single `LiteLLMProvider` class. Follows the existing `BaseModelProvider` pattern exactly.

## Motivation

OpenAgents currently supports several providers (OpenAI, Anthropic, Bedrock, Gemini, MiniMax) with dedicated classes, plus a `SimpleGenericProvider` for OpenAI-compatible APIs. LiteLLM is a lightweight Python SDK that routes requests to the correct provider based on the model string (e.g. `anthropic/claude-sonnet-4-5`, `vertex_ai/gemini-pro`, `cohere/command-r-plus`). This gives users access to providers like Vertex AI, Cohere, AI21, and self-hosted endpoints without needing new provider classes for each one.

## Changes

- `sdk/src/openagents/lms/providers.py` - new `LiteLLMProvider` class extending `BaseModelProvider`
- `sdk/src/openagents/lms/__init__.py` - registered in imports and `__all__`
- `sdk/src/openagents/config/llm_configs.py` - added `LITELLM` enum value, `MODEL_CONFIGS` entry, and `create_model_provider` factory case
- `pyproject.toml` - added `litellm>=1.55.0,<1.85` to `sdk` optional dependencies

## Implementation

`LiteLLMProvider` follows the same pattern as `OpenAIProvider`:
- `chat_completion()` calls `litellm.acompletion()` and returns the standardized `{"content": ..., "tool_calls": [...], "usage": {...}}` format
- `format_tools()` uses OpenAI-compatible format (same as `OpenAIProvider`)
- Tool calling support via `tools` and `tool_choice` parameters
- Token usage extraction from the response

## Example usage

```python
from openagents.config.llm_configs import create_model_provider
import asyncio

# Use any LiteLLM-supported provider
provider = create_model_provider("litellm", "anthropic/claude-sonnet-4-5")

result = asyncio.run(provider.chat_completion(
    messages=[{"role": "user", "content": "Hello!"}]
))
print(result["content"])
```

Provider-specific API keys are read from environment variables automatically (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). See https://docs.litellm.ai/docs/providers for the full list.

## Tests

```python
>>> provider = create_model_provider("litellm", "anthropic/claude-sonnet-4-5")
>>> result = asyncio.run(provider.chat_completion(
...     messages=[{"role": "user", "content": "What is 2+2? Answer with just the number."}]
... ))
>>> result["content"]
'4'
>>> result["usage"]
{'prompt_tokens': 20, 'completion_tokens': 5, 'total_tokens': 25}
```

## Risk / Compatibility

- Additive only. Existing providers untouched.
- `litellm>=1.55.0,<1.85` added to the `sdk` optional dependencies in `pyproject.toml`.
- Response format matches the existing standardized format used by all other providers.
