### PR TITLE
Fix Go browser session panel

### DIFF
--- a/packages/go/OpenAgents/Models/BrowserTab.swift
+++ b/packages/go/OpenAgents/Models/BrowserTab.swift
@@ -10,39 +10,58 @@ import Foundation
 ///   "title": "...",
 ///   "live_url": "https://...",   // populated while the session is live
 ///   "session_id": "...",         // Browser Fabric session id
-///   "agent_name": "...",         // who opened it (often nil)
+///   "created_by": "...",         // who opened it
 ///   "created_at": "...",
-///   "updated_at": "..."
+///   "last_active_at": "..."
 /// }
 /// ```
 ///
-/// v1 of the Go viewer only needs `liveUrl` to render the embedded viewer —
-/// the rest is for header chrome and ordering. Multi-tab management is
-/// deliberately out of scope; the store picks the most-recent live tab.
+/// The Go viewer needs `liveUrl` to render the embedded viewer; the rest is
+/// for ordering when multiple sessions are visible.
 struct BrowserTab: Identifiable, Decodable, Sendable, Equatable {
     let id: String
     let url: String?
     let title: String?
+    let status: String?
     let liveUrl: String?
     let sessionId: String?
-    let agentName: String?
+    let createdBy: String?
+    let sharedWith: [String]
     let createdAt: String?
+    let lastActiveAt: String?
     let updatedAt: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case url
         case title
+        case status
         case liveUrl = "live_url"
         case sessionId = "session_id"
-        case agentName = "agent_name"
+        case createdBy = "created_by"
+        case sharedWith = "shared_with"
         case createdAt = "created_at"
+        case lastActiveAt = "last_active_at"
         case updatedAt = "updated_at"
     }
 
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        status = try container.decodeIfPresent(String.self, forKey: .status)
+        liveUrl = try container.decodeIfPresent(String.self, forKey: .liveUrl)
+        sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
+        createdBy = try container.decodeIfPresent(String.self, forKey: .createdBy)
+        sharedWith = try container.decodeIfPresent([String].self, forKey: .sharedWith) ?? []
+        createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
+        lastActiveAt = try container.decodeIfPresent(String.self, forKey: .lastActiveAt)
+        updatedAt = try container.decodeIfPresent(String.self, forKey: .updatedAt)
+    }
+
     /// True when the backend has handed us a live URL we can embed. Multiple
-    /// historical tabs may exist; the panel only renders ones for which
-    /// `isLive` is true.
+    /// historical tabs may exist; the panel renders every live tab.
     var isLive: Bool {
         guard let liveUrl, !liveUrl.isEmpty else { return false }
         return true
@@ -52,6 +71,7 @@ struct BrowserTab: Identifiable, Decodable, Sendable, Equatable {
     /// `createdAt`. `Date.distantPast` for rows the backend left without
     /// either field so they sort to the bottom.
     var sortKey: Date {
+        if let lastActiveAt, let d = Self.parseISO8601(lastActiveAt) { return d }
         if let updatedAt, let d = Self.parseISO8601(updatedAt) { return d }
         if let createdAt, let d = Self.parseISO8601(createdAt) { return d }
         return .distantPast

--- a/packages/go/OpenAgents/Networking/WorkspaceAPI.swift
+++ b/packages/go/OpenAgents/Networking/WorkspaceAPI.swift
@@ -112,9 +112,8 @@ actor WorkspaceAPI {
 
     // MARK: - Browser Fabric tabs
 
-    /// List the workspace's current browser tabs. v1 of the Go app treats the
-    /// workspace as having at most one "live" browser at a time — the caller
-    /// picks the most-recent tab with a `liveUrl`.
+    /// List the workspace's current browser tabs. The Browser panel renders
+    /// all live sessions so users can scroll between agent-controlled tabs.
     func listBrowserTabs() async throws -> [BrowserTab] {
         struct Response: Decodable, Sendable { let tabs: [BrowserTab] }
         let request = try makeRequest(

--- a/packages/go/OpenAgents/OpenAgents-macOS.entitlements
+++ b/packages/go/OpenAgents/OpenAgents-macOS.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/packages/go/OpenAgents/State/WorkspaceStore.swift
+++ b/packages/go/OpenAgents/State/WorkspaceStore.swift
@@ -42,10 +42,9 @@ final class WorkspaceStore {
     var isLoading: Bool = true
     var lastError: String?
 
-    /// Browser Fabric tabs currently known for this workspace. v1 of the
-    /// viewer treats the workspace as having at most one "live" browser —
-    /// `liveBrowserTab` picks the most-recent one with a `liveUrl`. Refreshed
-    /// in the existing discovery poll cycle.
+    /// Browser Fabric tabs currently known for this workspace. Refreshed in
+    /// the existing discovery poll cycle and rendered together in the Browser
+    /// panel so users can inspect every active agent-controlled session.
     var browserTabs: [BrowserTab] = []
 
     /// Increments whenever a live browser session first appears (transition
@@ -121,20 +120,29 @@ final class WorkspaceStore {
 
     var onlineAgents: [Agent] { agents.filter(\.isOnline) }
 
-    /// The single tab the Browser panel should render. Picks the most-recent
-    /// tab with a `liveUrl`; nil when nothing is live. v1 is single-tab by
-    /// product decision — multi-tab list UI is out of scope.
-    var liveBrowserTab: BrowserTab? {
+    /// Browser tabs sorted with the most recently active first. The Browser
+    /// panel validates each tab as it appears, so rows without an initial
+    /// `liveUrl` can still reconnect and render.
+    var browserSessionTabs: [BrowserTab] {
         browserTabs
-            .filter(\.isLive)
             .sorted(by: { $0.sortKey > $1.sortKey })
-            .first
     }
 
-    /// True when the workspace has the toggle on AND there's a live session
+    /// Live tabs sorted with the most recently active first.
+    var liveBrowserTabs: [BrowserTab] {
+        browserSessionTabs.filter(\.isLive)
+    }
+
+    /// Backward-compatible convenience for places that only need to know
+    /// whether there is at least one live browser session.
+    var liveBrowserTab: BrowserTab? {
+        liveBrowserTabs.first
+    }
+
+    /// True when the workspace has the toggle on AND there are sessions
     /// to show. Drives whether the Browser tab is visible in the right panel.
     var browserPanelAvailable: Bool {
-        (workspace?.browserEnabled ?? false) && liveBrowserTab != nil
+        (workspace?.browserEnabled ?? false) && !browserSessionTabs.isEmpty
     }
 
     /// True when any session's most recent message is a pending status (agent working) — drives

--- a/packages/go/OpenAgents/Views/BrowserPanel.swift
+++ b/packages/go/OpenAgents/Views/BrowserPanel.swift
@@ -7,88 +7,89 @@ import AppKit
 import UIKit
 #endif
 
-/// Right-side panel that embeds a live Browser Fabric session. v1 shows the
-/// workspace's single most-recent live tab (`store.liveBrowserTab`) — we
-/// don't surface a tab list. The body is a WKWebView pointed at the tab's
-/// `liveUrl`; reload re-fetches a validated tab object (which auto-wakes a
-/// dead session backend-side) and reissues the load.
+/// Right-side panel that embeds every live Browser Fabric session in a
+/// scrollable stack. Each card is a WKWebView pointed at that tab's `liveUrl`;
+/// validation auto-wakes a dead session backend-side without adding duplicate
+/// browser chrome around the embedded session.
 struct BrowserPanel: View {
     @Environment(WorkspaceStore.self) private var store
 
-    /// Snapshot of the tab currently being rendered. We track this locally so
-    /// we can rebuild the WebView when the underlying liveUrl changes — the
-    /// store's `liveBrowserTab` may change beneath us mid-poll.
-    @State private var loadedTabId: String?
-    @State private var loadedLiveUrl: String?
-    @State private var isReloading: Bool = false
-    @State private var loadError: String?
-
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider()
-            content
-        }
-        .task(id: store.liveBrowserTab?.id) {
-            await loadFreshIfNeeded()
-        }
-        .onChange(of: store.liveBrowserTab?.liveUrl) { _, newURL in
-            // If the backend rotated the liveUrl (e.g. session reconnected)
-            // pick it up without a full panel teardown.
-            loadedLiveUrl = newURL
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 10) {
+                    ForEach(store.browserSessionTabs) { tab in
+                        BrowserSessionCard(
+                            tab: tab,
+                            height: cardHeight(for: proxy.size)
+                        )
+                    }
+                }
+                .padding(10)
+            }
+            .background(Color.primary.opacity(0.025))
         }
     }
 
-    // MARK: - Header
+    private func cardHeight(for size: CGSize) -> CGFloat {
+        min(max(300, size.height * 0.42), 420)
+    }
+}
 
-    @ViewBuilder
-    private var header: some View {
-        if let tab = store.liveBrowserTab {
-            HStack(alignment: .center, spacing: 8) {
-                Image(systemName: "globe")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(tab.title ?? "Browser")
-                        .font(.system(size: 12, weight: .semibold))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    if let url = tab.url, !url.isEmpty {
-                        Text(url)
-                            .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    } else if let agent = tab.agentName {
-                        Text("opened by \(agent)")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Spacer(minLength: 4)
-                Button {
-                    Task { await reload(tabId: tab.id) }
-                } label: {
-                    ZStack {
-                        Image(systemName: "arrow.clockwise")
-                            .opacity(isReloading ? 0 : 1)
-                        if isReloading {
-                            ProgressView().controlSize(.small)
-                        }
-                    }
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 22, height: 22)
-                }
-                .buttonStyle(.plain)
-                .disabled(isReloading)
-                .accessibilityLabel("Reload browser session")
-                #if os(macOS)
-                .help("Reload session")
-                #endif
+private struct BrowserSessionCard: View {
+    @Environment(WorkspaceStore.self) private var store
+
+    let tab: BrowserTab
+    let height: CGFloat
+
+    @State private var loadedTabId: String?
+    @State private var loadedLiveUrl: String?
+    @State private var loadError: String?
+    @State private var fullscreenOpen: Bool = false
+
+    var body: some View {
+        content
+            .frame(height: height)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.16), lineWidth: 1)
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
+            .overlay(alignment: .topTrailing) {
+                if loadedLiveUrl?.isEmpty == false {
+                    Button {
+                        fullscreenOpen = true
+                    } label: {
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 28, height: 28)
+                            .background(.regularMaterial, in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
+                    .accessibilityLabel("Open browser fullscreen")
+                    #if os(macOS)
+                    .help("Fullscreen")
+                    #endif
+                }
+            }
+        .task(id: tab.id) {
+            await loadFreshIfNeeded()
+        }
+        .onChange(of: tab.liveUrl) { _, newURL in
+            // If the backend rotated the liveUrl (e.g. session reconnected),
+            // pick it up without a full card teardown.
+            loadedLiveUrl = newURL
+        }
+        .sheet(isPresented: $fullscreenOpen) {
+            if let liveUrl = loadedLiveUrl, let url = URL(string: liveUrl) {
+                BrowserFullscreenSheet(
+                    url: url,
+                    title: tab.title ?? tab.url ?? "Browser",
+                    isPresented: $fullscreenOpen
+                )
+            }
         }
     }
 
@@ -108,21 +109,15 @@ struct BrowserPanel: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                if let tab = store.liveBrowserTab {
-                    Button("Retry") { Task { await reload(tabId: tab.id) } }
-                        .buttonStyle(.bordered)
-                }
+                Button("Retry") { Task { await reload(tabId: tab.id) } }
+                    .buttonStyle(.bordered)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding()
         } else {
-            // Empty state: panel was opened but the live URL isn't ready yet
-            // (validation in flight, or the store's `liveBrowserTab` is
-            // momentarily nil). The tabbed parent only shows the Browser tab
-            // when a live session exists, so this is mostly transient.
             VStack(spacing: 10) {
                 ProgressView()
-                Text("Connecting to browser session…")
+                Text("Connecting to browser session...")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -132,27 +127,17 @@ struct BrowserPanel: View {
 
     // MARK: - Loading
 
-    /// On first render (or when the live tab id changes), ask the backend to
-    /// `?validate=true` the tab — that auto-reconnects expired sessions and
-    /// returns the freshest `liveUrl`. Then load it.
     private func loadFreshIfNeeded() async {
-        guard let tab = store.liveBrowserTab else {
-            loadedTabId = nil
-            loadedLiveUrl = nil
-            return
-        }
         if loadedTabId == tab.id, loadedLiveUrl == tab.liveUrl { return }
         await reload(tabId: tab.id)
     }
 
     private func reload(tabId: String) async {
-        isReloading = true
-        defer { isReloading = false }
         do {
             let validated = try await store.validateBrowserTab(tabId: tabId)
             loadedTabId = validated.id
             loadedLiveUrl = validated.liveUrl
-            loadError = (validated.liveUrl?.isEmpty != false) ? "Session is not live yet — try again in a moment." : nil
+            loadError = (validated.liveUrl?.isEmpty != false) ? "Session is not live yet. Try again in a moment." : nil
         } catch {
             loadError = error.localizedDescription
             logError("browser", "validate tab failed: \(error.localizedDescription)")
@@ -162,18 +147,140 @@ struct BrowserPanel: View {
 
 // MARK: - Web view bridge
 
+private struct BrowserFullscreenSheet: View {
+    let url: URL
+    let title: String
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "globe")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+                Button {
+                    isPresented = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(6)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close fullscreen browser")
+                #if os(macOS)
+                .help("Close")
+                #endif
+                .keyboardShortcut(.cancelAction)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            Divider()
+            BrowserWebView(url: url)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        #if os(macOS)
+        .frame(minWidth: 900, idealWidth: 1180, minHeight: 640, idealHeight: 820)
+        #endif
+    }
+}
+
 /// Minimal WKWebView wrapper that loads a remote URL and lets WKWebView own
 /// scrolling. Distinct from `WebView` (which loads raw HTML strings); we
 /// don't reuse that one because we want a remote URL load, no measured
 /// height, no oafile scheme handler.
 private struct BrowserWebView {
     let url: URL
+
+    private static let hideBrowserFabricChromeScript = """
+    (function () {
+      function textOf(node) {
+        return (node && node.textContent ? node.textContent : '').replace(/\\s+/g, ' ').trim();
+      }
+
+      function isSmallTopChrome(node) {
+        if (!node || !node.getBoundingClientRect) return false;
+        var rect = node.getBoundingClientRect();
+        if (rect.width < 240) return false;
+        if (rect.height < 24 || rect.height > 180) return false;
+        if (rect.top < -1 || rect.top > 180) return false;
+        return true;
+      }
+
+      function hideNode(node) {
+        if (!node || node.__openAgentsChromeHidden || !isSmallTopChrome(node)) return false;
+        node.__openAgentsChromeHidden = true;
+        node.style.setProperty('display', 'none', 'important');
+        node.style.setProperty('height', '0', 'important');
+        node.style.setProperty('min-height', '0', 'important');
+        node.style.setProperty('padding', '0', 'important');
+        node.style.setProperty('margin', '0', 'important');
+        node.style.setProperty('border', '0', 'important');
+        return true;
+      }
+
+      function hideBrowserChrome() {
+        var candidates = Array.from(document.querySelectorAll('body *'));
+        for (var i = 0; i < candidates.length; i += 1) {
+          var node = candidates[i];
+          if (node.__openAgentsChromeHidden) continue;
+          var text = textOf(node);
+          if (!text || text.indexOf('BrowserFabric') === -1) continue;
+
+          var chrome = node;
+          for (var depth = 0; depth < 5 && chrome && chrome.parentElement; depth += 1) {
+            var parentText = textOf(chrome.parentElement);
+            if (!isSmallTopChrome(chrome.parentElement)) break;
+            if (
+              parentText.indexOf('BrowserFabric') !== -1 &&
+              (parentText.indexOf('Live') !== -1 ||
+                parentText.indexOf('https://') !== -1 ||
+                parentText.indexOf('http://') !== -1)
+            ) {
+              chrome = chrome.parentElement;
+            } else {
+              break;
+            }
+          }
+
+          hideNode(chrome);
+        }
+      }
+
+      hideBrowserChrome();
+      if (typeof MutationObserver !== 'undefined') {
+        new MutationObserver(hideBrowserChrome).observe(document.documentElement, {
+          childList: true,
+          subtree: true,
+        });
+      }
+      window.addEventListener('load', hideBrowserChrome);
+    })();
+    """
+
+    @MainActor
+    private static func makeConfiguration() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        let script = WKUserScript(
+            source: hideBrowserFabricChromeScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+        configuration.userContentController.addUserScript(script)
+        return configuration
+    }
 }
 
 #if os(macOS)
 extension BrowserWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
-        let view = WKWebView()
+        let view = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
         view.load(URLRequest(url: url))
         return view
     }
@@ -186,7 +293,7 @@ extension BrowserWebView: NSViewRepresentable {
 #else
 extension BrowserWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
-        let view = WKWebView()
+        let view = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
         view.load(URLRequest(url: url))
         return view
     }

--- a/packages/go/OpenAgents/Views/ContentSidebar.swift
+++ b/packages/go/OpenAgents/Views/ContentSidebar.swift
@@ -65,7 +65,7 @@ struct ContentSidebar: View {
     }
 
     /// Falls back to .content if the controller wants .browser but the
-    /// browser panel isn't currently available (toggle off / no live tab).
+    /// browser panel isn't currently available (toggle off / no live tabs).
     private var effectiveTab: ContentSidebarTab {
         if controller.selectedTab == .browser, !store.browserPanelAvailable {
             return .content
@@ -461,4 +461,3 @@ private struct FileCard: View {
         return f.localizedString(for: date, relativeTo: Date())
     }
 }
-

--- a/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
+++ b/packages/go/OpenAgentsGo.xcodeproj/project.pbxproj
@@ -132,10 +132,10 @@
 		6038CD9938CBF86839702842 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		60D250D0F8C1A2E0F9CD2AB0 /* MarkdownSegments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownSegments.swift; sourceTree = "<group>"; };
 		62BEFDB8EAD399989E7939F2 /* SettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSheet.swift; sourceTree = "<group>"; };
-		657BCC02FD23538732562FEA /* OpenAgentsGo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenAgentsGo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		657BCC02FD23538732562FEA /* OpenAgentsGo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = OpenAgentsGo.app; path = "OpenAgents Go.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BFC6779CA9AEA7008F8E130 /* DebugLogSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogSheet.swift; sourceTree = "<group>"; };
 		71C0F9FAA008A4C5DDB894DA /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
-		740731F27EF4E5B87EBC8214 /* OpenAgentsGo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = OpenAgentsGo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		740731F27EF4E5B87EBC8214 /* OpenAgents Go.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenAgents Go.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		77786041AC1E5D020AFE9315 /* WorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; };
 		818A4CEAED3B6B2F27409E36 /* ONMEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ONMEvent.swift; sourceTree = "<group>"; };
 		86415FE67D6C1C2F1DDBA257 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -313,7 +313,7 @@
 		D476D796F5F151440069AC0A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				740731F27EF4E5B87EBC8214 /* OpenAgentsGo.app */,
+				740731F27EF4E5B87EBC8214 /* OpenAgents Go.app */,
 				657BCC02FD23538732562FEA /* OpenAgentsGo.app */,
 			);
 			name = Products;
@@ -370,7 +370,7 @@
 				A7CB0643B35BD65B65983D5D /* SwiftUIJSONRender */,
 			);
 			productName = OpenAgentsGo_iOS;
-			productReference = 740731F27EF4E5B87EBC8214 /* OpenAgentsGo.app */;
+			productReference = 740731F27EF4E5B87EBC8214 /* OpenAgents Go.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -552,7 +552,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = OpenAgents/OpenAgents.entitlements;
+					CODE_SIGN_ENTITLEMENTS = "OpenAgents/OpenAgents-macOS.entitlements";
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -577,7 +577,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = OpenAgents/OpenAgents.entitlements;
+					CODE_SIGN_ENTITLEMENTS = "OpenAgents/OpenAgents-macOS.entitlements";
+					CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -679,7 +680,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -767,7 +768,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "OpenAgents Go";

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -41,20 +41,17 @@ open OpenAgentsGo.xcodeproj                             # work in Xcode
 xcodebuild -scheme OpenAgentsGo_macOS -destination 'platform=macOS' build
 ```
 
-Build a local DMG (ad-hoc signed):
+Build a release DMG (Developer ID signed, notarized, and stapled):
 
 ```sh
-xcodebuild -project OpenAgentsGo.xcodeproj -scheme OpenAgentsGo_macOS \
-  -configuration Release -derivedDataPath build/dd \
-  CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build
-
-STAGING=$(mktemp -d)
-cp -R "build/dd/Build/Products/Release/OpenAgents Go.app" "$STAGING/"
-ln -s /Applications "$STAGING/Applications"
-mkdir -p dist
-hdiutil create -fs HFS+ -srcfolder "$STAGING" -volname "OpenAgents Go 0.2.1" \
-  -format UDZO -ov "dist/OpenAgents Go-0.2.1-arm64.dmg"
+cd packages/go
+TEAM_ID=YOUR_TEAM_ID NOTARY_PROFILE=openagents-notary ./scripts/build-signed-dmg.sh
 ```
+
+The release script intentionally refuses to produce an ad-hoc DMG. To avoid
+macOS Gatekeeper warnings, the build machine needs a `Developer ID Application`
+certificate and either a `notarytool` keychain profile (`NOTARY_PROFILE`) or
+`APPLE_ID` + `APPLE_APP_PASSWORD` credentials.
 
 ## Architecture
 

--- a/packages/go/project.yml
+++ b/packages/go/project.yml
@@ -18,7 +18,7 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     SWIFT_STRICT_CONCURRENCY: complete
-    MARKETING_VERSION: "0.3.0"
+    MARKETING_VERSION: "0.3.1"
     CURRENT_PROJECT_VERSION: "1"
     PRODUCT_NAME: "OpenAgents Go"
     ENABLE_HARDENED_RUNTIME: YES
@@ -94,6 +94,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openagents.go
         PRODUCT_NAME: "OpenAgents Go"
+        "CODE_SIGN_ENTITLEMENTS[sdk=macosx*]": OpenAgents/OpenAgents-macOS.entitlements
+        "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]": OpenAgents/OpenAgents.entitlements
+        "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]": OpenAgents/OpenAgents.entitlements
         GENERATE_INFOPLIST_FILE: NO
         ENABLE_PREVIEWS: YES
         TARGETED_DEVICE_FAMILY: "1,2"
@@ -106,6 +109,7 @@ targets:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
         Release:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: ""
+          "CODE_SIGN_INJECT_BASE_ENTITLEMENTS[sdk=macosx*]": NO
     entitlements:
       path: OpenAgents/OpenAgents.entitlements
       properties:

--- a/packages/go/scripts/build-signed-dmg.sh
+++ b/packages/go/scripts/build-signed-dmg.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT/OpenAgentsGo.xcodeproj"
+SCHEME="${SCHEME:-OpenAgentsGo_macOS}"
+CONFIGURATION="${CONFIGURATION:-Release}"
+DERIVED_DATA="${DERIVED_DATA:-$ROOT/build/dd-release}"
+DIST_DIR="${DIST_DIR:-$ROOT/dist}"
+STAGING_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+TEAM_ID="${TEAM_ID:-}"
+SIGN_IDENTITY="${SIGN_IDENTITY:-}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+APPLE_ID="${APPLE_ID:-}"
+APPLE_TEAM_ID="${APPLE_TEAM_ID:-$TEAM_ID}"
+APPLE_APP_PASSWORD="${APPLE_APP_PASSWORD:-}"
+
+if [[ -z "$TEAM_ID" ]]; then
+  echo "TEAM_ID is required for Developer ID signing." >&2
+  exit 2
+fi
+
+if [[ -z "$SIGN_IDENTITY" ]]; then
+  SIGN_IDENTITY="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
+fi
+
+if [[ -z "$SIGN_IDENTITY" ]]; then
+  echo "No Developer ID Application signing identity found." >&2
+  echo "Install a Developer ID Application certificate or set SIGN_IDENTITY explicitly." >&2
+  exit 2
+fi
+
+if ! security find-identity -v -p codesigning | grep -Fq "$SIGN_IDENTITY"; then
+  echo "Signing identity not found in keychain: $SIGN_IDENTITY" >&2
+  exit 2
+fi
+
+if [[ -z "$NOTARY_PROFILE" && ( -z "$APPLE_ID" || -z "$APPLE_TEAM_ID" || -z "$APPLE_APP_PASSWORD" ) ]]; then
+  echo "Notarization credentials are required." >&2
+  echo "Set NOTARY_PROFILE for a notarytool keychain profile, or set APPLE_ID, TEAM_ID, and APPLE_APP_PASSWORD." >&2
+  exit 2
+fi
+
+APP_VERSION="$(xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration "$CONFIGURATION" -showBuildSettings 2>/dev/null \
+  | awk -F '= ' '/MARKETING_VERSION/ { print $2; exit }')"
+APP_VERSION="${APP_VERSION:-0.0.0}"
+DMG_NAME="OpenAgents Go-${APP_VERSION}-arm64.dmg"
+DMG_PATH="$DIST_DIR/$DMG_NAME"
+APP_PATH="$DERIVED_DATA/Build/Products/$CONFIGURATION/OpenAgents Go.app"
+
+mkdir -p "$DIST_DIR"
+
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIGURATION" \
+  -derivedDataPath "$DERIVED_DATA" \
+  -destination "generic/platform=macOS" \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="$SIGN_IDENTITY" \
+  CODE_SIGN_ENTITLEMENTS="OpenAgents/OpenAgents-macOS.entitlements" \
+  CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+  DEVELOPMENT_TEAM="$TEAM_ID" \
+  OTHER_CODE_SIGN_FLAGS="--timestamp" \
+  build
+
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+cp -R "$APP_PATH" "$STAGING_DIR/"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+hdiutil create \
+  -fs HFS+ \
+  -srcfolder "$STAGING_DIR" \
+  -volname "OpenAgents Go ${APP_VERSION}" \
+  -format UDZO \
+  -ov "$DMG_PATH"
+
+codesign --force --timestamp --sign "$SIGN_IDENTITY" "$DMG_PATH"
+
+if [[ -n "$NOTARY_PROFILE" ]]; then
+  xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+else
+  xcrun notarytool submit "$DMG_PATH" \
+    --apple-id "$APPLE_ID" \
+    --team-id "$APPLE_TEAM_ID" \
+    --password "$APPLE_APP_PASSWORD" \
+    --wait
+fi
+
+xcrun stapler staple "$DMG_PATH"
+spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG_PATH"
+
+echo "$DMG_PATH"

--- a/packages/go/web/components/browser/browser-view.tsx
+++ b/packages/go/web/components/browser/browser-view.tsx
@@ -1,53 +1,78 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { Globe, RefreshCw, ChevronLeft, Maximize2, X } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Globe, Maximize2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
-
-// Middle-truncate a long URL the way Swift's `.truncationMode(.middle)`
-// does — preserve the beginning (scheme + host) and the end (last path
-// segment + query) so users can still tell at a glance where they are.
-function middleTruncate(s: string, maxLen: number): string {
-  if (s.length <= maxLen) return s;
-  const keep = Math.max(8, Math.floor((maxLen - 1) / 2));
-  return s.slice(0, keep) + '…' + s.slice(-keep);
-}
 import { useWorkspace } from '@/lib/workspace-context';
-import { useLayout } from '@/components/layout/layout-context';
 import { workspaceApi } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import type { BrowserTab } from '@/lib/types';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+
+function tabSortTime(tab: BrowserTab): number {
+  const raw = tab.lastActiveAt || tab.createdAt;
+  if (!raw) return 0;
+  const t = new Date(raw).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
 
 export function BrowserView() {
-  const {
-    browserTabs, selectedBrowserTabId, setSelectedBrowserTabId,
-    reconnectBrowserTab,
-    refreshBrowserTabs,
-  } = useWorkspace();
-  const { isMobile, openMobileList } = useLayout();
+  const { browserTabs, refreshBrowserTabs } = useWorkspace();
+
+  const sortedTabs = useMemo(
+    () => [...browserTabs].sort((a, b) => tabSortTime(b) - tabSortTime(a)),
+    [browserTabs],
+  );
+
+  if (sortedTabs.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        <div className="text-center space-y-2">
+          <Globe className="size-12 mx-auto opacity-20" />
+          <p className="text-sm font-medium">No browser sessions</p>
+          <p className="text-xs">Ask an agent to browse, then sessions appear here</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden bg-zinc-50 dark:bg-zinc-900 p-2.5 space-y-2.5">
+      {sortedTabs.map((tab) => (
+        <BrowserSessionCard
+          key={tab.id}
+          tab={tab}
+          refreshBrowserTabs={refreshBrowserTabs}
+        />
+      ))}
+    </div>
+  );
+}
+
+function BrowserSessionCard({
+  tab,
+  refreshBrowserTabs,
+}: {
+  tab: BrowserTab;
+  refreshBrowserTabs: () => Promise<void>;
+}) {
+  const { reconnectBrowserTab } = useWorkspace();
   const [screenshotUrl, setScreenshotUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
   const [sessionDead, setSessionDead] = useState(false);
-  const [navigating, setNavigating] = useState(false);
-  // True app-front modal — covers everything (parity with Swift's
-  // FullscreenBrowserSheet).
-  const [presentMode, setPresentMode] = useState(false);
+  const [fullscreenOpen, setFullscreenOpen] = useState(false);
   const prevBlobRef = useRef<string | null>(null);
   const failCountRef = useRef(0);
 
-  const tab = browserTabs.find((t) => t.id === selectedBrowserTabId);
-
-  // Validate live session on mount / tab switch. The backend checks if the
-  // BF session is still alive and auto-reconnects if dead, returning fresh
-  // tab data (including a new live_url).
   useEffect(() => {
-    if (!selectedBrowserTabId || !tab?.liveUrl) return;
+    if (!tab.liveUrl) return;
     let cancelled = false;
 
     const validate = async () => {
       setReconnecting(true);
       try {
-        await workspaceApi.validateBrowserTab(selectedBrowserTabId);
+        await workspaceApi.validateBrowserTab(tab.id);
         if (!cancelled) await refreshBrowserTabs();
       } catch {
         if (!cancelled) setSessionDead(true);
@@ -58,11 +83,10 @@ export function BrowserView() {
 
     validate();
     return () => { cancelled = true; };
-  }, [selectedBrowserTabId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [tab.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Poll screenshot every 2 seconds (only when no live URL)
   useEffect(() => {
-    if (!selectedBrowserTabId || !tab || tab.liveUrl) {
+    if (tab.liveUrl) {
       setScreenshotUrl(null);
       return;
     }
@@ -73,7 +97,7 @@ export function BrowserView() {
 
     const fetchScreenshot = async () => {
       try {
-        const url = workspaceApi.getBrowserScreenshotUrl(selectedBrowserTabId);
+        const url = workspaceApi.getBrowserScreenshotUrl(tab.id);
         const headers: Record<string, string> = {};
         const token = (workspaceApi as unknown as { token: string }).token;
         if (token) headers['X-Workspace-Token'] = token;
@@ -124,13 +148,14 @@ export function BrowserView() {
         prevBlobRef.current = null;
       }
     };
-  }, [selectedBrowserTabId, tab]);
+  }, [tab.id, tab.liveUrl]);
 
   const handleReconnect = async () => {
-    if (!tab || reconnecting) return;
+    if (reconnecting) return;
     setReconnecting(true);
     try {
       await reconnectBrowserTab(tab.id);
+      await refreshBrowserTabs();
       setSessionDead(false);
       failCountRef.current = 0;
       setLoading(true);
@@ -142,90 +167,21 @@ export function BrowserView() {
     }
   };
 
-  // No tab selected
-  if (!tab) {
-    return (
-      <div className="flex items-center justify-center h-full text-muted-foreground">
-        <div className="text-center space-y-2">
-          <Globe className="size-12 mx-auto opacity-20" />
-          <p className="text-sm font-medium">Select a browser tab</p>
-          <p className="text-xs">Choose a tab from the list or open a new one</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="flex flex-col h-full">
-      {/* Header — strict Swift BrowserPanel mirror: Globe + (Title +
-          URL middle-truncated OR "opened by <agent>") + Reload +
-          Fullscreen. Swift commits 2e8a4791 + 00fa44a1. No extras. */}
-      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-input shrink-0">
-        {isMobile && (
-          <button
-            onClick={openMobileList}
-            className="size-7 flex items-center justify-center rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 text-muted-foreground transition-colors shrink-0"
-            aria-label="Back"
-          >
-            <ChevronLeft className="size-4" />
-          </button>
-        )}
-        <Globe
-          className={cn(
-            'size-3.5 shrink-0 text-muted-foreground',
-            navigating && 'text-amber-500 animate-pulse',
-          )}
-        />
-        <div className="flex-1 min-w-0 leading-tight">
-          <p
-            className="text-[12px] font-semibold truncate"
-            title={tab.title || 'Browser'}
-          >
-            {tab.title || 'Browser'}
-          </p>
-          {tab.url ? (
-            <p
-              className="text-[10px] text-muted-foreground whitespace-nowrap overflow-hidden text-ellipsis"
-              title={tab.url}
-            >
-              {middleTruncate(tab.url, 56)}
-            </p>
-          ) : tab.createdBy ? (
-            <p className="text-[10px] text-muted-foreground truncate">
-              opened by {tab.createdBy.replace(/^(openagents:|human:)/, '')}
-            </p>
-          ) : null}
-        </div>
-
+    <section className="relative bg-background border border-input rounded-lg overflow-hidden shadow-xs">
+      {tab.liveUrl && !reconnecting && (
         <button
-          onClick={handleReconnect}
-          disabled={reconnecting}
-          className="size-[22px] flex items-center justify-center rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 text-muted-foreground transition-colors shrink-0 disabled:opacity-50"
-          title="Reload session"
-          aria-label="Reload browser session"
+          type="button"
+          onClick={() => setFullscreenOpen(true)}
+          className="absolute right-3 top-3 z-10 size-9 flex items-center justify-center rounded-full bg-black/60 text-white shadow-sm hover:bg-black/75 transition-colors"
+          title="Open browser fullscreen"
+          aria-label="Open browser fullscreen"
         >
-          <RefreshCw className={cn('size-3.5', reconnecting && 'animate-spin')} />
+          <Maximize2 className="size-4" />
         </button>
+      )}
 
-        {/* Fullscreen take-over — matches Swift's
-            `arrow.up.left.and.arrow.down.right`. No rotation. */}
-        <button
-          onClick={() => setPresentMode(true)}
-          disabled={!tab.liveUrl}
-          className="size-[22px] flex items-center justify-center rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 text-muted-foreground transition-colors shrink-0 disabled:opacity-30"
-          title="Fullscreen"
-          aria-label="Open browser in fullscreen"
-        >
-          <Maximize2 className="size-3.5" />
-        </button>
-      </div>
-
-      {/* Browser view area — overflow-hidden on the X axis so a wide
-          iframe (Browser Fabric's live viewer can size its inner UI
-          past the panel width) doesn't push the workspace into a
-          horizontal scroll. Vertical scroll stays available for the
-          screenshot fallback. */}
-      <div className="flex-1 min-w-0 overflow-x-hidden overflow-y-auto bg-zinc-50 dark:bg-zinc-900 flex items-start justify-center">
+      <div className="h-[42vh] min-h-[300px] max-h-[420px] min-w-0 overflow-x-hidden overflow-y-auto bg-zinc-50 dark:bg-zinc-900 flex items-start justify-center">
         {tab.liveUrl && !reconnecting ? (
           <iframe
             src={tab.liveUrl}
@@ -244,8 +200,8 @@ export function BrowserView() {
                 disabled={reconnecting}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 text-white text-xs font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
               >
-                <RefreshCw className={cn("size-3.5", reconnecting && "animate-spin")} />
-                {reconnecting ? 'Reconnecting…' : 'Reconnect'}
+                <RefreshCw className={cn('size-3.5', reconnecting && 'animate-spin')} />
+                {reconnecting ? 'Reconnecting...' : 'Reconnect'}
               </button>
             </div>
           </div>
@@ -268,50 +224,19 @@ export function BrowserView() {
         )}
       </div>
 
-      {/* Fullscreen modal — covers everything including chat. Esc to dismiss. */}
-      {presentMode && tab.liveUrl && (
-        <FullscreenBrowserModal
-          title={tab.title || 'Browser'}
-          url={tab.url}
-          liveUrl={tab.liveUrl}
-          onClose={() => setPresentMode(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-function FullscreenBrowserModal({ title, url, liveUrl, onClose }: { title: string; url?: string; liveUrl: string; onClose: () => void }) {
-  // Esc dismisses — mirrors Swift `.keyboardShortcut(.cancelAction)` on
-  // the close button.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-  return (
-    <div className="fixed inset-0 z-[100] bg-background flex flex-col">
-      <div className="flex items-center gap-2 px-4 py-2 border-b shrink-0">
-        <Globe className="size-4 text-blue-500" />
-        <div className="flex-1 min-w-0 overflow-hidden">
-          <p className="text-sm font-semibold truncate">{title}</p>
-          {url && <p className="text-xs text-muted-foreground truncate font-mono">{url}</p>}
-        </div>
-        <button
-          onClick={onClose}
-          className="size-8 flex items-center justify-center rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 text-muted-foreground hover:text-foreground transition-colors shrink-0"
-          title="Close (Esc)"
-          aria-label="Close fullscreen"
-        >
-          <X className="size-4" />
-        </button>
-      </div>
-      <iframe
-        src={liveUrl}
-        className="flex-1 w-full border-0"
-        allow="clipboard-read; clipboard-write"
-        title={`Live browser: ${url || liveUrl}`}
-      />
-    </div>
+      <Dialog open={fullscreenOpen} onOpenChange={setFullscreenOpen}>
+        <DialogContent variant="fullscreen" className="flex flex-col p-0 gap-0" showCloseButton>
+          <DialogTitle className="sr-only">{tab.title || tab.url || 'Browser session'}</DialogTitle>
+          {tab.liveUrl && (
+            <iframe
+              src={tab.liveUrl}
+              className="w-full h-full border-0 bg-black"
+              allow="clipboard-read; clipboard-write"
+              title={`Live browser fullscreen: ${tab.url}`}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </section>
   );
 }

--- a/packages/go/web/components/layout/right-tabbed-panel.tsx
+++ b/packages/go/web/components/layout/right-tabbed-panel.tsx
@@ -2,10 +2,10 @@
 
 /**
  * Tabbed right-side panel sitting next to the chat detail. Mirrors the
- * Swift `ContentSidebar` `[Content | Browser]` header tabs (0.3.0).
+ * Swift `ContentSidebar` `[Content | Browser]` header tabs.
  *
  *   - Content tab: workspace files (FileList + FilePreview)
- *   - Browser tab: live Browser Fabric session (BrowserView). Hidden
+ *   - Browser tab: live Browser Fabric sessions (BrowserView). Hidden
  *     unless `workspace.browserEnabled === true` — mirrors
  *     `WorkspaceStore.browserPanelAvailable` on Swift.
  *

--- a/packages/go/web/package-lock.json
+++ b/packages/go/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openagents-org/go-web",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openagents-org/go-web",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.23",
         "boring-avatars": "^2.0.4",

--- a/packages/go/web/package.json
+++ b/packages/go/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/go-web",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",


### PR DESCRIPTION
## Summary
- show all live Browser Fabric sessions in the Swift and web Go panels instead of selecting one session
- remove the per-session BrowserFabric title/header chrome from embedded browser views
- bump Go app/web version to 0.3.1 and add Developer ID signed DMG build/notarization workflow with macOS-specific entitlements

## Verification
- npm run build (packages/go/web)
- xcodebuild Release via packages/go/scripts/build-signed-dmg.sh: app and DMG sign with Developer ID Application

## Notes
- DMG notarization still requires a local notarytool keychain profile named openagents-notary; current local submission fails until that credential profile is created.