### PR TITLE
fix: restore connect agent CLI create step

### DIFF
--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -41,6 +41,9 @@ function parseArgs(argv) {
 function getConnector(flags) {
   const opts = {};
   if (flags.config) opts.configDir = flags.config;
+  if (flags.endpoint || process.env.OPENAGENTS_ENDPOINT) {
+    opts.workspaceEndpoint = flags.endpoint || process.env.OPENAGENTS_ENDPOINT;
+  }
   return new AgentConnector(opts);
 }
 
@@ -341,6 +344,8 @@ async function cmdConnect(connector, flags, positional) {
     if (pid) {
       connector.sendDaemonCommand(`restart:${name}`);
       print('Daemon notified');
+    } else {
+      print('Daemon is not running. Run `agn up` to bring this agent online.');
     }
   } catch (e) {
     print(`Error: ${e.message}`);

--- a/workspace/frontend/components/connect/connect-agent-view.tsx
+++ b/workspace/frontend/components/connect/connect-agent-view.tsx
@@ -475,9 +475,27 @@ function LocalAgentsTab({
                   </div>
                 </div>
 
-                {/* Step 3: Connect */}
+                {/* Step 3: Create agent instance */}
                 <div>
-                  <span className="text-[11px] text-muted-foreground">3. Connect to this workspace</span>
+                  <span className="text-[11px] text-muted-foreground">3. Create an agent instance</span>
+                  <div className="relative group mt-1">
+                    <pre className="bg-zinc-900 text-zinc-100 rounded-md px-3.5 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
+                      <span className="text-zinc-500">$ </span>
+                      <span className="text-emerald-400">agn create my-{selectedEntry.name} --type {selectedEntry.name}</span>
+                    </pre>
+                    <button
+                      type="button"
+                      className="absolute top-1.5 right-1.5 size-6 flex items-center justify-center rounded bg-zinc-700/80 hover:bg-zinc-600 text-zinc-300 hover:text-white opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity"
+                      onClick={() => copyToClipboard(`agn create my-${selectedEntry.name} --type ${selectedEntry.name}`)}
+                    >
+                      {isCopied ? <Check className="size-3" /> : <Copy className="size-3" />}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Step 4: Connect */}
+                <div>
+                  <span className="text-[11px] text-muted-foreground">4. Connect to this workspace</span>
                   <div className="relative group mt-1">
                     <pre className="bg-zinc-900 text-zinc-100 rounded-md px-3.5 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
                       <span className="text-zinc-500">$ </span>

--- a/workspace/frontend/components/connect/connect-agent-view.tsx
+++ b/workspace/frontend/components/connect/connect-agent-view.tsx
@@ -509,6 +509,45 @@ function LocalAgentsTab({
                     </button>
                   </div>
                 </div>
+
+                {/* Step 5: Start daemon */}
+                <div>
+                  <span className="text-[11px] text-muted-foreground">5. Start the daemon</span>
+                  <div className="relative group mt-1">
+                    <pre className="bg-zinc-900 text-zinc-100 rounded-md px-3.5 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
+                      <span className="text-zinc-500">$ </span>
+                      <span className="text-emerald-400">agn up</span>
+                    </pre>
+                    <button
+                      type="button"
+                      className="absolute top-1.5 right-1.5 size-6 flex items-center justify-center rounded bg-zinc-700/80 hover:bg-zinc-600 text-zinc-300 hover:text-white opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity"
+                      onClick={() => copyToClipboard('agn up')}
+                    >
+                      {isCopied ? <Check className="size-3" /> : <Copy className="size-3" />}
+                    </button>
+                  </div>
+                  <p className="mt-1 text-[10px] text-muted-foreground">
+                    If the daemon is already running, connect will notify it automatically.
+                  </p>
+                </div>
+
+                {/* Step 6: Verify status */}
+                <div>
+                  <span className="text-[11px] text-muted-foreground">6. Verify the agent is running</span>
+                  <div className="relative group mt-1">
+                    <pre className="bg-zinc-900 text-zinc-100 rounded-md px-3.5 py-2.5 text-xs font-mono leading-relaxed overflow-x-auto">
+                      <span className="text-zinc-500">$ </span>
+                      <span className="text-emerald-400">agn status</span>
+                    </pre>
+                    <button
+                      type="button"
+                      className="absolute top-1.5 right-1.5 size-6 flex items-center justify-center rounded bg-zinc-700/80 hover:bg-zinc-600 text-zinc-300 hover:text-white opacity-100 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity"
+                      onClick={() => copyToClipboard('agn status')}
+                    >
+                      {isCopied ? <Check className="size-3" /> : <Copy className="size-3" />}
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Restore the CLI setup flow so users create an agent instance before connecting it to a workspace.
- Add daemon startup and verification steps (`agn up`, `agn status`) so the command-line onboarding actually brings agents online.
- Improve `agn connect` feedback when the daemon is not running by telling users to run `agn up`.
- Pass explicit workspace endpoint configuration (`--endpoint` / `OPENAGENTS_ENDPOINT`) into the connector so self-hosted workspace tokens resolve against the intended backend instead of the default hosted endpoint.

## Verification
- `node --test test/cli.test.js`
- `npm --prefix workspace/frontend run build` completed successfully once; a later repeated build attempt hit an existing Next `.next/lock` from the running dev/build process, not a TypeScript/build error.
- LSP/Biome diagnostics were checked on the touched files; remaining diagnostics are pre-existing in the broader files.
