### PR TITLE
fix(workspace-backend): align migration schema with models

### DIFF
--- a/workspace/backend/alembic/versions/001_initial_schema.py
+++ b/workspace/backend/alembic/versions/001_initial_schema.py
@@ -108,8 +108,27 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("agent_name"),
     )
 
+    # Browser tabs
+    op.create_table(
+        "browser_tabs",
+        sa.Column("id", sa.Text(), primary_key=True),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=False), sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False, server_default="about:blank"),
+        sa.Column("title", sa.Text()),
+        sa.Column("status", sa.Text(), nullable=False, server_default="active"),
+        sa.Column("created_by", sa.Text(), nullable=False),
+        sa.Column("shared_with", postgresql.JSONB(), server_default="[]"),
+        sa.Column("session_id", sa.Text()),
+        sa.Column("live_url", sa.Text()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()")),
+        sa.Column("last_active_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()")),
+    )
+    op.create_index("idx_browser_tabs_workspace_status", "browser_tabs", ["workspace_id", "status"])
+
 
 def downgrade() -> None:
+    op.drop_index("idx_browser_tabs_workspace_status", "browser_tabs")
+    op.drop_table("browser_tabs")
     op.drop_table("agents")
     op.drop_table("invitations")
     op.drop_table("channel_members")

--- a/workspace/backend/alembic/versions/005_add_workspace_collaborators.py
+++ b/workspace/backend/alembic/versions/005_add_workspace_collaborators.py
@@ -8,6 +8,8 @@ Create Date: 2026-03-11
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
 
 revision = "005"
 down_revision = "004"
@@ -18,8 +20,8 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "workspace_collaborators",
-        sa.Column("id", sa.Text(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
-        sa.Column("workspace_id", sa.Text(), sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("id", UUID(as_uuid=False), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("workspace_id", UUID(as_uuid=False), sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False),
         sa.Column("email", sa.Text(), nullable=False),
         sa.Column("role", sa.Text(), server_default="editor"),
         sa.Column("added_by", sa.Text(), nullable=True),

--- a/workspace/backend/alembic/versions/015_add_workspace_member_description.py
+++ b/workspace/backend/alembic/versions/015_add_workspace_member_description.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""Add description column to workspace_members table.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-05-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "015"
+down_revision = "014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace_members",
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspace_members", "description")


### PR DESCRIPTION
## Problem

The Workspace backend Alembic migrations fail on a clean database, blocking fresh deployments:

1. **Migration 005 FK type mismatch**: `workspace_collaborators.id` and `workspace_id` are defined as `sa.Text()`, but `workspaces.id` is a PostgreSQL native UUID. PostgreSQL enforces strict FK type compatibility — Text→UUID implicit conversion doesn't work, causing FK violations on INSERT.

2. **Migration 001 missing `browser_tabs` table**: Migration 006 runs `op.add_column("browser_tabs", ...)` to add a `context_id` FK, but migration 001 never creates the `browser_tabs` table, so `ALTER TABLE` fails with "table does not exist".

3. **Missing `workspace_members.description` migration**: Commit `a462ce3f` added `WorkspaceMember.description` to the SQLAlchemy model and API responses, but no Alembic revision added the column. Runtime ORM queries against a migrated database fail with `psycopg2.errors.UndefinedColumn: column workspace_members.description does not exist`.

Models in `app/models.py` use `UUID(as_uuid=False)` for all UUID columns and include `workspace_members.description` — migrations and models are inconsistent.

## Fix

- **005**: Changed `workspace_collaborators.id` and `workspace_id` from `sa.Text()` to `postgresql.UUID(as_uuid=False)`, added `from sqlalchemy.dialects.postgresql import UUID` import
- **001**: Added `browser_tabs` table creation (matching models) at end of upgrade, added corresponding `drop_index` + `drop_table` in downgrade
- **015**: Added `workspace_members.description` as nullable `Text`, matching the existing `WorkspaceMember.description` model field

## Verification

Ran `alembic upgrade head` (001→015, all 15 migrations) on a clean PostgreSQL instance — completed without errors. Verified generated schema includes:

- `workspace_collaborators` FK columns are UUID, matching `workspaces.id`
- `browser_tabs` exists before migration 006 alters it
- `workspace_members` includes `agent_type`, `server_host`, `working_dir`, `description`, `session_id`, and `session_started_at`

## Files Changed

- `workspace/backend/alembic/versions/001_initial_schema.py`
- `workspace/backend/alembic/versions/005_add_workspace_collaborators.py`
- `workspace/backend/alembic/versions/015_add_workspace_member_description.py`
