### PR TITLE
fix(launcher): support local workspace endpoints

### DIFF
--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -38,12 +38,13 @@ function normalizeWorkspaceEndpoint(value: unknown): string | undefined {
   if (!raw) return undefined
   try {
     const url = new URL(raw)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined
     if (url.hostname === "workspace.openagents.org") {
       return url.origin.replace("workspace.openagents.org", "workspace-endpoint.openagents.org")
     }
     return url.origin
   } catch {
-    return raw.replace(/\/$/, "")
+    return undefined
   }
 }
 
@@ -843,6 +844,7 @@ export class AgentManager extends EventEmitter {
   ): { endpoint?: string; slug?: string; token?: string } | null {
     try {
       const u = new URL(urlStr.trim())
+      if (u.protocol !== "http:" && u.protocol !== "https:") return null
       const host = u.hostname.toLowerCase()
       if (host === "workspace.openagents.org") {
         return null

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -28,6 +28,25 @@ const LAUNCHER_SESSIONS_DIR = path.join(CONFIG_DIR, "launcher-sessions")
 const DEFAULT_CHAT_CHANNEL = "main"
 const CHAT_POLL_INTERVAL_MS = 2500
 
+interface LauncherSettingsStore {
+  get(key?: string): unknown
+}
+
+function normalizeWorkspaceEndpoint(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const raw = value.trim()
+  if (!raw) return undefined
+  try {
+    const url = new URL(raw)
+    if (url.hostname === "workspace.openagents.org") {
+      return url.origin.replace("workspace.openagents.org", "workspace-endpoint.openagents.org")
+    }
+    return url.origin
+  } catch {
+    return raw.replace(/\/$/, "")
+  }
+}
+
 export interface InstalledAgentRecord {
   name: string
   version: string | null
@@ -258,9 +277,10 @@ function extractToolCalls(msg: ChatMessage): ChatToolCall[] | undefined {
 export function extractMentions(text: string): string[] {
   const out: string[] = []
   const re = /(^|\s)@([a-zA-Z0-9_-]+)/g
-  let m
-  while ((m = re.exec(text)) !== null) {
-    if (!out.includes(m[2])) out.push(m[2])
+  let match = re.exec(text)
+  while (match !== null) {
+    if (!out.includes(match[2])) out.push(match[2])
+    match = re.exec(text)
   }
   return out
 }
@@ -374,7 +394,7 @@ function resolveWorkingNode(
 let core: Record<string, unknown> | null = loadCore()
 
 export class AgentManager extends EventEmitter {
-  private _store: unknown
+  private _store: LauncherSettingsStore
   private _healthByType = new Map<string, unknown>()
   private _healthRefreshInFlight = new Set<string>()
   private _lastHealthRefreshAt = 0
@@ -409,16 +429,30 @@ export class AgentManager extends EventEmitter {
   private _chatPolls = new Map<string, ChatPollingState>()
   _connector: Record<string, unknown> | null = null
 
-  constructor(store: unknown) {
+  constructor(store: LauncherSettingsStore) {
     super()
     this._store = store
     if (!core) core = loadCore()
     if (core) {
-      const AgentConnector = (core as Record<string, unknown>)
-        .AgentConnector as new (opts: unknown) => Record<string, unknown>
-      this._connector = new AgentConnector({ configDir: CONFIG_DIR })
+      this._connector = this.createConnector()
     }
     ensureDir(LAUNCHER_SESSIONS_DIR)
+  }
+
+  private createConnector(): Record<string, unknown> {
+    const AgentConnector = (core as Record<string, unknown>)
+      .AgentConnector as new (opts: unknown) => Record<string, unknown>
+    const workspaceEndpoint = normalizeWorkspaceEndpoint(
+      this._store.get("workspaceEndpoint"),
+    )
+    return new AgentConnector({
+      configDir: CONFIG_DIR,
+      ...(workspaceEndpoint ? { workspaceEndpoint } : {}),
+    })
+  }
+
+  private configuredWorkspaceEndpoint(): string | undefined {
+    return normalizeWorkspaceEndpoint(this._store.get("workspaceEndpoint"))
   }
 
   getSupportedAgentTypes(): string[] {
@@ -451,9 +485,7 @@ export class AgentManager extends EventEmitter {
     for (const k of cacheKeys) delete require.cache[k]
     core = loadCore()
     if (core) {
-      const AgentConnector = (core as Record<string, unknown>)
-        .AgentConnector as new (opts: unknown) => Record<string, unknown>
-      this._connector = new AgentConnector({ configDir: CONFIG_DIR })
+      this._connector = this.createConnector()
     }
     this.clearCatalogCache()
     this._agentsCache = { value: [], at: 0 }
@@ -806,6 +838,24 @@ export class AgentManager extends EventEmitter {
     })
   }
 
+  private parseCustomWorkspaceUrl(
+    urlStr: string,
+  ): { endpoint?: string; slug?: string; token?: string } | null {
+    try {
+      const u = new URL(urlStr.trim())
+      const host = u.hostname.toLowerCase()
+      if (host === "workspace.openagents.org") {
+        return null
+      }
+      const endpoint = u.origin
+      const slug = u.pathname.replace(/^\//, "").split("/")[0] || undefined
+      const token = u.searchParams.get("token") || undefined
+      return { endpoint, slug, token }
+    } catch {
+      return null
+    }
+  }
+
   async registerWorkspaceFromToken(input: {
     url?: string
     token?: string
@@ -820,6 +870,38 @@ export class AgentManager extends EventEmitter {
     const tokenOrSlug = (input.token || input.slug || input.url || "").trim()
     if (!tokenOrSlug) throw new Error("Missing workspace URL or token")
 
+    const customParsed = input.url ? this.parseCustomWorkspaceUrl(input.url) : null
+    if (customParsed) {
+      const slug = input.slug || customParsed.slug
+      const token = input.token || customParsed.token
+      if (!slug)
+        throw new Error(
+          "Custom workspace URL must include slug (first path segment) or provide slug explicitly",
+        )
+      if (!token)
+        throw new Error(
+          "Custom workspace URL must include token query parameter or provide token explicitly",
+        )
+
+      const config = this._connector!.config as Record<string, unknown>
+      const addNetwork = config.addNetwork as (opts: unknown) => unknown
+      addNetwork.call(config, {
+        id: slug,
+        slug,
+        name: slug,
+        endpoint: customParsed.endpoint,
+        token,
+      })
+      this.signalReload()
+      return {
+        id: slug,
+        slug,
+        name: slug,
+        endpoint: customParsed.endpoint,
+        token,
+      }
+    }
+
     const resolveToken = this._connector!.resolveToken as (
       token: string,
     ) => Promise<{
@@ -831,6 +913,7 @@ export class AgentManager extends EventEmitter {
     const info = await resolveToken.call(this._connector, tokenOrSlug)
     const slug = info.slug || info.workspace_id || input.slug
     if (!slug) throw new Error("Could not resolve workspace from input")
+    const endpoint = info.endpoint || this.configuredWorkspaceEndpoint()
 
     const config = this._connector!.config as Record<string, unknown>
     const addNetwork = config.addNetwork as (opts: unknown) => unknown
@@ -838,7 +921,7 @@ export class AgentManager extends EventEmitter {
       id: info.workspace_id,
       slug,
       name: info.name || slug,
-      endpoint: info.endpoint,
+      endpoint,
       token: input.token || tokenOrSlug,
     })
     this.signalReload()
@@ -846,7 +929,7 @@ export class AgentManager extends EventEmitter {
       id: info.workspace_id,
       slug,
       name: info.name || slug,
-      endpoint: info.endpoint,
+      endpoint,
       token: input.token || tokenOrSlug,
     }
   }
@@ -867,6 +950,7 @@ export class AgentManager extends EventEmitter {
       const info = await resolveToken.call(this._connector, tokenOrSlug)
       const slug = info.slug || info.workspace_id
       const wsName = info.name || slug
+      const endpoint = info.endpoint || this.configuredWorkspaceEndpoint()
 
       const addNetwork = (this._connector!.config as Record<string, unknown>)
         .addNetwork as (opts: unknown) => void
@@ -874,7 +958,7 @@ export class AgentManager extends EventEmitter {
         id: info.workspace_id,
         slug,
         name: wsName,
-        endpoint: info.endpoint,
+        endpoint,
         token: tokenOrSlug,
       })
 
@@ -883,7 +967,13 @@ export class AgentManager extends EventEmitter {
         slug: string,
       ) => void
       connectWorkspace.call(this._connector, agentName, slug as string)
-    } catch {
+    } catch (err) {
+      const networks = this.getNetworks() as Array<{ id?: string; slug?: string }>
+      const existing = networks.some(
+        (network) => network.slug === tokenOrSlug || network.id === tokenOrSlug,
+      )
+      if (!existing) throw err
+
       const connectWorkspace = this._connector!.connectWorkspace as (
         name: string,
         slug: string,

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1415,7 +1415,12 @@ function setupIPC(): void {
   )
 
   ipcMain.handle("settings:get", (_e, key) => store.get(key))
-  ipcMain.handle("settings:set", (_e, key, value) => store.set(key, value))
+  ipcMain.handle("settings:set", (_e, key, value) => {
+    store.set(key, value)
+    if (key === "workspaceEndpoint" && agentManager) {
+      agentManager.reloadCore()
+    }
+  })
 
   // ── Connections ──
   ipcMain.handle("connections:list", () => connectionsStore.list())

--- a/packages/launcher/src/renderer/components/workspaces/WorkspaceCard.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/WorkspaceCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "./WorkspaceRecentActivity"
 import { platformLabel } from "../connections/platforms"
 import type { Agent, Workspace } from "../../types"
+import { workspaceDisplayHost } from "../../lib/workspace-urls"
 
 export interface WorkspaceCardData {
   ws: Workspace
@@ -72,7 +73,7 @@ export function WorkspaceCard({
             <WorkspaceHealth state={health} />
           </div>
           <div className="text-[11px] text-(--text-tertiary) truncate">
-            workspace.openagents.org/{slug}
+            {workspaceDisplayHost(ws.endpoint)}/{slug}
           </div>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">

--- a/packages/launcher/src/renderer/components/workspaces/WorkspaceQuickConnect.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/WorkspaceQuickConnect.tsx
@@ -57,31 +57,39 @@ export function WorkspaceQuickConnect({
     }
   }, [open])
 
-  const parseInput = (raw: string): { slug?: string; token?: string } => {
+  const parseInput = (
+    raw: string,
+  ): { url?: string; slug?: string; token?: string; customUrl?: boolean } => {
     const v = raw.trim()
     if (!v) return {}
     try {
       const u = new URL(v)
       const slug = u.pathname.replace(/^\//, "").split("/")[0] || undefined
       const token = u.searchParams.get("token") || undefined
-      if (slug || token) return { slug, token }
+      return {
+        url: v,
+        slug,
+        token,
+        customUrl: u.hostname.toLowerCase() !== "workspace.openagents.org",
+      }
     } catch {}
     return { token: v }
   }
 
   const handlePasteConnect = async (): Promise<void> => {
-    const { slug, token } = parseInput(pasted)
-    if (!slug && !token) {
+    const parsed = parseInput(pasted)
+    const { slug, token } = parsed
+    if (!parsed.url && !slug && !token) {
       showToast("Paste a workspace URL or token", "warning")
       return
     }
     setBusy(true)
     try {
-      const ws = await window.api.registerWorkspaceFromToken({
-        url: pasted.trim() || undefined,
-        token,
-        slug,
-      })
+      const ws = await window.api.registerWorkspaceFromToken(
+        parsed.customUrl
+          ? { url: parsed.url }
+          : { url: parsed.url, token, slug },
+      )
       const label = ws.name || ws.slug || slug || "workspace"
       showToast(
         `Registered ${label}. Open Agents tab to connect an agent.`,
@@ -157,11 +165,11 @@ export function WorkspaceQuickConnect({
             <Input
               value={pasted}
               onChange={(e) => setPasted(e.target.value)}
-              placeholder="https://workspace.openagents.org/my-team?token=…"
+              placeholder="https://workspace.openagents.org/my-team?token=… or http://localhost:8000/my-team?token=…"
               autoFocus
             />
             <div className="text-[11px] text-(--text-tertiary) mt-1.5">
-              Token and slug are extracted automatically.
+              Hosted URLs use remote token resolution. Custom URLs use the URL origin, first path segment, and token query parameter.
             </div>
           </div>
         </div>
@@ -211,7 +219,7 @@ export function WorkspaceQuickConnect({
               "Copy the workspace URL and paste it in the “Paste URL / token” tab.",
             ].map((step, i) => (
               <li
-                key={i}
+                key={step}
                 className="flex items-start gap-2.5 text-[11px] text-(--text-secondary) leading-relaxed"
               >
                 <span className="shrink-0 w-4.5 h-4.5 rounded-full bg-(--bg-input) text-(--text-primary) text-[10px] font-semibold flex items-center justify-center">

--- a/packages/launcher/src/renderer/lib/workspace-urls.ts
+++ b/packages/launcher/src/renderer/lib/workspace-urls.ts
@@ -1,0 +1,15 @@
+const DEFAULT_WORKSPACE_WEB_BASE_URL = "https://workspace.openagents.org"
+
+export function workspaceWebBaseUrl(endpoint?: string): string {
+  const baseUrl = (endpoint || DEFAULT_WORKSPACE_WEB_BASE_URL).replace(/\/$/, "")
+  return baseUrl.replace("workspace-endpoint", "workspace").replace(/\/v1$/, "")
+}
+
+export function workspaceDisplayHost(endpoint?: string): string {
+  const baseUrl = workspaceWebBaseUrl(endpoint)
+  try {
+    return new URL(baseUrl).host
+  } catch {
+    return baseUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  }
+}

--- a/packages/launcher/src/renderer/pages/agents/index.tsx
+++ b/packages/launcher/src/renderer/pages/agents/index.tsx
@@ -12,6 +12,7 @@ import { TopBar } from "../../components/TopBar"
 import type { Agent, CatalogEntry, EnvField, HealthCheck } from "../../types"
 import type { ToastType } from "../../hooks/useToast"
 import { cn } from "../../lib/utils"
+import { workspaceWebBaseUrl } from "../../lib/workspace-urls"
 
 function formatHealthLabel(health: HealthCheck | null): string {
   if (!health) return "Not configured"
@@ -164,7 +165,7 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
         (w) => w.slug === agent.network || w.id === agent.network,
       )
       const slug = (ws && ws.slug) || agent.network
-      let url = `https://workspace.openagents.org/${slug}`
+      let url = `${workspaceWebBaseUrl(ws?.endpoint)}/${slug}`
       if (ws && ws.token) url += `?token=${encodeURIComponent(ws.token)}`
       window.api.openExternal(url)
     } catch (err: unknown) {
@@ -482,8 +483,9 @@ function NewAgentDialog({
         ) : (
           <>
             <div className="form-group">
-              <label>Agent type</label>
+              <label htmlFor="agent-type">Agent type</label>
               <select
+                id="agent-type"
                 value={selectedType}
                 onChange={(e) => setSelectedType(e.target.value)}
               >
@@ -495,8 +497,9 @@ function NewAgentDialog({
               </select>
             </div>
             <div className="form-group">
-              <label>Agent name</label>
+              <label htmlFor="agent-name">Agent name</label>
               <input
+                id="agent-name"
                 type="text"
                 value={agentName}
                 onChange={(e) => setAgentName(e.target.value)}
@@ -504,8 +507,9 @@ function NewAgentDialog({
               />
             </div>
             <div className="form-group">
-              <label>Working directory (optional)</label>
+              <label htmlFor="agent-working-directory">Working directory (optional)</label>
               <input
+                id="agent-working-directory"
                 type="text"
                 value={agentPath}
                 onChange={(e) => setAgentPath(e.target.value)}
@@ -681,12 +685,13 @@ function ConfigureDialog({
             <div>
               {fields.map((f) => (
                 <div key={f.name} className="form-group">
-                  <label>
+                  <label htmlFor={`agent-config-${f.name}`}>
                     {f.description}
                     {f.required && <span className="required"> *</span>}
                   </label>
                   {f.password ? (
                     <PasswordInput
+                      id={`agent-config-${f.name}`}
                       value={values[f.name] || ""}
                       onChange={(e) =>
                         setValues((prev) => ({
@@ -698,6 +703,7 @@ function ConfigureDialog({
                     />
                   ) : (
                     <input
+                      id={`agent-config-${f.name}`}
                       type="text"
                       value={values[f.name] || ""}
                       onChange={(e) =>
@@ -770,6 +776,14 @@ function ConnectWorkspaceDialog({
   const [newWsName, setNewWsName] = useState("")
   const [token, setToken] = useState("")
 
+  const parseWorkspaceUrl = (raw: string): URL | null => {
+    try {
+      return new URL(raw.trim())
+    } catch {
+      return null
+    }
+  }
+
   useEffect(() => {
     if (!open) return
     setView("list")
@@ -819,12 +833,20 @@ function ConnectWorkspaceDialog({
   const doJoinToken = async (): Promise<void> => {
     const t = token.trim()
     if (!t) {
-      showToast("Token is required", "warning")
+      showToast("Workspace URL or token is required", "warning")
       return
     }
     try {
       showToast("Joining workspace...", "info")
-      await window.api.connectWorkspace(agentName, t)
+      const parsedUrl = parseWorkspaceUrl(t)
+      if (parsedUrl && parsedUrl.hostname !== "workspace.openagents.org") {
+        const ws = await window.api.registerWorkspaceFromToken({ url: t })
+        const workspaceKey = ws.slug || ws.id
+        if (!workspaceKey) throw new Error("Could not register workspace URL")
+        await window.api.connectWorkspace(agentName, workspaceKey)
+      } else {
+        await window.api.connectWorkspace(agentName, t)
+      }
       window.api.signalReload()
       showToast("Joined workspace", "success")
       onConnected()
@@ -842,12 +864,7 @@ function ConnectWorkspaceDialog({
             <div className="flex flex-col gap-1 mb-3.5">
               {workspaces.map((ws) => {
                 const display = ws.name || ws.slug || ws.id
-                const url =
-                  ws.endpoint &&
-                  (ws.endpoint.includes("localhost") ||
-                    ws.endpoint.includes("127.0.0.1"))
-                    ? `${ws.endpoint}/${ws.slug || ws.id}`
-                    : `workspace.openagents.org/${ws.slug || ws.id}`
+                const url = `${workspaceWebBaseUrl(ws.endpoint)}/${ws.slug || ws.id}`
                 return (
                   <button
                     key={ws.id}
@@ -871,7 +888,7 @@ function ConnectWorkspaceDialog({
                 className="text-left px-4 py-[11px] text-[13px] w-full rounded-sm bg-[var(--bg-card)] border border-[color:var(--border)] cursor-pointer transition-all duration-150 hover:bg-[var(--accent-bg)] hover:border-[color:var(--accent-border)]"
                 onClick={() => setView("token")}
               >
-                Join with Token
+                Join with URL or Token
               </button>
             </div>
             <Button onClick={onClose} className="w-full">
@@ -882,13 +899,13 @@ function ConnectWorkspaceDialog({
         {view === "create" && (
           <>
             <div className="form-group">
-              <label>Workspace name</label>
+              <label htmlFor="new-workspace-name">Workspace name</label>
               <input
+                id="new-workspace-name"
                 type="text"
                 value={newWsName}
                 onChange={(e) => setNewWsName(e.target.value)}
                 placeholder="my-workspace"
-                autoFocus
               />
             </div>
             <div className="form-actions">
@@ -902,13 +919,13 @@ function ConnectWorkspaceDialog({
         {view === "token" && (
           <>
             <div className="form-group">
-              <label>Paste workspace token</label>
+              <label htmlFor="workspace-url-or-token">Paste workspace URL or token</label>
               <input
+                id="workspace-url-or-token"
                 type="text"
                 value={token}
                 onChange={(e) => setToken(e.target.value)}
-                placeholder="Paste token here..."
-                autoFocus
+                placeholder="https://workspace.openagents.org/team?token=… or http://localhost:8000/team?token=…"
               />
             </div>
             <div className="form-actions">

--- a/packages/launcher/src/renderer/pages/settings/index.tsx
+++ b/packages/launcher/src/renderer/pages/settings/index.tsx
@@ -73,6 +73,7 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
   const [httpProxy, setHttpProxy] = useState("")
   const [httpsProxy, setHttpsProxy] = useState("")
   const [noProxy, setNoProxy] = useState("")
+  const [workspaceEndpoint, setWorkspaceEndpoint] = useState("")
   const [language, setLanguage] = useState("en")
   const [paths, setPaths] = useState<{
     userData: string
@@ -117,6 +118,7 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
       setHttpProxy((all.httpProxy as string) || "")
       setHttpsProxy((all.httpsProxy as string) || "")
       setNoProxy((all.noProxy as string) || "")
+      setWorkspaceEndpoint((all.workspaceEndpoint as string) || "")
       setLanguage((all.language as string) || "en")
     } catch {}
   }, [])
@@ -474,6 +476,20 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
             <SettingsCard title="Network">
               <Row
                 stacked
+                label="Workspace backend URL"
+                desc="Optional self-hosted Workspace server. Leave blank to use OpenAgents hosted Workspace."
+              >
+                <Input
+                  value={workspaceEndpoint}
+                  onChange={(e) => setWorkspaceEndpoint(e.target.value)}
+                  onBlur={() => void set("workspaceEndpoint", workspaceEndpoint)}
+                  placeholder="https://workspace-endpoint.openagents.org or http://localhost:8000"
+                  className="w-full"
+                />
+              </Row>
+              <Separator />
+              <Row
+                stacked
                 label="HTTP proxy"
                 desc="Used by agents and the launcher for outbound HTTP"
               >
@@ -629,15 +645,15 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
                 OpenAgents Launcher {launcherVersion}
               </p>
               <p className="text-[13px] m-0">
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
+                <button
+                  type="button"
+                  className="bg-transparent border-0 p-0 text-(--accent) underline cursor-pointer"
+                  onClick={() => {
                     window.api.openExternal("https://docs.openagents.com")
                   }}
                 >
                   Documentation
-                </a>
+                </button>
               </p>
             </SettingsCard>
           )}

--- a/packages/launcher/src/renderer/pages/workspaces/index.tsx
+++ b/packages/launcher/src/renderer/pages/workspaces/index.tsx
@@ -16,6 +16,7 @@ import { useWorkspacePrefs } from "../../store/workspace-prefs"
 import { useUiStore } from "../../store/ui"
 import type { Agent, ChatSessionMeta, Workspace } from "../../types"
 import type { ToastType } from "../../hooks/useToast"
+import { workspaceWebBaseUrl } from "../../lib/workspace-urls"
 
 interface Props {
   showToast: (msg: string, type?: ToastType) => void
@@ -217,7 +218,8 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
   const handleCopyUrl = async (ws: Workspace): Promise<void> => {
     markUsed(ws.id)
     const slug = ws.slug || ws.id
-    const url = `https://workspace.openagents.org/${slug}`
+    const baseUrl = workspaceWebBaseUrl(ws.endpoint)
+    const url = `${baseUrl}/${slug}`
     const full = ws.token ? `${url}?token=${encodeURIComponent(ws.token)}` : url
     try {
       await navigator.clipboard.writeText(full)
@@ -232,7 +234,8 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
   const handleOpenBrowser = (ws: Workspace): void => {
     markUsed(ws.id)
     const slug = ws.slug || ws.id
-    let url = `https://workspace.openagents.org/${slug}`
+    const baseUrl = workspaceWebBaseUrl(ws.endpoint)
+    let url = `${baseUrl}/${slug}`
     if (ws.token) url += `?token=${encodeURIComponent(ws.token)}`
     window.api.openExternal(url)
   }


### PR DESCRIPTION
## Summary
- allow launcher to register non-hosted workspace URLs directly from origin/slug/token
- pass configured workspace backend endpoint into the launcher connector and reload it after settings changes
- generate workspace display/open URLs from each saved network endpoint

## Test
- npm run build (packages/launcher)
