### PR TITLE
bump version for skill installer release

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.132",
+  "version": "0.2.133",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Bump `@openagents-org/agent-launcher` so the published package includes the Skill Hub installer wiring.

The current `0.2.132` npm package does not contain `src/skill-installer.js` or the `skill.install` handler in `src/adapters/base.js`. Users installing through `install.ps1` therefore get a daemon that ignores Skill Hub install events, while `npm run dev` works because it loads the local source tree.

Publishing `0.2.133` allows `install.ps1` to detect the newer version and install the daemon with Skill Hub installation support.