### PR TITLE
feat(workspace): add browser_enabled toggle to workspace

### DIFF
--- a/workspace/backend/app/routers/workspaces.py
+++ b/workspace/backend/app/routers/workspaces.py
@@ -92,6 +92,11 @@ class WorkspaceUpdateRequest(BaseModel):
     name: Optional[str] = None
     settings: Optional[dict] = None
     status: Optional[str] = None
+    # Convenience top-level toggle for the Browser Fabric viewer in clients.
+    # Stored inside `settings.browser_enabled` so we don't need a schema
+    # migration — but exposed as a typed field so clients don't have to
+    # round-trip the whole settings dict to flip one bool.
+    browser_enabled: Optional[bool] = None
 
 class CollaboratorAddRequest(BaseModel):
     email: str
@@ -124,12 +129,16 @@ def _format_workspace(ws: Workspace, members: list, now: datetime) -> dict:
             "joinedAt": m.joined_at.isoformat() if m.joined_at else None,
         })
 
+    settings = ws.settings or {}
     return {
         "workspaceId": str(ws.id),
         "slug": ws.slug,
         "name": ws.name,
         "creatorEmail": ws.creator_email,
-        "settings": ws.settings or {},
+        "settings": settings,
+        # Surface browser_enabled at the top level for clients that don't
+        # want to dig into the settings dict. Mirrors what's inside settings.
+        "browserEnabled": bool(settings.get("browser_enabled", False)),
         "status": ws.status,
         "createdAt": ws.created_at.isoformat() if ws.created_at else None,
         "lastActivityAt": ws.last_activity_at.isoformat() if ws.last_activity_at else None,
@@ -312,6 +321,13 @@ async def update_workspace(
         workspace.name = body.name
     if body.settings is not None:
         workspace.settings = body.settings
+    if body.browser_enabled is not None:
+        # Merge into settings rather than overwriting other keys. Must
+        # reassign the dict — SQLAlchemy JSONB mutation tracking won't
+        # pick up an in-place dict update.
+        current = dict(workspace.settings or {})
+        current["browser_enabled"] = body.browser_enabled
+        workspace.settings = current
     if body.status is not None:
         workspace.status = body.status
 

--- a/workspace/backend/tests/test_workspaces.py
+++ b/workspace/backend/tests/test_workspaces.py
@@ -100,6 +100,56 @@ class TestUpdateWorkspace:
         assert resp.status_code == 200
         assert resp.json()["data"]["settings"]["theme"] == "dark"
 
+    def test_browser_enabled_defaults_false(self, client, workspace):
+        """A fresh workspace has browserEnabled = false."""
+        resp = client.get(f"/v1/workspaces/{workspace['id']}",
+                          headers={"X-Workspace-Token": workspace["token"]})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["browserEnabled"] is False
+
+    def test_update_browser_enabled_true(self, client, workspace):
+        """Flip browser_enabled on; response surfaces it at the top level."""
+        resp = client.patch(f"/v1/workspaces/{workspace['id']}", json={
+            "browser_enabled": True,
+        }, headers={"X-Workspace-Token": workspace["token"]})
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["browserEnabled"] is True
+        # And it's mirrored inside the settings dict
+        assert data["settings"].get("browser_enabled") is True
+
+    def test_browser_enabled_round_trips(self, client, workspace):
+        """A subsequent GET reflects the persisted toggle."""
+        client.patch(f"/v1/workspaces/{workspace['id']}",
+                     json={"browser_enabled": True},
+                     headers={"X-Workspace-Token": workspace["token"]})
+        resp = client.get(f"/v1/workspaces/{workspace['id']}",
+                          headers={"X-Workspace-Token": workspace["token"]})
+        assert resp.json()["data"]["browserEnabled"] is True
+
+    def test_browser_enabled_preserves_other_settings(self, client, workspace):
+        """Flipping browser_enabled doesn't trample unrelated settings keys."""
+        client.patch(f"/v1/workspaces/{workspace['id']}",
+                     json={"settings": {"theme": "dark"}},
+                     headers={"X-Workspace-Token": workspace["token"]})
+        resp = client.patch(f"/v1/workspaces/{workspace['id']}", json={
+            "browser_enabled": True,
+        }, headers={"X-Workspace-Token": workspace["token"]})
+        data = resp.json()["data"]
+        assert data["settings"]["theme"] == "dark"
+        assert data["settings"]["browser_enabled"] is True
+        assert data["browserEnabled"] is True
+
+    def test_browser_enabled_false_clears_panel(self, client, workspace):
+        """Toggling off persists the false value."""
+        client.patch(f"/v1/workspaces/{workspace['id']}",
+                     json={"browser_enabled": True},
+                     headers={"X-Workspace-Token": workspace["token"]})
+        resp = client.patch(f"/v1/workspaces/{workspace['id']}", json={
+            "browser_enabled": False,
+        }, headers={"X-Workspace-Token": workspace["token"]})
+        assert resp.json()["data"]["browserEnabled"] is False
+
 
 class TestDeleteWorkspace:
     """DELETE /v1/workspaces/{id} — soft-delete workspace."""

--- a/workspace/frontend/.gitignore
+++ b/workspace/frontend/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 .next/
 .env.local
 .vercelignore
+
+# InsForge CLI local link (contains api_key — never commit)
+.insforge/


### PR DESCRIPTION
## Summary
Workspace-scoped toggle for the Browser Fabric viewer in clients (mac/iOS Go app first; React app can adopt the typed field later if desired).

- New typed `browser_enabled: Optional[bool]` field on `WorkspaceUpdateRequest`. PATCH merges into the existing `settings` JSONB (preserves other keys) — no schema migration needed.
- Response surfaces `browserEnabled` at the top level so clients don't have to dig into `settings`.
- 5 new tests cover default-false, round-trip, preservation of unrelated settings keys, and toggle-off.

## Why no migration
The `Workspace.settings` JSONB column already exists. A typed top-level API field with JSONB-backed storage gives us the ergonomics of a dedicated column without touching schema.

## Test plan
- [x] `pytest tests/test_workspaces.py -x -q` → 33 passed
- [ ] After deploy: PATCH `/v1/workspaces/{id}` with `{"browser_enabled": true}` → response shows `browserEnabled: true`
- [ ] Subsequent GET shows the persisted value