### PR TITLE
feat(agent-launcher): force Browser Fabric when workspace.browser_enabled=true (0.2.131)

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.130",
+  "version": "0.2.131",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/adapters/base.js
+++ b/packages/agent-connector/src/adapters/base.js
@@ -53,6 +53,11 @@ class BaseAdapter {
     // Per-channel task tracking for parallel execution
     this._channelBusy = new Set();
     this._channelQueues = {};
+    // Cached workspace.browser_enabled. Populated lazily on first read so we
+    // don't pay an HTTP roundtrip per message — adapters that toggle the
+    // workspace flag must reconnect/restart to pick up the change (matches
+    // the Python adapter behavior in workspace_prompt.py).
+    this._browserEnabledCache = null;
     // Wall-clock timestamp of adapter init, used by the `status` control
     // action to report uptime back to the channel. Reset on reinstantiation
     // (e.g. after a `restart` IPC bounce) so uptime tracks "time since last
@@ -705,6 +710,25 @@ class BaseAdapter {
 
   _sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Return whether the workspace has the Browser Fabric viewer toggle on.
+   * Cached for the lifetime of the adapter — restart to pick up a flip.
+   * Falls back to false on error so the prompt builders don't accidentally
+   * inject the strong directive against an older backend that can't route
+   * to Browser Fabric.
+   */
+  async getBrowserEnabled() {
+    if (this._browserEnabledCache === null) {
+      try {
+        const meta = await this.client.getWorkspaceMetadata(this.workspaceId, this.token);
+        this._browserEnabledCache = !!(meta && meta.browserEnabled);
+      } catch (e) {
+        this._browserEnabledCache = false;
+      }
+    }
+    return this._browserEnabledCache;
   }
 }
 

--- a/packages/agent-connector/src/adapters/claude.js
+++ b/packages/agent-connector/src/adapters/claude.js
@@ -358,7 +358,7 @@ class ClaudeAdapter extends BaseAdapter {
     return null;
   }
 
-  _buildClaudeCmd(prompt, channelName, { skipResume = false } = {}) {
+  _buildClaudeCmd(prompt, channelName, { skipResume = false, browserEnabled = false } = {}) {
     const claudeBin = this._findClaudeBinary();
     if (!claudeBin) {
       throw new Error('claude CLI not found. Install with: curl -fsSL https://claude.ai/install.sh | bash');
@@ -369,6 +369,7 @@ class ClaudeAdapter extends BaseAdapter {
       workspaceId: this.workspaceId,
       channelName,
       mode: this._mode,
+      browserEnabled,
     });
 
     // In skills mode, replace MCP tool references with curl-based instructions
@@ -432,6 +433,7 @@ class ClaudeAdapter extends BaseAdapter {
       agentName: this.agentName,
       channelName,
       disabledModules: this.disabledModules,
+      browserEnabled: this._browserEnabledCache === true,
     });
     fs.writeFileSync(skillFile, skillContent, 'utf-8');
     this._log(`Wrote workspace skill to ${skillFile}`);
@@ -648,7 +650,11 @@ class ClaudeAdapter extends BaseAdapter {
       }
 
       try {
-        const built = this._buildClaudeCmd(effectiveContent, msgChannel, { skipResume: attempt > 0 });
+        const browserEnabled = await this.getBrowserEnabled();
+        const built = this._buildClaudeCmd(effectiveContent, msgChannel, {
+          skipResume: attempt > 0,
+          browserEnabled,
+        });
         cmd = built.cmd;
         mcpConfigFile = built.mcpConfigFile;
       } catch (e) {

--- a/packages/agent-connector/src/adapters/workspace-prompt.js
+++ b/packages/agent-connector/src/adapters/workspace-prompt.js
@@ -12,6 +12,51 @@
 'use strict';
 
 /**
+ * Strong directive forcing agents to use the workspace browser when the
+ * workspace has Browser Fabric enabled. Emitted high in the system prompt
+ * so it wins against any earlier guidance that suggests local browsing
+ * tools.
+ *
+ * Returns '' when the toggle is off; the caller can unconditionally
+ * concatenate the result.
+ *
+ * Mirrors `build_browser_directive` in
+ * sdk/src/openagents/adapters/workspace_prompt.py.
+ */
+function buildBrowserDirective(browserEnabled) {
+  if (!browserEnabled) return '';
+  return (
+    '\n## Browser Use (MANDATORY)\n' +
+    'This workspace has the **shared Browser Fabric session** enabled. ' +
+    'All web browsing MUST go through it so the user can watch the ' +
+    'session live in their right-side panel and so cookies / state ' +
+    'persist across agents.\n\n' +
+    '**Use ONLY these tools for any web browsing:**\n' +
+    '- `mcp__openagents-workspace__workspace_browser_open`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_navigate`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_click`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_type`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_snapshot`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_screenshot`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_list_tabs`\n' +
+    '- `mcp__openagents-workspace__workspace_browser_close`\n' +
+    '\n' +
+    'If you don\'t have these MCP tools, use `Bash` + `curl` against ' +
+    '`/v1/browser/tabs` (documented below in Shared Browser).\n\n' +
+    '**FORBIDDEN — do NOT call any of these:**\n' +
+    '- `mcp__browsermcp__*` (any local Browser MCP extension tool)\n' +
+    '- `mcp__playwright__*`, `mcp__puppeteer__*`, `mcp__chrome-devtools__*`, or any other local-browser MCP\n' +
+    '- `WebFetch`, `WebSearch`, `web_fetch`, `web_search`, or any built-in network/browser tool\n' +
+    '\n' +
+    'If a local browser tool errors with "extension isn\'t connected" or ' +
+    '"connect your browser", do NOT ask the user to connect anything — ' +
+    'the local extension is irrelevant here. Immediately switch to the ' +
+    'workspace browser tools above. The Browser Fabric session is already ' +
+    'running on the backend.\n'
+  );
+}
+
+/**
  * Build the identity section common to all adapters.
  */
 function buildWorkspaceIdentity(agentName, workspaceId, channelName, mode = 'execute') {
@@ -365,7 +410,7 @@ function buildGuardrails() {
  * Build the system prompt for Claude adapter (MCP-based).
  * Claude gets identity + collaboration instructions but NOT API skills.
  */
-function buildClaudeSystemPrompt({ agentName, workspaceId, channelName, mode = 'execute' }) {
+function buildClaudeSystemPrompt({ agentName, workspaceId, channelName, mode = 'execute', browserEnabled = false }) {
   const parts = [];
   parts.push(buildWorkspaceIdentity(agentName, workspaceId, channelName, mode));
   parts.push(
@@ -375,6 +420,7 @@ function buildClaudeSystemPrompt({ agentName, workspaceId, channelName, mode = '
     'Use workspace_create_timer to set a reminder that wakes you up later.\n' +
     'Use workspace_create_routine to set up recurring scheduled tasks (e.g. daily reviews).\n'
   );
+  parts.push(buildBrowserDirective(browserEnabled));
   parts.push(buildCollaborationPrompt());
   parts.push(buildA2UIPrompt());
 
@@ -470,9 +516,10 @@ function buildA2UIPrompt() {
 /**
  * Build the full system prompt for OpenClaw/non-MCP agents.
  */
-function buildOpenclawSystemPrompt({ agentName, workspaceId, channelName, endpoint, token, mode = 'execute', disabledModules }) {
+function buildOpenclawSystemPrompt({ agentName, workspaceId, channelName, endpoint, token, mode = 'execute', disabledModules, browserEnabled = false }) {
   const parts = [];
   parts.push(buildWorkspaceIdentity(agentName, workspaceId, channelName, mode));
+  parts.push(buildBrowserDirective(browserEnabled));
   parts.push(buildCollaborationPrompt());
   parts.push(buildA2UIPrompt());
   parts.push(buildModePrompt(mode));
@@ -486,12 +533,13 @@ function buildOpenclawSystemPrompt({ agentName, workspaceId, channelName, endpoi
 /**
  * Build a SKILL.md file for OpenClaw's skill auto-discovery.
  */
-function buildOpenclawSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules }) {
+function buildOpenclawSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules, browserEnabled = false }) {
   const body = buildApiSkillsPrompt({
     endpoint, workspaceId, token, agentName, channelName, disabledModules, mode: 'execute',
   });
 
   const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute');
+  const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt();
 
   const frontmatter = (
@@ -508,18 +556,19 @@ function buildOpenclawSkillMd({ endpoint, workspaceId, token, agentName, channel
     '---\n\n'
   );
 
-  return frontmatter + identity + '\n' + collab + '\n' + body + '\n' + buildGuardrails();
+  return frontmatter + identity + directive + '\n' + collab + '\n' + body + '\n' + buildGuardrails();
 }
 
 /**
  * Build system prompt for OpenCode adapter.
  */
-function buildOpenCodeSystemPrompt({ agentName, workspaceId, channelName, endpoint, token, mode = 'execute', disabledModules }) {
+function buildOpenCodeSystemPrompt({ agentName, workspaceId, channelName, endpoint, token, mode = 'execute', disabledModules, browserEnabled = false }) {
   const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, mode);
+  const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt();
   const modePrompt = buildModePrompt(mode);
   const api = buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channelName, disabledModules, mode });
-  return identity + '\n' + collab + '\n' + modePrompt + '\n' + api + '\n' + buildGuardrails();
+  return identity + directive + '\n' + collab + '\n' + modePrompt + '\n' + api + '\n' + buildGuardrails();
 }
 
 /**
@@ -553,7 +602,7 @@ function buildOpenCodeSkillMd({ endpoint, workspaceId, token, agentName, channel
  * of spawning an MCP server. Claude Code discovers the skill via its
  * .claude/skills/ directory and uses Bash + curl to call workspace APIs.
  */
-function buildClaudeSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules }) {
+function buildClaudeSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules, browserEnabled = false }) {
   const api = buildApiSkillsPrompt({
     endpoint, workspaceId, token, agentName,
     channelName: channelName || 'general',
@@ -562,6 +611,7 @@ function buildClaudeSkillMd({ endpoint, workspaceId, token, agentName, channelNa
   });
 
   const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute');
+  const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt();
 
   const frontmatter =
@@ -574,7 +624,7 @@ function buildClaudeSkillMd({ endpoint, workspaceId, token, agentName, channelNa
     '  or collaborating with other agents via @mentions.\n' +
     '---\n\n';
 
-  return frontmatter + identity + '\n' + collab + '\n' + api + '\n' + buildGuardrails();
+  return frontmatter + identity + directive + '\n' + collab + '\n' + api + '\n' + buildGuardrails();
 }
 
 /**
@@ -583,7 +633,7 @@ function buildClaudeSkillMd({ endpoint, workspaceId, token, agentName, channelNa
  * Written to .cursor/skills/openagents-workspace.md before each CLI spawn.
  * Cursor discovers skills from the .cursor/skills/ directory automatically.
  */
-function buildCursorSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules }) {
+function buildCursorSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules, browserEnabled = false }) {
   const api = buildApiSkillsPrompt({
     endpoint, workspaceId, token, agentName,
     channelName: channelName || 'general',
@@ -592,6 +642,7 @@ function buildCursorSkillMd({ endpoint, workspaceId, token, agentName, channelNa
   });
 
   const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute');
+  const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt();
 
   const frontmatter =
@@ -604,11 +655,12 @@ function buildCursorSkillMd({ endpoint, workspaceId, token, agentName, channelNa
     '  or collaborating with other agents via @mentions.\n' +
     '---\n\n';
 
-  return frontmatter + identity + '\n' + collab + '\n' + api + '\n' + buildGuardrails();
+  return frontmatter + identity + directive + '\n' + collab + '\n' + api + '\n' + buildGuardrails();
 }
 
 module.exports = {
   buildWorkspaceIdentity,
+  buildBrowserDirective,
   buildCollaborationPrompt,
   buildModePrompt,
   buildGuardrails,

--- a/packages/agent-connector/src/workspace-client.js
+++ b/packages/agent-connector/src/workspace-client.js
@@ -337,6 +337,26 @@ class WorkspaceClient {
   }
 
   /**
+   * Get the workspace's top-level metadata via GET /v1/workspaces/{id}.
+   *
+   * Returns the full data block from the backend — adapters care about
+   * `browserEnabled` today, but more keys may be surfaced over time. On
+   * error, returns null so callers can fall back to defaults rather than
+   * crashing.
+   */
+  async getWorkspaceMetadata(workspaceId, token) {
+    try {
+      const data = await this._get(
+        `/v1/workspaces/${workspaceId}`,
+        this._wsHeaders(token),
+      );
+      return data.data || data || {};
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Get session/channel info via GET /v1/workspaces/{id}/channels/{name}.
    */
   async getSession(workspaceId, channelName, token) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openagents"
-version = "0.9.3.post19"
+version = "0.9.3.post20"
 description = "A flexible framework for building multi-agent systems with customizable protocols"
 readme = "README.md"
 authors = [

--- a/sdk/src/openagents/adapters/base.py
+++ b/sdk/src/openagents/adapters/base.py
@@ -55,6 +55,11 @@ class BaseAdapter(ABC):
         # Per-channel uploaded file tracking — files uploaded during message
         # handling are attached to the final response message.
         self._channel_uploaded_files: dict[str, list[dict]] = {}
+        # Cached workspace.browser_enabled. Populated lazily on first read so
+        # we don't pay the HTTP roundtrip until an adapter actually needs the
+        # value for prompt construction. The adapter pays it once per session
+        # — flipping the workspace toggle requires the agent to reconnect.
+        self._browser_enabled_cache: Optional[bool] = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -358,6 +363,32 @@ class BaseAdapter(ABC):
             )
         except Exception:
             pass
+
+    # ------------------------------------------------------------------
+    # Workspace flags (cached)
+    # ------------------------------------------------------------------
+
+    async def get_browser_enabled(self) -> bool:
+        """Return whether the workspace has the Browser Fabric viewer toggle on.
+
+        Result is cached for the lifetime of the adapter to avoid hitting
+        `/v1/workspaces/{id}` on every message — agents that watch this value
+        must reconnect to pick up a flip. The backend already surfaces the
+        flag at the top level (`browserEnabled` on the GET response). Falls
+        back to False when the backend is older or the request fails so the
+        prompt builders don't accidentally inject the strong directive
+        against a backend that can't actually route to Fabric.
+        """
+        if self._browser_enabled_cache is None:
+            try:
+                meta = await self.client.get_workspace_metadata(
+                    self.workspace_id, self.token,
+                )
+                self._browser_enabled_cache = bool(meta.get("browserEnabled", False))
+            except Exception as e:
+                logger.debug(f"browser_enabled fetch failed: {e}")
+                self._browser_enabled_cache = False
+        return self._browser_enabled_cache
 
     # ------------------------------------------------------------------
     # Abstract

--- a/sdk/src/openagents/adapters/claude.py
+++ b/sdk/src/openagents/adapters/claude.py
@@ -219,8 +219,15 @@ class ClaudeAdapter(BaseAdapter):
         except Exception as e:
             logger.debug(f"Failed to collect uploaded files for channel {channel}: {e}")
 
-    def _build_claude_cmd(self, prompt: str, channel_name: str) -> list[str]:
-        """Build the claude CLI command for a specific channel."""
+    def _build_claude_cmd(self, prompt: str, channel_name: str, browser_enabled: bool = False) -> list[str]:
+        """Build the claude CLI command for a specific channel.
+
+        `browser_enabled` flows from `WorkspaceStore.browserEnabled` (resolved
+        by `_handle_message` via the cached `get_browser_enabled()` helper);
+        when True the system prompt gets a strong directive forcing the agent
+        toward `workspace_browser_*` MCP tools and away from any local
+        `mcp__browsermcp__*` server it may also have wired.
+        """
         # On Windows, prefer .cmd/.exe wrappers over bare npm bash shims
         if platform.system() == "Windows":
             claude_bin = shutil.which("claude.cmd") or shutil.which("claude.exe") or shutil.which("claude")
@@ -236,6 +243,7 @@ class ClaudeAdapter(BaseAdapter):
             workspace_id=self.workspace_id,
             channel_name=channel_name,
             mode=self._mode,
+            browser_enabled=browser_enabled,
         )
 
         cmd = [
@@ -438,7 +446,8 @@ class ClaudeAdapter(BaseAdapter):
 
         mcp_config_file = None
         try:
-            cmd = self._build_claude_cmd(content, msg_channel)
+            browser_enabled = await self.get_browser_enabled()
+            cmd = self._build_claude_cmd(content, msg_channel, browser_enabled=browser_enabled)
             # Track the temp MCP config file for cleanup
             try:
                 idx = cmd.index("--mcp-config")

--- a/sdk/src/openagents/adapters/codex.py
+++ b/sdk/src/openagents/adapters/codex.py
@@ -76,7 +76,7 @@ class CodexAdapter(BaseAdapter):
         # Conversation history for multi-turn context
         self._conversation_history: list[dict] = []
 
-    def _build_system_context(self, channel_name: str) -> str:
+    def _build_system_context(self, channel_name: str, browser_enabled: bool = False) -> str:
         """Build workspace context to prepend to prompts."""
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
@@ -86,6 +86,7 @@ class CodexAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     # ------------------------------------------------------------------
@@ -144,7 +145,8 @@ class CodexAdapter(BaseAdapter):
         Used when OPENAI_API_KEY and OPENAI_BASE_URL are set.
         Streams the response and returns the full text.
         """
-        system_prompt = self._build_system_context(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_context(channel, browser_enabled=browser_enabled)
 
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend(self._conversation_history)
@@ -205,7 +207,7 @@ class CodexAdapter(BaseAdapter):
     # Subprocess mode (codex exec --json --full-auto)
     # ------------------------------------------------------------------
 
-    def _build_codex_cmd(self, prompt: str, channel_name: str) -> list[str]:
+    def _build_codex_cmd(self, prompt: str, channel_name: str, browser_enabled: bool = False) -> list[str]:
         """Build the codex CLI command."""
         # On Windows, prefer .cmd/.exe wrappers over bare npm bash shims
         if platform.system() == "Windows":
@@ -246,7 +248,7 @@ class CodexAdapter(BaseAdapter):
 
         # Prepend workspace context to the prompt so Codex knows
         # about shared resources and how to collaborate
-        context = self._build_system_context(channel_name)
+        context = self._build_system_context(channel_name, browser_enabled=browser_enabled)
         full_prompt = f"{context}\n\n---\n\n{prompt}"
         cmd.append(full_prompt)
         return cmd
@@ -290,7 +292,8 @@ class CodexAdapter(BaseAdapter):
     async def _run_codex_subprocess(self, content: str, msg_channel: str) -> str:
         """Run a Codex CLI subprocess and collect the response."""
         try:
-            cmd = self._build_codex_cmd(content, msg_channel)
+            browser_enabled = await self.get_browser_enabled()
+            cmd = self._build_codex_cmd(content, msg_channel, browser_enabled=browser_enabled)
         except FileNotFoundError as e:
             await self._send_error(msg_channel, str(e))
             return ""

--- a/sdk/src/openagents/adapters/cursor.py
+++ b/sdk/src/openagents/adapters/cursor.py
@@ -67,7 +67,7 @@ class CursorAdapter(BaseAdapter):
         # Conversation history for multi-turn context
         self._conversation_history: list[dict] = []
 
-    def _build_system_prompt(self, channel_name: str) -> str:
+    def _build_system_prompt(self, channel_name: str, browser_enabled: bool = False) -> str:
         """Build workspace context system prompt."""
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
@@ -77,6 +77,7 @@ class CursorAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     async def _handle_message(self, msg: dict):
@@ -137,7 +138,8 @@ class CursorAdapter(BaseAdapter):
         self, user_message: str, channel: str
     ) -> str:
         """Call OpenAI-compatible chat completions API directly."""
-        system_prompt = self._build_system_prompt(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_prompt(channel, browser_enabled=browser_enabled)
 
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend(self._conversation_history)

--- a/sdk/src/openagents/adapters/nanoclaw.py
+++ b/sdk/src/openagents/adapters/nanoclaw.py
@@ -68,7 +68,7 @@ class NanoClawAdapter(BaseAdapter):
         # Conversation history for multi-turn context
         self._conversation_history: list[dict] = []
 
-    def _build_system_prompt(self, channel_name: str) -> str:
+    def _build_system_prompt(self, channel_name: str, browser_enabled: bool = False) -> str:
         """Build workspace context system prompt."""
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
@@ -78,6 +78,7 @@ class NanoClawAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     async def _handle_message(self, msg: dict):
@@ -138,7 +139,8 @@ class NanoClawAdapter(BaseAdapter):
         self, user_message: str, channel: str
     ) -> str:
         """Call OpenAI-compatible chat completions API directly."""
-        system_prompt = self._build_system_prompt(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_prompt(channel, browser_enabled=browser_enabled)
 
         messages = [{"role": "system", "content": system_prompt}]
         messages.extend(self._conversation_history)

--- a/sdk/src/openagents/adapters/openclaw.py
+++ b/sdk/src/openagents/adapters/openclaw.py
@@ -228,8 +228,13 @@ class OpenClawAdapter(BaseAdapter):
                     return candidate
         return None
 
-    def _build_system_prompt(self, channel_name: str) -> str:
-        """Build system prompt with workspace context and API skills."""
+    def _build_system_prompt(self, channel_name: str, browser_enabled: bool = False) -> str:
+        """Build system prompt with workspace context and API skills.
+
+        `browser_enabled` is resolved by the caller (async) via
+        `self.get_browser_enabled()`; when True, the prompt forbids any
+        `mcp__browsermcp__*` or other local-browser tools.
+        """
         return build_openclaw_system_prompt(
             agent_name=self.agent_name,
             workspace_id=self.workspace_id,
@@ -238,6 +243,7 @@ class OpenClawAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     def _resolve_openclaw_workspace(self) -> Optional[Path]:
@@ -653,7 +659,8 @@ class OpenClawAdapter(BaseAdapter):
         """
         # Build messages
         history_text = await self._get_recent_history_text(channel)
-        system_prompt = self._build_system_prompt(channel)
+        browser_enabled = await self.get_browser_enabled()
+        system_prompt = self._build_system_prompt(channel, browser_enabled=browser_enabled)
         if history_text:
             system_prompt += "\n" + history_text
 

--- a/sdk/src/openagents/adapters/opencode.py
+++ b/sdk/src/openagents/adapters/opencode.py
@@ -118,7 +118,7 @@ class OpenCodeAdapter(BaseAdapter):
         except Exception:
             logger.debug("Could not write workspace skill to %s", skill_file)
 
-    def _build_system_context(self, channel_name: str) -> str:
+    def _build_system_context(self, channel_name: str, browser_enabled: bool = False) -> str:
         return build_opencode_system_prompt(
             agent_name=self.agent_name,
             workspace_id=self.workspace_id,
@@ -127,6 +127,7 @@ class OpenCodeAdapter(BaseAdapter):
             token=self.token,
             mode=self._mode,
             disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
         )
 
     # ------------------------------------------------------------------
@@ -298,7 +299,8 @@ class OpenCodeAdapter(BaseAdapter):
         else:
             # New session: inject workspace skill and prepend system context
             self._ensure_workspace_skill(msg_channel)
-            context = self._build_system_context(msg_channel)
+            browser_enabled = await self.get_browser_enabled()
+            context = self._build_system_context(msg_channel, browser_enabled=browser_enabled)
             full_prompt = f"{context}\n\n---\n\n{content}"
 
         if platform.system() == "Windows" and cmd[0].lower().endswith(".cmd"):

--- a/sdk/src/openagents/adapters/workspace_prompt.py
+++ b/sdk/src/openagents/adapters/workspace_prompt.py
@@ -14,6 +14,50 @@ instructions they can call via curl/requests/fetch.
 from typing import Optional
 
 
+def build_browser_directive(browser_enabled: bool) -> str:
+    """Strong directive forcing agents to use the workspace browser when the
+    workspace has Browser Fabric enabled.
+
+    Emitted high in the system prompt so it wins against any earlier guidance
+    that suggests local browsing tools. Empty string when the workspace toggle
+    is off so older agents continue to behave as before.
+
+    Returns "" when the toggle is off; the caller can unconditionally
+    concatenate the result.
+    """
+    if not browser_enabled:
+        return ""
+    return (
+        "\n## Browser Use (MANDATORY)\n"
+        "This workspace has the **shared Browser Fabric session** enabled. "
+        "All web browsing MUST go through it so the user can watch the "
+        "session live in their right-side panel and so cookies / state "
+        "persist across agents.\n\n"
+        "**Use ONLY these tools for any web browsing:**\n"
+        "- `mcp__openagents-workspace__workspace_browser_open`\n"
+        "- `mcp__openagents-workspace__workspace_browser_navigate`\n"
+        "- `mcp__openagents-workspace__workspace_browser_click`\n"
+        "- `mcp__openagents-workspace__workspace_browser_type`\n"
+        "- `mcp__openagents-workspace__workspace_browser_snapshot`\n"
+        "- `mcp__openagents-workspace__workspace_browser_screenshot`\n"
+        "- `mcp__openagents-workspace__workspace_browser_list_tabs`\n"
+        "- `mcp__openagents-workspace__workspace_browser_close`\n"
+        "\n"
+        "If you don't have these MCP tools, use `Bash` + `curl` against "
+        "`/v1/browser/tabs` (documented below in Shared Browser).\n\n"
+        "**FORBIDDEN — do NOT call any of these:**\n"
+        "- `mcp__browsermcp__*` (any local Browser MCP extension tool)\n"
+        "- `mcp__playwright__*`, `mcp__puppeteer__*`, `mcp__chrome-devtools__*`, or any other local-browser MCP\n"
+        "- `WebFetch`, `WebSearch`, `web_fetch`, `web_search`, or any built-in network/browser tool\n"
+        "\n"
+        "If a local browser tool errors with \"extension isn't connected\" or "
+        "\"connect your browser\", do NOT ask the user to connect anything — "
+        "the local extension is irrelevant here. Immediately switch to the "
+        "workspace browser tools above. The Browser Fabric session is already "
+        "running on the backend.\n"
+    )
+
+
 def build_workspace_identity(
     agent_name: str,
     workspace_id: str,
@@ -219,11 +263,15 @@ def build_claude_system_prompt(
     workspace_id: str,
     channel_name: str,
     mode: str = "execute",
+    browser_enabled: bool = False,
 ) -> str:
     """Build the system prompt for Claude adapter (MCP-based).
 
-    Claude gets identity + collaboration instructions but NOT API skills,
-    because it uses MCP tools instead.
+    Claude gets identity + collaboration instructions but NOT the full API
+    skills section — it uses MCP tools instead. When `browser_enabled` is
+    True we still inject the browser directive so the agent knows to prefer
+    `workspace_browser_*` over `mcp__browsermcp__*` and other local-browser
+    MCPs that might also be installed.
     """
     parts = []
     parts.append(build_workspace_identity(agent_name, workspace_id, channel_name, mode))
@@ -231,6 +279,7 @@ def build_claude_system_prompt(
         "Use workspace_get_history to read previous messages.\n"
         "Use workspace_get_agents to see other agents.\n"
     )
+    parts.append(build_browser_directive(browser_enabled))
     parts.append(build_collaboration_prompt())
 
     if mode == "plan":
@@ -257,14 +306,19 @@ def build_openclaw_system_prompt(
     token: str,
     mode: str = "execute",
     disabled_modules: Optional[set] = None,
+    browser_enabled: bool = False,
 ) -> str:
     """Build the full system prompt for OpenClaw/non-MCP agents.
 
-    Includes identity, collaboration, mode instructions, and
-    REST API skills for workspace resources.
+    Includes identity, collaboration, mode instructions, and REST API skills
+    for workspace resources. When `browser_enabled` is True, prepends the
+    strong directive that forbids local browser MCP tools (e.g. browsermcp,
+    playwright) — these agents typically have multiple MCP servers wired and
+    pick the wrong one without an explicit prohibition.
     """
     parts = []
     parts.append(build_workspace_identity(agent_name, workspace_id, channel_name, mode))
+    parts.append(build_browser_directive(browser_enabled))
     parts.append(build_collaboration_prompt())
     parts.append(build_mode_prompt(mode))
     parts.append(build_api_skills_prompt(
@@ -286,6 +340,7 @@ def build_openclaw_skill_md(
     agent_name: str,
     channel_name: str,
     disabled_modules: Optional[set] = None,
+    browser_enabled: bool = False,
 ) -> str:
     """Build a SKILL.md file for OpenClaw's skill auto-discovery.
 
@@ -307,6 +362,7 @@ def build_openclaw_skill_md(
     identity = build_workspace_identity(
         agent_name, workspace_id, channel_name, "execute"
     )
+    directive = build_browser_directive(browser_enabled)
     collab = build_collaboration_prompt()
 
     frontmatter = (
@@ -323,7 +379,7 @@ def build_openclaw_skill_md(
         "---\n\n"
     )
 
-    return frontmatter + identity + "\n" + collab + "\n" + body
+    return frontmatter + identity + directive + "\n" + collab + "\n" + body
 
 
 def _build_opencode_api_skills_prompt(
@@ -472,6 +528,7 @@ def build_opencode_system_prompt(
     token: str,
     mode: str = "execute",
     disabled_modules: Optional[set] = None,
+    browser_enabled: bool = False,
 ) -> str:
     parts = []
     parts.append(build_workspace_identity(agent_name, workspace_id, channel_name, mode))
@@ -486,6 +543,7 @@ def build_opencode_system_prompt(
         "for sharing files, browsing the web collaboratively, and discovering other agents.\n"
     )
 
+    parts.append(build_browser_directive(browser_enabled))
     parts.append(build_collaboration_prompt())
     parts.append(build_mode_prompt(mode))
     parts.append(

--- a/sdk/src/openagents/client/workspace_client.py
+++ b/sdk/src/openagents/client/workspace_client.py
@@ -416,6 +416,30 @@ class WorkspaceClient:
                     "status": result.get("status", "active"),
                 }
 
+    async def get_workspace_metadata(
+        self,
+        workspace_id: str,
+        token: str,
+    ) -> dict:
+        """Get the workspace's top-level metadata via GET /v1/workspaces/{id}.
+
+        Returns the full data block from the backend — adapters care about
+        `browserEnabled` today, but more keys may be surfaced over time.
+        On error, returns an empty dict so callers can fall back to defaults
+        rather than crashing.
+        """
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.endpoint}/v1/workspaces/{workspace_id}",
+                headers=self._ws_headers(token),
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status != 200:
+                    return {}
+                data = await resp.json()
+                return data.get("data", {}) or {}
+
     async def update_session(
         self,
         workspace_id: str,

--- a/tests/test_workspace_prompt_browser.py
+++ b/tests/test_workspace_prompt_browser.py
@@ -1,0 +1,129 @@
+"""
+Tests for the `browser_enabled` directive in workspace prompt builders.
+
+The whole point of the directive is to force agents away from
+`mcp__browsermcp__*` (and other local-browser MCP servers) when the
+workspace has the Browser Fabric viewer toggle on. These tests pin the
+shape of that contract.
+"""
+import pytest
+
+from openagents.adapters.workspace_prompt import (
+    build_browser_directive,
+    build_claude_system_prompt,
+    build_openclaw_system_prompt,
+    build_opencode_system_prompt,
+)
+
+
+class TestBrowserDirective:
+    def test_disabled_returns_empty(self):
+        """browser_enabled=False emits nothing — no opinion injected."""
+        assert build_browser_directive(False) == ""
+
+    def test_enabled_contains_mandatory_header(self):
+        out = build_browser_directive(True)
+        assert "Browser Use (MANDATORY)" in out
+
+    def test_enabled_names_workspace_browser_tools(self):
+        out = build_browser_directive(True)
+        # The agent has to know which tools to call instead.
+        for tool in (
+            "workspace_browser_open",
+            "workspace_browser_navigate",
+            "workspace_browser_click",
+            "workspace_browser_snapshot",
+        ):
+            assert tool in out, f"missing tool name: {tool}"
+
+    def test_enabled_explicitly_forbids_browsermcp(self):
+        """The original failure mode: agent picks `mcp__browsermcp__*`."""
+        out = build_browser_directive(True)
+        assert "mcp__browsermcp__*" in out
+        assert "FORBIDDEN" in out
+
+    def test_enabled_forbids_other_local_browser_mcps(self):
+        out = build_browser_directive(True)
+        # Other common locally-installed browser MCPs that would race for
+        # the same prompt — the directive must rule them out too.
+        for forbidden in ("mcp__playwright__", "mcp__puppeteer__", "WebFetch"):
+            assert forbidden in out, f"missing prohibition: {forbidden}"
+
+    def test_enabled_handles_extension_isnt_connected_error(self):
+        """If a local tool errors with 'extension isn't connected', the
+        agent must switch rather than ask the user to connect anything."""
+        out = build_browser_directive(True)
+        assert "extension isn't connected" in out
+        # And it must NOT ask the user — that was the bug in the screenshot.
+        assert "do NOT ask the user" in out
+
+
+class TestClaudeSystemPrompt:
+    def test_default_no_directive(self):
+        """Default (browser_enabled=False) keeps the v0.2 prompt shape."""
+        prompt = build_claude_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+        )
+        assert "Browser Use (MANDATORY)" not in prompt
+        assert "mcp__browsermcp__" not in prompt
+
+    def test_enabled_injects_directive(self):
+        prompt = build_claude_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            browser_enabled=True,
+        )
+        assert "Browser Use (MANDATORY)" in prompt
+        assert "mcp__browsermcp__*" in prompt
+        assert "workspace_browser_navigate" in prompt
+
+
+class TestOpenclawSystemPrompt:
+    def test_default_no_directive(self):
+        prompt = build_openclaw_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+        )
+        assert "Browser Use (MANDATORY)" not in prompt
+
+    def test_enabled_injects_directive(self):
+        prompt = build_openclaw_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+            browser_enabled=True,
+        )
+        assert "Browser Use (MANDATORY)" in prompt
+        assert "mcp__browsermcp__*" in prompt
+
+
+class TestOpencodeSystemPrompt:
+    def test_default_no_directive(self):
+        prompt = build_opencode_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+        )
+        assert "Browser Use (MANDATORY)" not in prompt
+
+    def test_enabled_injects_directive(self):
+        prompt = build_opencode_system_prompt(
+            agent_name="agent-1",
+            workspace_id="ws-1",
+            channel_name="session-1",
+            endpoint="https://api.example.com",
+            token="tok",
+            browser_enabled=True,
+        )
+        assert "Browser Use (MANDATORY)" in prompt
+        assert "mcp__browsermcp__*" in prompt


### PR DESCRIPTION
## Why
Sibling to PR #395 (Python SDK). The JavaScript \`@openagents-org/agent-launcher\` is what actually runs on daemon hosts that launch claude/openclaw/codex subprocesses — it builds the system prompt itself. The Python SDK change doesn't reach this code path.

Verified live: deployed the patched files to \`us.sandbox.readymojo.com\` via SCP and restarted the daemon. The \`Sales\` agent immediately issued a new \`GET /v1/workspaces/<UUID>\` call (which is what \`getBrowserEnabled()\` does) — confirming the new code is loaded.

## What
- \`workspace-prompt.js\`: new \`buildBrowserDirective(browserEnabled)\` — empty when off; strong directive when on. Threaded through \`buildClaudeSystemPrompt\`, \`buildOpenclawSystemPrompt\`, \`buildOpenCodeSystemPrompt\`, plus all four SKILL.md builders.
- \`workspace-client.js\`: new \`getWorkspaceMetadata(workspaceId, token)\` → \`GET /v1/workspaces/{id}\`.
- \`base.js\`: cached \`getBrowserEnabled()\` on BaseAdapter (per-session cache, restart to flip).
- \`claude.js\`: \`_buildClaudeCmd\` accepts \`browserEnabled\`; caller \`_handleMessage\` pre-resolves via \`await getBrowserEnabled()\` and threads through. SKILL.md path also reads the cached value.

Other adapters (openclaw / codex / cursor / nanoclaw / opencode) accept the new \`browserEnabled\` parameter in their prompt builders with default false — wiring their callers to actually pass it is a follow-up; today only Claude is in active use on the deploy host.

Directive forbids \`mcp__browsermcp__*\`, \`mcp__playwright__*\`, \`mcp__puppeteer__*\`, \`mcp__chrome-devtools__*\`, WebFetch, WebSearch by name; instructs the agent to switch to workspace_browser_* on the \"extension isn't connected\" error instead of asking the user to install anything.

## Depends on
- Backend PR #392 (\`browser_enabled\` on workspace) — already merged + deployed.

## Test plan
- [x] Local smoke test: \`buildBrowserDirective\` returns \"\" when off, contains MANDATORY/forbids when on, integrates into \`buildClaudeSystemPrompt\`.
- [x] Deployed to \`us.sandbox.readymojo.com\`, restarted daemon, confirmed via ECS logs that the new endpoint is being called.
- [ ] Re-send the failing test message in the Peakmojo Team workspace and confirm the agent picks \`workspace_browser_navigate\` instead of \`mcp__browsermcp__browser_navigate\`.