### PR TITLE
fix(cli): clarify local-only agent visibility in Workspace Dashboard

### DIFF
--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -128,6 +128,16 @@ async function cmdCreate(connector, flags, positional) {
     // Signal daemon to pick up the new agent
     try { connector.sendDaemonCommand('reload'); } catch {}
 
+    // Newly created agents are local-only until connected to a workspace.
+    // Without a workspace connection they will not appear in the Workspace Dashboard.
+    const created = connector.config.getAgent(name);
+    if (created && !created.network) {
+      print('');
+      print(`Note: '${name}' is local-only and will not appear in the Workspace Dashboard.`);
+      print(`To make it visible, connect it to a workspace:`);
+      print(`  agn connect ${name} <workspace-token>`);
+    }
+
     if (!connector.isInstalled(type)) {
       if (!flags.install) {
         print(`Runtime '${type}' is not installed. Run: agn install ${type}`);
@@ -278,9 +288,30 @@ async function cmdRuntimes(connector) {
 
 async function cmdConnect(connector, flags, positional) {
   const name = positional[0];
-  const token = positional[1] || flags.token;
-  if (!name || !token) {
+  // Token resolution order: positional arg / --token flag, then env vars.
+  // OPENAGENTS_WORKSPACE_TOKEN is preferred; OA_WORKSPACE_TOKEN is supported
+  // for compatibility with the existing mcp-server env var.
+  const token = positional[1]
+    || flags.token
+    || process.env.OPENAGENTS_WORKSPACE_TOKEN
+    || process.env.OA_WORKSPACE_TOKEN;
+
+  if (!name) {
     print('Usage: agn connect <agent-name> <token>');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!token) {
+    // No token supplied and none in the environment. Never prompt — keep
+    // CI / non-interactive environments from hanging. Print a helpful error
+    // explaining why the agent stays invisible and how to fix it.
+    print(`Error: no workspace token provided for '${name}'.`);
+    print(`Without a token, '${name}' stays local-only and will not appear in the Workspace Dashboard.`);
+    print('Provide a token in one of these ways:');
+    print(`  agn connect ${name} <workspace-token>`);
+    print(`  OPENAGENTS_WORKSPACE_TOKEN=<workspace-token> agn connect ${name}`);
+    process.exitCode = 1;
     return;
   }
 

--- a/packages/agent-connector/test/cli.test.js
+++ b/packages/agent-connector/test/cli.test.js
@@ -23,6 +23,34 @@ function runWithConfig(tmpDir, ...args) {
   }).trim();
 }
 
+// Run the CLI capturing stdout even when the process exits non-zero, with an
+// optional custom environment. `timeout` guards against any accidental hang.
+function runCapture({ env, timeout = 35000 } = {}, ...args) {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI, ...args], {
+      encoding: 'utf-8',
+      timeout,
+      env: env || process.env,
+    });
+    return { code: 0, stdout: stdout.trim() };
+  } catch (e) {
+    return {
+      code: typeof e.status === 'number' ? e.status : 1,
+      stdout: (e.stdout || '').toString().trim(),
+      stderr: (e.stderr || '').toString().trim(),
+    };
+  }
+}
+
+// Environment with the workspace token vars stripped, for deterministic
+// "missing token" assertions regardless of the host environment.
+function envWithoutTokens(extra = {}) {
+  const env = { ...process.env };
+  delete env.OPENAGENTS_WORKSPACE_TOKEN;
+  delete env.OA_WORKSPACE_TOKEN;
+  return { ...env, ...extra };
+}
+
 describe('CLI', () => {
   it('help', () => {
     const out = run('help');
@@ -135,6 +163,76 @@ describe('CLI', () => {
       const out = runWithConfig(tmpDir, 'logs');
       // Should not error — empty is fine
       assert.ok(typeof out === 'string');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('create prints local-only Dashboard warning when not connected', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
+    try {
+      const out = runWithConfig(tmpDir, 'create', 'local-agent', '--type', 'kimi');
+      assert.ok(out.includes("'local-agent' created"));
+      assert.ok(out.includes('local-only'));
+      assert.ok(out.includes('Workspace Dashboard'));
+      // Points the user at the next command, scoped to the new agent name.
+      assert.ok(out.includes('agn connect local-agent'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('connect with explicit token is accepted (backward compatible)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
+    try {
+      runWithConfig(tmpDir, 'create', 'conn-agent', '--type', 'kimi');
+      const { stdout } = runCapture(
+        { env: envWithoutTokens() },
+        'connect', 'conn-agent', 'tok-explicit-123', '--config', tmpDir,
+      );
+      // Token accepted: it proceeds to resolution rather than the
+      // missing-token error path. (Resolution itself may fail offline.)
+      assert.ok(stdout.includes('Resolving workspace token'));
+      assert.ok(!stdout.includes('no workspace token provided'));
+      // The token value must never be printed.
+      assert.ok(!stdout.includes('tok-explicit-123'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('connect reads OPENAGENTS_WORKSPACE_TOKEN from env', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
+    try {
+      runWithConfig(tmpDir, 'create', 'env-agent', '--type', 'kimi');
+      const { stdout } = runCapture(
+        { env: envWithoutTokens({ OPENAGENTS_WORKSPACE_TOKEN: 'tok-from-env-456' }) },
+        'connect', 'env-agent', '--config', tmpDir,
+      );
+      // Env token picked up: reaches resolution, not the missing-token error.
+      assert.ok(stdout.includes('Resolving workspace token'));
+      assert.ok(!stdout.includes('no workspace token provided'));
+      assert.ok(!stdout.includes('tok-from-env-456'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('connect without token in non-interactive mode errors and does not hang', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
+    try {
+      runWithConfig(tmpDir, 'create', 'noenv-agent', '--type', 'kimi');
+      // Short timeout proves the command returns immediately (never prompts).
+      const { code, stdout } = runCapture(
+        { env: envWithoutTokens(), timeout: 10000 },
+        'connect', 'noenv-agent', '--config', tmpDir,
+      );
+      assert.equal(code, 1);
+      assert.ok(stdout.includes('no workspace token provided'));
+      assert.ok(stdout.includes('Workspace Dashboard'));
+      assert.ok(stdout.includes('OPENAGENTS_WORKSPACE_TOKEN'));
+      // It must not have started resolving (no token was available).
+      assert.ok(!stdout.includes('Resolving workspace token'));
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

This PR improves the CLI onboarding flow for agents created locally with `agn create`.

Previously, `agn create <name> --type <type>` only created a local agent config. The agent appeared in `agn list` as `(local)`, but it did not appear in the Workspace Dashboard because it was not connected to any workspace. The CLI did not explain this, which made already-created agents look missing from the Dashboard.

This change:

- Prints a local-only warning after `agn create` when the created agent has no workspace network.
- Explains that local-only agents will not appear in the Workspace Dashboard until connected.
- Shows the next command:
  `agn connect <name> <workspace-token>`
- Improves `agn connect <agent>` when the token is missing.
- Reads the workspace token from `OPENAGENTS_WORKSPACE_TOKEN`, with `OA_WORKSPACE_TOKEN` as a compatibility fallback.
- Keeps existing `agn connect <agent> <token>` behavior unchanged.

This is intentionally scoped to guidance and token fallback only. It does not implement `agn create --connect` yet.

## Tests

- Added tests for local-only create warning.
- Added tests for explicit token compatibility.
- Added tests for `OPENAGENTS_WORKSPACE_TOKEN` fallback.
- Added tests for missing-token non-interactive behavior to ensure it exits with a helpful error and does not hang.

Result:

- 167 tests passed.
- ESLint was not run locally because dependencies are not installed.