### PR TITLE
show local agents as local and enable connect

### DIFF
--- a/packages/agent-connector/src/agent-rows.js
+++ b/packages/agent-connector/src/agent-rows.js
@@ -1,0 +1,73 @@
+/**
+ * Pure data helpers for the agent list, shared by the TUI (tui.js) and tests.
+ *
+ * Kept free of any UI/blessed dependency so the list-rendering logic — in
+ * particular the "(local)" labelling and Connect gating — can be unit-tested.
+ */
+
+'use strict';
+
+/**
+ * Build one display row per configured agent from a connector.
+ *
+ * `workspace` holds the resolved workspace URL (or '' when the agent is not
+ * connected). `workspaceLabel` is what the WORKSPACE column shows: the URL when
+ * connected, otherwise "(local)" — matching `agn list` so local-only agents are
+ * always visible rather than rendered as a blank cell.
+ */
+function loadAgentRows(connector) {
+  const config = connector.config.load();
+  const agents = config.agents || [];
+  const agentStatuses = connector.getDaemonStatus() || {};
+  const pid = connector.getDaemonPid();
+  const networks = config.networks || [];
+  return agents.map(agent => {
+    const info = agentStatuses[agent.name] || {};
+    const state = pid ? (info.state || 'stopped') : 'stopped';
+    let workspace = '';
+    if (agent.network) {
+      const net = networks.find(n => n.slug === agent.network || n.id === agent.network);
+      if (net) {
+        const slug = net.slug || net.id;
+        const isLocal = (net.endpoint || '').includes('localhost') || (net.endpoint || '').includes('127.0.0.1');
+        if (isLocal) workspace = `${net.endpoint}/${slug}`;
+        else workspace = `workspace.openagents.org/${slug}`;
+      } else {
+        workspace = agent.network;
+      }
+    }
+    let notReadyMsg = '';
+    let health = null;
+    try {
+      health = connector.healthCheck(agent.type || 'openclaw');
+      if (health && !health.ready) notReadyMsg = health.message || 'Not configured';
+    } catch {}
+
+    return {
+      name: agent.name,
+      type: agent.type || 'openclaw',
+      state,
+      workspace,
+      // "(local)" when there's no workspace connection; URL otherwise. `workspace`
+      // stays empty for local-only agents so Connect gating still treats them as
+      // connectable (see connectAvailable).
+      workspaceLabel: workspace || '(local)',
+      path: agent.path || '',
+      network: agent.network || '',
+      lastError: info.last_error || '',
+      notReadyMsg,
+      health,
+      configured: true,
+    };
+  });
+}
+
+/**
+ * An agent can be connected to a workspace when it's configured and not already
+ * bound to one. Mirrors the footer/menu gating so it can be unit-tested.
+ */
+function connectAvailable(row) {
+  return !!(row && row.configured && !row.workspace);
+}
+
+module.exports = { loadAgentRows, connectAvailable };

--- a/packages/agent-connector/src/tui.js
+++ b/packages/agent-connector/src/tui.js
@@ -8,6 +8,7 @@
 
 const blessed = require('blessed');
 const { AgentConnector } = require('./index');
+const { loadAgentRows, connectAvailable } = require('./agent-rows');
 const path = require('path');
 const fs = require('fs');
 const { spawn } = require('child_process');
@@ -62,49 +63,6 @@ function stateMarkup(state, hasWorkspace) {
 function getConnector() {
   const configDir = path.join(process.env.HOME || process.env.USERPROFILE || '.', '.openagents');
   return new AgentConnector({ configDir });
-}
-
-function loadAgentRows(connector) {
-  const config = connector.config.load();
-  const agents = config.agents || [];
-  const agentStatuses = connector.getDaemonStatus() || {};
-  const pid = connector.getDaemonPid();
-  const networks = config.networks || [];
-  return agents.map(agent => {
-    const info = agentStatuses[agent.name] || {};
-    const state = pid ? (info.state || 'stopped') : 'stopped';
-    let workspace = '';
-    if (agent.network) {
-      const net = networks.find(n => n.slug === agent.network || n.id === agent.network);
-      if (net) {
-        const slug = net.slug || net.id;
-        const isLocal = (net.endpoint || '').includes('localhost') || (net.endpoint || '').includes('127.0.0.1');
-        if (isLocal) workspace = `${net.endpoint}/${slug}`;
-        else workspace = `workspace.openagents.org/${slug}`;
-      } else {
-        workspace = agent.network;
-      }
-    }
-    let notReadyMsg = '';
-    let health = null;
-    try {
-      health = connector.healthCheck(agent.type || 'openclaw');
-      if (health && !health.ready) notReadyMsg = health.message || 'Not configured';
-    } catch {}
-
-    return {
-      name: agent.name,
-      type: agent.type || 'openclaw',
-      state,
-      workspace,
-      path: agent.path || '',
-      network: agent.network || '',
-      lastError: info.last_error || '',
-      notReadyMsg,
-      health,
-      configured: true,
-    };
-  });
 }
 
 function describeHealth(health) {
@@ -271,7 +229,7 @@ function createTUI() {
       const envFields = connector.registry.getEnvFields(agent.type);
       if (envFields && envFields.length > 0) items.push({ key: 'e', label: 'Configure' });
 
-      if (!agent.workspace) items.push({ key: 'c', label: 'Connect' });
+      if (connectAvailable(agent)) items.push({ key: 'c', label: 'Connect' });
       if (agent.workspace) items.push({ key: 'd', label: 'Disconnect' });
       if (agent.workspace) items.push({ key: 'w', label: 'Workspace' });
 
@@ -322,7 +280,8 @@ function createTUI() {
       const items = [];
       for (const r of agentRows) {
         const state = stateMarkup(r.state, !!r.workspace);
-        const ws = r.workspace || '';
+        // Local-only agents (no workspace) show a dimmed "(local)" marker.
+        const ws = r.workspace || `{gray-fg}${r.workspaceLabel}{/gray-fg}`;
         items.push(`  ${r.name.padEnd(22)} ${r.type.padEnd(14)} ${state.padEnd(30)} ${ws}`);
         // Detail row: working dir + config warning
         const details = [];
@@ -418,7 +377,7 @@ function createTUI() {
     if (isStopped) actions.push({ label: 'Start', key: 'start' });
     if (isRunning) actions.push({ label: 'Stop', key: 'stop' });
     if (agent.workspace) actions.push({ label: 'Open Workspace', key: 'open_workspace' });
-    if (!agent.workspace) actions.push({ label: 'Connect to Workspace', key: 'connect' });
+    if (connectAvailable(agent)) actions.push({ label: 'Connect to Workspace', key: 'connect' });
     if (agent.workspace) actions.push({ label: 'Disconnect from Workspace', key: 'disconnect' });
     actions.push({ label: 'Remove', key: 'remove' });
 
@@ -1403,7 +1362,7 @@ function createTUI() {
     Connect() {
       if (currentView !== 'main' || !selectedAgent()) return;
       const a = selectedAgent();
-      if (a.configured && !a.workspace) showConnectWorkspaceScreen(a.name);
+      if (connectAvailable(a)) showConnectWorkspaceScreen(a.name);
     },
     Disconnect() {
       if (currentView !== 'main' || !selectedAgent()) return;
@@ -1492,4 +1451,4 @@ function createTUI() {
 }
 
 function run() { createTUI(); }
-module.exports = { run };
+module.exports = { run, loadAgentRows, connectAvailable };

--- a/packages/agent-connector/test/tui.test.js
+++ b/packages/agent-connector/test/tui.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { Config } = require('../src/config');
+const { loadAgentRows, connectAvailable } = require('../src/agent-rows');
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-tui-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Minimal connector stub exposing exactly what loadAgentRows() consumes:
+// a real Config (so network writes are exercised), plus daemon/health hooks.
+function makeConnector(statuses = {}, { pid = 4321 } = {}) {
+  const config = new Config(tmpDir);
+  return {
+    config,
+    getDaemonStatus: () => statuses,
+    getDaemonPid: () => pid,
+    healthCheck: () => ({ ready: true, auth_mode: 'api_key' }),
+    // mirrors AgentConnector.connectWorkspace
+    connectWorkspace(name, slug) { config.setAgentNetwork(name, slug); },
+  };
+}
+
+function rowFor(rows, name) {
+  return rows.find((r) => r.name === name);
+}
+
+describe('TUI agent list — local-only display', () => {
+  it('shows "(local)" for an agent with no workspace', () => {
+    const connector = makeConnector({ 'my-agent0602001': { state: 'running' } });
+    connector.config.addAgent({ name: 'my-agent0602001', type: 'openclaw' });
+
+    const row = rowFor(loadAgentRows(connector), 'my-agent0602001');
+    assert.equal(row.workspace, '', 'no real workspace URL');
+    assert.equal(row.workspaceLabel, '(local)');
+    assert.equal(row.state, 'running');
+  });
+
+  it('shows "my-agent0602001 kimi running (local)" for a local-only kimi agent', () => {
+    const connector = makeConnector({ 'my-agent0602001': { state: 'running' } });
+    connector.config.addAgent({ name: 'my-agent0602001', type: 'kimi' });
+
+    const row = rowFor(loadAgentRows(connector), 'my-agent0602001');
+    assert.equal(row.name, 'my-agent0602001');
+    assert.equal(row.type, 'kimi');
+    assert.equal(row.state, 'running');
+    assert.equal(row.workspaceLabel, '(local)');
+    // Composed row matches the requested format.
+    assert.equal(
+      [row.name, row.type, row.state, row.workspaceLabel].join(' '),
+      'my-agent0602001 kimi running (local)',
+    );
+  });
+
+  it('marks a local-only agent as Connect-available', () => {
+    const connector = makeConnector({ 'lonely': { state: 'stopped' } });
+    connector.config.addAgent({ name: 'lonely', type: 'kimi' });
+
+    const row = rowFor(loadAgentRows(connector), 'lonely');
+    assert.equal(connectAvailable(row), true);
+  });
+});
+
+describe('TUI agent list — connecting refreshes the workspace label', () => {
+  it('updates the row from "(local)" to the workspace URL after create/join', () => {
+    const connector = makeConnector({ 'my-agent0602001': { state: 'running' } });
+    connector.config.addAgent({ name: 'my-agent0602001', type: 'kimi' });
+
+    // Before connecting: local-only.
+    let row = rowFor(loadAgentRows(connector), 'my-agent0602001');
+    assert.equal(row.workspaceLabel, '(local)');
+    assert.equal(connectAvailable(row), true);
+
+    // Simulate the create-workspace / join-token success path: persist the
+    // network, then bind the agent to it (what doCreateWorkspace/doJoinToken do).
+    connector.config.addNetwork({
+      id: 'ws-abc123',
+      slug: 'team-x',
+      name: "my-agent0602001's workspace",
+      endpoint: 'https://workspace.openagents.org',
+      token: 'tok-123',
+    });
+    connector.connectWorkspace('my-agent0602001', 'team-x');
+
+    // After refresh (re-running loadAgentRows): hosted URL, no longer local.
+    row = rowFor(loadAgentRows(connector), 'my-agent0602001');
+    assert.equal(row.workspace, 'workspace.openagents.org/team-x');
+    assert.equal(row.workspaceLabel, 'workspace.openagents.org/team-x');
+    assert.equal(connectAvailable(row), false);
+  });
+
+  it('keeps showing a localhost workspace endpoint normally (not "(local)")', () => {
+    const connector = makeConnector({ 'dev': { state: 'running' } });
+    connector.config.addNetwork({
+      id: 'ws-local',
+      slug: 'devspace',
+      name: 'Dev',
+      endpoint: 'http://localhost:8000',
+      token: 'tok',
+    });
+    connector.config.addAgent({ name: 'dev', type: 'openclaw' });
+    connector.connectWorkspace('dev', 'devspace');
+
+    const row = rowFor(loadAgentRows(connector), 'dev');
+    assert.equal(row.workspace, 'http://localhost:8000/devspace');
+    assert.equal(row.workspaceLabel, 'http://localhost:8000/devspace');
+    assert.equal(connectAvailable(row), false);
+  });
+});
+
+describe('TUI agent list — connected agents unchanged', () => {
+  it('renders a pre-connected hosted agent with its workspace URL', () => {
+    const connector = makeConnector({ 'worker': { state: 'running' } });
+    connector.config.addNetwork({
+      id: 'ws-1',
+      slug: 'prod',
+      name: 'Prod',
+      endpoint: 'https://workspace.openagents.org',
+      token: 'tok',
+    });
+    connector.config.addAgent({ name: 'worker', type: 'claude' });
+    connector.config.setAgentNetwork('worker', 'prod');
+
+    const row = rowFor(loadAgentRows(connector), 'worker');
+    assert.equal(row.workspace, 'workspace.openagents.org/prod');
+    assert.equal(row.workspaceLabel, 'workspace.openagents.org/prod');
+    assert.equal(connectAvailable(row), false);
+  });
+});


### PR DESCRIPTION
Local-only agents were already shown by `agn list` as `(local)`, but the TUI left the workspace column blank. This made local agents, including Kimi direct-API agents, look incomplete even though they could already use the existing Connect flow.

This change extracts agent row normalization into a blessed-free helper module and adds a `workspaceLabel` field so local-only agents render as `(local)` while preserving the raw empty `workspace` value for connection state.

The TUI now uses the shared `connectAvailable()` helper for all Connect entry points:
- footer Connect button
- Enter menu "Connect to Workspace"
- `c` key action

The existing Connect Workspace flow is reused unchanged, including:
- selecting an existing workspace
- creating a new workspace
- joining with token
- refreshing the agent row after connection

Kimi install/create/env/up behavior is unchanged.

Tests cover:
- local-only agents render as `(local)`
- Kimi local-only agents render correctly
- local-only agents remain connectable
- create workspace / join token updates network and refreshes the row
- connected agents and localhost workspace URLs remain unchanged