### PR TITLE
feat(agents): force Browser Fabric when workspace.browser_enabled=true

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openagents"
-version = "0.9.3.post19"
+version = "0.9.3.post20"
 description = "A flexible framework for building multi-agent systems with customizable protocols"
 readme = "README.md"
 authors = [

--- a/sdk/src/openagents/adapters/base.py
+++ b/sdk/src/openagents/adapters/base.py
@@ -55,6 +55,11 @@ class BaseAdapter(ABC):
         # Per-channel uploaded file tracking — files uploaded during message
         # handling are attached to the final response message.
         self._channel_uploaded_files: dict[str, list[dict]] = {}
+        # Cached workspace.browser_enabled. Populated lazily on first read so
+        # we don't pay the HTTP roundtrip until an adapter actually needs the
+        # value for prompt construction. The adapter pays it once per session
+        # — flipping the workspace toggle requires the agent to reconnect.
+        self._browser_enabled_cache: Optional[bool] = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -358,6 +363,32 @@ class BaseAdapter(ABC):
             )
         except Exception:
             pass
+
+    # ------------------------------------------------------------------
+    # Workspace flags (cached)
+    # ------------------------------------------------------------------
+
+    async def get_browser_enabled(self) -> bool:
+        """Return whether the workspace has the Browser Fabric viewer toggle on.
+
+        Result is cached for the lifetime of the adapter to avoid hitting
+        `/v1/workspaces/{id}` on every message — agents that watch this value
+        must reconnect to pick up a flip. The backend already surfaces the
+        flag at the top level (`browserEnabled` on the GET response). Falls
+        back to False when the backend is older or the request fails so the
+        prompt builders don't accidentally inject the strong directive
+        against a backend that can't actually route to Fabric.
+        """
+        if self._browser_enabled_cache is None:
+            try:
+                meta = await self.client.get_workspace_metadata(
+                    self.workspace_id, self.token,
+                )
+                self._browser_enabled_cache = bool(meta.get("browserEnabled", False))
+            except Exception as e:
+                logger.debug(f"browser_enabled fetch failed: {e}")
+                self._browser_enabled_cache = False
+        return self._browser_enabled_cache
 
     # ------------------------------------------------------------------
     # Abstract

--- a/sdk/src/openagents/adapters/claude.py
+++ b/sdk/src/openagents/adapters/claude.py
@@ -219,8 +219,15 @@ class ClaudeAdapter(BaseAdapter):
         except Exception as e:
             logger.debug(f"Failed to collect uploaded files for channel {channel}: {e}")
 
-    def _build_claude_cmd(self, prompt: str, channel_name: str) -> list[str]:
-        """Build the claude CLI command for a specific channel."""
+    def _build_claude_cmd(self, prompt: str, channel_name: str, browser_enabled: bool = False) -> list[str]:
+        """Build the claude CLI command for a specific channel.
+
+        `browser_enabled` flows from `WorkspaceStore.browserEnabled` (resolved
+        by `_handle_message` via the cached `get_browser_enabled()` helper);
+        when True the system prompt gets a strong directive forcing the agent
+        toward `workspace_browser_*` MCP tools and away from any local
+        `mcp__browsermcp__*` server it may also have wired.
+        """
         # On Windows, prefer .cmd/.exe wrappers over bare npm bash shims
         if platform.system() == "Windows":
             claude_bin = shutil.which("claude.cmd") or shutil.which("claude.exe") or shutil.which("claude")
@@ -236,6 +243,7 @@ class ClaudeAdapter(BaseAdapter):
             workspace_id=self.workspace_id,
             channel_name=channel_name,
             mode=self._mode,
+            browser_enabled=browser_enabled,
         )
 
         cmd = [
@@ -438,7 +446,8 @@ class ClaudeAdapter(BaseAdapter):
 
         mcp_config_file = None
         try:
-            cmd = self._build_claude_cmd(content, msg_channel)
+            browser_enabled = await self.get_browser_enabled()
+            cmd = self._build_claude_cmd(content, msg_channel, browser_enabled=browser_enabled)
             # Track the temp MCP config file for cleanup
             try:
                 idx = cmd.index("--mcp-config")

--- a/sdk/src/openagents/adapters/codex.py
+++ b/sdk/src/openagents/adapters/codex.py
@@ -76,7 +76,7 @@ class CodexAdapter(BaseAdapter):
         # Conversation history for multi-turn context
         self._conversation_history: list[dict] = []
 
-    def _build_system_context(self, channel_name: str) -> str:
+    def _build_system_context(self, channel_name: str, browser_enabled: bool = False) -> str:
         """Build workspace context to prepend to prompts."""
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
@@ -86,6 +86,7 @@ class CodexAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     # ------------------------------------------------------------------
@@ -144,7 +145,8 @@ class CodexAdapter(BaseAdapter):
         Used when OPENAI_API_KEY and OPENAI_BASE_URL are set.
         Streams the response and returns the full text.
         """
-        system_prompt = self._build_system_context(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_context(channel, browser_enabled=browser_enabled)
 
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend(self._conversation_history)
@@ -205,7 +207,7 @@ class CodexAdapter(BaseAdapter):
     # Subprocess mode (codex exec --json --full-auto)
     # ------------------------------------------------------------------
 
-    def _build_codex_cmd(self, prompt: str, channel_name: str) -> list[str]:
+    def _build_codex_cmd(self, prompt: str, channel_name: str, browser_enabled: bool = False) -> list[str]:
         """Build the codex CLI command."""
         # On Windows, prefer .cmd/.exe wrappers over bare npm bash shims
         if platform.system() == "Windows":
@@ -246,7 +248,7 @@ class CodexAdapter(BaseAdapter):
 
         # Prepend workspace context to the prompt so Codex knows
         # about shared resources and how to collaborate
-        context = self._build_system_context(channel_name)
+        context = self._build_system_context(channel_name, browser_enabled=browser_enabled)
         full_prompt = f"{context}\n\n---\n\n{prompt}"
         cmd.append(full_prompt)
         return cmd
@@ -290,7 +292,8 @@ class CodexAdapter(BaseAdapter):
     async def _run_codex_subprocess(self, content: str, msg_channel: str) -> str:
         """Run a Codex CLI subprocess and collect the response."""
         try:
-            cmd = self._build_codex_cmd(content, msg_channel)
+            browser_enabled = await self.get_browser_enabled()
+            cmd = self._build_codex_cmd(content, msg_channel, browser_enabled=browser_enabled)
         except FileNotFoundError as e:
             await self._send_error(msg_channel, str(e))
             return ""

--- a/sdk/src/openagents/adapters/cursor.py
+++ b/sdk/src/openagents/adapters/cursor.py
@@ -67,7 +67,7 @@ class CursorAdapter(BaseAdapter):
         # Conversation history for multi-turn context
         self._conversation_history: list[dict] = []
 
-    def _build_system_prompt(self, channel_name: str) -> str:
+    def _build_system_prompt(self, channel_name: str, browser_enabled: bool = False) -> str:
         """Build workspace context system prompt."""
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
@@ -77,6 +77,7 @@ class CursorAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     async def _handle_message(self, msg: dict):
@@ -137,7 +138,8 @@ class CursorAdapter(BaseAdapter):
         self, user_message: str, channel: str
     ) -> str:
         """Call OpenAI-compatible chat completions API directly."""
-        system_prompt = self._build_system_prompt(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_prompt(channel, browser_enabled=browser_enabled)
 
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend(self._conversation_history)

--- a/sdk/src/openagents/adapters/nanoclaw.py
+++ b/sdk/src/openagents/adapters/nanoclaw.py
@@ -68,7 +68,7 @@ class NanoClawAdapter(BaseAdapter):
         # Conversation history for multi-turn context
         self._conversation_history: list[dict] = []
 
-    def _build_system_prompt(self, channel_name: str) -> str:
+    def _build_system_prompt(self, channel_name: str, browser_enabled: bool = False) -> str:
         """Build workspace context system prompt."""
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
@@ -78,6 +78,7 @@ class NanoClawAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     async def _handle_message(self, msg: dict):
@@ -138,7 +139,8 @@ class NanoClawAdapter(BaseAdapter):
         self, user_message: str, channel: str
     ) -> str:
         """Call OpenAI-compatible chat completions API directly."""
-        system_prompt = self._build_system_prompt(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_prompt(channel, browser_enabled=browser_enabled)
 
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend(self._conversation_history)

--- a/sdk/src/openagents/adapters/openclaw.py
+++ b/sdk/src/openagents/adapters/openclaw.py
@@ -228,8 +228,13 @@ class OpenClawAdapter(BaseAdapter):
                     return candidate
         return None
 
-    def _build_system_prompt(self, channel_name: str) -> str:
-        """Build system prompt with workspace context and API skills."""
+    def _build_system_prompt(self, channel_name: str, browser_enabled: bool = False) -> str:
+        """Build system prompt with workspace context and API skills.
+
+        `browser_enabled` is resolved by the caller (async) via
+        `self.get_browser_enabled()`; when True, the prompt forbids any
+        `mcp__browsermcp__*` or other local-browser tools.
+        """
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
             workspace_id=self.workspace_id,
@@ -238,6 +243,7 @@ class OpenClawAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     def _resolve_openclaw_workspace(self) -> Optional[Path]:
@@ -653,7 +659,8 @@ class OpenClawAdapter(BaseAdapter):
         """
         # Build messages
         history_text = await self._get_recent_history_text(channel)
-        system_prompt = self._build_system_prompt(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_prompt(channel, browser_enabled=browser_enabled)
         if history_text:
             system_prompt += "\n" + history_text
 

--- a/sdk/src/openagents/adapters/opencode.py
+++ b/sdk/src/openagents/adapters/opencode.py
@@ -118,7 +118,7 @@ class OpenCodeAdapter(BaseAdapter):
         except Exception:
             logger.debug("Could not write workspace skill to %s", skill_file)
 
-    def _build_system_context(self, channel_name: str) -> str:
+    def _build_system_context(self, channel_name: str, browser_enabled: bool = False) -> str:
         return build_opencode_system_prompt(
             agent_name=self.agent_name,
             workspace_id=self.workspace_id,
@@ -127,6 +127,7 @@ class OpenCodeAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     # ------------------------------------------------------------------
@@ -298,7 +299,8 @@ class OpenCodeAdapter(BaseAdapter):
         else:
             # New session: inject workspace skill and prepend system context
             self._ensure_workspace_skill(msg_channel)
-            context = self._build_system_context(msg_channel)
+            browser_enabled = await self.get_browser_enabled()
+            context = self._build_system_context(msg_channel, browser_enabled=browser_enabled)
             full_prompt = f"{context}\n\n---\n\n{content}"
 
         if platform.system() == "Windows" and cmd[0].lower().endswith(".cmd"):

--- a/sdk/src/openagents/adapters/workspace_prompt.py
+++ b/sdk/src/openagents/adapters/workspace_prompt.py
@@ -14,6 +14,50 @@ instructions they can call via curl/requests/fetch.
 from typing import Optional
 
 
+def build_browser_directive(browser_enabled: bool) -> str:
+    """Strong directive forcing agents to use the workspace browser when the
+    workspace has Browser Fabric enabled.
+
+    Emitted high in the system prompt so it wins against any earlier guidance
+    that suggests local browsing tools. Empty string when the workspace toggle
+    is off so older agents continue to behave as before.
+
+    Returns "" when the toggle is off; the caller can unconditionally
+    concatenate the result.
+    """
+    if not browser_enabled:
+        return ""
+    return (
+        "\n## Browser Use (MANDATORY)\n"
+        "This workspace has the **shared Browser Fabric session** enabled. "
+        "All web browsing MUST go through it so the user can watch the "
+        "session live in their right-side panel and so cookies / state "
+        "persist across agents.\n\n"
+        "**Use ONLY these tools for any web browsing:**\n"
+        "- `mcp__openagents-workspace__workspace_browser_open`\n"
+        "- `mcp__openagents-workspace__workspace_browser_navigate`\n"
+        "- `mcp__openagents-workspace__workspace_browser_click`\n"
+        "- `mcp__openagents-workspace__workspace_browser_type`\n"
+        "- `mcp__openagents-workspace__workspace_browser_snapshot`\n"
+        "- `mcp__openagents-workspace__workspace_browser_screenshot`\n"
+        "- `mcp__openagents-workspace__workspace_browser_list_tabs`\n"
+        "- `mcp__openagents-workspace__workspace_browser_close`\n"
+        "\n"
+        "If you don't have these MCP tools, use `Bash` + `curl` against "
+        "`/v1/browser/tabs` (documented below in Shared Browser).\n\n"
+        "**FORBIDDEN — do NOT call any of these:**\n"
+        "- `mcp__browsermcp__*` (any local Browser MCP extension tool)\n"
+        "- `mcp__playwright__*`, `mcp__puppeteer__*`, `mcp__chrome-devtools__*`, or any other local-browser MCP\n"
+        "- `WebFetch`, `WebSearch`, `web_fetch`, `web_search`, or any built-in network/browser tool\n"
+        "\n"
+        "If a local browser tool errors with \"extension isn't connected\" or "
+        "\"connect your browser\", do NOT ask the user to connect anything — "
+        "the local extension is irrelevant here. Immediately switch to the "
+        "workspace browser tools above. The Browser Fabric session is already "
+        "running on the backend.\n"
+    )
+
+
 def build_workspace_identity(
     agent_name: str,
     workspace_id: str,
@@ -219,11 +263,15 @@ def build_claude_system_prompt(
     workspace_id: str,
     channel_name: str,
     mode: str = "execute",
+    browser_enabled: bool = False,
 ) -> str:
     """Build the system prompt for Claude adapter (MCP-based).
 
-    Claude gets identity + collaboration instructions but NOT API skills,
-    because it uses MCP tools instead.
+    Claude gets identity + collaboration instructions but NOT the full API
+    skills section — it uses MCP tools instead. When `browser_enabled` is
+    True we still inject the browser directive so the agent knows to prefer
+    `workspace_browser_*` over `mcp__browsermcp__*` and other local-browser
+    MCPs that might also be installed.
     """
     parts = []
     parts.append(build_workspace_identity(agent_name, workspace_id, channel_name, mode))
@@ -231,6 +279,7 @@ def build_claude_system_prompt(
         "Use workspace_get_history to read previous messages.\n"
         "Use workspace_get_agents to see other agents.\n"
     )
+    parts.append(build_browser_directive(browser_enabled))
     parts.append(build_collaboration_prompt())
 
     if mode == "plan":
@@ -257,14 +306,19 @@ def build_openclaw_system_prompt(
     token: str,
     mode: str = "execute",
     disabled_modules: Optional[set] = None,
+    browser_enabled: bool = False,
 ) -> str:
     """Build the full system prompt for OpenClaw/non-MCP agents.
 
-    Includes identity, collaboration, mode instructions, and
-    REST API skills for workspace resources.
+    Includes identity, collaboration, mode instructions, and REST API skills
+    for workspace resources. When `browser_enabled` is True, prepends the
+    strong directive that forbids local browser MCP tools (e.g. browsermcp,
+    playwright) — these agents typically have multiple MCP servers wired and
+    pick the wrong one without an explicit prohibition.
     """
     parts = []
     parts.append(build_workspace_identity(agent_name, workspace_id, channel_name, mode))
+    parts.append(build_browser_directive(browser_enabled))
     parts.append(build_collaboration_prompt())
     parts.append(build_mode_prompt(mode))
     parts.append(build_api_skills_prompt(
@@ -286,6 +340,7 @@ def build_openclaw_skill_md(
     agent_name: str,
     channel_name: str,
     disabled_modules: Optional[set] = None,
+    browser_enabled: bool = False,
 ) -> str:
     """Build a SKILL.md file for OpenClaw's skill auto-discovery.
 
@@ -307,6 +362,7 @@ def build_openclaw_skill_md(
     identity = build_workspace_identity(
         agent_name, workspace_id, channel_name, "execute"
     )
+    directive = build_browser_directive(browser_enabled)
     collab = build_collaboration_prompt()
 
     frontmatter = (
@@ -323,7 +379,7 @@ def build_openclaw_skill_md(
         "---\n\n"
     )
 
-    return frontmatter + identity + "\n" + collab + "\n" + body
+    return frontmatter + identity + directive + "\n" + collab + "\n" + body
 
 
 def _build_opencode_api_skills_prompt(
@@ -472,6 +528,7 @@ def build_opencode_system_prompt(
     token: str,
     mode: str = "execute",
     disabled_modules: Optional[set] = None,
+    browser_enabled: bool = False,
 ) -> str:
     parts = []
     parts.append(build_workspace_identity(agent_name, workspace_id, channel_name, mode))
@@ -486,6 +543,7 @@ def build_opencode_system_prompt(
         "for sharing files, browsing the web collaboratively, and discovering other agents.\n"
     )
 
+    parts.append(build_browser_directive(browser_enabled))
     parts.append(build_collaboration_prompt())
     parts.append(build_mode_prompt(mode))
     parts.append(

--- a/sdk/src/openagents/client/workspace_client.py
+++ b/sdk/src/openagents/client/workspace_client.py
@@ -416,6 +416,30 @@ class WorkspaceClient:
                     "status": result.get("status", "active"),
                 }
 
+    async def get_workspace_metadata(
+        self,
+        workspace_id: str,
+        token: str,
+    ) -> dict:
+        """Get the workspace's top-level metadata via GET /v1/workspaces/{id}.
+
+        Returns the full data block from the backend — adapters care about
+        `browserEnabled` today, but more keys may be surfaced over time.
+        On error, returns an empty dict so callers can fall back to defaults
+        rather than crashing.
+        """
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.endpoint}/v1/workspaces/{workspace_id}",
+                headers=self._ws_headers(token),
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status != 200:
+                    return {}
+                data = await resp.json()
+                return data.get("data", {}) or {}
+
     async def update_session(
         self,
         workspace_id: str,

--- a/tests/test_workspace_prompt_browser.py
+++ b/tests/test_workspace_prompt_browser.py
@@ -1,0 +1,129 @@
+"""
+Tests for the `browser_enabled` directive in workspace prompt builders.
+
+The whole point of the directive is to force agents away from
+`mcp__browsermcp__*` (and other local-browser MCP servers) when the
+workspace has the Browser Fabric viewer toggle on. These tests pin the
+shape of that contract.
+"""
+import pytest
+
+from openagents.adapters.workspace_prompt import (
+    build_browser_directive,
+    build_claude_system_prompt,
+    build_openclaw_system_prompt,
+    build_opencode_system_prompt,
+)
+
+
+class TestBrowserDirective:
+    def test_disabled_returns_empty(self):
+        """browser_enabled=False emits nothing — no opinion injected."""
+        assert build_browser_directive(False) == ""
+
+    def test_enabled_contains_mandatory_header(self):
+        out = build_browser_directive(True)
+        assert "Browser Use (MANDATORY)" in out
+
+    def test_enabled_names_workspace_browser_tools(self):
+        out = build_browser_directive(True)
+        # The agent has to know which tools to call instead.
+        for tool in (
+            "workspace_browser_open",
+            "workspace_browser_navigate",
+            "workspace_browser_click",
+            "workspace_browser_snapshot",
+        ):
+            assert tool in out, f"missing tool name: {tool}"
+
+    def test_enabled_explicitly_forbids_browsermcp(self):
+        """The original failure mode: agent picks `mcp__browsermcp__*`."""
+        out = build_browser_directive(True)
+        assert "mcp__browsermcp__*" in out
+        assert "FORBIDDEN" in out
+
+    def test_enabled_forbids_other_local_browser_mcps(self):
+        out = build_browser_directive(True)
+        # Other common locally-installed browser MCPs that would race for
+        # the same prompt — the directive must rule them out too.
+        for forbidden in ("mcp__playwright__", "mcp__puppeteer__", "WebFetch"):
+            assert forbidden in out, f"missing prohibition: {forbidden}"
+
+    def test_enabled_handles_extension_isnt_connected_error(self):
+        """If a local tool errors with 'extension isn't connected', the
+        agent must switch rather than ask the user to connect anything."""
+        out = build_browser_directive(True)
+        assert "extension isn't connected" in out
+        # And it must NOT ask the user — that was the bug in the screenshot.
+        assert "do NOT ask the user" in out
+
+
+class TestClaudeSystemPrompt:
+    def test_default_no_directive(self):
+        """Default (browser_enabled=False) keeps the v0.2 prompt shape."""
+        prompt = build_claude_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+        )
+        assert "Browser Use (MANDATORY)" not in prompt
+        assert "mcp__browsermcp__" not in prompt
+
+    def test_enabled_injects_directive(self):
+        prompt = build_claude_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            browser_enabled=True,
+        )
+        assert "Browser Use (MANDATORY)" in prompt
+        assert "mcp__browsermcp__*" in prompt
+        assert "workspace_browser_navigate" in prompt
+
+
+class TestOpenclawSystemPrompt:
+    def test_default_no_directive(self):
+        prompt = build_openclaw_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+        )
+        assert "Browser Use (MANDATORY)" not in prompt
+
+    def test_enabled_injects_directive(self):
+        prompt = build_openclaw_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+            browser_enabled=True,
+        )
+        assert "Browser Use (MANDATORY)" in prompt
+        assert "mcp__browsermcp__*" in prompt
+
+
+class TestOpencodeSystemPrompt:
+    def test_default_no_directive(self):
+        prompt = build_opencode_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+        )
+        assert "Browser Use (MANDATORY)" not in prompt
+
+    def test_enabled_injects_directive(self):
+        prompt = build_opencode_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+            browser_enabled=True,
+        )
+        assert "Browser Use (MANDATORY)" in prompt
+        assert "mcp__browsermcp__*" in prompt


### PR DESCRIPTION
## Why
Agent screenshot from prod: user said \"navigate to https://search.google.com/...\" → agent called `mcp__browsermcp__browser_navigate` (the local Chrome extension MCP) → got \"extension isn't connected\" → asked the user to install/connect a Chrome extension. The workspace had Browser Fabric configured server-side, so the agent should have used the workspace browser tools.

Root cause: agent has both `mcp__openagents-workspace__workspace_browser_*` (Browser Fabric-backed) and `mcp__browsermcp__*` (local Chrome) MCPs wired, with no prompt guidance on which to pick.

## What
Strong system-prompt directive injected high in the agent's prompt **when `workspace.browser_enabled == true`**, that:

- Names the eight workspace_browser_* MCP tools to use.
- Forbids `mcp__browsermcp__*`, `mcp__playwright__*`, `mcp__puppeteer__*`, `mcp__chrome-devtools__*`, `WebFetch`, `WebSearch`, and built-in browser tools by name.
- Instructs the agent: if a local tool errors with \"extension isn't connected,\" do NOT ask the user to connect — switch to the workspace browser tools and try again.

When `browser_enabled` is false, the directive is empty — no behavior change for workspaces that haven't opted into Browser Fabric.

## Plumbing
- `WorkspaceClient.get_workspace_metadata()` — new method, hits GET /v1/workspaces/{id} and returns the data block (already includes `browserEnabled` after PR #392).
- `BaseAdapter.get_browser_enabled()` — caches per-session (no per-message roundtrip; agent reconnects to pick up a flip).
- `workspace_prompt.build_browser_directive(browser_enabled)` — emits the block when on.
- Threaded through `build_claude_system_prompt`, `build_openclaw_system_prompt`, `build_opencode_system_prompt`.
- Each adapter (claude, openclaw, codex, cursor, nanoclaw, opencode) calls `await self.get_browser_enabled()` and passes the value.

## Test plan
- [x] 12 new prompt tests, all passing — directive presence, tool-name list, explicit forbids, the \"don't ask user to connect\" line.
- [ ] Reproduce the screenshot scenario in prod with browser_enabled=true → agent picks `workspace_browser_navigate` instead of `mcp__browsermcp__browser_navigate`.
- [ ] Confirm older backends (no `browserEnabled` field) → `get_browser_enabled()` returns False, no directive injected, no behavior change.

## Depends on
- Backend PR #392 (`browser_enabled` on workspace). Already deployed to `agents-api.caremojo.app`.