### PR TITLE
fix: repair Connect Agents workspace token copy button

### DIFF
--- a/packages/go/web/hooks/use-copy-to-clipboard.ts
+++ b/packages/go/web/hooks/use-copy-to-clipboard.ts
@@ -2,6 +2,33 @@
 
 import * as React from 'react';
 
+async function writeToClipboard(value: string): Promise<boolean> {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fall through to legacy copy below.
+  }
+
+  try {
+    const textArea = document.createElement('textarea');
+    textArea.value = value;
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-9999px';
+    document.body.appendChild(textArea);
+    textArea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(textArea);
+    return copied;
+  } catch {
+    return false;
+  }
+}
+
 export function useCopyToClipboard({
   timeout = 2000,
   onCopy,
@@ -12,13 +39,11 @@ export function useCopyToClipboard({
   const [isCopied, setIsCopied] = React.useState(false);
 
   const copyToClipboard = (value: string) => {
-    if (typeof window === 'undefined' || !navigator.clipboard.writeText) {
-      return;
-    }
-
     if (!value) return;
 
-    navigator.clipboard.writeText(value).then(() => {
+    void writeToClipboard(value).then((copied) => {
+      if (!copied) return;
+
       setIsCopied(true);
 
       if (onCopy) {
@@ -28,7 +53,7 @@ export function useCopyToClipboard({
       setTimeout(() => {
         setIsCopied(false);
       }, timeout);
-    }, console.error);
+    });
   };
 
   return { isCopied, copyToClipboard };

--- a/workspace/frontend/components/connect/connect-agent-view.tsx
+++ b/workspace/frontend/components/connect/connect-agent-view.tsx
@@ -62,6 +62,7 @@ export function ConnectAgentView() {
   const { setViewMode } = useLayout();
   const { workspace, token, refreshWorkspace } = useWorkspace();
   const { isCopied, copyToClipboard } = useCopyToClipboard();
+  const { isCopied: isTokenCopied, copyToClipboard: copyTokenToClipboard } = useCopyToClipboard();
 
   const [activeTab, setActiveTab] = useState<'local' | 'cloud'>('local');
   const [loading, setLoading] = useState(true);
@@ -69,7 +70,6 @@ export function ConnectAgentView() {
   // Local agents
   const [catalog, setCatalog] = useState<AgentCatalogEntry[]>([]);
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
-  const [tokenCopied, setTokenCopied] = useState(false);
 
   // Cloud agents
   const [cloudProviders, setCloudProviders] = useState<CloudAgentProvider[]>([]);
@@ -147,12 +147,6 @@ export function ConnectAgentView() {
       setCfgName(model.label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''));
     }
   }, [cfgModel, selectedProviderInfo]);
-
-  const handleCopyToken = () => {
-    navigator.clipboard.writeText(token);
-    setTokenCopied(true);
-    setTimeout(() => setTokenCopied(false), 2000);
-  };
 
   const maskedToken = token.length > 16
     ? `${token.slice(0, 8)}${'•'.repeat(8)}${token.slice(-4)}`
@@ -264,8 +258,8 @@ export function ConnectAgentView() {
             onSelectAgent={setSelectedAgent}
             token={token}
             maskedToken={maskedToken}
-            tokenCopied={tokenCopied}
-            onCopyToken={handleCopyToken}
+            isTokenCopied={isTokenCopied}
+            onCopyToken={() => copyTokenToClipboard(token)}
             isCopied={isCopied}
             copyToClipboard={copyToClipboard}
           />
@@ -311,7 +305,7 @@ function LocalAgentsTab({
   onSelectAgent,
   token,
   maskedToken,
-  tokenCopied,
+  isTokenCopied,
   onCopyToken,
   isCopied,
   copyToClipboard,
@@ -322,7 +316,7 @@ function LocalAgentsTab({
   onSelectAgent: (name: string | null) => void;
   token: string;
   maskedToken: string;
-  tokenCopied: boolean;
+  isTokenCopied: boolean;
   onCopyToken: () => void;
   isCopied: boolean;
   copyToClipboard: (text: string) => void;
@@ -509,10 +503,10 @@ function LocalAgentsTab({
                 </span>
                 <span className={cn(
                   'flex items-center gap-1 text-[10px] font-medium shrink-0 transition-colors',
-                  tokenCopied ? 'text-emerald-600' : 'text-muted-foreground group-hover:text-foreground',
+                  isTokenCopied ? 'text-emerald-600' : 'text-muted-foreground group-hover:text-foreground',
                 )}>
-                  {tokenCopied ? <Check className="size-3" /> : <Copy className="size-3" />}
-                  {tokenCopied ? 'Copied' : 'Copy'}
+                  {isTokenCopied ? <Check className="size-3" /> : <Copy className="size-3" />}
+                  {isTokenCopied ? 'Copied' : 'Copy'}
                 </span>
               </button>
             </div>

--- a/workspace/frontend/hooks/use-copy-to-clipboard.ts
+++ b/workspace/frontend/hooks/use-copy-to-clipboard.ts
@@ -2,6 +2,33 @@
 
 import * as React from 'react';
 
+async function writeToClipboard(value: string): Promise<boolean> {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fall through to legacy copy below.
+  }
+
+  try {
+    const textArea = document.createElement('textarea');
+    textArea.value = value;
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-9999px';
+    document.body.appendChild(textArea);
+    textArea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(textArea);
+    return copied;
+  } catch {
+    return false;
+  }
+}
+
 export function useCopyToClipboard({
   timeout = 2000,
   onCopy,
@@ -12,13 +39,11 @@ export function useCopyToClipboard({
   const [isCopied, setIsCopied] = React.useState(false);
 
   const copyToClipboard = (value: string) => {
-    if (typeof window === 'undefined' || !navigator.clipboard.writeText) {
-      return;
-    }
-
     if (!value) return;
 
-    navigator.clipboard.writeText(value).then(() => {
+    void writeToClipboard(value).then((copied) => {
+      if (!copied) return;
+
       setIsCopied(true);
 
       if (onCopy) {
@@ -28,7 +53,7 @@ export function useCopyToClipboard({
       setTimeout(() => {
         setIsCopied(false);
       }, timeout);
-    }, console.error);
+    });
   };
 
   return { isCopied, copyToClipboard };


### PR DESCRIPTION
## Summary
- Fix the Workspace Token **Copy** button on the Connect Agents page, which crashed in non-HTTPS environments because `navigator.clipboard` was accessed unsafely.
- Harden `useCopyToClipboard` with optional chaining and an `execCommand` fallback so clipboard copy works on HTTP/local dev.
- Route Connect Agents token copy through a dedicated hook instance and only show **Copied** after a successful write.

## Test plan
- [ ] Open Connect Agents → Local Agents, select an agent, click **Copy** on Workspace Token
- [ ] Verify token is copied to clipboard and UI shows **Copied** briefly
- [ ] Verify no runtime error on HTTP/local dev (where `navigator.clipboard` is undefined)
- [ ] Verify command-line snippet copy buttons still work