### PR TITLE
fix `agn update` failing on Windows

### DIFF
--- a/packages/agent-connector/src/update-check.js
+++ b/packages/agent-connector/src/update-check.js
@@ -104,32 +104,75 @@ function detectInstallPrefix() {
   return null;
 }
 
-function findNpmBin() {
-  const nodeDir = path.dirname(process.execPath);
-  for (const name of ['npm', 'npm.cmd']) {
+/**
+ * Locate the npm executable next to the running node binary, falling back to
+ * a PATH lookup. On Windows the runnable file is `npm.cmd`; the extensionless
+ * `npm` shipped alongside it is a Unix shell script that cmd.exe / PowerShell
+ * cannot execute, so it must be checked AFTER `npm.cmd`. The opts are injectable
+ * to keep this testable across platforms.
+ */
+function findNpmBin(opts = {}) {
+  const platform = opts.platform || process.platform;
+  const nodeDir = opts.nodeDir || path.dirname(process.execPath);
+  const exists = opts.exists || fs.existsSync;
+  const names = platform === 'win32' ? ['npm.cmd', 'npm'] : ['npm'];
+  for (const name of names) {
     const candidate = path.join(nodeDir, name);
-    if (fs.existsSync(candidate)) return candidate;
+    if (exists(candidate)) return candidate;
   }
-  try {
-    return execSync(process.platform === 'win32' ? 'where npm' : 'which npm', {
+  // PATH fallback (injectable so tests can exercise the hard fallback
+  // deterministically regardless of the host OS).
+  const lookup = opts.lookup || (() =>
+    execSync(platform === 'win32' ? 'where npm' : 'which npm', {
       encoding: 'utf-8', timeout: 3000,
-    }).trim().split(/\r?\n/)[0];
-  } catch { return 'npm'; }
+    }).trim().split(/\r?\n/)[0]);
+  try {
+    return lookup() || (platform === 'win32' ? 'npm.cmd' : 'npm');
+  } catch { return platform === 'win32' ? 'npm.cmd' : 'npm'; }
 }
 
 /**
  * Run npm install to update to the latest version. Blocking.
- * Returns true on success.
+ * Returns true on success. `opts` are injectable for testing.
  */
-function runUpdate() {
-  const prefix = detectInstallPrefix();
-  const npmBin = findNpmBin();
+function runUpdate(opts = {}) {
+  const platform = opts.platform || process.platform;
+  const spawn = opts.spawn || spawnSync;
+  const npmBin = opts.npmBin || findNpmBin({ platform });
+  const prefix = opts.prefix !== undefined ? opts.prefix : detectInstallPrefix();
   const args = ['install', '--no-save', `${PKG_NAME}@latest`];
   if (prefix) args.push('--prefix', prefix);
   else args.push('-g');
+
+  // On Windows, npm.cmd is a batch file and must be invoked through cmd.exe.
+  // Passing the args via cmd.exe with shell:false lets Node quote paths that
+  // contain spaces (e.g. C:\Program Files\nodejs\npm.cmd) correctly.
+  let cmd, cmdArgs;
+  if (platform === 'win32') {
+    cmd = process.env.ComSpec || 'cmd.exe';
+    cmdArgs = ['/d', '/s', '/c', npmBin, ...args];
+  } else {
+    cmd = npmBin;
+    cmdArgs = args;
+  }
+
   process.stderr.write(`[launcher] Running: ${npmBin} ${args.join(' ')}\n`);
-  const r = spawnSync(npmBin, args, { stdio: 'inherit' });
-  return r.status === 0;
+  const r = spawn(cmd, cmdArgs, { stdio: 'inherit' });
+
+  // spawn failed to even start the process (ENOENT / EINVAL / EACCES ...).
+  if (r && r.error) {
+    process.stderr.write(`[launcher] Failed to run npm (${cmd}): ${r.error.message}\n`);
+    return false;
+  }
+  // npm started but exited non-zero. Its own stderr was already streamed via
+  // stdio:'inherit'; surface the exit code so the failure isn't silent.
+  if (!r || r.status !== 0) {
+    const code = r ? r.status : 'unknown';
+    const sig = r && r.signal ? ` (signal ${r.signal})` : '';
+    process.stderr.write(`[launcher] npm exited with code ${code}${sig}\n`);
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -179,5 +222,6 @@ module.exports = {
   checkForUpdate,
   notifyAndMaybeUpdate,
   runUpdate,
+  findNpmBin,
   currentVersion,
 };

--- a/packages/agent-connector/test/update-check.test.js
+++ b/packages/agent-connector/test/update-check.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { findNpmBin, runUpdate } = require('../src/update-check');
+
+// Capture everything written to process.stderr while `fn` runs.
+function captureStderr(fn) {
+  const original = process.stderr.write;
+  let out = '';
+  process.stderr.write = (chunk) => { out += chunk; return true; };
+  try {
+    const result = fn();
+    return { result, out };
+  } finally {
+    process.stderr.write = original;
+  }
+}
+
+describe('findNpmBin', () => {
+  it('prefers npm.cmd on Windows', () => {
+    // Both files exist next to node — Windows must pick npm.cmd, not the
+    // extensionless Unix shell script.
+    const bin = findNpmBin({
+      platform: 'win32',
+      nodeDir: 'C:\\Program Files\\nodejs',
+      exists: () => true,
+    });
+    assert.ok(bin.endsWith('npm.cmd'), `expected npm.cmd, got ${bin}`);
+  });
+
+  it('prefers npm on non-Windows', () => {
+    const bin = findNpmBin({
+      platform: 'linux',
+      nodeDir: '/usr/local/bin',
+      exists: () => true,
+    });
+    assert.ok(bin.endsWith('npm'), `expected npm, got ${bin}`);
+    assert.ok(!bin.endsWith('npm.cmd'));
+  });
+
+  it('falls back to npm.cmd name on Windows when PATH lookup fails', () => {
+    const bin = findNpmBin({
+      platform: 'win32',
+      nodeDir: 'C:\\nowhere',
+      exists: () => false,            // skip the next-to-node candidates
+      lookup: () => { throw new Error('no npm on PATH'); }, // force hard fallback
+    });
+    // The hard fallback must be the runnable Windows name, not the Unix script.
+    assert.equal(bin, 'npm.cmd');
+  });
+});
+
+describe('runUpdate', () => {
+  it('returns false and prints the error when spawn fails to start', () => {
+    const err = new Error('spawn npm.cmd ENOENT');
+    err.code = 'ENOENT';
+    const { result, out } = captureStderr(() =>
+      runUpdate({
+        platform: 'win32',
+        npmBin: 'npm.cmd',
+        prefix: null,
+        spawn: () => ({ error: err }),
+      }));
+    assert.equal(result, false);
+    assert.ok(out.includes('Failed to run npm'));
+    assert.ok(out.includes('ENOENT'));
+  });
+
+  it('returns false and prints the exit code when npm exits non-zero', () => {
+    const { result, out } = captureStderr(() =>
+      runUpdate({
+        platform: 'linux',
+        npmBin: 'npm',
+        prefix: null,
+        spawn: () => ({ status: 1 }),
+      }));
+    assert.equal(result, false);
+    assert.ok(out.includes('exited with code 1'));
+  });
+
+  it('returns true when npm exits zero', () => {
+    const { result } = captureStderr(() =>
+      runUpdate({
+        platform: 'linux',
+        npmBin: 'npm',
+        prefix: null,
+        spawn: () => ({ status: 0 }),
+      }));
+    assert.equal(result, true);
+  });
+
+  it('invokes npm.cmd through cmd.exe on Windows', () => {
+    let captured = null;
+    captureStderr(() =>
+      runUpdate({
+        platform: 'win32',
+        npmBin: 'C:\\Program Files\\nodejs\\npm.cmd',
+        prefix: null,
+        spawn: (cmd, args) => { captured = { cmd, args }; return { status: 0 }; },
+      }));
+    assert.ok(/cmd\.exe$/i.test(captured.cmd) || captured.cmd.toLowerCase().includes('cmd'));
+    assert.deepEqual(captured.args.slice(0, 4), ['/d', '/s', '/c', 'C:\\Program Files\\nodejs\\npm.cmd']);
+    assert.ok(captured.args.includes('-g')); // prefix:null → global install
+  });
+
+  it('invokes npm directly on non-Windows', () => {
+    let captured = null;
+    captureStderr(() =>
+      runUpdate({
+        platform: 'linux',
+        npmBin: '/usr/local/bin/npm',
+        prefix: null,
+        spawn: (cmd, args) => { captured = { cmd, args }; return { status: 0 }; },
+      }));
+    assert.equal(captured.cmd, '/usr/local/bin/npm');
+    assert.equal(captured.args[0], 'install');
+  });
+});


### PR DESCRIPTION
## Problem
On Windows, `agn update` always failed with a bare `Update failed.` message.
`findNpmBin()` checked `['npm', 'npm.cmd']` in order. The Node install dir on
Windows (e.g. `C:\Program Files\nodejs\`) ships both an extensionless `npm`
(a Unix shell script cmd.exe/PowerShell can't run) and `npm.cmd`. The
extensionless one matched first, and `spawnSync` launched it without a shell,
so npm never ran → non-zero status → silent `Update failed.`.

## Fix
- findNpmBin: prefer npm.cmd on win32, npm elsewhere; platform-aware fallback
- runUpdate: invoke npm.cmd via `cmd.exe /d /s /c` on Windows (shell:false so
  paths with spaces are quoted); macOS/Linux unchanged
- surface real errors (spawn error.message + npm exit code) instead of a bare
  "Update failed"

## Tests
New test/update-check.test.js (8 cases). Full suite 175 passing.

## Verify
```powershell
npm install -g @openagents-org/agent-launcher@latest
agn update