### PR TITLE
fix(gitignore): untrack packages/go/web/lib/ silently swallowed by root lib/ rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ lib/
 !packages/launcher/src/renderer/lib/**
 !workspace/frontend/lib/
 !workspace/frontend/lib/**
+!packages/go/web/lib/
+!packages/go/web/lib/**
 lib64/
 parts/
 sdist/

--- a/packages/go/web/lib/api.ts
+++ b/packages/go/web/lib/api.ts
@@ -1,0 +1,771 @@
+import type {
+  AgentCatalogEntry,
+  ApiResponse,
+  BrowserPersistentContext,
+  BrowserTab,
+  DMConversation,
+  EventPollResponse,
+  MessagePollResponse,
+  NetworkDiscovery,
+  NetworkProfile,
+  ONMEvent,
+  TimerItem,
+  TodoItem,
+  Workspace,
+  WorkspaceAgent,
+  WorkspaceCollaborator,
+  WorkspaceFile,
+  WorkspaceInvitation,
+  WorkspaceSession,
+} from './types';
+import { eventToMessage } from './types';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+
+/** Map snake_case file response from backend to camelCase WorkspaceFile. */
+function mapFileResponse(raw: Record<string, unknown>): WorkspaceFile {
+  return {
+    id: raw.id as string,
+    filename: raw.filename as string,
+    contentType: (raw.content_type || raw.contentType || 'application/octet-stream') as string,
+    size: raw.size as number,
+    uploadedBy: (raw.uploaded_by || raw.uploadedBy || 'unknown') as string,
+    channelName: (raw.channel_name ?? raw.channelName ?? null) as string | null,
+    status: (raw.status || 'active') as string,
+    createdAt: (raw.created_at || raw.createdAt || null) as string | null,
+  };
+}
+
+class WorkspaceApi {
+  private token: string = '';
+  private bearerToken: string = '';
+  private workspaceId: string = '';
+
+  configure(workspaceId: string, token: string, bearerToken?: string) {
+    this.workspaceId = workspaceId;
+    this.token = token;
+    if (bearerToken !== undefined) this.bearerToken = bearerToken;
+  }
+
+  setBearerToken(bearerToken: string) {
+    this.bearerToken = bearerToken;
+  }
+
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const authHeaders: Record<string, string> = {};
+    if (this.token) {
+      authHeaders['X-Workspace-Token'] = this.token;
+    }
+    if (this.bearerToken) {
+      authHeaders['Authorization'] = `Bearer ${this.bearerToken}`;
+    }
+
+    const url = `${API_URL}${path}`;
+    const res = await fetch(url, {
+      ...options,
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+        ...options.headers,
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`API ${res.status}: ${body}`);
+    }
+
+    const json: ApiResponse<T> = await res.json();
+    return json.data;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace CRUD (REST endpoints — not event-based)
+  // ---------------------------------------------------------------------------
+
+  async getWorkspace(): Promise<Workspace> {
+    return this.request<Workspace>(`/v1/workspaces/${this.workspaceId}`);
+  }
+
+  async updateWorkspace(updates: {
+    name?: string;
+    settings?: Record<string, unknown>;
+    /**
+     * Typed top-level flip — backend merges this into `settings`
+     * without trampling other keys. Use this instead of round-tripping
+     * the whole settings dict to flip one bool.
+     */
+    browser_enabled?: boolean;
+  }): Promise<Workspace> {
+    return this.request<Workspace>(`/v1/workspaces/${this.workspaceId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(updates),
+    });
+  }
+
+  async setBrowserEnabled(enabled: boolean): Promise<Workspace> {
+    return this.updateWorkspace({ browser_enabled: enabled });
+  }
+
+  async claimWorkspace(): Promise<Workspace> {
+    return this.request<Workspace>(`/v1/workspaces/${this.workspaceId}/claim`, {
+      method: 'POST',
+    });
+  }
+
+  async updateMember(agentName: string, updates: { description?: string; role?: string }): Promise<unknown> {
+    return this.request(`/v1/workspaces/${this.workspaceId}/members/${agentName}`, {
+      method: 'PATCH',
+      body: JSON.stringify(updates),
+    });
+  }
+
+  async updateChannel(channelName: string, updates: { title?: string; status?: string; starred?: boolean }): Promise<unknown> {
+    return this.request(`/v1/workspaces/${this.workspaceId}/channels/${channelName}`, {
+      method: 'PATCH',
+      body: JSON.stringify(updates),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Network discovery
+  // ---------------------------------------------------------------------------
+
+  /** Discover agents, channels, and resources in the network. */
+  async discover(): Promise<NetworkDiscovery> {
+    return this.request<NetworkDiscovery>(`/v1/discover?network=${this.workspaceId}`);
+  }
+
+  /** Get network profile metadata. */
+  async networkProfile(): Promise<NetworkProfile> {
+    return this.request<NetworkProfile>(`/v1/profile?network=${this.workspaceId}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Channels (sessions) — via ONM events
+  // ---------------------------------------------------------------------------
+
+  /** Create a new channel (thread) by emitting a network.channel.create event. */
+  async createChannel(opts: {
+    title?: string;
+    master?: string;
+    participants?: string[];
+    resumeFrom?: string;
+  } = {}): Promise<WorkspaceSession> {
+    const event = await this.sendEvent({
+      type: 'network.channel.create',
+      source: 'human:user',
+      target: 'core',
+      payload: {
+        ...(opts.title && { title: opts.title }),
+        ...(opts.master && { master: opts.master }),
+        ...(opts.participants && { participants: opts.participants }),
+        ...(opts.resumeFrom && { resume_from: opts.resumeFrom }),
+      },
+    });
+
+    // Build a WorkspaceSession from the event response
+    const channelName = (event.metadata?.channel_name as string) || '';
+    return {
+      sessionId: channelName,
+      workspaceId: this.workspaceId,
+      createdBy: 'human:user',
+      title: opts.title || 'New Thread',
+      status: 'active',
+      starred: false,
+      participants: opts.participants || [],
+      master: opts.master || null,
+      createdAt: new Date(event.timestamp).toISOString(),
+      lastEventAt: null,
+    };
+  }
+
+  /** Add an agent to an existing channel. */
+  async addChannelParticipant(channelName: string, agentName: string): Promise<void> {
+    await this.sendEvent({
+      type: 'network.channel.join',
+      source: 'human:user',
+      target: `channel/${channelName}`,
+      payload: { channel: channelName, agent_name: agentName },
+    });
+  }
+
+  /** Remove an agent from an existing channel. */
+  async removeChannelParticipant(channelName: string, agentName: string): Promise<void> {
+    await this.sendEvent({
+      type: 'network.channel.leave',
+      source: 'human:user',
+      target: `channel/${channelName}`,
+      payload: { channel: channelName, agent_name: agentName },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Messages — via ONM events
+  // ---------------------------------------------------------------------------
+
+  /** Send a chat message by emitting a workspace.message.posted event. */
+  async sendMessage(
+    channelName: string,
+    content: string,
+    senderName = 'user',
+    mentions?: string[],
+    attachments?: { fileId: string; filename: string; contentType: string; url: string }[],
+  ): Promise<ONMEvent> {
+    return this.sendEvent({
+      type: 'workspace.message.posted',
+      source: `human:${senderName}`,
+      target: `channel/${channelName}`,
+      payload: {
+        content,
+        sender_type: 'human',
+        ...(mentions && mentions.length > 0 ? { mentions } : {}),
+        ...(attachments && attachments.length > 0 ? { attachments } : {}),
+      },
+      visibility: 'channel',
+    });
+  }
+
+  /**
+   * Poll messages for a channel (session) via the event API.
+   * Returns WorkspaceMessage[] for component compatibility.
+   */
+  async pollMessages(channelName: string, after?: string): Promise<MessagePollResponse> {
+    const result = await this.pollEvents({
+      channel: channelName,
+      type: 'workspace.message',
+      after,
+      limit: 200,
+    });
+
+    return {
+      messages: result.events.map(eventToMessage),
+      hasMore: result.has_more,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Agent control — mode changes etc.
+  // ---------------------------------------------------------------------------
+
+  /** Send a control event to an agent (e.g. mode change). */
+  async sendAgentControl(
+    agentName: string,
+    action: string,
+    params: Record<string, unknown> = {},
+  ): Promise<ONMEvent> {
+    return this.sendEvent({
+      type: 'workspace.agent.control',
+      source: 'human:user',
+      target: `openagents:${agentName}`,
+      payload: { action, ...params },
+      visibility: 'direct',
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Files
+  // ---------------------------------------------------------------------------
+
+  /** Upload a file to workspace shared storage. */
+  async uploadFile(file: File, channelName?: string): Promise<WorkspaceFile> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('network', this.workspaceId);
+    if (channelName) formData.append('channel_name', channelName);
+
+    const authHeaders: Record<string, string> = {};
+    if (this.token) authHeaders['X-Workspace-Token'] = this.token;
+    if (this.bearerToken) authHeaders['Authorization'] = `Bearer ${this.bearerToken}`;
+
+    const url = `${API_URL}/v1/files`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: authHeaders,
+      body: formData,
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Upload failed: ${body}`);
+    }
+
+    const json = await res.json();
+    return mapFileResponse(json.data);
+  }
+
+  /** List files in the workspace. */
+  async listFiles(): Promise<{ files: WorkspaceFile[]; total: number }> {
+    const raw = await this.request<{ files: Record<string, unknown>[]; total: number }>(
+      `/v1/files?network=${this.workspaceId}`
+    );
+    return {
+      files: raw.files.map(mapFileResponse),
+      total: raw.total,
+    };
+  }
+
+  /** Get the download URL for a file. */
+  getFileUrl(fileId: string): string {
+    const params = new URLSearchParams();
+    if (this.token) params.set('token', this.token);
+    const qs = params.toString();
+    return `${API_URL}/v1/files/${fileId}${qs ? `?${qs}` : ''}`;
+  }
+
+  /** Delete a file. */
+  async deleteFile(fileId: string): Promise<void> {
+    await this.request<unknown>(`/v1/files/${fileId}`, { method: 'DELETE' });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Browser
+  // ---------------------------------------------------------------------------
+
+  /** Map raw backend tab object to BrowserTab. */
+  private mapTab(t: Record<string, unknown>): BrowserTab {
+    return {
+      id: t.id as string,
+      url: t.url as string,
+      title: (t.title as string) || null,
+      status: t.status as string,
+      createdBy: (t.created_by as string) || 'unknown',
+      sharedWith: (t.shared_with as string[]) || [],
+      liveUrl: (t.live_url as string) || null,
+      sessionId: (t.session_id as string) || null,
+      contextId: (t.context_id as string) || null,
+      createdAt: (t.created_at as string) || null,
+      lastActiveAt: (t.last_active_at as string) || null,
+    };
+  }
+
+  /** Map raw backend context object to BrowserPersistentContext. */
+  private mapContext(c: Record<string, unknown>): BrowserPersistentContext {
+    return {
+      id: c.id as string,
+      name: c.name as string,
+      domain: (c.domain as string) || null,
+      status: (c.status as string) || 'active',
+      createdBy: (c.created_by as string) || 'unknown',
+      sharedWith: (c.shared_with as string[]) || [],
+      createdAt: (c.created_at as string) || null,
+      lastUsedAt: (c.last_used_at as string) || null,
+    };
+  }
+
+  /** List active browser tabs. */
+  async listBrowserTabs(): Promise<{ tabs: BrowserTab[]; total: number }> {
+    const result = await this.request<{ tabs: unknown[]; total: number }>(
+      `/v1/browser/tabs?network=${this.workspaceId}`
+    );
+    return {
+      tabs: (result.tabs as Record<string, unknown>[]).map((t) => this.mapTab(t)),
+      total: result.total,
+    };
+  }
+
+  /** Open a new browser tab. Optionally open with a persistent context (already logged in). */
+  async openBrowserTab(url = 'about:blank', contextId?: string): Promise<BrowserTab> {
+    const body: Record<string, unknown> = { url, network: this.workspaceId, source: 'human:user' };
+    if (contextId) body.context_id = contextId;
+    const result = await this.request<Record<string, unknown>>('/v1/browser/tabs', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    return this.mapTab(result);
+  }
+
+  /** Validate a browser tab session — auto-reconnects if expired. */
+  async validateBrowserTab(tabId: string): Promise<BrowserTab> {
+    const result = await this.request<Record<string, unknown>>(
+      `/v1/browser/tabs/${tabId}?validate=true`,
+    );
+    return this.mapTab(result);
+  }
+
+  /** Reconnect an expired browser tab (creates a new session). */
+  async reconnectBrowserTab(tabId: string): Promise<BrowserTab> {
+    const result = await this.request<Record<string, unknown>>(
+      `/v1/browser/tabs/${tabId}/reconnect`,
+      { method: 'POST' },
+    );
+    return this.mapTab(result);
+  }
+
+  /** Navigate a browser tab to a new URL. */
+  async navigateBrowserTab(tabId: string, url: string): Promise<BrowserTab> {
+    const result = await this.request<Record<string, unknown>>(
+      `/v1/browser/tabs/${tabId}/navigate`,
+      { method: 'POST', body: JSON.stringify({ url }) },
+    );
+    return this.mapTab(result);
+  }
+
+  /** Close a browser tab. */
+  async closeBrowserTab(tabId: string): Promise<void> {
+    await this.request<unknown>(`/v1/browser/tabs/${tabId}`, { method: 'DELETE' });
+  }
+
+  /** Get screenshot URL for a browser tab. */
+  getBrowserScreenshotUrl(tabId: string): string {
+    return `${API_URL}/v1/browser/tabs/${tabId}/screenshot`;
+  }
+
+  /** Remove persistent state from a browser tab (revert to temporal). */
+  async unpersistBrowserTab(tabId: string): Promise<BrowserTab> {
+    const result = await this.request<Record<string, unknown>>(
+      `/v1/browser/tabs/${tabId}/unpersist`,
+      { method: 'POST' },
+    );
+    return this.mapTab(result);
+  }
+
+  /** Mark a browser tab as persistent (saves cookies/storage for reuse). */
+  async persistBrowserTab(tabId: string, name: string): Promise<{ tab: BrowserTab; context: BrowserPersistentContext }> {
+    const result = await this.request<{ tab: Record<string, unknown>; context: Record<string, unknown> }>(
+      `/v1/browser/tabs/${tabId}/persist`,
+      { method: 'POST', body: JSON.stringify({ name }) },
+    );
+    return { tab: this.mapTab(result.tab), context: this.mapContext(result.context) };
+  }
+
+  /** List persistent browser contexts (saved sessions). */
+  async listBrowserContexts(): Promise<{ contexts: BrowserPersistentContext[]; total: number }> {
+    const result = await this.request<{ contexts: unknown[]; total: number }>(
+      `/v1/browser/contexts?network=${this.workspaceId}`,
+    );
+    return {
+      contexts: (result.contexts as Record<string, unknown>[]).map((c) => this.mapContext(c)),
+      total: result.total,
+    };
+  }
+
+  /** Delete a persistent browser context (removes saved cookies/storage permanently). */
+  async deleteBrowserContext(contextId: string): Promise<void> {
+    await this.request<unknown>(`/v1/browser/contexts/${contextId}`, { method: 'DELETE' });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Agent management (stubs — not yet event-native)
+  // ---------------------------------------------------------------------------
+
+  async listAgents(): Promise<WorkspaceAgent[]> {
+    const discovery = await this.discover();
+    return discovery.agents.map((a) => ({
+      agentName: a.address.replace(/^openagents:/, ''),
+      role: a.role,
+      agentType: a.agent_type || null,
+      serverHost: a.server_host || null,
+      workingDir: a.working_dir || null,
+      description: a.description || null,
+      status: a.status,
+      lastHeartbeatAt: null,
+      joinedAt: null,
+    }));
+  }
+
+  /** Fetch the catalog of supported agent client types. */
+  async getAgentCatalog(): Promise<AgentCatalogEntry[]> {
+    return this.request<AgentCatalogEntry[]>('/v1/agent-catalog');
+  }
+
+  async updateAgentRole(_agentName: string, _role: string): Promise<WorkspaceAgent> {
+    throw new Error('Agent role management is not yet available in event-native mode');
+  }
+
+  async removeAgent(agentName: string): Promise<void> {
+    await this.request<unknown>('/v1/remove', {
+      method: 'POST',
+      body: JSON.stringify({ agent_name: agentName, network: this.workspaceId }),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Invitations (stubs — not yet event-native)
+  // ---------------------------------------------------------------------------
+
+  async createInvitation(_targetAgentName: string, _expiresInHours = 168): Promise<WorkspaceInvitation> {
+    throw new Error('Invitations are not yet available in event-native mode');
+  }
+
+  async listInvitations(_status?: string): Promise<WorkspaceInvitation[]> {
+    return []; // Return empty list — invitations not yet migrated
+  }
+
+  // ---------------------------------------------------------------------------
+  // Collaborators (email-based sharing)
+  // ---------------------------------------------------------------------------
+
+  /** List email-based collaborators for this workspace. */
+  async listCollaborators(): Promise<{ collaborators: WorkspaceCollaborator[]; owner: string | null }> {
+    return this.request<{ collaborators: WorkspaceCollaborator[]; owner: string | null }>(
+      `/v1/workspaces/${this.workspaceId}/collaborators`
+    );
+  }
+
+  /** Add an email-based collaborator. */
+  async addCollaborator(email: string, role: string = 'editor'): Promise<WorkspaceCollaborator> {
+    return this.request<WorkspaceCollaborator>(`/v1/workspaces/${this.workspaceId}/collaborators`, {
+      method: 'POST',
+      body: JSON.stringify({ email, role }),
+    });
+  }
+
+  /** Remove an email-based collaborator. */
+  async removeCollaborator(email: string): Promise<void> {
+    await this.request<unknown>(`/v1/workspaces/${this.workspaceId}/collaborators/${encodeURIComponent(email)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Low-level ONM event API
+  // ---------------------------------------------------------------------------
+
+  /** Send an event through the mod pipeline. */
+  async sendEvent(event: {
+    type: string;
+    source: string;
+    target: string;
+    payload?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    visibility?: string;
+  }): Promise<ONMEvent> {
+    return this.request<ONMEvent>('/v1/events', {
+      method: 'POST',
+      body: JSON.stringify({ ...event, network: this.workspaceId }),
+    });
+  }
+
+  /**
+   * Post the result of a user interaction with an A2UI-rendered component
+   * back upstream. Mirrors the Swift app's `WorkspaceAPI.sendToolResult`.
+   * The agent runtime interprets `workspace.tool_result` as the response
+   * to the originating `render_ui` invocation.
+   */
+  async sendToolResult(opts: {
+    channel: string;
+    actionId: string;
+    toolCallId?: string | null;
+    value?: unknown;
+  }): Promise<ONMEvent> {
+    const payload: Record<string, unknown> = { action_id: opts.actionId };
+    if (opts.toolCallId) payload.tool_call_id = opts.toolCallId;
+    if (opts.value !== undefined) payload.value = opts.value;
+    return this.sendEvent({
+      type: 'workspace.tool_result',
+      source: 'human:user',
+      target: `channel/${opts.channel}`,
+      payload,
+      visibility: 'direct',
+    });
+  }
+
+  /** Poll events from the network. */
+  async pollEvents(opts: {
+    after?: string;
+    before?: string;
+    target?: string;
+    channel?: string;
+    type?: string;
+    search?: string;
+    sort?: 'asc' | 'desc';
+    limit?: number;
+  } = {}): Promise<EventPollResponse> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    if (opts.after) params.set('after', opts.after);
+    if (opts.before) params.set('before', opts.before);
+    if (opts.target) params.set('target', opts.target);
+    if (opts.channel) params.set('channel', opts.channel);
+    if (opts.type) params.set('type', opts.type);
+    if (opts.search) params.set('search', opts.search);
+    if (opts.sort) params.set('sort', opts.sort);
+    if (opts.limit) params.set('limit', String(opts.limit));
+    return this.request<EventPollResponse>(`/v1/events?${params}`);
+  }
+
+  /**
+   * Load message history for a channel (most recent first).
+   * Used for initial load and infinite scroll (loading older messages).
+   */
+  async loadMessageHistory(
+    channelName: string,
+    options?: { before?: string; limit?: number },
+  ): Promise<EventPollResponse> {
+    return this.pollEvents({
+      channel: channelName,
+      type: 'workspace.message',
+      before: options?.before,
+      sort: 'desc',
+      limit: options?.limit ?? 50,
+    });
+  }
+
+  /** Search messages across all channels. Returns events grouped by channel. */
+  async searchMessages(query: string): Promise<{ channelName: string; snippet: string; messageId: string }[]> {
+    const result = await this.pollEvents({
+      type: 'workspace.message',
+      search: query,
+      limit: 50,
+    });
+    return result.events.map((e) => ({
+      channelName: e.target.replace(/^channel\//, ''),
+      snippet: (e.payload as Record<string, string>)?.content || '',
+      messageId: e.id,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Agent DM conversations
+  // ---------------------------------------------------------------------------
+
+  /** List active agent-to-agent DM conversations. */
+  async listConversations(agentFilter?: string): Promise<DMConversation[]> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    if (agentFilter) params.set('agent', agentFilter);
+    const result = await this.request<{ conversations: Array<{
+      agents: [string, string];
+      last_message: { content: string; sender: string; timestamp: number };
+      message_count: number;
+    }> }>(`/v1/events/conversations?${params}`);
+    return result.conversations.map((c) => ({
+      agents: c.agents,
+      lastMessage: c.last_message,
+      messageCount: c.message_count,
+    }));
+  }
+
+  /** Poll messages for a DM conversation between two agents. */
+  async pollConversation(
+    agentA: string,
+    agentB: string,
+    opts?: { after?: string; before?: string; sort?: 'asc' | 'desc'; limit?: number },
+  ): Promise<EventPollResponse> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    params.set('conversation', `${agentA},${agentB}`);
+    params.set('type', 'workspace.message');
+    if (opts?.after) params.set('after', opts.after);
+    if (opts?.before) params.set('before', opts.before);
+    if (opts?.sort) params.set('sort', opts.sort);
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    return this.request<EventPollResponse>(`/v1/events?${params}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulk thread previews
+  // ---------------------------------------------------------------------------
+
+  /** Fetch the latest message event per channel in a single request. */
+  async latestPerChannel(): Promise<{ channels: Record<string, ONMEvent> }> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    return this.request<{ channels: Record<string, ONMEvent> }>(`/v1/events/latest-per-channel?${params}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Todos / Tasks
+  // ---------------------------------------------------------------------------
+
+  async listTodos(): Promise<{ todos: TodoItem[] }> {
+    const params = new URLSearchParams({ network: this.workspaceId, all: 'true' });
+    const raw = await this.request<{ todos: Record<string, unknown>[] }>(`/v1/todos?${params}`);
+    return {
+      todos: (raw.todos || []).map((t): TodoItem => ({
+        id: t.id as string,
+        content: t.content as string,
+        status: t.status as TodoItem['status'],
+        assignee: t.assignee as string,
+        createdBy: (t.created_by || '') as string,
+        channelName: (t.channel_name || '') as string,
+        threadId: (t.thread_id || null) as string | null,
+        position: (t.position || 0) as number,
+        createdAt: (t.created_at || null) as string | null,
+        updatedAt: (t.updated_at || null) as string | null,
+      })),
+    };
+  }
+
+  async listTimers(channel?: string): Promise<{ timers: TimerItem[] }> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    if (channel) params.set('channel', channel);
+    const raw = await this.request<{ timers: Record<string, unknown>[] }>(`/v1/timers?${params}`);
+    return {
+      timers: (raw.timers || []).map((t): TimerItem => ({
+        id: t.id as string,
+        message: t.message as string,
+        delaySeconds: (t.delay_seconds || 0) as number,
+        firesAt: (t.fires_at || '') as string,
+        status: (t.status || 'active') as string,
+        createdBy: (t.created_by || '') as string,
+        channelName: (t.channel_name || '') as string,
+        createdAt: (t.created_at || null) as string | null,
+      })),
+    };
+  }
+
+  async cancelTimer(timerId: string): Promise<void> {
+    await this.request<unknown>(`/v1/timers/${timerId}`, { method: 'DELETE' });
+  }
+
+  async cancelQueuedMessage(channelName: string, queueId: string): Promise<void> {
+    await this.sendEvent({
+      type: 'workspace.message.posted',
+      source: 'human:user',
+      target: `channel/${channelName}`,
+      payload: {
+        content: `__queue_cancel:${queueId}`,
+        message_type: 'queue_cancel',
+      },
+    });
+  }
+
+  async listRoutines(): Promise<{ routines: import('./types').RoutineItem[] }> {
+    const params = new URLSearchParams({ network: this.workspaceId });
+    const raw = await this.request<{ routines: Record<string, unknown>[] }>(`/v1/routines?${params}`);
+    return {
+      routines: (raw.routines || []).map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        message: r.message as string,
+        scheduleHour: (r.schedule_hour || 0) as number,
+        scheduleMinute: (r.schedule_minute || 0) as number,
+        scheduleDays: (r.schedule_days || null) as number[] | null,
+        timezone: (r.timezone || 'UTC') as string,
+        nextFiresAt: (r.next_fires_at || '') as string,
+        lastFiredAt: (r.last_fired_at || null) as string | null,
+        status: (r.status || 'active') as string,
+        createdBy: (r.created_by || '') as string,
+        channelName: (r.channel_name || '') as string,
+        createdAt: (r.created_at || null) as string | null,
+      })),
+    };
+  }
+
+  async cancelRoutine(routineId: string): Promise<void> {
+    await this.request<unknown>(`/v1/routines/${routineId}`, { method: 'DELETE' });
+  }
+
+  async cancelChannelTodos(channel: string, source: string): Promise<void> {
+    const params = new URLSearchParams({ network: this.workspaceId, channel, source });
+    const raw = await this.request<{ todos: Record<string, unknown>[] }>(`/v1/todos?${params}`);
+    const todos = raw.todos || [];
+    const hasActive = todos.some((t) => t.status === 'pending' || t.status === 'in_progress');
+    if (!hasActive) return;
+    const updated = todos.map((t) => ({
+      content: t.content as string,
+      status: (t.status === 'pending' || t.status === 'in_progress') ? 'cancelled' : t.status as string,
+      assignee: t.assignee as string,
+    }));
+    await this.request<unknown>('/v1/todos', {
+      method: 'PUT',
+      body: JSON.stringify({
+        todos: updated,
+        network: this.workspaceId,
+        channel,
+        source,
+      }),
+    });
+  }
+}
+
+export const workspaceApi = new WorkspaceApi();

--- a/packages/go/web/lib/auth-context.tsx
+++ b/packages/go/web/lib/auth-context.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { getStoredAuth, clearAuth, login as doLogin } from './auth';
+
+interface AuthContextValue {
+  user: { email: string; displayName: string } | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<{ email: string; displayName: string } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const stored = getStoredAuth();
+    if (stored.accessToken && stored.userEmail) {
+      setUser({ email: stored.userEmail, displayName: stored.displayName || stored.userEmail });
+    }
+    setLoading(false);
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const auth = await doLogin(email, password);
+    if (auth.userEmail) {
+      setUser({ email: auth.userEmail, displayName: auth.displayName || auth.userEmail });
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    clearAuth();
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/packages/go/web/lib/auth.ts
+++ b/packages/go/web/lib/auth.ts
@@ -1,0 +1,74 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+
+const STORAGE_KEYS = {
+  accessToken: 'oa_access_token',
+  refreshToken: 'oa_refresh_token',
+  userEmail: 'oa_user_email',
+  displayName: 'oa_display_name',
+} as const;
+
+export interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  userEmail: string | null;
+  displayName: string | null;
+}
+
+export function getStoredAuth(): AuthState {
+  if (typeof window === 'undefined') {
+    return { accessToken: null, refreshToken: null, userEmail: null, displayName: null };
+  }
+  return {
+    accessToken: localStorage.getItem(STORAGE_KEYS.accessToken),
+    refreshToken: localStorage.getItem(STORAGE_KEYS.refreshToken),
+    userEmail: localStorage.getItem(STORAGE_KEYS.userEmail),
+    displayName: localStorage.getItem(STORAGE_KEYS.displayName),
+  };
+}
+
+export function storeAuth(data: {
+  access_token: string;
+  refresh_token: string;
+  user: { email: string; display_name: string };
+}) {
+  localStorage.setItem(STORAGE_KEYS.accessToken, data.access_token);
+  localStorage.setItem(STORAGE_KEYS.refreshToken, data.refresh_token);
+  localStorage.setItem(STORAGE_KEYS.userEmail, data.user.email);
+  localStorage.setItem(STORAGE_KEYS.displayName, data.user.display_name);
+}
+
+export function clearAuth() {
+  Object.values(STORAGE_KEYS).forEach((k) => localStorage.removeItem(k));
+}
+
+export async function login(email: string, password: string): Promise<AuthState> {
+  const res = await fetch(`${API_URL}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message || body?.detail || `Login failed (${res.status})`);
+  }
+  const json = await res.json();
+  storeAuth(json.data);
+  return getStoredAuth();
+}
+
+export async function refreshAccessToken(): Promise<string | null> {
+  const { refreshToken } = getStoredAuth();
+  if (!refreshToken) return null;
+  const res = await fetch(`${API_URL}/v1/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  });
+  if (!res.ok) {
+    clearAuth();
+    return null;
+  }
+  const json = await res.json();
+  localStorage.setItem(STORAGE_KEYS.accessToken, json.data.access_token);
+  return json.data.access_token;
+}

--- a/packages/go/web/lib/dashboard-api.ts
+++ b/packages/go/web/lib/dashboard-api.ts
@@ -1,0 +1,82 @@
+import { getStoredAuth, refreshAccessToken } from './auth';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://workspace-endpoint.openagents.org';
+
+export interface WorkspaceSummary {
+  workspaceId: string;
+  slug: string;
+  name: string;
+  status: string;
+  token: string;
+  agentCount: number;
+  createdAt: string | null;
+  lastActivityAt: string | null;
+}
+
+export interface PaginatedWorkspaces {
+  items: WorkspaceSummary[];
+  pagination: {
+    page: number;
+    page_size: number;
+    total: number | null;
+    total_pages: number | null;
+    has_next: boolean;
+    has_prev: boolean;
+  };
+}
+
+async function authFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const { accessToken } = getStoredAuth();
+
+  const doFetch = async (token: string) =>
+    fetch(`${API_URL}${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        ...options.headers,
+      },
+    });
+
+  let res = await doFetch(accessToken!);
+
+  if (res.status === 401) {
+    const newToken = await refreshAccessToken();
+    if (!newToken) throw new Error('Session expired');
+    res = await doFetch(newToken);
+  }
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new Error(body?.message || body?.detail || `API error (${res.status})`);
+  }
+
+  const json = await res.json();
+  return json.data;
+}
+
+export async function listMyWorkspaces(
+  page = 1,
+  pageSize = 50,
+  status?: string,
+): Promise<PaginatedWorkspaces> {
+  let url = `/v1/ws?page=${page}&page_size=${pageSize}`;
+  if (status) url += `&status=${status}`;
+  return authFetch<PaginatedWorkspaces>(url);
+}
+
+export async function createWorkspace(
+  agentName: string,
+  name?: string,
+): Promise<{
+  workspaceId: string;
+  slug: string;
+  name: string;
+  token: string;
+  url: string;
+}> {
+  return authFetch('/v1/ws', {
+    method: 'POST',
+    body: JSON.stringify({ agent_name: agentName, name: name || undefined }),
+  });
+}

--- a/packages/go/web/lib/firebase.ts
+++ b/packages/go/web/lib/firebase.ts
@@ -1,0 +1,46 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+  type User,
+} from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyCXgN-7HfgAQiN0pRKqGi8jMbGGo9e9X34',
+  authDomain: 'openagentsweb.firebaseapp.com',
+  projectId: 'openagentsweb',
+  storageBucket: 'openagentsweb.firebasestorage.app',
+  messagingSenderId: '796726902048',
+  appId: '1:796726902048:web:5b9079c5b2c3061edc2b45',
+  measurementId: 'G-1QYBRXC8RK',
+};
+
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+const auth = getAuth(app);
+
+const googleProvider = new GoogleAuthProvider();
+googleProvider.setCustomParameters({ prompt: 'select_account' });
+
+export async function signInWithGoogle() {
+  const result = await signInWithPopup(auth, googleProvider);
+  return result.user;
+}
+
+export async function signOutUser() {
+  await signOut(auth);
+}
+
+export function onAuthChange(callback: (user: User | null) => void) {
+  return onAuthStateChanged(auth, callback);
+}
+
+export async function getIdToken(): Promise<string | null> {
+  const user = auth.currentUser;
+  if (!user) return null;
+  return user.getIdToken(true);
+}
+
+export { auth };

--- a/packages/go/web/lib/helpers.ts
+++ b/packages/go/web/lib/helpers.ts
@@ -1,0 +1,80 @@
+export function uid(): string {
+  return (Date.now() + Math.floor(Math.random() * 1000)).toString();
+}
+
+export function getInitials(
+  name: string | null | undefined,
+  count?: number,
+): string {
+  if (!name || typeof name !== 'string') {
+    return '';
+  }
+
+  const initials = name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase());
+
+  return count && count > 0
+    ? initials.slice(0, count).join('')
+    : initials.join('');
+}
+
+export function timeAgo(date: Date | string): string {
+  const now = new Date();
+  const inputDate = typeof date === 'string' ? new Date(date) : date;
+  const diff = Math.floor((now.getTime() - inputDate.getTime()) / 1000);
+
+  if (diff < 60) return 'just now';
+  if (diff < 3600)
+    return `${Math.floor(diff / 60)} minute${Math.floor(diff / 60) > 1 ? 's' : ''} ago`;
+  if (diff < 86400)
+    return `${Math.floor(diff / 3600)} hour${Math.floor(diff / 3600) > 1 ? 's' : ''} ago`;
+  if (diff < 604800)
+    return `${Math.floor(diff / 86400)} day${Math.floor(diff / 86400) > 1 ? 's' : ''} ago`;
+  if (diff < 2592000)
+    return `${Math.floor(diff / 604800)} week${Math.floor(diff / 604800) > 1 ? 's' : ''} ago`;
+  if (diff < 31536000)
+    return `${Math.floor(diff / 2592000)} month${Math.floor(diff / 2592000) > 1 ? 's' : ''} ago`;
+
+  return `${Math.floor(diff / 31536000)} year${Math.floor(diff / 31536000) > 1 ? 's' : ''} ago`;
+}
+
+export function formatDate(input: Date | string | number): string {
+  const date = new Date(input);
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+// ── Agent freshness ──
+
+/** Threshold in ms — offline agents older than this are hidden from sidebar. */
+const STALE_AGENT_THRESHOLD = 60 * 60 * 1000; // 1 hour
+
+/** Returns true if agent should be visible in sidebar (online or recently seen). */
+export function isRecentAgent(agent: { status: string; lastHeartbeatAt: string | null }): boolean {
+  if (agent.status === 'online') return true;
+  if (!agent.lastHeartbeatAt) return false;
+  const elapsed = Date.now() - new Date(agent.lastHeartbeatAt).getTime();
+  return elapsed < STALE_AGENT_THRESHOLD;
+}
+
+// ── Multi-agent visual differentiation ──
+
+const AGENT_COLORS = [
+  { bg: 'bg-blue-50 dark:bg-blue-950/30', text: 'text-blue-700 dark:text-blue-300', initials: 'bg-blue-500', border: 'border-blue-200 dark:border-blue-800' },
+  { bg: 'bg-purple-50 dark:bg-purple-950/30', text: 'text-purple-700 dark:text-purple-300', initials: 'bg-purple-500', border: 'border-purple-200 dark:border-purple-800' },
+  { bg: 'bg-emerald-50 dark:bg-emerald-950/30', text: 'text-emerald-700 dark:text-emerald-300', initials: 'bg-emerald-500', border: 'border-emerald-200 dark:border-emerald-800' },
+  { bg: 'bg-amber-50 dark:bg-amber-950/30', text: 'text-amber-700 dark:text-amber-300', initials: 'bg-amber-500', border: 'border-amber-200 dark:border-amber-800' },
+  { bg: 'bg-rose-50 dark:bg-rose-950/30', text: 'text-rose-700 dark:text-rose-300', initials: 'bg-rose-500', border: 'border-rose-200 dark:border-rose-800' },
+];
+
+export type AgentColor = typeof AGENT_COLORS[0];
+
+export function getAgentColor(agentName: string, allAgentNames: string[]): AgentColor {
+  const index = allAgentNames.indexOf(agentName);
+  return AGENT_COLORS[(index >= 0 ? index : 0) % AGENT_COLORS.length];
+}

--- a/packages/go/web/lib/openagents-auth-context.tsx
+++ b/packages/go/web/lib/openagents-auth-context.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+interface OpenAgentsUser {
+  email: string;
+  displayName: string;
+  photoURL: string | null;
+}
+
+interface OpenAgentsAuthContextValue {
+  user: OpenAgentsUser | null;
+  idToken: string | null;
+  loading: boolean;
+  isOpenAgentsDomain: boolean;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const OPENAGENTS_HOSTNAMES = ['workspace.openagents.org', 'localhost'];
+
+const OpenAgentsAuthContext = createContext<OpenAgentsAuthContextValue | null>(null);
+
+export function useOpenAgentsAuth() {
+  const ctx = useContext(OpenAgentsAuthContext);
+  if (!ctx) throw new Error('useOpenAgentsAuth must be used within OpenAgentsAuthProvider');
+  return ctx;
+}
+
+export function OpenAgentsAuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<OpenAgentsUser | null>(null);
+  const [idToken, setIdToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isOpenAgentsDomain, setIsOpenAgentsDomain] = useState(false);
+
+  useEffect(() => {
+    const hostname = typeof window !== 'undefined' ? window.location.hostname : '';
+    const isDomain = OPENAGENTS_HOSTNAMES.includes(hostname);
+    setIsOpenAgentsDomain(isDomain);
+
+    if (!isDomain) {
+      setLoading(false);
+      return;
+    }
+
+    // Dynamically import firebase to avoid loading it on non-openagents domains
+    let unsubscribe: (() => void) | undefined;
+
+    import('./firebase').then(({ onAuthChange, getIdToken }) => {
+      unsubscribe = onAuthChange(async (firebaseUser) => {
+        if (firebaseUser) {
+          const token = await getIdToken();
+          setUser({
+            email: firebaseUser.email || '',
+            displayName: firebaseUser.displayName || firebaseUser.email || '',
+            photoURL: firebaseUser.photoURL,
+          });
+          setIdToken(token);
+        } else {
+          setUser(null);
+          setIdToken(null);
+        }
+        setLoading(false);
+      });
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
+
+  const signIn = useCallback(async () => {
+    const { signInWithGoogle, getIdToken } = await import('./firebase');
+    const firebaseUser = await signInWithGoogle();
+    const token = await getIdToken();
+    setUser({
+      email: firebaseUser.email || '',
+      displayName: firebaseUser.displayName || firebaseUser.email || '',
+      photoURL: firebaseUser.photoURL,
+    });
+    setIdToken(token);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const { signOutUser } = await import('./firebase');
+    await signOutUser();
+    setUser(null);
+    setIdToken(null);
+  }, []);
+
+  return (
+    <OpenAgentsAuthContext.Provider value={{ user, idToken, loading, isOpenAgentsDomain, signIn, signOut }}>
+      {children}
+    </OpenAgentsAuthContext.Provider>
+  );
+}

--- a/packages/go/web/lib/types.ts
+++ b/packages/go/web/lib/types.ts
@@ -1,0 +1,358 @@
+export interface Workspace {
+  workspaceId: string;
+  slug: string;
+  name: string;
+  creatorEmail: string | null;
+  settings: Record<string, unknown>;
+  /**
+   * Workspace-scoped toggle for the Browser Fabric viewer in clients.
+   * Backed by `settings.browser_enabled` but surfaced as a typed
+   * top-level field for ergonomics. Older backends omit it — default to
+   * false when reading.
+   */
+  browserEnabled?: boolean;
+  status: string;
+  createdAt: string | null;
+  lastActivityAt: string | null;
+  agents: WorkspaceAgent[];
+}
+
+export interface WorkspaceAgent {
+  agentName: string;
+  role: string;
+  agentType: string | null;
+  serverHost: string | null;
+  workingDir: string | null;
+  description: string | null;
+  status: string;
+  lastHeartbeatAt: string | null;
+  joinedAt: string | null;
+}
+
+export interface WorkspaceSession {
+  sessionId: string;
+  workspaceId: string;
+  createdBy: string | null;
+  title: string;
+  status: string;
+  starred: boolean;
+  participants: string[];
+  master: string | null;
+  createdAt: string | null;
+  lastEventAt: number | null; // unix ms timestamp of last message
+}
+
+export interface WorkspaceMessage {
+  messageId: string;
+  sessionId: string;
+  senderType: string;
+  senderName: string;
+  content: string;
+  mentions: string[];
+  targetAgents: string[] | null;
+  messageType: string;
+  metadata: Record<string, unknown>;
+  createdAt: string | null;
+  /**
+   * Optional A2UI spec emitted by the agent — a JSON tree of
+   * `{ type, props, children?, action? }` nodes. When present, the chat
+   * bubble renders it inline below the markdown content (mirrors the
+   * Swift `A2UIRendererView` placement). Lives on `payload.spec` in the
+   * source ONM event.
+   */
+  spec?: Record<string, unknown> | null;
+  /**
+   * Tool-call id correlating an A2UI spec back to the originating
+   * `render_ui` invocation. Sent back upstream as part of the
+   * workspace.tool_result event when the user interacts with the spec.
+   * Lives on `payload.spec_tool_call_id` in the source event.
+   */
+  specToolCallId?: string | null;
+}
+
+export interface WorkspaceCollaborator {
+  email: string;
+  role: 'editor' | 'viewer';
+  addedBy: string | null;
+  addedAt: string | null;
+}
+
+export interface WorkspaceInvitation {
+  invitationId: string;
+  workspaceId: string;
+  targetAgentName: string;
+  inviteToken: string;
+  workspaceName?: string;
+  status: 'pending' | 'accepted' | 'rejected' | 'expired';
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface WorkspaceFile {
+  id: string;
+  filename: string;
+  contentType: string;
+  size: number;
+  uploadedBy: string;
+  channelName: string | null;
+  status: string;
+  createdAt: string | null;
+}
+
+export interface BrowserTab {
+  id: string;
+  url: string;
+  title: string | null;
+  status: string;
+  createdBy: string;
+  sharedWith: string[];
+  liveUrl: string | null;
+  sessionId: string | null;
+  contextId: string | null;
+  createdAt: string | null;
+  lastActiveAt: string | null;
+}
+
+export interface BrowserPersistentContext {
+  id: string;
+  name: string;
+  domain: string | null;
+  status: string;
+  createdBy: string;
+  sharedWith: string[];
+  createdAt: string | null;
+  lastUsedAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Todos / Tasks (agent planning)
+// ---------------------------------------------------------------------------
+
+export interface TodoItem {
+  id: string;
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+  assignee: string;
+  createdBy: string;
+  channelName: string;
+  threadId: string | null;
+  position: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface TimerItem {
+  id: string;
+  message: string;
+  delaySeconds: number;
+  firesAt: string;
+  status: string;
+  createdBy: string;
+  channelName: string;
+  createdAt: string | null;
+}
+
+export interface RoutineItem {
+  id: string;
+  name: string;
+  message: string;
+  scheduleHour: number;
+  scheduleMinute: number;
+  scheduleDays: number[] | null;
+  timezone: string;
+  nextFiresAt: string;
+  lastFiredAt: string | null;
+  status: string;
+  createdBy: string;
+  channelName: string;
+  createdAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Agent catalog (supported client types)
+// ---------------------------------------------------------------------------
+
+export interface AgentCatalogEntry {
+  name: string;
+  label: string;
+  description: string;
+  install_command: string;
+  homepage: string;
+  tags: string[];
+  builtin: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// ONM Event types (event-native API)
+// ---------------------------------------------------------------------------
+
+export interface ONMEvent {
+  id: string;
+  type: string;
+  source: string;
+  target: string;
+  payload: Record<string, unknown> | null;
+  metadata: Record<string, unknown>;
+  timestamp: number;
+  visibility: string;
+}
+
+export interface EventPollResponse {
+  events: ONMEvent[];
+  has_more: boolean;
+  oldest_id: string | null;
+  newest_id: string | null;
+}
+
+export interface NetworkAgent {
+  address: string;
+  role: string;
+  status: string;
+  agent_type: string | null;
+  server_host: string | null;
+  working_dir: string | null;
+  description: string | null;
+  last_heartbeat_at: string | null;
+  joined_at: string | null;
+}
+
+export interface NetworkChannel {
+  address: string;
+  title: string | null;
+  master: string | null;
+  participants: string[];
+  created_at: number | null;
+  last_event_at: number | null;
+  status: string;
+  starred: boolean;
+}
+
+export interface NetworkDiscovery {
+  agents: NetworkAgent[];
+  channels: NetworkChannel[];
+  mods: string[];
+  resources: string[];
+}
+
+export interface NetworkProfile {
+  id: string;
+  slug: string;
+  name: string;
+  access: { policy: string; min_verification: number };
+  status: string;
+  capabilities: string[];
+  agents_online: number;
+}
+
+// ---------------------------------------------------------------------------
+// API response wrappers
+// ---------------------------------------------------------------------------
+
+export interface ApiResponse<T> {
+  code: number;
+  message: string;
+  data: T;
+}
+
+export interface PaginationMeta {
+  page: number;
+  page_size: number;
+  total: number | null;
+  total_pages: number | null;
+  has_next: boolean;
+  has_prev: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  pagination: PaginationMeta;
+}
+
+export interface MessagePollResponse {
+  messages: WorkspaceMessage[];
+  hasMore: boolean;
+}
+
+export interface DMConversation {
+  agents: [string, string];
+  lastMessage: { content: string; sender: string; timestamp: number };
+  messageCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Converters — map ONM types to component-friendly types
+// ---------------------------------------------------------------------------
+
+/** Convert an ONM event to a WorkspaceMessage for the chat UI. */
+export function eventToMessage(event: ONMEvent): WorkspaceMessage {
+  const isHuman = event.source.startsWith('human:');
+  const senderName = event.source.replace(/^(openagents:|human:)/, '');
+  const payload = (event.payload || {}) as Record<string, unknown>;
+
+  // Pull the A2UI spec off the payload when present — agents can include
+  // an inline JSON object (preferred) or a pre-serialized string. Accept
+  // both so the backend isn't pinned to one encoding.
+  let spec: Record<string, unknown> | null = null;
+  const rawSpec = payload.spec;
+  if (rawSpec && typeof rawSpec === 'object') {
+    spec = rawSpec as Record<string, unknown>;
+  } else if (typeof rawSpec === 'string' && rawSpec.trim().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(rawSpec);
+      if (parsed && typeof parsed === 'object') spec = parsed as Record<string, unknown>;
+    } catch {
+      // Malformed spec — leave null, renderer falls back to plain content.
+    }
+  }
+
+  return {
+    messageId: event.id,
+    sessionId: event.target.replace(/^channel\//, ''),
+    senderType: isHuman ? 'human' : 'agent',
+    senderName,
+    content: (payload.content as string) || '',
+    mentions: (payload.mentions as string[]) || [],
+    targetAgents: (event.metadata?.target_agents as string[]) || null,
+    messageType: (payload.message_type as string) || 'chat',
+    metadata: {
+      ...(event.metadata || {}),
+      ...(payload.attachments ? { attachments: payload.attachments } : {}),
+      ...(payload.todos ? { todos: payload.todos } : {}),
+    },
+    createdAt: new Date(event.timestamp).toISOString(),
+    spec,
+    specToolCallId: (payload.spec_tool_call_id as string) ?? null,
+  };
+}
+
+/** Convert a NetworkAgent from discover to a WorkspaceAgent. */
+export function networkAgentToWorkspaceAgent(agent: NetworkAgent): WorkspaceAgent {
+  return {
+    agentName: agent.address.replace(/^openagents:/, ''),
+    role: agent.role,
+    agentType: agent.agent_type || null,
+    serverHost: agent.server_host || null,
+    workingDir: agent.working_dir || null,
+    description: agent.description || null,
+    status: agent.status,
+    lastHeartbeatAt: agent.last_heartbeat_at || null,
+    joinedAt: agent.joined_at || null,
+  };
+}
+
+/** Convert a NetworkChannel from discover to a WorkspaceSession for the thread UI. */
+export function networkChannelToSession(ch: NetworkChannel, workspaceId: string): WorkspaceSession {
+  const name = ch.address.replace(/^channel\//, '');
+  return {
+    sessionId: name,
+    workspaceId,
+    createdBy: null,
+    title: ch.title || name,
+    status: ch.status || 'active',
+    starred: ch.starred || false,
+    participants: ch.participants,
+    master: ch.master,
+    createdAt: ch.created_at ? new Date(ch.created_at).toISOString() : null,
+    lastEventAt: ch.last_event_at,
+  };
+}

--- a/packages/go/web/lib/utils.ts
+++ b/packages/go/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/go/web/lib/workspace-context.tsx
+++ b/packages/go/web/lib/workspace-context.tsx
@@ -1,0 +1,951 @@
+'use client';
+
+import React, { createContext, useContext, useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { workspaceApi } from './api';
+import { networkAgentToWorkspaceAgent, networkChannelToSession } from './types';
+import type { BrowserPersistentContext, BrowserTab, DMConversation, RoutineItem, TodoItem, Workspace, WorkspaceAgent, WorkspaceFile, WorkspaceSession } from './types';
+
+interface LastMessageInfo {
+  content: string;
+  senderName: string;
+  isStatus?: boolean;
+}
+
+interface WorkspaceContextValue {
+  workspace: Workspace | null;
+  token: string;
+  agents: WorkspaceAgent[];
+  sessions: WorkspaceSession[];
+  files: WorkspaceFile[];
+  selectedFileId: string | null;
+  currentFilePath: string;
+  currentSessionId: string | null;
+  loading: boolean;
+  error: string | null;
+  lastMessageBySession: Record<string, LastMessageInfo>;
+  activeSessionIds: Set<string>;
+  stoppingSessionIds: Set<string>;
+  completedSessionIds: Set<string>;
+  monitorMode: boolean;
+  acknowledgeCompletion: (sessionId: string) => void;
+  agentModes: Record<string, string>;
+  updateLastMessage: (sessionId: string, senderName: string, content: string, isStatus?: boolean) => void;
+  setSessionActive: (sessionId: string, active: boolean) => void;
+  updateAgentMode: (agentName: string, mode: string) => void;
+  toggleAgentMode: (agentName: string) => void;
+  stopAllAgents: (sessionId?: string) => Promise<void>;
+  setCurrentSessionId: (id: string | null, options?: { skipFocus?: boolean }) => void;
+  /** Read-and-clear: was the most recent setCurrentSessionId asked to skip auto-focus? */
+  consumeSkipFocus: () => boolean;
+  setSelectedFileId: (id: string | null) => void;
+  setCurrentFilePath: (path: string) => void;
+  createSession: (opts?: { title?: string; master?: string; participants?: string[]; resumeFrom?: string }) => Promise<WorkspaceSession>;
+  renameSession: (sessionId: string, title: string) => Promise<void>;
+  updateSession: (sessionId: string, updates: { starred?: boolean; status?: string }) => Promise<void>;
+  addParticipant: (sessionId: string, agentName: string) => Promise<void>;
+  removeParticipant: (sessionId: string, agentName: string) => Promise<void>;
+  renameWorkspace: (name: string) => Promise<void>;
+  /**
+   * Flip the workspace-scoped Browser Fabric viewer toggle. Optimistic
+   * local flip + debounced PATCH to /v1/workspaces/{id}; rolls back on
+   * error.
+   */
+  setBrowserEnabled: (enabled: boolean) => Promise<void>;
+  refreshWorkspace: () => Promise<void>;
+  refreshAgents: () => Promise<void>;
+  refreshFiles: () => Promise<void>;
+  uploadFile: (file: File) => Promise<WorkspaceFile>;
+  deleteFile: (fileId: string) => Promise<void>;
+  browserTabs: BrowserTab[];
+  selectedBrowserTabId: string | null;
+  setSelectedBrowserTabId: (id: string | null) => void;
+  refreshBrowserTabs: () => Promise<void>;
+  openBrowserTab: (url?: string, contextId?: string) => Promise<BrowserTab>;
+  closeBrowserTab: (tabId: string) => Promise<void>;
+  navigateBrowserTab: (tabId: string, url: string) => Promise<BrowserTab>;
+  reconnectBrowserTab: (tabId: string) => Promise<BrowserTab>;
+  browserContexts: BrowserPersistentContext[];
+  refreshBrowserContexts: () => Promise<void>;
+  persistBrowserTab: (tabId: string, name: string) => Promise<BrowserPersistentContext>;
+  unpersistBrowserTab: (tabId: string) => Promise<void>;
+  deleteBrowserContext: (contextId: string) => Promise<void>;
+  openBrowserTabWithContext: (contextId: string, url?: string) => Promise<BrowserTab>;
+  dmConversations: DMConversation[];
+  refreshDMConversations: () => Promise<void>;
+  todos: TodoItem[];
+  refreshTodos: () => Promise<void>;
+  routines: RoutineItem[];
+  refreshRoutines: () => Promise<void>;
+  notificationSound: boolean;
+  setNotificationSound: (enabled: boolean) => void;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+export function useWorkspace() {
+  const ctx = useContext(WorkspaceContext);
+  if (!ctx) throw new Error('useWorkspace must be used within WorkspaceProvider');
+  return ctx;
+}
+
+export function WorkspaceProvider({
+  workspaceId,
+  token,
+  bearerToken,
+  children,
+}: {
+  workspaceId: string;
+  token: string;
+  bearerToken?: string;
+  children: React.ReactNode;
+}) {
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [agents, setAgents] = useState<WorkspaceAgent[]>([]);
+  const [sessions, setSessions] = useState<WorkspaceSession[]>([]);
+  const [currentSessionId, _setCurrentSessionId] = useState<string | null>(null);
+  // Set by setCurrentSessionId({ skipFocus: true }) and consumed by ChatView's
+  // auto-focus effect, so keyboard-driven thread switches (1-9) don't steal
+  // focus from the user. Cleared on read.
+  const skipFocusRef = useRef(false);
+  const setCurrentSessionId = useCallback((id: string | null, options?: { skipFocus?: boolean }) => {
+    if (options?.skipFocus) skipFocusRef.current = true;
+    _setCurrentSessionId(id);
+    if (id) {
+      setCompletedSessionIds((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }, []);
+  const consumeSkipFocus = useCallback(() => {
+    const v = skipFocusRef.current;
+    skipFocusRef.current = false;
+    return v;
+  }, []);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastMessageBySession, setLastMessageBySession] = useState<Record<string, LastMessageInfo>>({});
+  const [activeSessionIds, setActiveSessionIds] = useState<Set<string>>(new Set());
+  const [stoppingSessionIds, setStoppingSessionIds] = useState<Set<string>>(new Set());
+  const stoppingSessionIdsRef = useRef(stoppingSessionIds);
+  stoppingSessionIdsRef.current = stoppingSessionIds;
+  const [completedSessionIds, setCompletedSessionIds] = useState<Set<string>>(new Set());
+  const [agentModes, setAgentModes] = useState<Record<string, string>>({});
+  const [files, setFiles] = useState<WorkspaceFile[]>([]);
+  const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
+  const [currentFilePath, setCurrentFilePath] = useState('');
+  const [browserTabs, setBrowserTabs] = useState<BrowserTab[]>([]);
+  const [selectedBrowserTabId, setSelectedBrowserTabId] = useState<string | null>(null);
+  const [browserContexts, setBrowserContexts] = useState<BrowserPersistentContext[]>([]);
+  const [dmConversations, setDMConversations] = useState<DMConversation[]>([]);
+  const [todos, setTodos] = useState<TodoItem[]>([]);
+  const [routines, setRoutines] = useState<RoutineItem[]>([]);
+  const [manuallyRenamedSessions, setManuallyRenamedSessions] = useState<Set<string>>(new Set());
+
+  // Auto-select browser tabs for split browser view:
+  // - On first load: select the most recently created agent tab (if any)
+  // - On subsequent polls: select any newly appearing tab
+  const prevTabIdsRef = useRef<Set<string>>(new Set());
+  const initialSelectDoneRef = useRef(false);
+  useEffect(() => {
+    if (browserTabs.length === 0) return;
+    const currentIds = new Set(browserTabs.map(t => t.id));
+    const prevIds = prevTabIdsRef.current;
+
+    if (!initialSelectDoneRef.current) {
+      // First load — pick the most recent agent-opened tab if nothing is selected
+      initialSelectDoneRef.current = true;
+      if (!selectedBrowserTabId) {
+        const agentTabs = browserTabs.filter(t => t.createdBy?.startsWith('openagents:'));
+        if (agentTabs.length > 0) {
+          setSelectedBrowserTabId(agentTabs[agentTabs.length - 1].id);
+        }
+      }
+    } else {
+      // Subsequent polls — auto-select any newly appearing tab
+      const newTabs = browserTabs.filter(t => !prevIds.has(t.id));
+      if (newTabs.length > 0) {
+        setSelectedBrowserTabId(newTabs[newTabs.length - 1].id);
+      }
+    }
+    prevTabIdsRef.current = currentIds;
+  }, [browserTabs]);
+
+  // Notification sound — client-side preference stored in localStorage
+  const [notificationSound, _setNotificationSound] = useState(false);
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('oa_notification_sound');
+      if (stored === 'true') _setNotificationSound(true);
+    } catch {}
+  }, []);
+  const setNotificationSound = useCallback((enabled: boolean) => {
+    _setNotificationSound(enabled);
+    try { localStorage.setItem('oa_notification_sound', String(enabled)); } catch {}
+  }, []);
+
+  const updateLastMessage = useCallback((sessionId: string, senderName: string, content: string, isStatus?: boolean) => {
+    if (!isStatus || /stopped|stopping failed/i.test(content)) {
+      setStoppingSessionIds((prev) => {
+        if (!prev.has(sessionId)) return prev;
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
+    setLastMessageBySession((prev) => {
+      if (!content && !prev[sessionId]) return prev;
+      const existing = prev[sessionId];
+      const truncated = content.slice(0, 100);
+      if (existing && existing.content === truncated && existing.senderName === senderName && existing.isStatus === isStatus) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [sessionId]: { senderName, content: truncated, isStatus },
+      };
+    });
+  }, []);
+
+  const setSessionActive = useCallback((sessionId: string, active: boolean) => {
+    setActiveSessionIds((prev) => {
+      const next = new Set(prev);
+      if (active && !stoppingSessionIdsRef.current.has(sessionId)) next.add(sessionId);
+      else next.delete(sessionId);
+      return next;
+    });
+  }, []);
+
+  const updateAgentMode = useCallback((agentName: string, mode: string) => {
+    setAgentModes((prev) => {
+      if (prev[agentName] === mode) return prev;
+      return { ...prev, [agentName]: mode };
+    });
+  }, []);
+
+  const toggleAgentMode = useCallback(async (agentName: string) => {
+    const current = agentModes[agentName] || 'execute';
+    const next = current === 'execute' ? 'plan' : 'execute';
+    // Optimistic update
+    setAgentModes((prev) => ({ ...prev, [agentName]: next }));
+    try {
+      await workspaceApi.sendAgentControl(agentName, 'set_mode', { mode: next });
+    } catch {
+      // Revert on failure
+      setAgentModes((prev) => ({ ...prev, [agentName]: current }));
+    }
+  }, [agentModes]);
+
+  const stopAllAgents = useCallback(async (targetSessionId?: string) => {
+    const sessionIds = targetSessionId
+      ? (activeSessionIds.has(targetSessionId) ? [targetSessionId] : [])
+      : Array.from(activeSessionIds);
+    if (sessionIds.length === 0) return;
+
+    setStoppingSessionIds((prev) => {
+      const next = new Set(prev);
+      sessionIds.forEach((sid) => next.add(sid));
+      return next;
+    });
+    setActiveSessionIds((prev) => {
+      const next = new Set(prev);
+      sessionIds.forEach((sid) => next.delete(sid));
+      return next;
+    });
+    setLastMessageBySession((prev) => {
+      const next = { ...prev };
+      sessionIds.forEach((sid) => {
+        next[sid] = { senderName: 'system', content: 'Stopping...', isStatus: true };
+      });
+      return next;
+    });
+
+    const targetAgents = targetSessionId
+      ? agents.filter((a) => {
+          const session = sessions.find((s) => s.sessionId === targetSessionId);
+          return session && (session.participants || []).includes(a.agentName);
+        })
+      : agents;
+
+    const sendStop = () => Promise.allSettled(
+      targetAgents.map((a) => {
+        const channel = targetSessionId || undefined;
+        return workspaceApi.sendAgentControl(a.agentName, 'stop', { channel });
+      })
+    );
+    await sendStop();
+
+    window.setTimeout(() => {
+      setStoppingSessionIds((prevStopping) => {
+        const stillStopping = sessionIds.filter((sid) => prevStopping.has(sid));
+        if (stillStopping.length > 0) void sendStop();
+        return prevStopping;
+      });
+    }, 3000);
+  }, [activeSessionIds, agents, sessions]);
+
+  // Configure API client on mount
+  useEffect(() => {
+    workspaceApi.configure(workspaceId, token, bearerToken || undefined);
+  }, [workspaceId, token, bearerToken]);
+
+  const refreshWorkspace = useCallback(async () => {
+    try {
+      const ws = await workspaceApi.getWorkspace();
+      setWorkspace(ws);
+      setAgents(ws.agents);
+      setError(null);
+      // Drop a record into local history so the workspace switcher
+      // popover can list this workspace as a recent. Mirrors Swift's
+      // `WorkspaceHistory.shared.add(...)` on connect.
+      if (typeof window !== 'undefined' && ws.slug && token) {
+        import('./workspace-history').then(({ WorkspaceHistory }) => {
+          WorkspaceHistory.record({
+            workspaceId: ws.slug,
+            workspaceToken: token,
+            name: ws.name,
+          });
+        });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load workspace');
+    }
+  }, [token]);
+
+  // Track last known event timestamps per channel for change detection
+  const lastKnownEventAtRef = React.useRef<Record<string, number | null>>({});
+  const currentSessionIdRef = React.useRef<string | null>(currentSessionId);
+  currentSessionIdRef.current = currentSessionId;
+
+  /** Refresh agents and channels from the discover endpoint. */
+  const refreshDiscovery = useCallback(async () => {
+    try {
+      const discovery = await workspaceApi.discover();
+      setAgents(discovery.agents.map(networkAgentToWorkspaceAgent));
+
+      const updated = discovery.channels.map((ch) =>
+        networkChannelToSession(ch, workspaceId)
+      );
+
+      setSessions((prev) => {
+        const existingIds = new Set(prev.map((s) => s.sessionId));
+        const newChannels = updated.filter((s) => !existingIds.has(s.sessionId));
+        // Merge: update metadata but preserve user-renamed titles
+        const updatedMap = new Map(updated.map((s) => [s.sessionId, s]));
+        const merged = prev
+          .filter((s) => {
+            // Drop sessions not in remote discovery (deleted/removed on backend)
+            if (!updatedMap.has(s.sessionId)) return false;
+            return true;
+          })
+          .map((s) => {
+            const remote = updatedMap.get(s.sessionId)!;
+            // Keep local title if user manually renamed in this browser session
+            const keepLocalTitle = manuallyRenamedSessions.has(s.sessionId);
+            return {
+              ...s,
+              title: keepLocalTitle ? s.title : remote.title,
+              participants: remote.participants,
+              master: remote.master,
+              lastEventAt: remote.lastEventAt,
+              createdAt: remote.createdAt || s.createdAt,
+              status: remote.status,
+              starred: remote.starred,
+            };
+          });
+        return [...merged, ...newChannels];
+      });
+
+      // Detect channels with new activity and fetch their latest message preview
+      const staleChannels = updated.filter((ch) => {
+        const prev = lastKnownEventAtRef.current[ch.sessionId];
+        return ch.lastEventAt && ch.lastEventAt !== prev;
+      });
+
+      // Update known timestamps for the current session (ChatView handles its preview)
+      // Other channels' timestamps are updated after successful preview fetch
+      const currentSid = currentSessionIdRef.current;
+      if (currentSid) {
+        const currentCh = updated.find((ch) => ch.sessionId === currentSid);
+        if (currentCh) lastKnownEventAtRef.current[currentSid] = currentCh.lastEventAt;
+      }
+
+      // Fetch preview for changed channels (skip current session — ChatView handles it)
+      const toFetch = staleChannels.filter((ch) => ch.sessionId !== currentSid);
+      if (toFetch.length > 0) {
+        const previews = await Promise.all(
+          toFetch.map(async (ch) => {
+            try {
+              const result = await workspaceApi.pollEvents({
+                channel: ch.sessionId,
+                type: 'workspace.message',
+                sort: 'desc',
+                limit: 10,
+              });
+              if (result.events.length === 0) return null;
+              const latest = result.events[0];
+              const latestPayload = latest.payload as Record<string, string>;
+              const latestType = latestPayload?.message_type || 'chat';
+              const isAgentWorking = latestType === 'status' || latestType === 'thinking';
+              // Find the latest chat/thinking message (not status) for preview
+              const lastChat = result.events.find((e) => {
+                const mt = (e.payload as Record<string, string>)?.message_type || 'chat';
+                return mt !== 'status' && mt !== 'thinking';
+              });
+              // If agent is actively working, show the status; otherwise show last chat
+              const pick = isAgentWorking ? latest : (lastChat || latest);
+              const payload = pick.payload as Record<string, string>;
+              const sender = pick.source.replace(/^(openagents:|human:)/, '');
+              const content = payload?.content || '';
+              const msgType = payload?.message_type || 'chat';
+              const isStatus = msgType === 'status' || msgType === 'thinking';
+              return { sessionId: ch.sessionId, senderName: sender, content, isStatus };
+            } catch { /* ignore */ }
+            return null;
+          })
+        );
+        const batch: Record<string, LastMessageInfo> = {};
+        for (let i = 0; i < previews.length; i++) {
+          const p = previews[i];
+          if (p && p.content) {
+            batch[p.sessionId] = { senderName: p.senderName, content: p.content.slice(0, 100), isStatus: p.isStatus };
+          }
+          // Mark timestamp as known only after successful fetch (so failures retry next poll)
+          if (p) {
+            const ch = toFetch[i];
+            lastKnownEventAtRef.current[ch.sessionId] = ch.lastEventAt;
+          }
+        }
+        if (Object.keys(batch).length > 0) {
+          // Update active/completed state for background threads
+          setLastMessageBySession((prev) => {
+            const newActive = new Set<string>();
+            const newCompleted = new Set<string>();
+            const newInactive = new Set<string>();
+            for (const [sid, info] of Object.entries(batch)) {
+              const wasStatus = prev[sid]?.isStatus;
+              const isStopping = stoppingSessionIds.has(sid);
+              if (info.isStatus) {
+                if (isStopping) {
+                  if (/stopped|stopping failed/i.test(info.content)) {
+                    setStoppingSessionIds((s) => {
+                      if (!s.has(sid)) return s;
+                      const next = new Set(s);
+                      next.delete(sid);
+                      return next;
+                    });
+                    newInactive.add(sid);
+                  }
+                } else {
+                  newActive.add(sid);
+                }
+              } else {
+                setStoppingSessionIds((s) => {
+                  if (!s.has(sid)) return s;
+                  const next = new Set(s);
+                  next.delete(sid);
+                  return next;
+                });
+                // Latest event is a real message — session is not working.
+                // Always clear active so the shimmer doesn't stick when the
+                // status→chat transition happens between polls or while
+                // chat-view is unmounted (homepage / monitor mode).
+                newInactive.add(sid);
+                if (wasStatus) newCompleted.add(sid);
+              }
+            }
+            if (newActive.size > 0 || newInactive.size > 0) {
+              setActiveSessionIds((s) => {
+                const next = new Set(s);
+                Array.from(newActive).forEach((sid) => next.add(sid));
+                Array.from(newInactive).forEach((sid) => next.delete(sid));
+                return next;
+              });
+            }
+            if (newCompleted.size > 0) {
+              setCompletedSessionIds((s) => {
+                const next = new Set(s);
+                Array.from(newCompleted).forEach((sid) => next.add(sid));
+                return next;
+              });
+            }
+            return { ...prev, ...batch };
+          });
+        }
+      }
+
+      // Also refresh files, browser tabs, persistent contexts, and DM conversations so sidebar counts stay current
+      workspaceApi.listFiles().then((r) => setFiles(r.files)).catch(() => {});
+      workspaceApi.listBrowserTabs().then((r) => setBrowserTabs(r.tabs)).catch(() => {});
+      workspaceApi.listBrowserContexts().then((r) => setBrowserContexts(r.contexts)).catch(() => {});
+      workspaceApi.listConversations().then((c) => setDMConversations(c)).catch(() => {});
+      workspaceApi.listTodos().then((r) => setTodos(r.todos)).catch(() => {});
+      workspaceApi.listRoutines().then((r) => setRoutines(r.routines)).catch(() => {});
+    } catch {
+      // Non-critical — keep existing state
+    }
+  }, [workspaceId, stoppingSessionIds]);
+
+  // Alias for backward compat
+  const refreshAgents = refreshDiscovery;
+
+  const refreshFiles = useCallback(async () => {
+    try {
+      const result = await workspaceApi.listFiles();
+      setFiles(result.files);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const refreshTodos = useCallback(async () => {
+    try {
+      const result = await workspaceApi.listTodos();
+      setTodos(result.todos);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const refreshRoutines = useCallback(async () => {
+    try {
+      const result = await workspaceApi.listRoutines();
+      setRoutines(result.routines);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const uploadFile = useCallback(async (file: File) => {
+    const result = await workspaceApi.uploadFile(file);
+    await refreshFiles();
+    return result;
+  }, [refreshFiles]);
+
+  const deleteFile = useCallback(async (fileId: string) => {
+    await workspaceApi.deleteFile(fileId);
+    setFiles((prev) => prev.filter((f) => f.id !== fileId));
+    if (selectedFileId === fileId) setSelectedFileId(null);
+  }, [selectedFileId]);
+
+  const refreshBrowserTabs = useCallback(async () => {
+    try {
+      const result = await workspaceApi.listBrowserTabs();
+      setBrowserTabs(result.tabs);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const openBrowserTab = useCallback(async (url = 'about:blank') => {
+    const tab = await workspaceApi.openBrowserTab(url);
+    await refreshBrowserTabs();
+    return tab;
+  }, [refreshBrowserTabs]);
+
+  const closeBrowserTab = useCallback(async (tabId: string) => {
+    await workspaceApi.closeBrowserTab(tabId);
+    setBrowserTabs((prev) => prev.filter((t) => t.id !== tabId));
+    if (selectedBrowserTabId === tabId) setSelectedBrowserTabId(null);
+  }, [selectedBrowserTabId]);
+
+  const navigateBrowserTab = useCallback(async (tabId: string, url: string) => {
+    const tab = await workspaceApi.navigateBrowserTab(tabId, url);
+    setBrowserTabs((prev) => prev.map((t) => (t.id === tabId ? tab : t)));
+    return tab;
+  }, []);
+
+  const reconnectBrowserTab = useCallback(async (tabId: string) => {
+    const tab = await workspaceApi.reconnectBrowserTab(tabId);
+    setBrowserTabs((prev) => prev.map((t) => (t.id === tabId ? tab : t)));
+    return tab;
+  }, []);
+
+  const refreshBrowserContexts = useCallback(async () => {
+    try {
+      const result = await workspaceApi.listBrowserContexts();
+      setBrowserContexts(result.contexts);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  const persistBrowserTab = useCallback(async (tabId: string, name: string) => {
+    const result = await workspaceApi.persistBrowserTab(tabId, name);
+    // Update the tab in state with the new context_id
+    setBrowserTabs((prev) => prev.map((t) => (t.id === tabId ? result.tab : t)));
+    // Add the new context to state
+    setBrowserContexts((prev) => [result.context, ...prev]);
+    return result.context;
+  }, []);
+
+  const unpersistBrowserTab = useCallback(async (tabId: string) => {
+    const updatedTab = await workspaceApi.unpersistBrowserTab(tabId);
+    setBrowserTabs((prev) => prev.map((t) => (t.id === tabId ? updatedTab : t)));
+    // Refresh contexts to remove the deleted one
+    await refreshBrowserContexts();
+  }, [refreshBrowserContexts]);
+
+  const deleteBrowserContext = useCallback(async (contextId: string) => {
+    await workspaceApi.deleteBrowserContext(contextId);
+    setBrowserContexts((prev) => prev.filter((c) => c.id !== contextId));
+    // Clear context_id from any tabs that referenced it
+    setBrowserTabs((prev) => prev.map((t) => (t.contextId === contextId ? { ...t, contextId: null } : t)));
+  }, []);
+
+  const openBrowserTabWithContext = useCallback(async (contextId: string, url = 'about:blank') => {
+    const tab = await workspaceApi.openBrowserTab(url, contextId);
+    await refreshBrowserTabs();
+    setSelectedBrowserTabId(tab.id);
+    return tab;
+  }, [refreshBrowserTabs]);
+
+  const refreshDMConversations = useCallback(async () => {
+    try {
+      const convos = await workspaceApi.listConversations();
+      setDMConversations(convos);
+    } catch {
+      // Non-critical
+    }
+  }, []);
+
+  // Initial load: workspace metadata + discover for channels
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const [ws, discovery] = await Promise.all([
+          workspaceApi.getWorkspace(),
+          workspaceApi.discover(),
+          workspaceApi.listFiles().then((r) => setFiles(r.files)).catch(() => {}),
+          workspaceApi.listBrowserTabs().then((r) => setBrowserTabs(r.tabs)).catch(() => {}),
+          workspaceApi.listBrowserContexts().then((r) => setBrowserContexts(r.contexts)).catch(() => {}),
+          workspaceApi.listTodos().then((r) => setTodos(r.todos)).catch(() => {}),
+          workspaceApi.listRoutines().then((r) => setRoutines(r.routines)).catch(() => {}),
+        ]);
+        if (cancelled) return;
+
+        setWorkspace(ws);
+        setAgents(discovery.agents.map(networkAgentToWorkspaceAgent));
+
+        const channelSessions = discovery.channels.map((ch) =>
+          networkChannelToSession(ch, workspaceId)
+        );
+        setSessions(channelSessions);
+
+        // Initialize last-known event timestamps so first discovery poll doesn't re-fetch all
+        for (const ch of channelSessions) {
+          lastKnownEventAtRef.current[ch.sessionId] = ch.lastEventAt;
+        }
+
+        // Auto-select first session
+        if (channelSessions.length > 0 && !currentSessionId) {
+          setCurrentSessionId(channelSessions[0].sessionId);
+        }
+
+        // Seed previews from localStorage for instant display
+        const cacheKey = `previews:${workspaceId}`;
+        try {
+          const cached = localStorage.getItem(cacheKey);
+          if (cached && !cancelled) {
+            setLastMessageBySession((prev) => ({ ...JSON.parse(cached), ...prev }));
+          }
+        } catch { /* ignore corrupt cache */ }
+
+        // Bulk fetch latest message per channel (1 request instead of N)
+        try {
+          const bulk = await workspaceApi.latestPerChannel();
+          if (!cancelled) {
+            const batch: Record<string, LastMessageInfo> = {};
+            for (const [channelName, event] of Object.entries(bulk.channels)) {
+              const payload = event.payload as Record<string, string>;
+              const sender = event.source.replace(/^(openagents:|human:)/, '');
+              const content = payload?.content || '';
+              const msgType = payload?.message_type || 'chat';
+              const isStatus = msgType === 'status' || msgType === 'thinking';
+              if (content) {
+                batch[channelName] = { senderName: sender, content: content.slice(0, 100), isStatus };
+              }
+            }
+            setLastMessageBySession((prev) => ({ ...prev, ...batch }));
+            try {
+              localStorage.setItem(cacheKey, JSON.stringify(batch));
+            } catch { /* storage full */ }
+          }
+        } catch { /* non-critical */ }
+
+        // Also fetch DM conversations
+        workspaceApi.listConversations().then((c) => {
+          if (!cancelled) setDMConversations(c);
+        }).catch(() => {});
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load workspace');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workspaceId, token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Persist previews to localStorage for instant rendering on reload
+  useEffect(() => {
+    if (Object.keys(lastMessageBySession).length === 0) return;
+    try {
+      localStorage.setItem(`previews:${workspaceId}`, JSON.stringify(lastMessageBySession));
+    } catch { /* storage full */ }
+  }, [lastMessageBySession, workspaceId]);
+
+  // Discovery polling — adaptive: 5s when agents are active, 15s when idle
+  const hasActiveAgentsRef = React.useRef(false);
+  hasActiveAgentsRef.current = Object.values(lastMessageBySession).some((m) => m.isStatus);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      const delay = hasActiveAgentsRef.current ? 5_000 : 15_000;
+      timeout = setTimeout(async () => {
+        await refreshDiscovery();
+        schedule();
+      }, delay);
+    };
+    schedule();
+    return () => clearTimeout(timeout);
+  }, [refreshDiscovery]);
+
+  const createSession = useCallback(async (opts?: { title?: string; master?: string; participants?: string[]; resumeFrom?: string }) => {
+    const masterAgent = opts?.master || agents.find((a) => a.role === 'master')?.agentName;
+    const participants = opts?.participants || agents.map((a) => a.agentName);
+
+    const session = await workspaceApi.createChannel({
+      title: opts?.title,
+      master: masterAgent,
+      participants,
+      resumeFrom: opts?.resumeFrom,
+    });
+    setSessions((prev) => [session, ...prev]);
+    setCurrentSessionId(session.sessionId);
+    return session;
+  }, [agents]);
+
+  const renameWorkspace = useCallback(async (name: string) => {
+    setWorkspace((prev) => (prev ? { ...prev, name } : prev));
+    try {
+      await workspaceApi.updateWorkspace({ name });
+    } catch {
+      // Best-effort — local update already applied
+    }
+  }, []);
+
+  const setBrowserEnabled = useCallback(async (enabled: boolean) => {
+    // Optimistic local flip — UI updates immediately.
+    setWorkspace((prev) => (prev ? { ...prev, browserEnabled: enabled } : prev));
+    try {
+      const updated = await workspaceApi.setBrowserEnabled(enabled);
+      // Reconcile with the authoritative server response (typically a
+      // no-op, but covers cases where the backend coerces / merges with
+      // other settings keys).
+      setWorkspace((prev) => (prev ? { ...prev, ...updated } : updated));
+    } catch (err) {
+      // Roll back optimistic flip and surface the failure.
+      setWorkspace((prev) => (prev ? { ...prev, browserEnabled: !enabled } : prev));
+      toast.error(err instanceof Error ? err.message : 'Failed to update browser setting');
+      throw err;
+    }
+  }, []);
+
+  const renameSession = useCallback(async (sessionId: string, title: string) => {
+    setSessions((prev) =>
+      prev.map((s) => (s.sessionId === sessionId ? { ...s, title } : s))
+    );
+    setManuallyRenamedSessions((prev) => new Set(prev).add(sessionId));
+    try {
+      await workspaceApi.updateChannel(sessionId, { title });
+    } catch {
+      // Best-effort — local update already applied
+    }
+  }, []);
+
+  const updateSession = useCallback(async (sessionId: string, updates: { starred?: boolean; status?: string }) => {
+    // Capture previous state for rollback
+    const previousSession = sessions.find((s) => s.sessionId === sessionId);
+    // Optimistic update
+    setSessions((prev) =>
+      prev.map((s) => (s.sessionId === sessionId ? { ...s, ...updates } : s))
+    );
+    // If deleting the current session, switch away
+    const previousSessionId = currentSessionId;
+    if (updates.status === 'deleted' || updates.status === 'archived') {
+      if (currentSessionId === sessionId) {
+        const remaining = sessions.filter((s) => s.sessionId !== sessionId && s.status === 'active');
+        setCurrentSessionId(remaining.length > 0 ? remaining[0].sessionId : null);
+      }
+    }
+    try {
+      await workspaceApi.updateChannel(sessionId, updates);
+    } catch {
+      // Revert optimistic update on failure
+      if (previousSession) {
+        setSessions((prev) =>
+          prev.map((s) => (s.sessionId === sessionId ? previousSession : s))
+        );
+        if (previousSessionId !== currentSessionId) {
+          setCurrentSessionId(previousSessionId);
+        }
+      }
+    }
+  }, [currentSessionId, sessions]);
+
+  const addParticipant = useCallback(async (sessionId: string, agentName: string) => {
+    // Optimistic update
+    setSessions((prev) =>
+      prev.map((s) =>
+        s.sessionId === sessionId && !s.participants.includes(agentName)
+          ? { ...s, participants: [...s.participants, agentName] }
+          : s
+      )
+    );
+    try {
+      await workspaceApi.addChannelParticipant(sessionId, agentName);
+    } catch {
+      // Revert on failure
+      setSessions((prev) =>
+        prev.map((s) =>
+          s.sessionId === sessionId
+            ? { ...s, participants: s.participants.filter((p) => p !== agentName) }
+            : s
+        )
+      );
+    }
+  }, []);
+
+  const removeParticipant = useCallback(async (sessionId: string, agentName: string) => {
+    // Optimistic update
+    setSessions((prev) =>
+      prev.map((s) =>
+        s.sessionId === sessionId
+          ? { ...s, participants: s.participants.filter((p) => p !== agentName) }
+          : s
+      )
+    );
+    try {
+      await workspaceApi.removeChannelParticipant(sessionId, agentName);
+    } catch {
+      // Revert on failure
+      setSessions((prev) =>
+        prev.map((s) =>
+          s.sessionId === sessionId && !s.participants.includes(agentName)
+            ? { ...s, participants: [...s.participants, agentName] }
+            : s
+        )
+      );
+    }
+  }, []);
+
+  const monitorMode = !!(workspace?.settings?.monitorMode);
+
+  const acknowledgeCompletion = useCallback((sessionId: string) => {
+    setCompletedSessionIds((prev) => {
+      if (!prev.has(sessionId)) return prev;
+      const next = new Set(prev);
+      next.delete(sessionId);
+      return next;
+    });
+  }, []);
+
+  // Play notification sound when a thread completes
+  const notificationSoundRef = React.useRef(notificationSound);
+  notificationSoundRef.current = notificationSound;
+  const prevCompletedRef = React.useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!notificationSoundRef.current) {
+      prevCompletedRef.current = completedSessionIds;
+      return;
+    }
+    // Detect newly completed sessions
+    const prev = prevCompletedRef.current;
+    const hasNew = Array.from(completedSessionIds).some((id) => !prev.has(id));
+    prevCompletedRef.current = completedSessionIds;
+    if (hasNew) {
+      try {
+        const audio = new Audio('/notification.mp3');
+        audio.volume = 0.25;
+        audio.play().catch(() => {});
+      } catch {}
+    }
+  }, [completedSessionIds]);
+
+  return (
+    <WorkspaceContext.Provider
+      value={{
+        workspace,
+        token,
+        agents,
+        sessions,
+        files,
+        selectedFileId,
+        currentSessionId,
+        loading,
+        error,
+        lastMessageBySession,
+        activeSessionIds,
+        stoppingSessionIds,
+        completedSessionIds,
+        monitorMode,
+        acknowledgeCompletion,
+        agentModes,
+        updateLastMessage,
+        setSessionActive,
+        updateAgentMode,
+        toggleAgentMode,
+        stopAllAgents,
+        setCurrentSessionId,
+        consumeSkipFocus,
+        setSelectedFileId,
+        currentFilePath,
+        setCurrentFilePath,
+        createSession,
+        renameSession,
+        updateSession,
+        addParticipant,
+        removeParticipant,
+        renameWorkspace,
+        setBrowserEnabled,
+        refreshWorkspace,
+        refreshAgents,
+        refreshFiles,
+        uploadFile,
+        deleteFile,
+        browserTabs,
+        selectedBrowserTabId,
+        setSelectedBrowserTabId,
+        refreshBrowserTabs,
+        openBrowserTab,
+        closeBrowserTab,
+        navigateBrowserTab,
+        reconnectBrowserTab,
+        browserContexts,
+        refreshBrowserContexts,
+        persistBrowserTab,
+        unpersistBrowserTab,
+        deleteBrowserContext,
+        openBrowserTabWithContext,
+        dmConversations,
+        refreshDMConversations,
+        todos,
+        refreshTodos,
+        routines,
+        refreshRoutines,
+        notificationSound,
+        setNotificationSound,
+      }}
+    >
+      {children}
+    </WorkspaceContext.Provider>
+  );
+}

--- a/packages/go/web/lib/workspace-history.ts
+++ b/packages/go/web/lib/workspace-history.ts
@@ -1,0 +1,82 @@
+'use client';
+
+// localStorage-backed recent-workspaces list, mirrors the Swift
+// `WorkspaceHistory` shape so the switcher popover can list past
+// workspaces the same way the macOS/iOS app's selector view does.
+
+export interface WorkspaceHistoryEntry {
+  workspaceId: string;
+  workspaceToken: string;
+  name?: string;
+  // ISO timestamp of the most recent open. Used to sort.
+  lastOpenedAt: string;
+}
+
+const KEY = 'oa_workspace_history_v1';
+const MAX_ENTRIES = 12;
+
+function read(): WorkspaceHistoryEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e) =>
+        e && typeof e.workspaceId === 'string' && typeof e.workspaceToken === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function write(entries: WorkspaceHistoryEntry[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(KEY, JSON.stringify(entries.slice(0, MAX_ENTRIES)));
+  } catch {
+    // quota / private-mode failure — silent, history is convenience-only
+  }
+}
+
+export const WorkspaceHistory = {
+  entries(): WorkspaceHistoryEntry[] {
+    return read().sort(
+      (a, b) => Date.parse(b.lastOpenedAt) - Date.parse(a.lastOpenedAt),
+    );
+  },
+  record(entry: Omit<WorkspaceHistoryEntry, 'lastOpenedAt'>) {
+    const existing = read().filter((e) => e.workspaceId !== entry.workspaceId);
+    write([
+      { ...entry, lastOpenedAt: new Date().toISOString() },
+      ...existing,
+    ]);
+  },
+  remove(workspaceId: string) {
+    write(read().filter((e) => e.workspaceId !== workspaceId));
+  },
+  clear() {
+    write([]);
+  },
+};
+
+/** Parse a workspace URL like https://host/<id>?token=<t> into its parts. */
+export function parseWorkspaceURL(input: string):
+  | { workspaceId: string; token: string }
+  | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    // First path segment is the workspace id/slug.
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (segments.length === 0) return null;
+    const workspaceId = segments[0];
+    const token = url.searchParams.get('token') ?? '';
+    if (!workspaceId || !token) return null;
+    return { workspaceId, token };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

The root `.gitignore` has a top-level `lib/` rule (for Python build artifacts) that was silently matching `packages/go/web/lib/` and dropping the entire workspace REST client from version control: `api.ts`, `workspace-context.tsx`, `types.ts`, `helpers.ts`, `auth/*`, `dashboard-api.ts`, `firebase.ts`, `workspace-history.ts`, `utils.ts`.

Every web build still worked because the files lived in contributors' worktrees — but a fresh clone of `develop` cannot build the web app, and InsForge/Vercel only deployed correctly because the deploy ran from a pre-existing checkout that had the untracked files.

## Changes

- `.gitignore`: add `!packages/go/web/lib/` + `!packages/go/web/lib/**` negation (mirrors the existing `!workspace/frontend/lib/**` pattern).
- Force-add the 11 files as they exist on contributors' machines today. No behaviour change for any deployed surface.

## Test plan

- [ ] Fresh clone → `cd packages/go/web && npm install && npm run build` succeeds
- [ ] Diff this branch against develop shows only `.gitignore` (2 lines) + 11 new files under `packages/go/web/lib/`
- [ ] PR #413 (`fix/inbox-swift`) rebases cleanly on top of this once merged