### PR TITLE
detect Cursor agent in Windows local app data

### DIFF
--- a/packages/agent-connector/src/adapters/cursor.js
+++ b/packages/agent-connector/src/adapters/cursor.js
@@ -205,7 +205,13 @@ class CursorAdapter extends BaseAdapter {
     }
 
     // Tier 3: Common install locations
+    const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
     const candidates = IS_WINDOWS ? [
+      // Windows native installer (install?win32=true) drops the CLI here.
+      path.join(localAppData, 'cursor-agent', 'cursor-agent.cmd'),
+      path.join(localAppData, 'cursor-agent', 'cursor-agent.exe'),
+      path.join(localAppData, 'cursor-agent', 'agent.cmd'),
+      path.join(localAppData, 'cursor-agent', 'agent.exe'),
       path.join(home, '.cursor', 'bin', 'cursor-agent.cmd'),
       path.join(home, '.cursor', 'bin', 'cursor-agent.exe'),
       path.join(home, '.cursor', 'bin', 'cursor-agent'),

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -179,8 +179,16 @@ function _addWindowsPaths(dirs) {
   // Portable Node.js installed by OpenAgents Launcher
   _push(dirs, path.join(HOME, '.openagents', 'nodejs'));
 
-  // Cursor CLI native installer
+  // Cursor CLI native installer.
+  //   - ~/.cursor/bin            : the curl|bash layout (also used by some setups)
+  //   - %LOCALAPPDATA%\cursor-agent : where the Windows installer
+  //     (irm 'https://cursor.com/install?win32=true' | iex) actually drops
+  //     cursor-agent.cmd / agent.cmd. The installer edits the *registry* PATH,
+  //     so an already-running launcher/daemon process never sees it via `where`
+  //     unless we add the dir here explicitly.
   _push(dirs, path.join(HOME, '.cursor', 'bin'));
+  if (localAppData) _push(dirs, path.join(localAppData, 'cursor-agent'));
+  _push(dirs, path.join(HOME, '.local', 'bin'));
 
   // Node.js install
   _push(dirs, path.join(programFiles, 'nodejs'));

--- a/packages/agent-connector/test/installer.test.js
+++ b/packages/agent-connector/test/installer.test.js
@@ -156,6 +156,70 @@ describe('Installer', () => {
     assert.equal(info.location, null);
   });
 
+  it('getInstallInfo reports installed (global) when agent.cmd is found in %LOCALAPPDATA%\\cursor-agent', () => {
+    // Windows: the native installer drops agent.cmd into %LOCALAPPDATA%\cursor-agent,
+    // outside ~/.openagents. Once the enhanced PATH can see that dir, _whichBinary
+    // resolves it and Cursor must read as installed (global/unmanaged, not "Install").
+    const inst = new Installer(mockRegistry, tmpDir);
+    const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    const agentCmd = path.join(localAppData, 'cursor-agent', 'agent.cmd');
+    inst._whichBinary = () => agentCmd;
+    const info = inst.getInstallInfo('cursor');
+    assert.equal(info.installed, true);
+    assert.equal(info.managed, false);
+    assert.equal(info.location, 'global');
+  });
+
+  it('getInstallInfo reports installed (global) when cursor-agent.cmd is found in %LOCALAPPDATA%\\cursor-agent', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    const cursorAgentCmd = path.join(localAppData, 'cursor-agent', 'cursor-agent.cmd');
+    inst._whichBinary = () => cursorAgentCmd;
+    const info = inst.getInstallInfo('cursor');
+    assert.equal(info.installed, true);
+    assert.equal(info.managed, false);
+    assert.equal(info.location, 'global');
+  });
+
+  it('Cursor detection searches cursor-agent/agent, not the cursor editor binary', () => {
+    // The "cursor" CLI is the editor launcher (C:\cursor\resources\app\bin\cursor),
+    // NOT the agent runtime. Detection must key off cursor-agent / agent only, so a
+    // machine with only the editor present is correctly NOT treated as runtime-installed.
+    const entry = mockRegistry.getEntry('cursor');
+    const names = [entry.install.binary, ...(entry.install.binary_aliases || [])];
+    assert.deepEqual(names, ['cursor-agent', 'agent']);
+    assert.ok(!names.includes('cursor'), 'editor binary "cursor" must not be a detection name');
+
+    // Editor present but no cursor-agent/agent CLI → _whichBinary misses → not installed.
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    const info = inst.getInstallInfo('cursor');
+    assert.equal(info.installed, false);
+  });
+
+  it('detection survives a non-ASCII home/config path (e.g. C:\\Users\\王思瑶)', () => {
+    // Regression guard: the reporting user is 王思瑶, installed under
+    // C:\Users\王思瑶\AppData\Local\cursor-agent. Path parsing / marker IO / the
+    // ~/.openagents prefix comparison must not throw or misclassify on non-ASCII.
+    const nonAsciiCfg = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-王思瑶-'));
+    try {
+      const inst = new Installer(mockRegistry, nonAsciiCfg);
+      const nonAsciiBin = path.join(nonAsciiCfg, 'AppData', 'Local', 'cursor-agent', 'agent.cmd');
+      inst._whichBinary = () => nonAsciiBin;
+      const info = inst.getInstallInfo('cursor');
+      assert.equal(info.installed, true);
+      assert.equal(info.managed, false);
+
+      // Marker write/read round-trips through the non-ASCII config dir.
+      inst._whichBinary = () => null;
+      inst._markInstalled('cursor');
+      assert.ok(inst._hasMarker('cursor'));
+      assert.equal(inst.getInstallInfo('cursor').installed, true);
+    } finally {
+      fs.rmSync(nonAsciiCfg, { recursive: true, force: true });
+    }
+  });
+
   it('_markInstalled invalidates the paths whichBinary cache', () => {
     const { whichBinary, clearBinaryLookupCache } = require('../src/paths');
     const fakeName = `_oa_installer_test_${process.pid}_${Date.now()}`;

--- a/packages/agent-connector/test/paths.test.js
+++ b/packages/agent-connector/test/paths.test.js
@@ -75,6 +75,34 @@ describe('Paths', () => {
     }
   });
 
+  it('getExtraBinDirs includes %LOCALAPPDATA%\\cursor-agent on Windows', () => {
+    // The Windows Cursor installer (irm 'https://cursor.com/install?win32=true' | iex)
+    // drops cursor-agent.cmd / agent.cmd into %LOCALAPPDATA%\cursor-agent and only
+    // edits the registry PATH, so a running launcher/daemon can't see it via `where`.
+    // The dir must be added to the enhanced PATH so detection + spawn succeed.
+    if (!IS_WINDOWS) return; // Windows-only layout; runs on the Windows CI runner
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'paths-lad-'));
+    const cursorAgentDir = path.join(tmp, 'cursor-agent');
+    fs.mkdirSync(cursorAgentDir, { recursive: true });
+    const originalLAD = process.env.LOCALAPPDATA;
+    try {
+      process.env.LOCALAPPDATA = tmp;
+      clearBinaryLookupCache();
+      const dirs = getExtraBinDirs();
+      assert.ok(
+        dirs.includes(cursorAgentDir),
+        `expected ${cursorAgentDir} in extra bin dirs, got: ${dirs.join(', ')}`,
+      );
+      // And it must be reflected in the enhanced PATH used to spawn/locate the CLI.
+      assert.ok(getEnhancedPATH().includes(cursorAgentDir));
+    } finally {
+      if (originalLAD === undefined) delete process.env.LOCALAPPDATA;
+      else process.env.LOCALAPPDATA = originalLAD;
+      try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+      clearBinaryLookupCache();
+    }
+  });
+
   it('clearBinaryLookupCache lets whichBinary re-resolve after PATH changes', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'paths-cache-'));
     const fakeName = `_oa_test_bin_${process.pid}_${Date.now()}`;

--- a/sdk/src/openagents/registry/loader.py
+++ b/sdk/src/openagents/registry/loader.py
@@ -106,11 +106,18 @@ def _find_in_known_install_dirs(binary_names: list) -> Optional[str]:
     Returns the first matching executable path, or ``None``.
     """
     home = Path.home()
+    is_windows = platform.system() == "Windows"
     extra_dirs = [
-        home / ".cursor" / "bin",   # Cursor CLI native installer
+        home / ".cursor" / "bin",   # Cursor CLI native installer (curl|bash)
         home / ".local" / "bin",    # pipx / user installs
     ]
-    is_windows = platform.system() == "Windows"
+    if is_windows:
+        # The Windows installer (irm 'https://cursor.com/install?win32=true' | iex)
+        # drops cursor-agent.cmd / agent.cmd into %LOCALAPPDATA%\cursor-agent and
+        # only edits the registry PATH, so a daemon-spawned process can't see it
+        # via shutil.which. Mirror packages/agent-connector/src/paths.js.
+        local_app_data = os.environ.get("LOCALAPPDATA") or str(home / "AppData" / "Local")
+        extra_dirs.insert(0, Path(local_app_data) / "cursor-agent")
     # Windows shims carry an extension (.exe/.cmd/.bat); Unix binaries don't.
     exts = (".exe", ".cmd", ".bat", "") if is_windows else ("",)
     for directory in extra_dirs:


### PR DESCRIPTION
Fix Cursor Agent install detection on Windows.

The Cursor Windows installer places agent.cmd and cursor-agent.cmd under %LOCALAPPDATA%\cursor-agent, but the launcher/connector enhanced PATH did not include that directory. Since the running Launcher/daemon process keeps the old PATH snapshot after installation, Cursor could install successfully while the Install page still failed to detect the runtime.

This adds the Windows Cursor Agent install directory to the connector enhanced PATH, the Cursor adapter fallback lookup, and the Python registry loader fallback paths so detection stays consistent across Launcher, daemon, and SDK/CLI flows.

The UI semantics are preserved: a system-level Cursor Agent installation is shown as Global + Reinstall, not as a managed OpenAgents runtime. Additional tests cover agent.cmd, cursor-agent.cmd, editor-only non-detection, non-ASCII user paths, and the Global button state.