### PR TITLE
feat(go): A2UI-style generative UI rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,7 @@ docs/projects
 .mcp.json
 /*.png
 *.db
+*.sqlite
 .next/
 .playwright-mcp/
 tsconfig.tsbuildinfo

--- a/packages/agent-connector/src/adapters/base.js
+++ b/packages/agent-connector/src/adapters/base.js
@@ -499,8 +499,15 @@ class BaseAdapter {
   }
 
   async sendThinking(channel, content) {
+    // Strip ```a2ui blocks if they leak into Claude's intermediate thinking
+    // trace — the real spec gets emitted via sendResponse with proper
+    // payload.spec extraction, so showing the raw block here is just noise
+    // (and a duplicate). If stripping leaves the thinking message empty,
+    // skip it entirely.
+    const { cleanContent } = extractA2UISpec(content);
+    if (!cleanContent || !cleanContent.trim()) return;
     try {
-      await this.client.sendMessage(this.workspaceId, channel, this.token, content, {
+      await this.client.sendMessage(this.workspaceId, channel, this.token, cleanContent, {
         senderType: 'agent',
         senderName: this.agentName,
         messageType: 'thinking',

--- a/packages/agent-connector/src/adapters/base.js
+++ b/packages/agent-connector/src/adapters/base.js
@@ -42,6 +42,7 @@ class BaseAdapter {
     this.workingDir = workingDir || undefined;
     this.client = new WorkspaceClient(this.endpoint);
     this._lastEventId = null;
+    this._lastToolResultId = null;
     this._running = false;
     this._sessionId = null;  // issued by server on /v1/join; used to prove liveness
     this._processedIds = new Set();
@@ -358,6 +359,31 @@ class BaseAdapter {
         idleCount++;
       }
 
+      // Sidecar poll: A2UI tool_result events. These are the user's response
+      // to a UI spec this agent (or any agent in the network) emitted. We
+      // surface each one as a synthetic user message so the LLM sees it as
+      // the next turn and can react. Failures here don't break the main
+      // message poll.
+      try {
+        const toolResult = await this.client.pollToolResults(
+          this.workspaceId, this.token,
+          { after: this._lastToolResultId }
+        );
+        if (toolResult.cursor) this._lastToolResultId = toolResult.cursor;
+        for (const event of toolResult.events || []) {
+          const msgId = event.id;
+          if (msgId && this._processedIds.has(msgId)) continue;
+          if (msgId) this._processedIds.add(msgId);
+          const synth = synthesizeToolResultMessage(event);
+          if (synth) await this._dispatchMessage(synth);
+        }
+      } catch (e) {
+        // Non-fatal — log once per poll if it fails
+        if (pollCount <= 3 || pollCount % 20 === 0) {
+          this._log(`tool_result poll #${pollCount} failed: ${e.message}`);
+        }
+      }
+
       // Adaptive polling: 2s active, up to 15s idle.
       // Each connected agent runs this loop, so faster rates multiply across
       // every workspace member — keep this conservative and tune separately
@@ -487,11 +513,14 @@ class BaseAdapter {
   }
 
   async sendResponse(channel, content) {
+    const { cleanContent, spec, specToolCallId } = extractA2UISpec(content);
     try {
-      await this.client.sendMessage(this.workspaceId, channel, this.token, content, {
+      await this.client.sendMessage(this.workspaceId, channel, this.token, cleanContent, {
         senderType: 'agent',
         senderName: this.agentName,
         sessionId: this._sessionId,
+        spec,
+        specToolCallId,
       });
     } catch (e) {
       if (e instanceof SessionRevokedError) {
@@ -599,4 +628,74 @@ class BaseAdapter {
   }
 }
 
+// ------------------------------------------------------------------
+// A2UI helpers
+// ------------------------------------------------------------------
+
+/**
+ * Pull the first ```a2ui ... ``` fenced block out of LLM-produced content.
+ * Returns the content with the block stripped, the parsed spec, and a
+ * tool-call id derived from `spec.tool_call_id` (if present) or a new one.
+ * If no block is present or parsing fails, returns the content unchanged
+ * with null spec — the message still goes out as plain markdown.
+ */
+/**
+ * Convert a workspace.tool_result event into a synthetic user-message
+ * shape that the agent's _handleMessage can dispatch. The LLM sees this
+ * as the next user turn — the content is a short, machine-readable line
+ * the LLM can parse without ambiguity. The original spec it emitted is
+ * already in the LLM's conversation history; the tool_call_id lets the
+ * LLM correlate this back.
+ */
+function synthesizeToolResultMessage(event) {
+  if (!event || !event.payload) return null;
+  const p = event.payload;
+  const actionId = p.action_id || '';
+  const toolCallId = p.tool_call_id || '';
+  let valueStr = '';
+  if (p.value !== undefined && p.value !== null) {
+    try { valueStr = JSON.stringify(p.value); } catch (_) { valueStr = String(p.value); }
+  }
+  const lines = [
+    '[ui_action]',
+    `action=${actionId}`,
+    toolCallId ? `tool_call_id=${toolCallId}` : null,
+    valueStr ? `value=${valueStr}` : null,
+  ].filter(Boolean);
+  const content = lines.join(' ');
+  const target = event.target || '';
+  return {
+    messageId: event.id || '',
+    sessionId: target.startsWith('channel/') ? target.replace('channel/', '') : target,
+    senderType: 'human',
+    senderName: 'user',
+    content,
+    mentions: [],
+    messageType: 'chat',
+    metadata: event.metadata || {},
+  };
+}
+
+function extractA2UISpec(content) {
+  if (!content || typeof content !== 'string') {
+    return { cleanContent: content, spec: null, specToolCallId: null };
+  }
+  const match = content.match(/```a2ui\s*\n([\s\S]*?)\n```/);
+  if (!match) return { cleanContent: content, spec: null, specToolCallId: null };
+
+  let spec;
+  try {
+    spec = JSON.parse(match[1]);
+  } catch (_) {
+    return { cleanContent: content, spec: null, specToolCallId: null };
+  }
+
+  const specToolCallId = (spec && spec.tool_call_id) || `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  if (spec && spec.tool_call_id) delete spec.tool_call_id;
+
+  const cleanContent = content.replace(match[0], '').trim();
+  return { cleanContent, spec, specToolCallId };
+}
+
 module.exports = BaseAdapter;
+module.exports.extractA2UISpec = extractA2UISpec;

--- a/packages/agent-connector/src/adapters/workspace-prompt.js
+++ b/packages/agent-connector/src/adapters/workspace-prompt.js
@@ -343,6 +343,7 @@ function buildClaudeSystemPrompt({ agentName, workspaceId, channelName, mode = '
     'Use workspace_create_routine to set up recurring scheduled tasks (e.g. daily reviews).\n'
   );
   parts.push(buildCollaborationPrompt());
+  parts.push(buildA2UIPrompt());
 
   if (mode === 'plan') {
     parts.push(
@@ -357,12 +358,59 @@ function buildClaudeSystemPrompt({ agentName, workspaceId, channelName, mode = '
 }
 
 /**
+ * Teach the LLM how to emit interactive UI alongside its text response.
+ * The frontend (OpenAgents Go) renders any A2UI-shaped JSON spec inline
+ * in the chat bubble; the agent-connector strips the fenced block before
+ * posting and ferries the spec via payload.spec.
+ */
+function buildA2UIPrompt() {
+  return (
+    '\n## Rendering interactive UI\n' +
+    'When you want the user to interact with structured UI (a button choice, ' +
+    'a form, a chart, a table, a confirmation dialog) instead of just reading ' +
+    'text, emit a fenced code block tagged `a2ui` containing a JSON spec. The ' +
+    "frontend renders it inline below any markdown narration you write.\n\n" +
+    "The spec is a tree of `{ type, props, children?, action? }` nodes. " +
+    'Supported component types include `Stack`, `Heading`, `Text`, `Image`, ' +
+    '`Icon`, `Button`, `ChoiceList`, `ConfirmDialog`, `AmountInput`, `Card`, ' +
+    '`Divider`, `Spacer`, `Alert`, `LineChart`, `PieChart`, `AssetPrice`, ' +
+    '`BalanceCard`, `TransactionList`, `TransactionRow`. Unknown types render ' +
+    'as a placeholder chip, so feel free to compose freely.\n\n' +
+    'Interactive components attach an `action` object with a `name` field you ' +
+    'choose. Example:\n\n' +
+    '```a2ui\n' +
+    '{\n' +
+    '  "type": "Stack",\n' +
+    '  "props": { "direction": "vertical", "spacing": 12 },\n' +
+    '  "children": [\n' +
+    '    { "type": "Heading", "props": { "text": "Pick a time", "level": 2 } },\n' +
+    '    { "type": "Button", "props": { "label": "Morning", "action": { "name": "pick_morning" } } },\n' +
+    '    { "type": "Button", "props": { "label": "Evening", "action": { "name": "pick_evening" } } }\n' +
+    '  ]\n' +
+    '}\n' +
+    '```\n\n' +
+    'When the user interacts with a rendered component, you will receive a ' +
+    "user message shaped like `[ui_action] action=pick_morning tool_call_id=... value=...`. " +
+    "Use the `action` name (which you chose) to decide what to do next; the " +
+    "spec you emitted earlier is in your conversation history for context.\n\n" +
+    'Use a spec when:\n' +
+    '- The user needs to make a discrete choice (offer buttons rather than ' +
+    'asking them to type a free-form answer).\n' +
+    '- Structured data is easier to scan as a chart or table than as prose.\n' +
+    '- You need explicit confirmation before a destructive action.\n' +
+    "- A form would gather several fields faster than back-and-forth chat.\n\n" +
+    "Don't emit a spec for ordinary prose answers — narration alone is fine.\n"
+  );
+}
+
+/**
  * Build the full system prompt for OpenClaw/non-MCP agents.
  */
 function buildOpenclawSystemPrompt({ agentName, workspaceId, channelName, endpoint, token, mode = 'execute', disabledModules }) {
   const parts = [];
   parts.push(buildWorkspaceIdentity(agentName, workspaceId, channelName, mode));
   parts.push(buildCollaborationPrompt());
+  parts.push(buildA2UIPrompt());
   parts.push(buildModePrompt(mode));
   parts.push(buildApiSkillsPrompt({
     endpoint, workspaceId, token, agentName, channelName, disabledModules, mode,

--- a/packages/agent-connector/src/adapters/workspace-prompt.js
+++ b/packages/agent-connector/src/adapters/workspace-prompt.js
@@ -389,6 +389,37 @@ function buildA2UIPrompt() {
     '  ]\n' +
     '}\n' +
     '```\n\n' +
+    '### Exact prop names (these are checked verbatim — guessing will render "No data")\n\n' +
+    'Layout / content:\n' +
+    '- `Stack` — props: `direction` ("vertical"|"horizontal"), `spacing`, `alignment`\n' +
+    '- `Card` — props: `title`, `padding`, `cornerRadius`\n' +
+    '- `Divider`, `Spacer` — props: `size`, `orientation`\n' +
+    '- `Heading` — props: `text`, `level` (1–4)\n' +
+    '- `Text` — props: `content` **(NOT `text`)**, `style`, `weight`, `color`\n' +
+    '- `Image` — props: `url`, `name`, `contentMode`, `width`, `height`\n' +
+    '- `Icon` — props: `name`, `size`, `color`\n\n' +
+    'Interactive:\n' +
+    '- `Button` — props: `label`, `style` ("primary"|"secondary"|"destructive"), `icon`, `disabled`, `action: {name, params?}`\n' +
+    '- `ConfirmDialog` — props: `title`, `message`, `confirmLabel`, `cancelLabel`, `triggerLabel`, `action`\n' +
+    '- `ChoiceList` — props: `question`, `options: [{id, label}]`, `action`\n' +
+    '- `AmountInput` — props: `label`, `placeholder`, `currency`, `action`\n' +
+    '- `input` (lowercase) — props: `inputType` ("text"|"choice"|"number"|"date"), `id`, `label`, `placeholder`, `options`\n\n' +
+    'Feedback:\n' +
+    '- `Alert` — props: `title`, `message`, `severity` ("info"|"success"|"warning"|"error"), `dismissible`, `action`\n\n' +
+    'Charts (Swift Charts under the hood — needs **non-empty** data with the right key):\n' +
+    '- `LineChart` — props: `title`, `color`, `points: [{x, y}]` **(NOT `data`)**\n' +
+    '- `PieChart` — props: `title`, `segments: [{label, value, color?}]` **(NOT `slices`)**, `showLegend`\n' +
+    '- `chart` (lowercase) — simple sparkline/bar: props: `style` ("sparkline"|"bar"), `data: [number, ...]`, `labels`, `color`\n\n' +
+    'Data display:\n' +
+    '- `metric` (lowercase) — props: `label`, `value`, `caption`, `captionColor`, `icon`\n' +
+    '- `list` (lowercase) — props: `items: [{title, subtitle, trailing, icon}]`, `maxVisible`, `expandLabel`\n' +
+    '- `table` (lowercase) — **key-value rows only, not multi-column**: props: `rows: [{label, value}]`, `maxVisible`\n\n' +
+    'There is no multi-column data table in the catalog. For tabular data with ' +
+    'columns you have two choices: (a) use `list` with title/subtitle/trailing ' +
+    'mapped to your columns, or (b) compose a Stack of horizontal Stacks of Text ' +
+    'manually. Pick whichever reads better.\n\n' +
+    'If your data is empty or you can\'t fit it into the available primitives, ' +
+    'fall back to plain markdown — don\'t emit a spec just to wrap text in a card.\n\n' +
     'When the user interacts with a rendered component, you will receive a ' +
     "user message shaped like `[ui_action] action=pick_morning tool_call_id=... value=...`. " +
     "Use the `action` name (which you chose) to decide what to do next; the " +

--- a/packages/agent-connector/src/workspace-client.js
+++ b/packages/agent-connector/src/workspace-client.js
@@ -156,12 +156,15 @@ class WorkspaceClient {
    */
   async sendMessage(workspaceId, channelName, token, content, {
     senderType = 'agent', senderName, messageType = 'chat', metadata, attachments, sessionId,
+    spec, specToolCallId,
   } = {}) {
     const sourcePrefix = senderType === 'agent' ? 'openagents' : 'human';
     const source = senderName ? `${sourcePrefix}:${senderName}` : `${sourcePrefix}:unknown`;
 
     const payload = { content, message_type: messageType };
     if (attachments && attachments.length) payload.attachments = attachments;
+    if (spec) payload.spec = spec;
+    if (specToolCallId) payload.spec_tool_call_id = specToolCallId;
 
     return this.sendEvent(workspaceId, {
       type: 'workspace.message.posted',
@@ -170,6 +173,30 @@ class WorkspaceClient {
       payload,
       metadata: metadata || {},
     }, token, sessionId);
+  }
+
+  /**
+   * Poll workspace.tool_result events — the client's response to an agent's
+   * render_ui invocation. Returns events directly (no message normalization)
+   * because the caller treats them differently than chat messages.
+   */
+  async pollToolResults(workspaceId, token, { after, limit = 50 } = {}) {
+    const params = new URLSearchParams({
+      network: workspaceId,
+      type: 'workspace.tool_result',
+      limit: String(limit),
+    });
+    if (after) params.set('after', after);
+
+    const data = await this._get(`/v1/events?${params}`, this._wsHeaders(token));
+    const result = data.data || data;
+    const events = (result && result.events) || [];
+
+    let cursor = null;
+    if (events.length > 0) {
+      cursor = events[events.length - 1].id || null;
+    }
+    return { events, cursor };
   }
 
   /**

--- a/packages/go/OpenAgents/Models/A2UISpec.swift
+++ b/packages/go/OpenAgents/Models/A2UISpec.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A declarative UI specification emitted by an agent, intended to be
+/// rendered by the client into native views. The decoder accepts any `type`
+/// string and any prop shape, so the renderer is the sole authority on what's
+/// actually drawable. Unknown types decode fine — they fall through to a
+/// placeholder at render time rather than blocking the whole tree.
+struct A2UISpec: Decodable, Sendable, Equatable {
+    let schemaVersion: String?
+    let root: A2UIComponent
+}
+
+/// A single node in the spec tree. `type` is an opaque discriminator; the
+/// renderer maps it to a view (or to a fallback for unknown types). `props`
+/// and `action.value` are kept as `JSONValue` so unknown components remain
+/// introspectable without losing fidelity.
+struct A2UIComponent: Decodable, Sendable, Equatable {
+    let type: String
+    let id: String?
+    let props: JSONValue?
+    let children: [A2UIComponent]?
+    let action: A2UIAction?
+}
+
+/// Action descriptor on interactive components. `id` is round-tripped verbatim
+/// back to the agent as part of the tool-call result; the client does not
+/// interpret it. `value` carries any extra payload the agent wants delivered
+/// alongside the user's interaction.
+struct A2UIAction: Decodable, Sendable, Equatable {
+    let id: String
+    let value: JSONValue?
+}

--- a/packages/go/OpenAgents/Models/Message.swift
+++ b/packages/go/OpenAgents/Models/Message.swift
@@ -13,6 +13,10 @@ struct Message: Identifiable, Sendable, Equatable {
     let messageType: String
     /// Unix milliseconds.
     let timestamp: Int64
+    /// Optional agent-emitted UI spec rendered inline in the bubble. `content`
+    /// (markdown narration) and the spec coexist — agents may narrate above
+    /// and render below.
+    let attachment: A2UIAttachment?
 
     var id: String { messageId }
     var isFromUser: Bool { senderType == "human" }
@@ -33,10 +37,20 @@ struct Message: Identifiable, Sendable, Equatable {
             mentions: [],
             messageType: "status",
             timestamp: now,
+            attachment: nil,
         )
     }
 
     static func localStoppingStatus(channel: String) -> Message {
         localStatus(channel: channel, content: "Stopping...", idPrefix: "local-stopping-")
     }
+}
+
+/// An agent-emitted UI spec attached to a Message. `json` is the raw spec
+/// string passed verbatim to `A2UIRendererView`. `toolCallId` lets us route
+/// user interactions back to the originating tool call when we send the
+/// action result upstream (Phase 5).
+struct A2UIAttachment: Sendable, Equatable {
+    let json: String
+    let toolCallId: String?
 }

--- a/packages/go/OpenAgents/Models/ONMEvent.swift
+++ b/packages/go/OpenAgents/Models/ONMEvent.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A small JSON value type so payload/metadata can cross actor boundaries (Sendable) without
 /// reaching for `Any`. Only the cases we actually need.
-enum JSONValue: Decodable, Sendable, Equatable {
+enum JSONValue: Codable, Sendable, Equatable {
     case null
     case bool(Bool)
     case int(Int64)
@@ -29,6 +29,19 @@ enum JSONValue: Decodable, Sendable, Equatable {
             self = .object(object)
         } else {
             self = .null
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:                     try container.encodeNil()
+        case .bool(let value):          try container.encode(value)
+        case .int(let value):           try container.encode(value)
+        case .double(let value):        try container.encode(value)
+        case .string(let value):        try container.encode(value)
+        case .array(let value):         try container.encode(value)
+        case .object(let value):        try container.encode(value)
         }
     }
 
@@ -68,6 +81,7 @@ struct ONMEvent: Decodable, Sendable {
         let content = payload?["content"]?.stringValue ?? ""
         let messageType = payload?["message_type"]?.stringValue ?? "chat"
         let mentions = payload?["mentions"]?.stringArrayValue ?? []
+        let attachment = ONMEvent.extractAttachment(from: payload)
 
         return Message(
             messageId: id,
@@ -78,7 +92,30 @@ struct ONMEvent: Decodable, Sendable {
             mentions: mentions,
             messageType: messageType,
             timestamp: timestamp,
+            attachment: attachment,
         )
+    }
+
+    /// Pull an A2UI spec out of the message payload, if present. The agent
+    /// can deliver it as either an inline JSON object (preferred) or a
+    /// pre-serialized string — we accept both so we don't bind the backend
+    /// to a single encoding choice. Returns nil when there's no spec.
+    private static func extractAttachment(from payload: JSONValue?) -> A2UIAttachment? {
+        guard let specValue = payload?["spec"] else { return nil }
+        let toolCallId = payload?["spec_tool_call_id"]?.stringValue
+
+        switch specValue {
+        case .string(let s) where !s.isEmpty:
+            return A2UIAttachment(json: s, toolCallId: toolCallId)
+        case .object:
+            guard let data = try? JSONEncoder().encode(specValue),
+                  let json = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return A2UIAttachment(json: json, toolCallId: toolCallId)
+        default:
+            return nil
+        }
     }
 }
 

--- a/packages/go/OpenAgents/Networking/WorkspaceAPI.swift
+++ b/packages/go/OpenAgents/Networking/WorkspaceAPI.swift
@@ -172,6 +172,35 @@ actor WorkspaceAPI {
         return try JSONEncoder().encode(body)
     }
 
+    /// Post the result of a user interaction with an A2UI-rendered component
+    /// back upstream. Emits a `workspace.tool_result` event addressed to the
+    /// channel; the agent runtime is expected to interpret it as the response
+    /// to the originating `render_ui` invocation.
+    ///
+    /// - Parameter channel: chat channel id (no `channel/` prefix; this method adds it).
+    /// - Parameter toolCallId: the id from the originating render_ui invocation.
+    ///   May be nil — the result still posts but cannot be correlated.
+    /// - Parameter actionId: opaque id the agent attached to the action; round-tripped verbatim.
+    /// - Parameter value: payload the agent receives alongside the interaction
+    ///   (e.g. selected option, filled form values). Optional.
+    func sendToolResult(
+        channel: String,
+        toolCallId: String?,
+        actionId: String,
+        value: JSONValue?,
+    ) async throws -> ONMEvent {
+        var payload: [String: any Encodable & Sendable] = ["action_id": actionId]
+        if let toolCallId { payload["tool_call_id"] = toolCallId }
+        if let value { payload["value"] = value }
+        return try await sendEvent(
+            type: "workspace.tool_result",
+            source: "human:user",
+            target: "channel/\(channel)",
+            payload: payload,
+            visibility: "direct",
+        )
+    }
+
     /// Send a control event to an agent (e.g. "stop"). Mirrors the React app's
     /// `sendAgentControl` — posts a `workspace.agent.control` event addressed to
     /// `openagents:<agentName>` with `action` (and optional extra params) in the payload.

--- a/packages/go/OpenAgents/OpenAgentsApp.swift
+++ b/packages/go/OpenAgents/OpenAgentsApp.swift
@@ -1,7 +1,17 @@
 import SwiftUI
+import SwiftUIJSONRender
 
 @main
 struct OpenAgentsApp: App {
+    init() {
+        // SwiftUIJSONRender's built-in component catalog is registered lazily
+        // via a private static let — nothing accesses it on its own, so the
+        // registry stays empty and JSONView falls back to "Unsupported"
+        // placeholders for everything. Force the init here so Stack / Button
+        // / Heading / etc. resolve.
+        SwiftUIJSONRender.initializeJSONRender()
+    }
+
     #if os(iOS)
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var pushSink = PushSink()

--- a/packages/go/OpenAgents/Rendering/A2UIRendererView.swift
+++ b/packages/go/OpenAgents/Rendering/A2UIRendererView.swift
@@ -26,7 +26,7 @@ struct A2UIRendererView: View {
 
     var body: some View {
         JSONView(json)
-            .unknownComponentBehavior(.placeholder)
+            .theme(OpenAgentsGoTheme.self)
             .onAction { action in
                 onAction?(bridge(action))
             }

--- a/packages/go/OpenAgents/Rendering/A2UIRendererView.swift
+++ b/packages/go/OpenAgents/Rendering/A2UIRendererView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import SwiftUIJSONRender
+
+/// Renders an A2UI-shaped JSON spec emitted by an agent. The spec format
+/// aligns with SwiftUIJSONRender's schema (type/props/children + action),
+/// which is structurally A2UI-shaped — a formal A2UI/SwiftUIJSONRender shim
+/// gets added here as the two schemas diverge.
+///
+/// All failure modes (malformed JSON, schema version mismatch, unknown
+/// component types) are handled by the underlying `JSONView`:
+/// - parse error → error banner inside the bubble
+/// - version mismatch → version banner
+/// - unknown `type` → small placeholder chip (default `.placeholder` behavior)
+///
+/// Siblings of a failed/unknown component still render; one bad subtree never
+/// blanks the rest of the spec.
+struct A2UIRendererView: View {
+    /// Raw JSON string emitted by the agent. We pass it through verbatim so
+    /// we don't lose fidelity in a re-encode round-trip.
+    let json: String
+
+    /// Fired when the user interacts with any action-bearing component in the
+    /// spec (button, choice list, confirm dialog, etc). The agent's `action.name`
+    /// is round-tripped as `A2UIAction.id`; any params land in `value`.
+    var onAction: ((A2UIAction) -> Void)?
+
+    var body: some View {
+        JSONView(json)
+            .unknownComponentBehavior(.placeholder)
+            .onAction { action in
+                onAction?(bridge(action))
+            }
+    }
+
+    /// Bridge SwiftUIJSONRender's `Action` shape (`name` + `params`) to our
+    /// `A2UIAction` (`id` + `value`). The agent decides what the id means;
+    /// we never interpret it.
+    private func bridge(_ action: SwiftUIJSONRender.Action) -> A2UIAction {
+        let value: JSONValue?
+        if let params = action.params, !params.isEmpty {
+            value = JSONValue.fromAnyCodableDictionary(params)
+        } else {
+            value = nil
+        }
+        return A2UIAction(id: action.name, value: value)
+    }
+}
+
+extension JSONValue {
+    /// Best-effort conversion from SwiftUIJSONRender's `[String: AnyCodable]` to
+    /// our `JSONValue`. Re-encodes through `JSONEncoder` to avoid handling each
+    /// AnyCodable case by hand; the round-trip is robust because `AnyCodable`
+    /// itself is JSON-compatible.
+    static func fromAnyCodableDictionary(_ dict: [String: AnyCodable]) -> JSONValue? {
+        guard let data = try? JSONEncoder().encode(dict) else { return nil }
+        return try? JSONDecoder().decode(JSONValue.self, from: data)
+    }
+}

--- a/packages/go/OpenAgents/Rendering/A2UIRendererView.swift
+++ b/packages/go/OpenAgents/Rendering/A2UIRendererView.swift
@@ -56,3 +56,65 @@ extension JSONValue {
         return try? JSONDecoder().decode(JSONValue.self, from: data)
     }
 }
+
+// MARK: - Previews
+
+#Preview("Prose") {
+    A2UIRendererView(json: """
+    {
+      "type": "Stack",
+      "props": { "direction": "vertical", "spacing": 8 },
+      "children": [
+        { "type": "Heading", "props": { "text": "Hello", "level": 2 } },
+        { "type": "Text", "props": { "content": "A simple prose layout." } }
+      ]
+    }
+    """)
+    .padding()
+}
+
+#Preview("Choice list") {
+    A2UIRendererView(json: """
+    {
+      "type": "Stack",
+      "props": { "direction": "vertical", "spacing": 12 },
+      "children": [
+        { "type": "Heading", "props": { "text": "Pick a date", "level": 2 } },
+        { "type": "Button",
+          "props": { "label": "Today",
+                     "action": { "name": "pick_today" } } },
+        { "type": "Button",
+          "props": { "label": "Tomorrow",
+                     "action": { "name": "pick_tomorrow" } } },
+        { "type": "Button",
+          "props": { "label": "Custom",
+                     "action": { "name": "pick_custom" } } }
+      ]
+    }
+    """) { action in
+        print("Action: \\(action.id)")
+    }
+    .padding()
+}
+
+#Preview("Unknown component fallback") {
+    A2UIRendererView(json: """
+    {
+      "type": "Stack",
+      "props": { "direction": "vertical", "spacing": 8 },
+      "children": [
+        { "type": "Heading", "props": { "text": "Mixed render", "level": 2 } },
+        { "type": "InteractiveDataExplorer3D",
+          "props": { "data": [1, 2, 3] } },
+        { "type": "Text",
+          "props": { "content": "Sibling rendered fine despite the unknown above." } }
+      ]
+    }
+    """)
+    .padding()
+}
+
+#Preview("Malformed JSON") {
+    A2UIRendererView(json: "not even json")
+        .padding()
+}

--- a/packages/go/OpenAgents/Rendering/OpenAgentsGoTheme.swift
+++ b/packages/go/OpenAgents/Rendering/OpenAgentsGoTheme.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import SwiftUIJSONRender
+
+/// Theme applied to A2UI-rendered specs so they feel native inside Go's
+/// iMessage-style bubbles. Pulls from system tokens (system accent, primary/
+/// secondary text, default fonts) so the result tracks light/dark mode and
+/// the user's macOS accent-color preference automatically.
+struct OpenAgentsGoTheme: JSONRenderTheme {
+    // Brand — track the system accent color so buttons match the user
+    // bubble tint and the app's general affordance color.
+    static var primaryColor: Color { .accentColor }
+    static var secondaryColor: Color { .secondary }
+
+    // Surfaces — keep the inner card light so it blends with the bubble it
+    // sits inside, rather than drawing a hard secondary background. The
+    // bubble already provides the surrounding chrome.
+    static var backgroundColor: Color { .clear }
+    static var surfaceColor: Color { Color.primary.opacity(0.04) }
+
+    // Type — system body / headline align with the rest of the chat. The
+    // heading is bumped to title3 so a "Pick a time of day" headline reads
+    // as a header rather than a single bold line.
+    static var headingFont: Font { .title3.weight(.semibold) }
+    static var bodyFont: Font { .body }
+    static var captionFont: Font { .footnote }
+
+    // Corner radii — buttons land at 14pt (pill-ish, iOS-native), cards
+    // at 14pt (softer than the bubble), and any large surfaces at 18pt
+    // to match MessageBubble exactly.
+    static var radiusSM: CGFloat { 14 }
+    static var radiusMD: CGFloat { 14 }
+    static var radiusLG: CGFloat { 18 }
+
+    // Spacing — tighten the defaults a notch so the spec doesn't dominate
+    // a single bubble.
+    static var spacingXS: CGFloat { 4 }
+    static var spacingSM: CGFloat { 8 }
+    static var spacingMD: CGFloat { 12 }
+    static var spacingLG: CGFloat { 18 }
+
+    // Subtle alert backgrounds (lighter than the SwiftUIJSONRender default
+    // so they sit calmer next to chat content).
+    static var alertBackgroundOpacity: Double { 0.08 }
+    static var alertBorderOpacity: Double { 0.18 }
+}

--- a/packages/go/OpenAgents/State/WorkspaceStore.swift
+++ b/packages/go/OpenAgents/State/WorkspaceStore.swift
@@ -711,6 +711,29 @@ final class WorkspaceStore {
         }
     }
 
+    /// Forward an A2UI action result upstream. Called when the user interacts
+    /// with a rendered spec component; non-throwing so SwiftUI callbacks stay
+    /// fire-and-forget. Failures are logged but never surface as banners —
+    /// a missed interaction is less disruptive than blocking the chat UI.
+    func sendToolResult(
+        channel: String,
+        toolCallId: String?,
+        actionId: String,
+        value: JSONValue?,
+    ) async {
+        do {
+            _ = try await api.sendToolResult(
+                channel: channel,
+                toolCallId: toolCallId,
+                actionId: actionId,
+                value: value,
+            )
+            logInfo("a2ui", "tool_result sent action=\(actionId) tc=\(toolCallId ?? "nil")")
+        } catch {
+            logError("a2ui", "tool_result failed action=\(actionId): \(error.localizedDescription)")
+        }
+    }
+
     func createThread(master: String, participants: [String]) async {
         do {
             let session = try await api.createChannel(master: master, participants: participants)

--- a/packages/go/OpenAgents/State/WorkspaceStore.swift
+++ b/packages/go/OpenAgents/State/WorkspaceStore.swift
@@ -433,6 +433,7 @@ final class WorkspaceStore {
             mentions: [],
             messageType: "chat",
             timestamp: Int64(Date().timeIntervalSince1970 * 1000),
+            attachment: nil,
         )
         var page = pagesBySession[channel] ?? ChannelMessages()
         page.messages.append(optimistic)
@@ -482,6 +483,7 @@ final class WorkspaceStore {
                     mentions: prev.mentions,
                     messageType: prev.messageType,
                     timestamp: prev.timestamp,
+                    attachment: prev.attachment,
                 )
                 pagesBySession[channel] = p
             }

--- a/packages/go/OpenAgents/Views/ChatView.swift
+++ b/packages/go/OpenAgents/Views/ChatView.swift
@@ -1229,7 +1229,8 @@ private struct MessageBubble: View {
 
     var body: some View {
         let segments = MarkdownSegmenter.segments(in: message.content)
-        let hasWideContent = segments.contains { segment in
+        let hasAttachment = message.attachment != nil
+        let hasWideContent = hasAttachment || segments.contains { segment in
             switch segment {
             case .prose, .fileChip: return false
             case .code, .table, .htmlBlock: return true
@@ -1326,6 +1327,14 @@ private struct MessageBubble: View {
                         )
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                }
+                if let attachment = message.attachment {
+                    A2UIRendererView(json: attachment.json) { action in
+                        // Phase 5 wires this to send a tool-result upstream.
+                        // For now, log so devs can see the agent's action id round-trip locally.
+                        logInfo("a2ui", "action id=\(action.id) toolCallId=\(attachment.toolCallId ?? "nil")")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             // Only force full-row width when the bubble actually contains code/table; otherwise

--- a/packages/go/OpenAgents/Views/ChatView.swift
+++ b/packages/go/OpenAgents/Views/ChatView.swift
@@ -1300,67 +1300,87 @@ private struct MessageBubble: View {
                     .padding(.leading, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            VStack(alignment: alignment, spacing: 6) {
-                ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                    switch segment {
-                    case .prose(let text):
-                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty {
-                            // For prose-only bubbles we let the Text size to its content so short
-                            // messages ("hi") hug the text. When the row contains wide content
-                            // (code/table), we still expand prose to row width so it aligns with
-                            // those blocks.
-                            if fillsRow {
-                                Text(.init(trimmed))
-                                    .textSelection(.enabled)
-                                    .multilineTextAlignment(textAlignment)
-                                    .fixedSize(horizontal: false, vertical: true)
-                                    .frame(maxWidth: .infinity, alignment: frameAlignment)
-                            } else {
-                                Text(.init(trimmed))
-                                    .textSelection(.enabled)
-                                    .multilineTextAlignment(textAlignment)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                        }
-                    case .code(let lang, let code):
-                        CodeBlockView(language: lang, content: code, onLightBubble: !message.isFromUser)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    case .htmlBlock(let html):
-                        HTMLBlockView(html: html, onLightBubble: !message.isFromUser)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    case .fileChip(let fileId, let label):
-                        FileChipView(fileId: fileId, label: label, onLightBubble: !message.isFromUser)
-                            .frame(maxWidth: .infinity, alignment: alignment == .trailing ? .trailing : .leading)
-                    case .table(let headers, let rows, let alignments):
-                        TableView(
-                            headers: headers,
-                            rows: rows,
-                            alignments: alignments,
-                            onLightBubble: !message.isFromUser,
-                        )
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-                if let attachment = message.attachment {
-                    A2UIRendererView(json: attachment.json) { action in
-                        onAttachmentAction?(action)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            // Text bubble — rendered only when there are non-empty segments.
+            // The A2UI attachment lives OUTSIDE this bubble's chrome (see below)
+            // so a spec doesn't get visually merged with narration / error text
+            // into one big container.
+            let hasVisibleSegments = segments.contains { seg in
+                switch seg {
+                case .prose(let t): return !t.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                case .code, .htmlBlock, .fileChip, .table: return true
                 }
             }
-            // Only force full-row width when the bubble actually contains code/table; otherwise
-            // let it shrink to its prose content.
-            .modifier(BubbleFillModifier(fillsRow: fillsRow, alignment: frameAlignment))
-            .padding(.horizontal, 14)
-            .padding(.vertical, 9)
-            .background(bubbleBackground)
-            .foregroundStyle(message.isFromUser ? .white : .primary)
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(.black.opacity(message.isFromUser ? 0 : 0.06), lineWidth: 0.5),
-            )
+            if hasVisibleSegments {
+                VStack(alignment: alignment, spacing: 6) {
+                    ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+                        switch segment {
+                        case .prose(let text):
+                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !trimmed.isEmpty {
+                                // For prose-only bubbles we let the Text size to its content so short
+                                // messages ("hi") hug the text. When the row contains wide content
+                                // (code/table), we still expand prose to row width so it aligns with
+                                // those blocks.
+                                if fillsRow {
+                                    Text(.init(trimmed))
+                                        .textSelection(.enabled)
+                                        .multilineTextAlignment(textAlignment)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .frame(maxWidth: .infinity, alignment: frameAlignment)
+                                } else {
+                                    Text(.init(trimmed))
+                                        .textSelection(.enabled)
+                                        .multilineTextAlignment(textAlignment)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                        case .code(let lang, let code):
+                            CodeBlockView(language: lang, content: code, onLightBubble: !message.isFromUser)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        case .htmlBlock(let html):
+                            HTMLBlockView(html: html, onLightBubble: !message.isFromUser)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        case .fileChip(let fileId, let label):
+                            FileChipView(fileId: fileId, label: label, onLightBubble: !message.isFromUser)
+                                .frame(maxWidth: .infinity, alignment: alignment == .trailing ? .trailing : .leading)
+                        case .table(let headers, let rows, let alignments):
+                            TableView(
+                                headers: headers,
+                                rows: rows,
+                                alignments: alignments,
+                                onLightBubble: !message.isFromUser,
+                            )
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+                // Only force full-row width when the bubble actually contains code/table; otherwise
+                // let it shrink to its prose content.
+                .modifier(BubbleFillModifier(fillsRow: fillsRow, alignment: frameAlignment))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(bubbleBackground)
+                .foregroundStyle(message.isFromUser ? .white : .primary)
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(.black.opacity(message.isFromUser ? 0 : 0.06), lineWidth: 0.5),
+                )
+            }
+
+            // A2UI attachment renders as its own standalone element, NOT inside
+            // the text bubble. Lets the spec own its visual identity instead
+            // of being swallowed by the surrounding chat-bubble chrome. Capped
+            // at 420pt so primary buttons (which explicitly request maxWidth=
+            // .infinity inside SwiftUIJSONRender) don't stretch across the
+            // whole chat panel — matches iMessage app-card sizing.
+            if let attachment = message.attachment {
+                A2UIRendererView(json: attachment.json) { action in
+                    onAttachmentAction?(action)
+                }
+                .frame(maxWidth: 420, alignment: .leading)
+                .padding(.top, hasVisibleSegments ? 6 : 0)
+            }
 
             if !message.isFromUser {
                 copyButton

--- a/packages/go/OpenAgents/Views/ChatView.swift
+++ b/packages/go/OpenAgents/Views/ChatView.swift
@@ -350,6 +350,16 @@ struct ChatView: View {
                             MessageBubble(
                                 message: message,
                                 showSenderLabel: shouldShowSenderLabel(for: message, groupIndex: index, in: groups),
+                                onAttachmentAction: { action in
+                                    Task {
+                                        await store.sendToolResult(
+                                            channel: message.sessionId,
+                                            toolCallId: message.attachment?.toolCallId,
+                                            actionId: action.id,
+                                            value: action.value,
+                                        )
+                                    }
+                                },
                             )
                             .id(message.id)
                         case .steps(let stepMessages):
@@ -1213,6 +1223,10 @@ private struct ErrorBanner: View {
 private struct MessageBubble: View {
     let message: Message
     var showSenderLabel: Bool = true
+    /// Fired when the user interacts with an A2UI-rendered component. Caller
+    /// is responsible for routing this back to the agent (typically via
+    /// `WorkspaceStore.sendToolResult`).
+    var onAttachmentAction: ((A2UIAction) -> Void)? = nil
 
     /// Opposite-side gap between the bubble and the chat edge.
     private static let sideGap: CGFloat = 60
@@ -1330,9 +1344,7 @@ private struct MessageBubble: View {
                 }
                 if let attachment = message.attachment {
                     A2UIRendererView(json: attachment.json) { action in
-                        // Phase 5 wires this to send a tool-result upstream.
-                        // For now, log so devs can see the agent's action id round-trip locally.
-                        logInfo("a2ui", "action id=\(action.id) toolCallId=\(attachment.toolCallId ?? "nil")")
+                        onAttachmentAction?(action)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
+++ b/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		9F71FF770F7CC4CBA766C90F /* ThreadListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49A1295D6A71CF2F15A8BBA /* ThreadListView.swift */; };
 		A2CD5A2CB225F7792DC53C66 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12A6515B7075FE8EAE5A481 /* Workspace.swift */; };
 		A3C18161FE398E035D71F5BB /* PushSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31485CDEBC641234F7197935 /* PushSink.swift */; };
+		A4C7B55A692D2FB4B340570C /* SwiftUIJSONRender in Frameworks */ = {isa = PBXBuildFile; productRef = B645A3127E122F8A66288F2E /* SwiftUIJSONRender */; };
 		A51F0D9F2D06EE9B22459C81 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D1A314CF8BC692761F6F63 /* ChatView.swift */; };
 		A624D346DFEA3F8F4C41D376 /* PushSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31485CDEBC641234F7197935 /* PushSink.swift */; };
 		A8866B86D85D3C7A631EB1EA /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4309C1958ECD63080F3246 /* DateFormatting.swift */; };
@@ -89,6 +90,7 @@
 		F66D94202E74F614CBD85FA8 /* SettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEFDB8EAD399989E7939F2 /* SettingsSheet.swift */; };
 		F677A439515DA1875D05ECC0 /* AgentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD5F352606D678F99957E2F /* AgentColor.swift */; };
 		FA11CAB36EF0F2227BFFCF11 /* FileChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F64D81367061DABBA5EC83 /* FileChipView.swift */; };
+		FACFD5EC0A0A67CDD735CD57 /* SwiftUIJSONRender in Frameworks */ = {isa = PBXBuildFile; productRef = A7CB0643B35BD65B65983D5D /* SwiftUIJSONRender */; };
 		FCD128EB844C8F45F0785004 /* MarkdownSegments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D250D0F8C1A2E0F9CD2AB0 /* MarkdownSegments.swift */; };
 		FE51D3BDF4335B083EC9DD12 /* HTMLBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8E461D6AC4E8EA6FB20B1D /* HTMLBlockView.swift */; };
 /* End PBXBuildFile section */
@@ -142,12 +144,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3488993BE768466CD572C46A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A4C7B55A692D2FB4B340570C /* SwiftUIJSONRender in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DAEA24F945A83ED04D3D0498 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				B6529A1C4C517B0D91163E46 /* FirebaseCore in Frameworks */,
 				25AFCD33B25544F88BF2094D /* FirebaseMessaging in Frameworks */,
+				FACFD5EC0A0A67CDD735CD57 /* SwiftUIJSONRender in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,6 +297,7 @@
 			buildPhases = (
 				87ED0EF694E0A5E040C7085A /* Sources */,
 				5C8BF21875C2A512674A92AE /* Resources */,
+				3488993BE768466CD572C46A /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -293,6 +305,7 @@
 			);
 			name = OpenAgentsGo_macOS;
 			packageProductDependencies = (
+				B645A3127E122F8A66288F2E /* SwiftUIJSONRender */,
 			);
 			productName = OpenAgentsGo_macOS;
 			productReference = 657BCC02FD23538732562FEA /* OpenAgentsGo.app */;
@@ -314,6 +327,7 @@
 			packageProductDependencies = (
 				A0AA091EAC84A3FD2AC24C00 /* FirebaseCore */,
 				61AFC404B631FCEF5138C2D2 /* FirebaseMessaging */,
+				A7CB0643B35BD65B65983D5D /* SwiftUIJSONRender */,
 			);
 			productName = OpenAgentsGo_iOS;
 			productReference = 740731F27EF4E5B87EBC8214 /* OpenAgentsGo.app */;
@@ -347,6 +361,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				6F501275FB3611BB98A1B2F3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				B5257B404DB78704678823FD /* XCRemoteSwiftPackageReference "swiftui-json-render" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = D476D796F5F151440069AC0A /* Products */;
@@ -748,6 +763,14 @@
 				minimumVersion = 11.0.0;
 			};
 		};
+		B5257B404DB78704678823FD /* XCRemoteSwiftPackageReference "swiftui-json-render" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/bipa-app/swiftui-json-render";
+			requirement = {
+				kind = exactVersion;
+				version = 0.2.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -760,6 +783,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6F501275FB3611BB98A1B2F3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCore;
+		};
+		A7CB0643B35BD65B65983D5D /* SwiftUIJSONRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5257B404DB78704678823FD /* XCRemoteSwiftPackageReference "swiftui-json-render" */;
+			productName = SwiftUIJSONRender;
+		};
+		B645A3127E122F8A66288F2E /* SwiftUIJSONRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5257B404DB78704678823FD /* XCRemoteSwiftPackageReference "swiftui-json-render" */;
+			productName = SwiftUIJSONRender;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
+++ b/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		099E9B968143C4CA1D6709D9 /* WorkspaceFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43001578E4561E362DB6F9C9 /* WorkspaceFile.swift */; };
 		09D41C6E862A35FF92FD186D /* DebugLogSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFC6779CA9AEA7008F8E130 /* DebugLogSheet.swift */; };
 		0B87DB8BA07CEB69E241145C /* StepParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8BEF28DD556E8D6004C2BC2 /* StepParser.swift */; };
+		0C4791EFADF4966DAB3CA2DE /* OpenAgentsGoTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9D34096F6754E61758DDA7 /* OpenAgentsGoTheme.swift */; };
 		151417A50A06B919E11EAA33 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6038CD9938CBF86839702842 /* GoogleService-Info.plist */; };
 		16385E5C4FF9D0CA3376AA32 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9C2588A4A9C0C5E36DA1C5 /* APIError.swift */; };
 		21B8A36DF9F40292036E1855 /* WorkspaceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE66E2EFD9113C2A2F91F4D /* WorkspaceAPI.swift */; };
@@ -37,6 +38,7 @@
 		4AD0E8D3B5DE5C67B82B2156 /* ComposerTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E1E2B60417F9A251427176 /* ComposerTextView.swift */; };
 		4C67B9550721C3DDFF650F32 /* WorkspaceSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EFFC2C331F1ED7BA618194 /* WorkspaceSelectorView.swift */; };
 		523F316A244E7D2CC03FC1F1 /* ContentSidebarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA032E023FE142F032BD6BC /* ContentSidebarController.swift */; };
+		549C0C84E0B931B368A83379 /* OpenAgentsGoTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9D34096F6754E61758DDA7 /* OpenAgentsGoTheme.swift */; };
 		5D56E1B94AE40201B9BC3727 /* SettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEFDB8EAD399989E7939F2 /* SettingsSheet.swift */; };
 		61A55CCA5488FC6090B6B29C /* ImageDownsampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D52064E94D462C6F465928F /* ImageDownsampler.swift */; };
 		6360319D9AE46885DB83FA03 /* WorkspaceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE66E2EFD9113C2A2F91F4D /* WorkspaceAPI.swift */; };
@@ -106,6 +108,7 @@
 		0CA032E023FE142F032BD6BC /* ContentSidebarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSidebarController.swift; sourceTree = "<group>"; };
 		0F9C2588A4A9C0C5E36DA1C5 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		2B8E461D6AC4E8EA6FB20B1D /* HTMLBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLBlockView.swift; sourceTree = "<group>"; };
+		2B9D34096F6754E61758DDA7 /* OpenAgentsGoTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAgentsGoTheme.swift; sourceTree = "<group>"; };
 		31485CDEBC641234F7197935 /* PushSink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushSink.swift; sourceTree = "<group>"; };
 		31EBC1F1766D711824BD98EA /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		3D1186F6668EBB7CADC2F719 /* IntermediateStepsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntermediateStepsView.swift; sourceTree = "<group>"; };
@@ -199,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				9C711AA33A030CA030F2B428 /* A2UIRendererView.swift */,
+				2B9D34096F6754E61758DDA7 /* OpenAgentsGoTheme.swift */,
 			);
 			path = Rendering;
 			sourceTree = "<group>";
@@ -443,6 +447,7 @@
 				42C1CEF4A0A76D3A9F6BE8BB /* NewThreadSheet.swift in Sources */,
 				F1E0953AB01A250338EA07EE /* ONMEvent.swift in Sources */,
 				CFC7CD12880ED3F6F57BDE44 /* OpenAgentsApp.swift in Sources */,
+				0C4791EFADF4966DAB3CA2DE /* OpenAgentsGoTheme.swift in Sources */,
 				A624D346DFEA3F8F4C41D376 /* PushSink.swift in Sources */,
 				C61ED8789874F36B7F1E31B5 /* RootView.swift in Sources */,
 				383094D64CFB715CAC402865 /* Session.swift in Sources */,
@@ -491,6 +496,7 @@
 				285B357EF4CEB51AB9BEB3E6 /* NewThreadSheet.swift in Sources */,
 				EB4E8661A4DA95F6A1B2738C /* ONMEvent.swift in Sources */,
 				7E497A494723F3C79B69EE47 /* OpenAgentsApp.swift in Sources */,
+				549C0C84E0B931B368A83379 /* OpenAgentsGoTheme.swift in Sources */,
 				A3C18161FE398E035D71F5BB /* PushSink.swift in Sources */,
 				446ACD8FC0FAF3FADBE0140A /* RootView.swift in Sources */,
 				48559F3627FEF12697B6D7BD /* Session.swift in Sources */,

--- a/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
+++ b/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
@@ -44,11 +44,13 @@
 		6703D64150505304A4C352C3 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C267C1A37576B7294C15292F /* WorkspaceStore.swift */; };
 		69633D697FB506EF464AF84A /* IntermediateStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1186F6668EBB7CADC2F719 /* IntermediateStepsView.swift */; };
 		6D6012BDA06DF8813B4DAC06 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511AB5EFE9EDD596ADE0FF9C /* AppDelegate.swift */; };
+		6EEC478AA9B833DC6D4CE1EE /* A2UISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913BDDD175A7D65A9A6BCDC7 /* A2UISpec.swift */; };
 		740AD543DDC8D97BC3B6BCD2 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B135DC42112DC8B87C20D3 /* Commands.swift */; };
 		780890658985AE8370F3EF0E /* ImageDownsampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D52064E94D462C6F465928F /* ImageDownsampler.swift */; };
 		796E034098D65B920232106D /* Agent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75C05C810E421587E53523 /* Agent.swift */; };
 		7E497A494723F3C79B69EE47 /* OpenAgentsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3A7C86384A4BFBF462241C /* OpenAgentsApp.swift */; };
 		7E703418D00E5A308C587C46 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D1A314CF8BC692761F6F63 /* ChatView.swift */; };
+		81EC3D12D7538934EF123417 /* A2UISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913BDDD175A7D65A9A6BCDC7 /* A2UISpec.swift */; };
 		8503302A20C920B299CEDA87 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86415FE67D6C1C2F1DDBA257 /* Message.swift */; };
 		8621786ABFF955DFC5703895 /* AuthorizedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C106C643D23BFCF5DF3B1349 /* AuthorizedAsyncImage.swift */; };
 		9093372B766D9F35E4552730 /* ContentSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FA26EFFAD4DCF035A141B3 /* ContentSidebar.swift */; };
@@ -80,6 +82,7 @@
 		D10BCA2F43ABECAF4E563EFA /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86415FE67D6C1C2F1DDBA257 /* Message.swift */; };
 		D207AB0F972D408B4E28B7EE /* DebugLogSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFC6779CA9AEA7008F8E130 /* DebugLogSheet.swift */; };
 		D337BC86D1E6A2F4FC470B7C /* IntermediateStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1186F6668EBB7CADC2F719 /* IntermediateStepsView.swift */; };
+		D57655F62FBD1759DB75871F /* A2UIRendererView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C711AA33A030CA030F2B428 /* A2UIRendererView.swift */; };
 		DF78B120686B12BC605792D1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6038CD9938CBF86839702842 /* GoogleService-Info.plist */; };
 		DFFF5BEDDF0FE10395C7861B /* AgentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD5F352606D678F99957E2F /* AgentColor.swift */; };
 		E1878144B53A9FA6E121E76B /* ContentSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FA26EFFAD4DCF035A141B3 /* ContentSidebar.swift */; };
@@ -90,6 +93,7 @@
 		F66D94202E74F614CBD85FA8 /* SettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BEFDB8EAD399989E7939F2 /* SettingsSheet.swift */; };
 		F677A439515DA1875D05ECC0 /* AgentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD5F352606D678F99957E2F /* AgentColor.swift */; };
 		FA11CAB36EF0F2227BFFCF11 /* FileChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F64D81367061DABBA5EC83 /* FileChipView.swift */; };
+		FAB0FB8E6AFFF81508C0ACED /* A2UIRendererView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C711AA33A030CA030F2B428 /* A2UIRendererView.swift */; };
 		FACFD5EC0A0A67CDD735CD57 /* SwiftUIJSONRender in Frameworks */ = {isa = PBXBuildFile; productRef = A7CB0643B35BD65B65983D5D /* SwiftUIJSONRender */; };
 		FCD128EB844C8F45F0785004 /* MarkdownSegments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D250D0F8C1A2E0F9CD2AB0 /* MarkdownSegments.swift */; };
 		FE51D3BDF4335B083EC9DD12 /* HTMLBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8E461D6AC4E8EA6FB20B1D /* HTMLBlockView.swift */; };
@@ -122,7 +126,9 @@
 		818A4CEAED3B6B2F27409E36 /* ONMEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ONMEvent.swift; sourceTree = "<group>"; };
 		86415FE67D6C1C2F1DDBA257 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		8FD5F352606D678F99957E2F /* AgentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentColor.swift; sourceTree = "<group>"; };
+		913BDDD175A7D65A9A6BCDC7 /* A2UISpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A2UISpec.swift; sourceTree = "<group>"; };
 		91B2C08AA423DF283FD25539 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9C711AA33A030CA030F2B428 /* A2UIRendererView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A2UIRendererView.swift; sourceTree = "<group>"; };
 		B12A6515B7075FE8EAE5A481 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		B2D1A314CF8BC692761F6F63 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		B8BEF28DD556E8D6004C2BC2 /* StepParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepParser.swift; sourceTree = "<group>"; };
@@ -189,6 +195,14 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
+		49CE8D0EC86FE96A6348405F /* Rendering */ = {
+			isa = PBXGroup;
+			children = (
+				9C711AA33A030CA030F2B428 /* A2UIRendererView.swift */,
+			);
+			path = Rendering;
+			sourceTree = "<group>";
+		};
 		678AC8562AD1EBD69CEE084E /* OpenAgents */ = {
 			isa = PBXGroup;
 			children = (
@@ -200,6 +214,7 @@
 				ABCCA64FB260EB86C15E4D29 /* Models */,
 				3B78FE7CF6EFC04027819B79 /* Networking */,
 				F22745B83A97D2D4EDE1E988 /* Notifications */,
+				49CE8D0EC86FE96A6348405F /* Rendering */,
 				6877DD2C83643A2FF46814FF /* Resources */,
 				BAD2C93FC27DFF6F0D777597 /* State */,
 				CA78D19A3251CDC837458C32 /* Views */,
@@ -226,6 +241,7 @@
 		ABCCA64FB260EB86C15E4D29 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				913BDDD175A7D65A9A6BCDC7 /* A2UISpec.swift */,
 				BA75C05C810E421587E53523 /* Agent.swift */,
 				CA3085A25ECB8AF0A98D6F47 /* Attachment.swift */,
 				86415FE67D6C1C2F1DDBA257 /* Message.swift */,
@@ -400,6 +416,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAB0FB8E6AFFF81508C0ACED /* A2UIRendererView.swift in Sources */,
+				81EC3D12D7538934EF123417 /* A2UISpec.swift in Sources */,
 				16385E5C4FF9D0CA3376AA32 /* APIError.swift in Sources */,
 				472A18F2B5849141C9E09E99 /* Agent.swift in Sources */,
 				F677A439515DA1875D05ECC0 /* AgentColor.swift in Sources */,
@@ -446,6 +464,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D57655F62FBD1759DB75871F /* A2UIRendererView.swift in Sources */,
+				6EEC478AA9B833DC6D4CE1EE /* A2UISpec.swift in Sources */,
 				05AD508037170D0EFCB712E7 /* APIError.swift in Sources */,
 				796E034098D65B920232106D /* Agent.swift in Sources */,
 				DFFF5BEDDF0FE10395C7861B /* AgentColor.swift in Sources */,

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -99,6 +99,82 @@ owns two background polling tasks — discovery (agents + sessions + previews,
 5–15s adaptive) and the active channel's messages (1.5–3s adaptive). All HTTP
 calls live in `WorkspaceAPI`, an `actor` that serializes requests.
 
+## Generative UI (A2UI-shaped specs)
+
+The chat bubble can render an agent-emitted UI spec inline alongside its
+markdown content. The agent decides what to render; the client renders
+whatever comes in via [`bipa-app/swiftui-json-render`](https://github.com/bipa-app/swiftui-json-render).
+Unknown component types fall back to a placeholder rather than blocking
+the message, so the agent's vocabulary is open-ended — there's no
+client-side scenario list to maintain.
+
+### Wire contract
+
+A spec rides inside a `workspace.message` event's `payload`:
+
+```jsonc
+{
+  "id": "...",
+  "type": "workspace.message",
+  "source": "openagents:my_agent",
+  "target": "channel/<id>",
+  "payload": {
+    "content": "Here's a chart of your activity:",   // optional markdown
+    "message_type": "chat",
+    "spec": {                                         // the A2UI spec
+      "type": "Stack",
+      "props": { "direction": "vertical", "spacing": 12 },
+      "children": [
+        { "type": "Heading", "props": { "text": "Last 7 days", "level": 2 } },
+        { "type": "LineChart", "props": { "data": [...] } },
+        { "type": "Button",
+          "props": { "label": "Refresh",
+                     "action": { "name": "refresh_chart", "params": {} } } }
+      ]
+    },
+    "spec_tool_call_id": "tc_42"                      // optional, see below
+  }
+}
+```
+
+Both an inline JSON object (preferred) and a pre-serialized string are
+accepted for `payload.spec`.
+
+### Interaction round-trip
+
+When the user interacts with an action-bearing component (button, choice
+list, confirm dialog), the client posts a `workspace.tool_result` event
+back to the channel:
+
+```jsonc
+{
+  "type": "workspace.tool_result",
+  "source": "human:user",
+  "target": "channel/<id>",
+  "payload": {
+    "action_id": "refresh_chart",            // verbatim from the spec
+    "tool_call_id": "tc_42",                 // if the spec set one
+    "value": { /* whatever the agent declared in action.params */ }
+  }
+}
+```
+
+The agent runtime is responsible for interpreting this event as the user's
+response to its `render_ui` invocation and continuing the conversation.
+The generic `/v1/events` endpoint accepts this type without code changes;
+only the agent's prompt / handler logic needs to know the contract.
+
+### Component vocabulary
+
+We do not maintain a closed component list. Today the client renders the
+21 components shipped with SwiftUIJSONRender (Stack, Heading, Text, Image,
+Icon, Button, ChoiceList, AmountInput, ConfirmDialog, Card, Divider,
+Spacer, Alert, LineChart, PieChart, AssetPrice, BalanceCard,
+TransactionList, TransactionRow, and a few more — see the upstream
+package). Unknown types render as a placeholder chip showing the type
+name, so the agent emitting an unsupported `type` never blanks the
+bubble; sibling components in the same tree still render fine.
+
 ## Differences from the Electron app
 
 - No SSE/WebSocket — polling only (Electron does the same).

--- a/packages/go/project.yml
+++ b/packages/go/project.yml
@@ -11,6 +11,9 @@ packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
     from: 11.0.0
+  SwiftUIJSONRender:
+    url: https://github.com/bipa-app/swiftui-json-render
+    exactVersion: "0.2.1"
 settings:
   base:
     SWIFT_VERSION: "6.0"
@@ -37,6 +40,8 @@ targets:
       - package: Firebase
         product: FirebaseMessaging
         platforms: [iOS]
+      - package: SwiftUIJSONRender
+        product: SwiftUIJSONRender
     info:
       path: OpenAgents/Info.plist
       properties:

--- a/workspace/frontend/.gitignore
+++ b/workspace/frontend/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .next/
 .env.local
+.vercelignore


### PR DESCRIPTION
## Summary

- Agents can now emit a UI spec (table, form, chart, custom buttons — anything `SwiftUIJSONRender` knows how to draw, plus a placeholder fallback for unknown component types) and have it render inline in the chat bubble.
- User interactions with the rendered components (button taps, choices, form submits) round-trip back to the agent as a `workspace.tool_result` event referencing the originating `tool_call_id`.
- Open-ended by design: no client-side scenario list, no predefined component catalog gated at the data-model level. The agent decides what to render; the renderer never refuses input it doesn't recognize.

## What's on the wire

`packages/go/README.md` § "Generative UI (A2UI-shaped specs)" documents the contract end-to-end. In short:

- **Agent → client**: `workspace.message` event with `payload.spec` (inline JSON object preferred; string also accepted) + optional `payload.spec_tool_call_id`
- **Client → agent**: `workspace.tool_result` event with `{ action_id, tool_call_id?, value? }`

The generic `/v1/events` endpoint already accepts both — no backend code change required for transport. The agent runtime needs to learn the contract (i.e., to emit specs and interpret tool_result events); that's a prompt/handler change, sibling to this PR.

## Architecture

- `Models/A2UISpec.swift` — open Codable model: `type: String`, `id: String?`, `props: JSONValue?`, `children: [A2UIComponent]?`, `action: A2UIAction?`. Decodes anything, never refuses.
- `Rendering/A2UIRendererView.swift` — thin SwiftUI wrapper over `SwiftUIJSONRender.JSONView`. The library already handles parse errors / version mismatch / unknown components (`.placeholder` default), so the shim is degenerate today; A2UI ↔ JSONRender translations land here as the schemas diverge.
- `Models/ONMEvent.swift` — `toMessage()` pulls `payload.spec` into a new optional `Message.attachment` carrying the raw JSON + tool_call_id. `JSONValue` now `Codable` (was Decodable-only) to support the inline-object re-serialize.
- `Views/ChatView.swift` — `MessageBubble` renders the attachment below markdown segments, treats it as wide content, and routes `onAttachmentAction` to `store.sendToolResult`.
- `Networking/WorkspaceAPI.swift` + `State/WorkspaceStore.swift` — new `sendToolResult(channel:, toolCallId:, actionId:, value:)` posting a `workspace.tool_result` event.

## Failure handling

Layered, all upstream of the application:

- Malformed JSON → JSONView renders its built-in error banner
- Schema version mismatch → JSONView renders its version banner
- Unknown component type → small placeholder chip; siblings still render
- Missing/malformed action → inert button (no crash)

The "AI-decided" property: no switch statement in the app says \"if button.action.id == X, do Y\". The agent attaches an opaque `action.id`; the client round-trips it verbatim; the agent's own memory gives it meaning.

## Out of scope (deliberate, for landability)

- Streaming partial specs (use `tool_call_args` deltas for live render — separate PR)
- Native Swift Charts integration beyond what SwiftUIJSONRender ships
- Custom theming pass to match Go's iMessage aesthetic
- Per-thread shared state with `StateDelta` (separate, larger PR)
- AG-UI SSE transport adoption
- Agent runtime / prompt changes to actually emit specs and consume tool_results — coordinate separately

## Test plan

- [x] `xcodebuild build` Release passes for `OpenAgentsGo_macOS`
- [ ] Run the SwiftUI Previews in `A2UIRendererView.swift` — verify the four fixtures (prose, choice list, unknown fallback, malformed JSON) render with expected fail-soft behavior
- [ ] Hand-craft a `workspace.message` event with `payload.spec` via the `/v1/events` endpoint, confirm it renders in a bubble in a live thread
- [ ] Tap a button on a rendered spec, confirm a `workspace.tool_result` event appears in the backend events table referencing the original `tool_call_id`
- [ ] On iOS device, confirm the bubble sizes and the renderer doesn't break layout (no test target yet — visual check)

## Dependency

Adds `https://github.com/bipa-app/swiftui-json-render` pinned at `exactVersion: 0.2.1`. Apache 2, ~5K LOC, single library product. Pre-release (v0.x) — pinned exact to avoid surprise breakage.