### PR TITLE
fix: handle stale launcher daemon pid

### DIFF
--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -300,7 +300,17 @@ class Daemon {
    * Read daemon PID, returning null if not running.
    */
   static readDaemonPid(configDir) {
-    return Daemon._readPid(path.join(configDir, 'daemon.pid'));
+    const pidFile = path.join(configDir, 'daemon.pid');
+    const statusFile = path.join(configDir, 'daemon.status.json');
+    const pid = Daemon._readPid(pidFile);
+    if (!pid) return null;
+
+    if (!Daemon._isAlive(pid)) {
+      Daemon._cleanupStaleDaemonFiles(pidFile, statusFile);
+      return null;
+    }
+
+    return pid;
   }
 
   // ---------------------------------------------------------------------------
@@ -818,6 +828,17 @@ class Daemon {
       return isNaN(pid) ? null : pid;
     } catch {
       return null;
+    }
+  }
+
+  static _cleanupStaleDaemonFiles(pidFile, statusFile) {
+    Daemon._unlinkIfExists(pidFile);
+    Daemon._unlinkIfExists(statusFile);
+  }
+
+  static _unlinkIfExists(filePath) {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
     }
   }
 

--- a/packages/agent-connector/test/daemon.test.js
+++ b/packages/agent-connector/test/daemon.test.js
@@ -175,10 +175,16 @@ describe('Daemon', () => {
     assert.equal(Daemon.readDaemonPid(tmpDir), process.pid);
   });
 
-  it('readDaemonPid returns pid without validating liveness', () => {
-    fs.writeFileSync(path.join(tmpDir, 'daemon.pid'), '99999999', 'utf-8');
-    // PID validation removed — returns raw value (liveness checked elsewhere)
-    assert.equal(Daemon.readDaemonPid(tmpDir), 99999999);
+  it('readDaemonPid removes stale pid and status files', () => {
+    const pidFile = path.join(tmpDir, 'daemon.pid');
+    const statusFile = path.join(tmpDir, 'daemon.status.json');
+
+    fs.writeFileSync(pidFile, '99999999', 'utf-8');
+    fs.writeFileSync(statusFile, '{"agents":{}}', 'utf-8');
+
+    assert.equal(Daemon.readDaemonPid(tmpDir), null);
+    assert.equal(fs.existsSync(pidFile), false);
+    assert.equal(fs.existsSync(statusFile), false);
   });
 
   it('_reload is serialized (concurrent calls queue)', async () => {


### PR DESCRIPTION
## Summary
- validate daemon pid liveness before reporting the launcher daemon as running
- clean stale daemon pid/status files so `agn up` can start a fresh daemon
- update daemon tests to cover stale pid cleanup

## Test plan
- `node --test test/daemon.test.js`
- `npm test`
- manual stale pid CLI check with a temporary `--config` directory