### PR TITLE
clarify local-only guidance in create/connect

### DIFF
--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -123,7 +123,6 @@ async function cmdCreate(connector, flags, positional) {
 
   try {
     connector.addAgent({ name, type, role, path: flags.path || process.cwd() });
-    print(`Agent '${name}' created (type: ${type})`);
 
     // Signal daemon to pick up the new agent
     try { connector.sendDaemonCommand('reload'); } catch {}
@@ -132,10 +131,14 @@ async function cmdCreate(connector, flags, positional) {
     // Without a workspace connection they will not appear in the Workspace Dashboard.
     const created = connector.config.getAgent(name);
     if (created && !created.network) {
+      print(`Created local agent: ${name} (type: ${type})`);
       print('');
-      print(`Note: '${name}' is local-only and will not appear in the Workspace Dashboard.`);
-      print(`To make it visible, connect it to a workspace:`);
+      print('This agent is local-only and will not appear in Workspace Dashboard yet.');
+      print('');
+      print('To connect it to a Workspace, run:');
       print(`  agn connect ${name} <workspace-token>`);
+    } else {
+      print(`Agent '${name}' created (type: ${type})`);
     }
 
     if (!connector.isInstalled(type)) {
@@ -306,11 +309,10 @@ async function cmdConnect(connector, flags, positional) {
     // No token supplied and none in the environment. Never prompt — keep
     // CI / non-interactive environments from hanging. Print a helpful error
     // explaining why the agent stays invisible and how to fix it.
-    print(`Error: no workspace token provided for '${name}'.`);
-    print(`Without a token, '${name}' stays local-only and will not appear in the Workspace Dashboard.`);
-    print('Provide a token in one of these ways:');
+    print('Workspace token is required.');
+    print('Local-only agents do not appear in Workspace Dashboard until connected.');
+    print('Run:');
     print(`  agn connect ${name} <workspace-token>`);
-    print(`  OPENAGENTS_WORKSPACE_TOKEN=<workspace-token> agn connect ${name}`);
     process.exitCode = 1;
     return;
   }

--- a/packages/agent-connector/test/cli.test.js
+++ b/packages/agent-connector/test/cli.test.js
@@ -97,7 +97,7 @@ describe('CLI', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
     try {
       const createOut = runWithConfig(tmpDir, 'create', 'test-agent', '--type', 'claude');
-      assert.ok(createOut.includes("'test-agent' created"));
+      assert.ok(createOut.includes('Created local agent: test-agent'));
       assert.ok(!createOut.includes('Installing claude...'));
 
       const listOut = runWithConfig(tmpDir, 'list');
@@ -172,7 +172,7 @@ describe('CLI', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
     try {
       const out = runWithConfig(tmpDir, 'create', 'local-agent', '--type', 'kimi');
-      assert.ok(out.includes("'local-agent' created"));
+      assert.ok(out.includes('Created local agent: local-agent'));
       assert.ok(out.includes('local-only'));
       assert.ok(out.includes('Workspace Dashboard'));
       // Points the user at the next command, scoped to the new agent name.
@@ -193,7 +193,7 @@ describe('CLI', () => {
       // Token accepted: it proceeds to resolution rather than the
       // missing-token error path. (Resolution itself may fail offline.)
       assert.ok(stdout.includes('Resolving workspace token'));
-      assert.ok(!stdout.includes('no workspace token provided'));
+      assert.ok(!stdout.includes('Workspace token is required'));
       // The token value must never be printed.
       assert.ok(!stdout.includes('tok-explicit-123'));
     } finally {
@@ -211,7 +211,7 @@ describe('CLI', () => {
       );
       // Env token picked up: reaches resolution, not the missing-token error.
       assert.ok(stdout.includes('Resolving workspace token'));
-      assert.ok(!stdout.includes('no workspace token provided'));
+      assert.ok(!stdout.includes('Workspace token is required'));
       assert.ok(!stdout.includes('tok-from-env-456'));
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -228,9 +228,9 @@ describe('CLI', () => {
         'connect', 'noenv-agent', '--config', tmpDir,
       );
       assert.equal(code, 1);
-      assert.ok(stdout.includes('no workspace token provided'));
+      assert.ok(stdout.includes('Workspace token is required.'));
       assert.ok(stdout.includes('Workspace Dashboard'));
-      assert.ok(stdout.includes('OPENAGENTS_WORKSPACE_TOKEN'));
+      assert.ok(stdout.includes('agn connect noenv-agent <workspace-token>'));
       // It must not have started resolving (no token was available).
       assert.ok(!stdout.includes('Resolving workspace token'));
     } finally {


### PR DESCRIPTION
- `agn create`: print "Created local agent" plus how to connect to a Workspace
- `agn connect` without a token: read OPENAGENTS_WORKSPACE_TOKEN / OA_WORKSPACE_TOKEN, else print a clear "token required" error and exit non-zero (never prompts, never prints the token)
- update cli tests for the new wording