### PR TITLE
Feature/workspace support amp

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,28 @@ agn connect my-agent <workspace-token>    # connect agent into workspace
 | **Hermes Agent** | ✅ Supported | Nous Hermes CLI with tools, profiles, and memory |
 | **Cursor** | ✅ Supported | AI code editor |
 | **OpenCode** | ✅ Supported | Open-source terminal agent |
-| Aider, Goose, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+| **Amp** | ✅ Supported | Sourcegraph's coding agent (CLI execute mode) |
+| Aider, Goose, Gemini CLI, Copilot | 🔜 Coming soon | |
+
+#### Connecting Amp
+
+Amp runs in its non-interactive execute mode (`amp -x --stream-json`); the
+adapter keeps a separate Amp thread per workspace channel for follow-up context
+and writes any file changes into the agent's configured working directory.
+
+```bash
+agn install amp                              # install the Amp CLI (ampcode.com)
+amp login                                    # authenticate (browser) ...
+agn env amp --set AMP_API_KEY=<your-key>     # ... or set a key for headless use
+agn create my-amp --type amp --path ~/code   # create an instance + working dir
+agn up                                        # start the daemon
+agn connect my-amp <workspace-token>         # connect Amp into a workspace
+```
+
+Authenticate with **either** `amp login` (stores credentials locally) **or**
+`AMP_API_KEY` (required for fully headless/CI runs). Set `AMP_URL` only for
+enterprise/self-hosted Amp deployments. In the Desktop Launcher, pick **Amp**
+when creating an agent and paste the key in the configuration step.
 
 ---
 

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -27,11 +27,37 @@
       "cli",
       "vscode"
     ],
+    "builtin": true,
+    "support": { "install": true, "workspace": true, "collaboration": true },
     "install": {
       "binary": "amp",
       "macos": "curl -fsSL https://ampcode.com/install.sh | bash",
       "linux": "curl -fsSL https://ampcode.com/install.sh | bash",
       "windows": "powershell -c \\\"irm https://ampcode.com/install.ps1 | iex\\\""
+    },
+    "adapter": {
+      "module": "openagents.adapters.amp",
+      "class": "AmpAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "AMP_API_KEY",
+        "description": "Amp API key (create one at https://ampcode.com/settings) — leave blank if you have run `amp login`",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "AMP_URL",
+        "description": "Amp server URL for enterprise/self-hosted deployments (leave blank for the default)",
+        "required": false
+      }
+    ],
+    "check_ready": {
+      "login_command": "amp login",
+      "not_ready_message": "Not installed — run: openagents install amp"
     }
   },
   {

--- a/packages/agent-connector/src/adapters/amp.js
+++ b/packages/agent-connector/src/adapters/amp.js
@@ -36,6 +36,13 @@ const IS_WINDOWS = process.platform === 'win32';
 // turn) — guards the daemon against a hung Amp process without arbitrary sleeps.
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
+/** Platform-appropriate Amp CLI install command for "not found" messages. */
+function ampInstallHint() {
+  return IS_WINDOWS
+    ? 'powershell -NoProfile -Command "irm https://ampcode.com/install.ps1 | iex"'
+    : 'curl -fsSL https://ampcode.com/install.sh | bash';
+}
+
 class AmpAdapter extends BaseAdapter {
   constructor(opts) {
     super(opts);
@@ -58,7 +65,7 @@ class AmpAdapter extends BaseAdapter {
     if (this._ampBin) {
       this._log(`Using Amp CLI: ${this._ampBin}`);
     } else {
-      this._log('Warning: Amp CLI not found — install with: curl -fsSL https://ampcode.com/install.sh | bash');
+      this._log(`Warning: Amp CLI not found — install with: ${ampInstallHint()}`);
     }
   }
 
@@ -215,7 +222,7 @@ class AmpAdapter extends BaseAdapter {
 
     if (!this._ampBin) this._ampBin = this._findAmpBinary();
     if (!this._ampBin) {
-      await this.sendError(msgChannel, 'Amp CLI not found. Install with: curl -fsSL https://ampcode.com/install.sh | bash');
+      await this.sendError(msgChannel, `Amp CLI not found. Install with: ${ampInstallHint()}`);
       return;
     }
 

--- a/packages/agent-connector/src/adapters/amp.js
+++ b/packages/agent-connector/src/adapters/amp.js
@@ -1,0 +1,398 @@
+/**
+ * Amp adapter for OpenAgents workspace.
+ *
+ * Bridges Sourcegraph's Amp CLI to an OpenAgents workspace by running the
+ * agent in its official non-interactive *execute* mode with structured output:
+ *
+ *   amp -x --stream-json                                  // first turn (new thread)
+ *   amp threads continue <threadId> -x --stream-json      // follow-up turns
+ *
+ * The prompt is fed on stdin (the documented `echo "..." | amp -x` path), which
+ * avoids ARG_MAX / shell-quoting issues with the large workspace system context.
+ * Amp's `--stream-json` output is intentionally compatible with Claude Code's
+ * stream-json schema, so the event handling mirrors the Claude adapter: `system`
+ * (init / session id), `assistant` (text + tool_use blocks), and `result`
+ * (final text + session id).
+ *
+ * Reuses all shared connectivity / dispatch / state machinery in BaseAdapter;
+ * only the Amp-specific subprocess invocation and parsing live here.
+ *
+ * Mirrors the Python adapter: sdk/src/openagents/adapters/amp.py
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
+const { whichBinary, getEnhancedEnv } = require('../paths');
+
+const IS_WINDOWS = process.platform === 'win32';
+// Terminate the subprocess if it produces no output for this long (a wedged
+// turn) — guards the daemon against a hung Amp process without arbitrary sleeps.
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+class AmpAdapter extends BaseAdapter {
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+
+    // channel -> Amp thread id (for `amp threads continue <id>`)
+    this._channelThreads = {};
+    // channel -> running child process (for stop / cleanup)
+    this._channelProcesses = {};
+    // channels the user explicitly stopped (suppress "no response" noise)
+    this._stoppingChannels = new Set();
+
+    this._sessionsFile = path.join(
+      os.homedir(), '.openagents', 'sessions',
+      `${this.workspaceId}_${this.agentName}_amp.json`,
+    );
+    this._loadSessions();
+
+    this._ampBin = this._findAmpBinary();
+    if (this._ampBin) {
+      this._log(`Using Amp CLI: ${this._ampBin}`);
+    } else {
+      this._log('Warning: Amp CLI not found — install with: curl -fsSL https://ampcode.com/install.sh | bash');
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Session (thread id) persistence
+  // ------------------------------------------------------------------
+
+  _loadSessions() {
+    try {
+      if (fs.existsSync(this._sessionsFile)) {
+        const data = JSON.parse(fs.readFileSync(this._sessionsFile, 'utf-8'));
+        if (data && typeof data === 'object') {
+          Object.assign(this._channelThreads, data);
+          this._log(`Loaded ${Object.keys(data).length} Amp thread(s)`);
+        }
+      }
+    } catch {
+      this._log('Could not load Amp sessions file, starting fresh');
+    }
+  }
+
+  _saveSessions() {
+    try {
+      fs.mkdirSync(path.dirname(this._sessionsFile), { recursive: true });
+      fs.writeFileSync(this._sessionsFile, JSON.stringify(this._channelThreads));
+    } catch {}
+  }
+
+  _rememberThread(channel, threadId) {
+    if (!threadId) return;
+    if (this._channelThreads[channel] !== threadId) {
+      this._channelThreads[channel] = threadId;
+      this._saveSessions();
+      this._log(`Amp thread for ${channel}: ${threadId}`);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Binary resolution (cross-platform)
+  // ------------------------------------------------------------------
+
+  _findAmpBinary() {
+    const home = os.homedir();
+    const ext = IS_WINDOWS ? '.cmd' : '';
+
+    // Tier 0: isolated runtime prefix (~/.openagents/runtimes/amp/)
+    const runtimeCandidate = path.join(home, '.openagents', 'runtimes', 'amp', 'node_modules', '.bin', `amp${ext}`);
+    if (fs.existsSync(runtimeCandidate)) return runtimeCandidate;
+
+    // Tier 1: shared cross-platform resolver. It runs `which`/`where` against
+    // an ENHANCED PATH that includes nvm/fnm/volta/homebrew, ~/.local/bin and
+    // the Amp installer's ~/.amp/bin. This is what makes detection work inside
+    // a GUI- or daemon-spawned process that did NOT inherit the user's
+    // interactive shell PATH (the common "installed but not found" case).
+    const resolved = whichBinary('amp');
+    if (resolved) return resolved;
+
+    // Tier 2: explicit known install dirs as a last resort. The official
+    // installer (curl https://ampcode.com/install.sh | bash) writes the
+    // canonical binary to ~/.amp/bin and only symlinks into ~/.local/bin
+    // (or ~/bin, ~/.bin) when one of those is already on PATH.
+    const candidates = IS_WINDOWS ? [
+      path.join(home, '.amp', 'bin', 'amp.exe'),
+      path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'amp', 'amp.exe'),
+      path.join(process.env.APPDATA || '', 'npm', 'amp.cmd'),
+    ] : [
+      path.join(home, '.amp', 'bin', 'amp'),
+      path.join(home, '.local', 'bin', 'amp'),
+      path.join(home, 'bin', 'amp'),
+      '/usr/local/bin/amp',
+      '/opt/homebrew/bin/amp',
+    ];
+    for (const c of candidates) {
+      if (c && fs.existsSync(c)) return c;
+    }
+
+    return null;
+  }
+
+  // ------------------------------------------------------------------
+  // Prompt / command construction
+  // ------------------------------------------------------------------
+
+  _buildSystemContext(channelName, browserEnabled = false) {
+    return buildOpenclawSystemPrompt({
+      agentName: this.agentName,
+      workspaceId: this.workspaceId,
+      channelName,
+      endpoint: this.endpoint,
+      token: this.token,
+      mode: this._mode,
+      disabledModules: this.disabledModules,
+      browserEnabled,
+    });
+  }
+
+  _buildAmpCmd(channelName, resume) {
+    const threadId = resume ? this._channelThreads[channelName] : null;
+    if (threadId) {
+      return [this._ampBin, 'threads', 'continue', threadId, '-x', '--stream-json'];
+    }
+    return [this._ampBin, '-x', '--stream-json'];
+  }
+
+  // ------------------------------------------------------------------
+  // Control actions (stop)
+  // ------------------------------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      for (const [channel, proc] of Object.entries(this._channelProcesses)) {
+        this._stoppingChannels.add(channel);
+        await this._stopProcess(proc);
+        delete this._channelProcesses[channel];
+        try { await this.sendStatus(channel, 'Execution stopped by user'); } catch {}
+      }
+      return;
+    }
+    // Shared actions (status, routines, skill.install/uninstall).
+    await super._onControlAction(action, payload);
+  }
+
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000 }); } catch {}
+        return;
+      }
+      // POSIX: kill the whole process group (proc was detached) so child
+      // tool processes are reaped too.
+      try { process.kill(-proc.pid, 'SIGTERM'); } catch { proc.kill('SIGTERM'); }
+      await new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          try { process.kill(-proc.pid, 'SIGKILL'); } catch { proc.kill('SIGKILL'); }
+          resolve();
+        }, 5000);
+        proc.on('exit', () => { clearTimeout(timeout); resolve(); });
+      });
+    } catch {}
+  }
+
+  // ------------------------------------------------------------------
+  // Message handler
+  // ------------------------------------------------------------------
+
+  async _handleMessage(msg) {
+    const content = (msg.content || '').trim();
+    if (!content) return;
+
+    const msgChannel = msg.sessionId || this.channelName;
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${msgChannel}: ${content.slice(0, 80)}...`);
+
+    if (!this._ampBin) this._ampBin = this._findAmpBinary();
+    if (!this._ampBin) {
+      await this.sendError(msgChannel, 'Amp CLI not found. Install with: curl -fsSL https://ampcode.com/install.sh | bash');
+      return;
+    }
+
+    await this._autoTitleChannel(msgChannel, content);
+    this._stoppingChannels.delete(msgChannel);
+    await this.sendStatus(msgChannel, 'thinking...');
+
+    let responseText = '';
+    try {
+      responseText = await this._runAmp(content, msgChannel);
+    } catch (e) {
+      this._log(`Error handling message: ${e.message}`);
+      await this.sendError(msgChannel, `Error processing message: ${e.message}`);
+      return;
+    }
+
+    if (this._stoppingChannels.has(msgChannel)) {
+      this._stoppingChannels.delete(msgChannel);
+      return;
+    }
+    if (responseText) {
+      await this.sendResponse(msgChannel, responseText);
+    } else {
+      await this.sendResponse(msgChannel, 'No response generated. Please try again.');
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Subprocess execution + stream-json parsing
+  // ------------------------------------------------------------------
+
+  async _runAmp(content, msgChannel) {
+    const browserEnabled = await this.getBrowserEnabled();
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const resume = attempt === 0 && !!this._channelThreads[msgChannel];
+      const cmd = this._buildAmpCmd(msgChannel, resume);
+
+      let prompt;
+      if (resume) {
+        // Resumed Amp thread already carries the workspace context.
+        prompt = content;
+      } else {
+        const context = this._buildSystemContext(msgChannel, browserEnabled);
+        prompt = `${context}\n\n---\n\n${content}`;
+      }
+
+      const { text, stale } = await this._spawnAmp(cmd, prompt, msgChannel);
+
+      if (this._stoppingChannels.has(msgChannel)) return '';
+      if (text) return text;
+      if (stale && resume) {
+        this._log(`Amp thread for ${msgChannel} appears stale — retrying fresh`);
+        delete this._channelThreads[msgChannel];
+        this._saveSessions();
+        continue;
+      }
+      return '';
+    }
+    return '';
+  }
+
+  async _spawnAmp(cmd, prompt, msgChannel) {
+    return new Promise((resolve, reject) => {
+      // Pass the agent env with an enhanced PATH (nvm/fnm/volta/homebrew,
+      // ~/.local/bin, ~/.amp/bin) so the amp subprocess and any tools it shells
+      // out to resolve, even in a GUI/daemon process. AMP_API_KEY / AMP_URL
+      // flow through unchanged and are never logged.
+      const env = getEnhancedEnv(this.agentEnv);
+
+      const proc = spawn(cmd[0], cmd.slice(1), {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env,
+        cwd: this.workingDir,
+        detached: !IS_WINDOWS,
+        windowsHide: true,
+        shell: IS_WINDOWS && String(cmd[0]).toLowerCase().endsWith('.cmd'),
+      });
+      this._channelProcesses[msgChannel] = proc;
+
+      let lastTurnText = [];
+      let resultText = '';
+      let hasToolUseSinceText = false;
+      let lineBuffer = '';
+      let stderrBuf = '';
+      let pending = Promise.resolve();
+
+      // Idle watchdog — reset on any stdout activity.
+      let idleTimer = null;
+      const armIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          this._log(`Amp produced no output for ${IDLE_TIMEOUT_MS / 1000}s — terminating`);
+          this._stopProcess(proc);
+        }, IDLE_TIMEOUT_MS);
+      };
+      armIdle();
+
+      if (proc.stderr) {
+        proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString('utf-8'); });
+      }
+
+      if (proc.stdin) {
+        proc.stdin.write(prompt || '', 'utf-8');
+        proc.stdin.end();
+      }
+
+      const processLine = async (line) => {
+        line = line.trim();
+        if (!line) return;
+        let event;
+        try { event = JSON.parse(line); } catch { return; }
+
+        const eventType = event.type;
+        if (eventType === 'system') {
+          if (event.session_id) this._rememberThread(msgChannel, event.session_id);
+        } else if (eventType === 'assistant') {
+          const blocks = (event.message && event.message.content) || [];
+          for (const block of blocks) {
+            if (block.type === 'text') {
+              const text = (block.text || '').trim();
+              if (!text) continue;
+              if (hasToolUseSinceText) {
+                lastTurnText = [];
+                hasToolUseSinceText = false;
+              }
+              lastTurnText.push(text);
+              try { await this.sendThinking(msgChannel, text); } catch {}
+            } else if (block.type === 'tool_use') {
+              hasToolUseSinceText = true;
+              lastTurnText = [];
+              const toolName = block.name || '';
+              const toolInput = String(JSON.stringify(block.input || {})).slice(0, 200);
+              try { await this.sendStatus(msgChannel, `**Using tool:** \`${toolName}\`\n\`\`\`\n${toolInput}\n\`\`\``); } catch {}
+            }
+          }
+        } else if (eventType === 'result') {
+          if (event.session_id) this._rememberThread(msgChannel, event.session_id);
+          if (event.is_error) this._log(`Amp result error: ${String(event.result || '').slice(0, 200)}`);
+          if (event.result) resultText = event.result;
+        }
+      };
+
+      proc.stdout.on('data', (chunk) => {
+        armIdle();
+        lineBuffer += chunk.toString('utf-8');
+        const lines = lineBuffer.split('\n');
+        lineBuffer = lines.pop();
+        for (const line of lines) {
+          pending = pending.then(() => processLine(line)).catch(() => {});
+        }
+      });
+
+      proc.on('exit', async (code) => {
+        if (idleTimer) clearTimeout(idleTimer);
+        try { await pending; } catch {}
+        for (const line of lineBuffer.split('\n')) {
+          try { await processLine(line); } catch {}
+        }
+        delete this._channelProcesses[msgChannel];
+
+        if (code !== 0 && stderrBuf.trim()) {
+          this._log(`Amp exited ${code}; stderr: ${stderrBuf.trim().slice(0, 300)}`);
+        }
+
+        const text = lastTurnText.filter(Boolean).join('\n').trim() || resultText.trim();
+        const stale = code !== 0 && !text;
+        resolve({ text, exitCode: code, stale });
+      });
+
+      proc.on('error', (err) => {
+        if (idleTimer) clearTimeout(idleTimer);
+        delete this._channelProcesses[msgChannel];
+        reject(err);
+      });
+    });
+  }
+}
+
+module.exports = AmpAdapter;

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -14,6 +14,7 @@ const CursorAdapter = require('./cursor');
 const HermesAdapter = require('./hermes');
 const GeminiAdapter = require('./gemini');
 const KimiAdapter = require('./kimi');
+const AmpAdapter = require('./amp');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -25,11 +26,12 @@ const ADAPTER_MAP = {
   hermes: HermesAdapter,
   gemini: GeminiAdapter,
   kimi: KimiAdapter,
+  amp: AmpAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, amp)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -52,6 +54,7 @@ module.exports = {
   HermesAdapter,
   GeminiAdapter,
   KimiAdapter,
+  AmpAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -90,6 +90,20 @@ class Installer {
     // Fallback: check if binary exists on PATH (system install)
     const binaryPath = this._whichBinary(agentType);
     if (!binaryPath) {
+      // Amp-only: a marker alone is NOT sufficient evidence of an install.
+      // Amp's CLI lives outside any npm package (curl/ps1 installer → ~/.amp/bin),
+      // so a historical "installed" marker can outlive a missing/never-landed
+      // binary. Require a real resolvable binary; when only a stale marker
+      // remains, report not-installed with a 'cli-missing' diagnostic (carried
+      // by the existing `location` field — no new field/enum) instead of the
+      // generic marker fallback. The marker itself is left untouched.
+      if (agentType === 'amp') {
+        return {
+          installed: false,
+          managed: false,
+          location: this._hasMarker(agentType) ? 'cli-missing' : null,
+        };
+      }
       // If a successful install wrote a marker, surface installed=true even
       // when binary detection can't (yet) see the freshly-installed CLI —
       // e.g. PATH caches not yet picking up a brand-new ~/.cursor/bin. The
@@ -142,6 +156,82 @@ class Installer {
       } catch { return false; }
     }
     return this.isInstalled(agentType);
+  }
+
+  /**
+   * Amp-only post-install verification.
+   *
+   * Confirms a REAL amp binary exists on disk before the install is recorded.
+   * The Amp install script can exit 0 without landing a runnable binary (wrong
+   * $HOME, blocked download, custom AMP_HOME), which would otherwise leave a
+   * "marker says installed but CLI missing" state. Deliberately does NOT consult
+   * the installed marker (unlike verifyInstalled()->isInstalled()), so it can't
+   * be satisfied by its own about-to-be-written record.
+   *
+   * Hard condition for success: an absolute path resolves AND the file exists.
+   * `amp --version` is a best-effort enhancement used only for logging — a flaky
+   * or non-interactive `--version` failure does NOT fail the install.
+   *
+   * Scoped to Amp; never called for any other agent type.
+   *
+   * @returns {{ path: string, version: string|null } | null}
+   */
+  _verifyAmpBinary() {
+    // Drop the 30s PATH/whichBinary cache so we see the freshly-installed dir
+    // (e.g. ~/.amp/bin) instead of the pre-install snapshot.
+    try { clearBinaryLookupCache(); } catch {}
+
+    const isWin = process.platform === 'win32';
+    const names = isWin ? ['amp.exe', 'amp.cmd', 'amp'] : ['amp'];
+    const candidates = [];
+    // 1) Whatever the shared cross-platform resolver finds on the enhanced PATH
+    //    (already includes ~/.amp/bin).
+    const resolved = this._whichBinary('amp');
+    if (resolved) candidates.push(resolved);
+    // 2) Honor a custom AMP_HOME, then the installer's default ~/.amp/bin —
+    //    covers a binary that exists but whose dir isn't on PATH yet.
+    const binDirs = [];
+    if (process.env.AMP_HOME) binDirs.push(path.join(process.env.AMP_HOME, 'bin'));
+    binDirs.push(path.join(os.homedir(), '.amp', 'bin'));
+    for (const dir of binDirs) {
+      for (const name of names) candidates.push(path.join(dir, name));
+    }
+
+    let found = null;
+    for (const c of candidates) {
+      try { if (c && fs.existsSync(c)) { found = c; break; } } catch {}
+    }
+    if (!found) return null;
+
+    let version = null;
+    try {
+      version = require('child_process').execSync(`"${found}" --version`, {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 8000,
+        env: getEnhancedEnv(),
+        windowsHide: true,
+        encoding: 'utf-8',
+      }).trim() || null;
+    } catch {
+      // Best-effort only — file existence above is the hard condition.
+    }
+    return { path: found, version };
+  }
+
+  /**
+   * Amp-only: message shown when the install command exits 0 but no runnable
+   * amp binary can be found. Points at the canonical (or AMP_HOME) location.
+   */
+  _ampBinaryNotFoundMessage() {
+    const isWin = process.platform === 'win32';
+    const baseDir = process.env.AMP_HOME
+      ? path.join(process.env.AMP_HOME, 'bin')
+      : path.join(os.homedir(), '.amp', 'bin');
+    const expected = path.join(baseDir, isWin ? 'amp.exe' : 'amp');
+    return (
+      'Amp install command completed, but the Amp CLI binary could not be found.\n\n' +
+      `Expected path:\n${expected}`
+    );
   }
 
   /**
@@ -385,6 +475,22 @@ class Installer {
     }
 
     const output = await this._execShell(cmd);
+
+    // Amp-only: the install script can exit 0 without landing a runnable
+    // binary, so verify the real CLI exists BEFORE recording the install.
+    // Other agent types keep the original "exit 0 → mark installed" behavior.
+    if (agentType === 'amp') {
+      const amp = this._verifyAmpBinary();
+      if (!amp) {
+        throw new Error(this._ampBinaryNotFoundMessage());
+      }
+      this._markInstalled(agentType);
+      return {
+        success: true,
+        output: `${output}\nAmp CLI resolved: ${amp.path}${amp.version ? ` (${amp.version})` : ''}`,
+      };
+    }
+
     this._markInstalled(agentType);
     return { success: true, output };
   }
@@ -502,6 +608,19 @@ class Installer {
       proc.on('error', (err) => reject(err));
       proc.on('close', (code) => {
         if (code === 0) {
+          // Amp-only: confirm a real binary exists before recording the
+          // install (verify-before-mark; never writes/rolls back a marker on
+          // failure). Other agent types are unaffected.
+          if (agentType === 'amp') {
+            const amp = this._verifyAmpBinary();
+            if (!amp) {
+              const msg = this._ampBinaryNotFoundMessage();
+              if (onData) onData(`\n${msg}\n`);
+              reject(new Error(msg));
+              return;
+            }
+            if (onData) onData(`\nAmp CLI resolved: ${amp.path}${amp.version ? ` (${amp.version})` : ''}\n`);
+          }
           this._markInstalled(agentType);
           if (onData) onData(`\nDone! ${agentType} is now installed.\n`);
           resolve({ success: true, command: displayCmd });

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -197,6 +197,12 @@ function _addWindowsPaths(dirs) {
   if (localAppData) _push(dirs, path.join(localAppData, 'cursor-agent'));
   _push(dirs, path.join(HOME, '.local', 'bin'));
 
+  // Amp CLI (irm https://ampcode.com/install.ps1 | iex) — same registry-PATH
+  // staleness as Cursor; add the canonical install dir(s) so an already-running
+  // daemon resolves amp without a reboot.
+  _push(dirs, path.join(HOME, '.amp', 'bin'));
+  if (localAppData) _push(dirs, path.join(localAppData, 'amp'));
+
   // Hermes CLI native (no-WSL) installer drops hermes.exe in the portable
   // venv's Scripts dir and the uv shim in %LOCALAPPDATA%\hermes\bin. Same
   // registry-PATH staleness as Cursor — add explicitly so an already-running
@@ -291,6 +297,12 @@ function _addUnixPaths(dirs) {
 
   // Cursor CLI native installer (curl https://cursor.com/install | bash)
   _push(dirs, path.join(HOME, '.cursor', 'bin'));
+
+  // Amp CLI native installer (curl https://ampcode.com/install.sh | bash)
+  // drops the binary in ~/.amp/bin and only symlinks into ~/.local/bin when
+  // that dir is already on PATH — so a GUI- or daemon-spawned process never
+  // sees it unless the canonical dir is listed here explicitly.
+  _push(dirs, path.join(HOME, '.amp', 'bin'));
 }
 
 // ---- macOS-specific ----

--- a/packages/agent-connector/test/amp-install.test.js
+++ b/packages/agent-connector/test/amp-install.test.js
@@ -1,0 +1,283 @@
+'use strict';
+
+/**
+ * Amp-only post-install verification tests.
+ *
+ * Pins the fix for the "install command exited 0 but no runnable amp.exe →
+ * Launcher still showed installed" bug. The verification is scoped to
+ * agentType === 'amp'; these tests also assert other agent types keep the
+ * original "exit 0 → mark installed" behavior (no new binary check).
+ *
+ * No real install runs: install() stubs _execShell, installStreaming() mocks
+ * child_process.spawn, and binary resolution is controlled via _whichBinary +
+ * an isolated HOME / AMP_HOME so the on-disk candidate checks are deterministic.
+ *
+ * Run: node --test test/amp-install.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { EventEmitter } = require('node:events');
+const cp = require('child_process');
+
+const { Installer } = require('../src/installer');
+
+const mockRegistry = {
+  getEntry: (name) => {
+    if (name === 'amp') {
+      return {
+        name: 'amp',
+        install: {
+          binary: 'amp',
+          macos: 'curl -fsSL https://ampcode.com/install.sh | bash',
+          linux: 'curl -fsSL https://ampcode.com/install.sh | bash',
+          windows: 'powershell -c "irm https://ampcode.com/install.ps1 | iex"',
+        },
+      };
+    }
+    // A non-npm "other agent" used to prove the non-amp path is unchanged
+    // (non-npm avoids installStreaming's npm/nodejs bootstrap machinery).
+    if (name === 'otherapp') {
+      return {
+        name: 'otherapp',
+        install: {
+          binary: 'otherapp',
+          macos: 'echo install',
+          linux: 'echo install',
+          windows: 'echo install',
+        },
+      };
+    }
+    return null;
+  },
+};
+
+let tmpDir;
+let tmpHome;
+let saved;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amp-inst-'));
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'amp-home-'));
+  saved = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    AMP_HOME: process.env.AMP_HOME,
+    spawn: cp.spawn,
+  };
+  // os.homedir() honors $HOME on POSIX and %USERPROFILE% on Windows.
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  delete process.env.AMP_HOME;
+});
+
+afterEach(() => {
+  cp.spawn = saved.spawn;
+  for (const k of ['HOME', 'USERPROFILE', 'AMP_HOME']) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+function markerHas(name) {
+  const f = path.join(tmpDir, 'installed_agents.json');
+  if (!fs.existsSync(f)) return false;
+  try { return JSON.parse(fs.readFileSync(f, 'utf-8')).includes(name); } catch { return false; }
+}
+
+// Fake child_process.spawn: emits the given exit code with no output. The
+// installer destructures `spawn` from require('child_process') per call, so
+// mutating cp.spawn here is picked up by installStreaming().
+function mockSpawnExit(code) {
+  cp.spawn = () => {
+    const proc = new EventEmitter();
+    const mkStream = () => { const e = new EventEmitter(); e.setEncoding = () => {}; return e; };
+    proc.stdout = mkStream();
+    proc.stderr = mkStream();
+    proc.pid = 4321;
+    setImmediate(() => proc.emit('close', code));
+    return proc;
+  };
+}
+
+function writeAmpBinary(dir) {
+  const isWin = process.platform === 'win32';
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, isWin ? 'amp.exe' : 'amp');
+  // Executable stub so the best-effort `--version` probe can succeed too.
+  fs.writeFileSync(p, isWin ? 'amp\n' : '#!/bin/sh\necho "amp 1.0.0-test"\n');
+  if (!isWin) fs.chmodSync(p, 0o755);
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — install command succeeds but no real binary → must FAIL, no marker
+// ---------------------------------------------------------------------------
+
+describe('Amp install — verification failure (no binary)', () => {
+  it('install(): exit 0 but binary missing → throws, writes no marker', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'install output';
+    inst._whichBinary = () => null; // not on PATH; ~/.amp/bin absent in tmpHome
+
+    await assert.rejects(
+      () => inst.install('amp'),
+      /Amp install command completed, but the Amp CLI binary could not be found/,
+    );
+    assert.equal(markerHas('amp'), false, 'no marker must be written on verification failure');
+  });
+
+  it('installStreaming(): exit 0 but binary missing → rejects, no marker, no "Done"', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    mockSpawnExit(0);
+
+    const out = [];
+    await assert.rejects(
+      () => inst.installStreaming('amp', (d) => out.push(d)),
+      /Amp CLI binary could not be found/,
+    );
+    assert.equal(markerHas('amp'), false);
+    const joined = out.join('');
+    assert.ok(!joined.includes('Done!'), 'must NOT print "Done!" when verification fails');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — binary present at ~/.amp/bin (or AMP_HOME), not on PATH → SUCCESS
+// ---------------------------------------------------------------------------
+
+describe('Amp install — verification success (binary resolved off PATH)', () => {
+  it('install(): binary in ~/.amp/bin (not on PATH) → marker written + resolved path logged', async () => {
+    const ampPath = writeAmpBinary(path.join(tmpHome, '.amp', 'bin'));
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'install output';
+    inst._whichBinary = () => null; // force fallback to the ~/.amp/bin candidate
+
+    const res = await inst.install('amp');
+    assert.equal(res.success, true);
+    assert.equal(markerHas('amp'), true);
+    assert.ok(
+      res.output.includes(`Amp CLI resolved: ${ampPath}`),
+      `output should log the resolved absolute path; got:\n${res.output}`,
+    );
+  });
+
+  it('installStreaming(): binary in ~/.amp/bin → marker written + "Done!" + resolved path', async () => {
+    const ampPath = writeAmpBinary(path.join(tmpHome, '.amp', 'bin'));
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    mockSpawnExit(0);
+
+    const out = [];
+    const res = await inst.installStreaming('amp', (d) => out.push(d));
+    assert.equal(res.success, true);
+    assert.equal(markerHas('amp'), true);
+    const joined = out.join('');
+    assert.ok(joined.includes(`Amp CLI resolved: ${ampPath}`));
+    assert.ok(joined.includes('Done!'));
+  });
+
+  it('install(): respects AMP_HOME/bin when resolving the binary', async () => {
+    const ampHome = fs.mkdtempSync(path.join(os.tmpdir(), 'amp-AMPHOME-'));
+    process.env.AMP_HOME = ampHome;
+    const ampPath = writeAmpBinary(path.join(ampHome, 'bin'));
+    try {
+      const inst = new Installer(mockRegistry, tmpDir);
+      inst._execShell = async () => 'ok';
+      inst._whichBinary = () => null;
+
+      const res = await inst.install('amp');
+      assert.equal(res.success, true);
+      assert.equal(markerHas('amp'), true);
+      assert.ok(res.output.includes(`Amp CLI resolved: ${ampPath}`));
+    } finally {
+      try { fs.rmSync(ampHome, { recursive: true, force: true }); } catch {}
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — non-amp agents are UNCHANGED (no new binary verification)
+// ---------------------------------------------------------------------------
+
+describe('Amp install — no impact on other agent types', () => {
+  it('install(): non-amp still marks installed on exit 0 even without a resolvable binary', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'ok';
+    inst._whichBinary = () => null; // binary not resolvable
+
+    const res = await inst.install('otherapp');
+    assert.equal(res.success, true);
+    assert.equal(markerHas('otherapp'), true, 'non-amp must keep original exit0 → marker behavior');
+    assert.ok(!String(res.output).includes('Amp CLI resolved'), 'non-amp must not run amp verification');
+  });
+
+  it('installStreaming(): non-amp still marks installed + prints "Done" on exit 0', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    mockSpawnExit(0);
+
+    const out = [];
+    const res = await inst.installStreaming('otherapp', (d) => out.push(d));
+    assert.equal(res.success, true);
+    assert.equal(markerHas('otherapp'), true);
+    const joined = out.join('');
+    assert.ok(joined.includes('Done!'));
+    assert.ok(!joined.includes('Amp CLI resolved'), 'non-amp must not run amp verification');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale-marker reconciliation — getInstallInfo()/isInstalled() for Amp
+// ---------------------------------------------------------------------------
+
+describe('Amp install status — historical marker reconciliation', () => {
+  it('amp marker present but no real CLI → NOT installed, cli-missing, marker preserved', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._markInstalled('amp');        // simulate a historical/stale install record
+    inst._whichBinary = () => null;    // real CLI absent (and ~/.amp/bin isolated/empty)
+
+    const info = inst.getInstallInfo('amp');
+    assert.equal(info.installed, false, 'a stale marker alone must not count as installed for amp');
+    assert.equal(info.location, 'cli-missing', 'diagnostic must distinguish "record exists but CLI missing"');
+    assert.equal(inst.isInstalled('amp'), false);
+    assert.equal(markerHas('amp'), true, 'the historical marker must NOT be deleted');
+  });
+
+  it('amp marker AND real CLI present → installed (real CLI takes priority over marker)', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._markInstalled('amp');
+    inst._whichBinary = () => '/usr/bin/amp'; // real CLI resolves outside ~/.openagents
+
+    const info = inst.getInstallInfo('amp');
+    assert.equal(info.installed, true);
+    assert.equal(info.location, 'global');
+    assert.equal(inst.isInstalled('amp'), true);
+  });
+
+  it('amp without marker but real CLI present → installed', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => '/usr/bin/amp';
+
+    assert.equal(inst.getInstallInfo('amp').installed, true);
+    assert.equal(inst.isInstalled('amp'), true);
+    assert.equal(markerHas('amp'), false);
+  });
+
+  it('non-amp marker present but no CLI → still installed via marker (UNCHANGED)', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._markInstalled('otherapp');
+    inst._whichBinary = () => null;
+
+    const info = inst.getInstallInfo('otherapp');
+    assert.equal(info.installed, true, 'non-amp marker fallback must be unchanged');
+    assert.equal(info.location, 'marker');
+    assert.equal(inst.isInstalled('otherapp'), true);
+  });
+});

--- a/packages/agent-connector/test/amp.test.js
+++ b/packages/agent-connector/test/amp.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+/**
+ * Unit tests for the Amp adapter (Node / agent-connector runtime).
+ *
+ * No real `amp` binary or workspace is needed: `child_process.spawn` is faked
+ * to emit Amp's Claude-compatible `--stream-json` events, and network helpers
+ * (sendThinking/sendStatus/sendResponse) are stubbed on the instance.
+ *
+ * Covered: registration in ADAPTER_MAP, execute/threads-continue command
+ * construction, stream-json parsing + per-channel thread persistence, working
+ * dir + AMP_API_KEY env passing, secret never logged, stop control, and that
+ * existing adapters keep loading.
+ */
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const EventEmitter = require('node:events');
+const cp = require('node:child_process');
+
+// Install a swappable spawn shim BEFORE requiring the adapter, so the
+// module-level `const { spawn } = require('child_process')` binds to it.
+const realSpawn = cp.spawn;
+let spawnImpl = null;
+let lastSpawn = null;
+cp.spawn = (...args) => spawnImpl(...args);
+
+const { createAdapter, ADAPTER_MAP, AmpAdapter } = require('../src/adapters');
+
+after(() => { cp.spawn = realSpawn; });
+
+function streamLines() {
+  const events = [
+    { type: 'system', subtype: 'init', session_id: 'T-thread-1' },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'Looking into it' }] } },
+    { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }] } },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'All done!' }] } },
+    { type: 'result', subtype: 'success', is_error: false, result: 'All done!', session_id: 'T-thread-1' },
+  ];
+  return events.map((e) => JSON.stringify(e) + '\n');
+}
+
+function makeFakeSpawn(lines, exitCode = 0, stderr = '') {
+  return (cmd, args, opts) => {
+    const proc = new EventEmitter();
+    proc.pid = 4242;
+    proc.exitCode = null;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    let stdinBuf = '';
+    proc.stdin = {
+      write(d) { stdinBuf += d.toString(); },
+      end() { proc._stdin = stdinBuf; },
+    };
+    lastSpawn = { cmd, args, opts, get stdin() { return proc._stdin; } };
+    setImmediate(() => {
+      for (const line of lines) proc.stdout.emit('data', Buffer.from(line, 'utf-8'));
+      if (stderr) proc.stderr.emit('data', Buffer.from(stderr, 'utf-8'));
+      proc.exitCode = exitCode;
+      proc.emit('exit', exitCode);
+    });
+    return proc;
+  };
+}
+
+function makeAdapter(extra = {}) {
+  const adapter = createAdapter('amp', {
+    workspaceId: 'ws',
+    channelName: 'general',
+    token: 'tok',
+    agentName: 'amp-bot',
+    endpoint: 'https://example.invalid',
+    agentType: 'amp',
+    agentEnv: extra.agentEnv || {},
+    workingDir: extra.workingDir || '/tmp/proj',
+  });
+  adapter._ampBin = '/usr/bin/amp';
+  adapter._saveSessions = () => {};
+  // Stub network helpers — record what was streamed.
+  adapter._streamed = { thinking: [], status: [] };
+  adapter.sendThinking = async (_c, content) => adapter._streamed.thinking.push(content);
+  adapter.sendStatus = async (_c, content) => adapter._streamed.status.push(content);
+  return adapter;
+}
+
+describe('Amp adapter — registration', () => {
+  it('is registered under the "amp" agent type', () => {
+    assert.equal('amp' in ADAPTER_MAP, true);
+    assert.equal(typeof AmpAdapter, 'function');
+  });
+
+  it('createAdapter("amp") returns an AmpAdapter', () => {
+    const a = makeAdapter();
+    assert.equal(a.constructor.name, 'AmpAdapter');
+    assert.equal(typeof a._handleMessage, 'function');
+  });
+
+  it('does not disturb the existing adapter map', () => {
+    for (const t of ['claude', 'codex', 'opencode', 'cursor', 'gemini', 'kimi']) {
+      assert.equal(t in ADAPTER_MAP, true, `${t} should still be registered`);
+    }
+  });
+});
+
+describe('Amp adapter — binary resolution', () => {
+  it('includes the Amp installer dir (~/.amp/bin) in the shared resolver search path', () => {
+    const os = require('node:os');
+    const path = require('node:path');
+    const fs = require('node:fs');
+    const { getExtraBinDirs, clearBinaryLookupCache } = require('../src/paths');
+    const ampBin = path.join(os.homedir(), '.amp', 'bin');
+
+    // getExtraBinDirs() returns only dirs that actually exist and aren't
+    // already on PATH, so materialize ~/.amp/bin for the assertion.
+    const created = !fs.existsSync(ampBin);
+    if (created) fs.mkdirSync(ampBin, { recursive: true });
+    try {
+      clearBinaryLookupCache();
+      const onPath = (process.env.PATH || '').split(path.delimiter).includes(ampBin);
+      if (!onPath) {
+        assert.ok(
+          getExtraBinDirs().includes(ampBin),
+          `expected getExtraBinDirs() to include ${ampBin} so a GUI/daemon ` +
+          `process resolves amp when ~/.amp/bin is not on PATH`,
+        );
+      }
+    } finally {
+      if (created) { try { fs.rmdirSync(ampBin); } catch {} }
+      clearBinaryLookupCache();
+    }
+  });
+});
+
+describe('Amp adapter — command construction', () => {
+  it('builds a new-thread execute command', () => {
+    const a = makeAdapter();
+    assert.deepEqual(a._buildAmpCmd('general', false), ['/usr/bin/amp', '-x', '--stream-json']);
+  });
+
+  it('builds a threads-continue command when resuming', () => {
+    const a = makeAdapter();
+    a._channelThreads.general = 'T-123';
+    assert.deepEqual(
+      a._buildAmpCmd('general', true),
+      ['/usr/bin/amp', 'threads', 'continue', 'T-123', '-x', '--stream-json'],
+    );
+  });
+});
+
+describe('Amp adapter — stream-json execution', () => {
+  beforeEach(() => { lastSpawn = null; });
+
+  it('parses the final assistant turn and persists the thread id', async () => {
+    spawnImpl = makeFakeSpawn(streamLines());
+    const a = makeAdapter();
+    const { text, stale } = await a._spawnAmp(['/usr/bin/amp', '-x', '--stream-json'], 'PROMPT', 'general');
+    assert.equal(text, 'All done!');
+    assert.equal(stale, false);
+    assert.equal(a._channelThreads.general, 'T-thread-1');
+    assert.ok(a._streamed.thinking.includes('Looking into it'));
+    assert.ok(a._streamed.status.some((s) => s.includes('Bash')));
+  });
+
+  it('feeds the prompt on stdin and runs in the working directory', async () => {
+    spawnImpl = makeFakeSpawn(streamLines());
+    const a = makeAdapter({ workingDir: '/tmp/myproject' });
+    await a._spawnAmp(['/usr/bin/amp', '-x', '--stream-json'], 'PROMPT-BODY', 'general');
+    assert.equal(lastSpawn.opts.cwd, '/tmp/myproject');
+    assert.equal(lastSpawn.stdin, 'PROMPT-BODY');
+  });
+
+  it('passes AMP_API_KEY through to the subprocess env', async () => {
+    spawnImpl = makeFakeSpawn(streamLines());
+    const a = makeAdapter({ agentEnv: { AMP_API_KEY: 'sk-amp-secret' } });
+    await a._spawnAmp(['/usr/bin/amp', '-x', '--stream-json'], 'PROMPT', 'general');
+    assert.equal(lastSpawn.opts.env.AMP_API_KEY, 'sk-amp-secret');
+  });
+
+  it('never writes AMP_API_KEY to the logs', async () => {
+    spawnImpl = makeFakeSpawn(streamLines(), 1, 'some stderr noise');
+    const a = makeAdapter({ agentEnv: { AMP_API_KEY: 'sk-amp-supersecret' } });
+    const logs = [];
+    a._log = (m) => logs.push(m);
+    await a._spawnAmp(['/usr/bin/amp', '-x', '--stream-json'], 'PROMPT', 'general');
+    assert.ok(!logs.join('\n').includes('sk-amp-supersecret'));
+  });
+
+  it('flags a stale thread when a resumed run fails with no output', async () => {
+    spawnImpl = makeFakeSpawn(['{"type":"result","is_error":true}\n'], 1, 'thread not found');
+    const a = makeAdapter();
+    a._channelThreads.general = 'T-old';
+    const { text, stale } = await a._spawnAmp(
+      ['/usr/bin/amp', 'threads', 'continue', 'T-old', '-x', '--stream-json'], 'PROMPT', 'general',
+    );
+    assert.equal(text, '');
+    assert.equal(stale, true);
+  });
+});
+
+describe('Amp adapter — stop control', () => {
+  it('terminates the running process and marks the channel stopped', async () => {
+    const a = makeAdapter();
+    const stopped = [];
+    a._stopProcess = async () => stopped.push('killed');
+    const statuses = [];
+    a.sendStatus = async (_c, content) => statuses.push(content);
+
+    const proc = new EventEmitter();
+    proc.pid = 99;
+    proc.exitCode = null;
+    a._channelProcesses.general = proc;
+
+    await a._onControlAction('stop', {});
+
+    assert.equal(stopped.length, 1);
+    assert.equal('general' in a._channelProcesses, false);
+    assert.equal(a._stoppingChannels.has('general'), true);
+    assert.deepEqual(statuses, ['Execution stopped by user']);
+  });
+});

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -306,6 +306,7 @@ const CORE_AGENTS: readonly string[] = [
   "hermes",
   "kimi",
   "gemini",
+  "amp",
 ]
 const CORE_AGENT_ORDER = new Map<string, number>(
   CORE_AGENTS.map((name, i) => [name, i]),
@@ -454,6 +455,16 @@ async function testLLMConnection(
         success: false,
         error:
           "Cursor signs in through its own service — there's no key endpoint to test here. Save the key and launch the agent to verify.",
+      }
+    }
+
+    // ── Amp: authenticates against Sourcegraph's own service (AMP_API_KEY or
+    // `amp login`); there is no OpenAI-style endpoint to probe here. ──
+    if (pick("AMP_API_KEY") && !anthropicKey && !openaiKey) {
+      return {
+        success: false,
+        error:
+          "Amp signs in through Sourcegraph's own service — there's no key endpoint to test here. Save the key (or run `amp login`) and launch the agent to verify.",
       }
     }
 

--- a/sdk/src/openagents/adapters/amp.py
+++ b/sdk/src/openagents/adapters/amp.py
@@ -51,6 +51,13 @@ _READ_TIMEOUT = 15.0
 _MAX_IDLE_READS = 20
 
 
+def _amp_install_hint() -> str:
+    """Platform-appropriate Amp CLI install command for 'not found' messages."""
+    if platform.system() == "Windows":
+        return 'powershell -NoProfile -Command "irm https://ampcode.com/install.ps1 | iex"'
+    return "curl -fsSL https://ampcode.com/install.sh | bash"
+
+
 class AmpAdapter(BaseAdapter):
     """Connects the Amp CLI to an OpenAgents workspace."""
 
@@ -86,8 +93,7 @@ class AmpAdapter(BaseAdapter):
             logger.info("Using Amp CLI: %s", self._amp_binary)
         else:
             logger.warning(
-                "Amp binary not found. Install with: "
-                "curl -fsSL https://ampcode.com/install.sh | bash"
+                "Amp binary not found. Install with: %s", _amp_install_hint()
             )
 
     # ------------------------------------------------------------------
@@ -202,8 +208,7 @@ class AmpAdapter(BaseAdapter):
             self._amp_binary = amp_bin
         if not amp_bin:
             raise FileNotFoundError(
-                "amp CLI not found. Install with: "
-                "curl -fsSL https://ampcode.com/install.sh | bash"
+                f"amp CLI not found. Install with: {_amp_install_hint()}"
             )
 
         thread_id = self._channel_threads.get(channel_name) if resume else None

--- a/sdk/src/openagents/adapters/amp.py
+++ b/sdk/src/openagents/adapters/amp.py
@@ -1,0 +1,540 @@
+"""
+Amp adapter for OpenAgents workspace.
+
+Bridges Sourcegraph's Amp CLI to an OpenAgents workspace by running the
+agent in its official non-interactive *execute* mode with structured output:
+
+    amp -x --stream-json                       # first turn (new thread)
+    amp threads continue <thread_id> -x --stream-json   # follow-up turns
+
+The prompt is fed on **stdin** (the documented ``echo "..." | amp -x`` path),
+which avoids ARG_MAX / shell-quoting issues with the large workspace system
+context. Amp's ``--stream-json`` output is intentionally compatible with Claude
+Code's stream-json schema, so the event handling here mirrors the Claude
+adapter: ``system`` (init / session id), ``assistant`` (text + tool_use blocks),
+and ``result`` (final text + session id).
+
+Per-channel Amp thread IDs are persisted so each workspace thread keeps its own
+Amp conversation context across messages. Authentication uses ``AMP_API_KEY``
+(or a prior ``amp login``); the key is read from the environment and is never
+written to logs, error messages, or workspace messages.
+
+This adapter reuses all of the shared connectivity, process-dispatch, and
+state machinery in :class:`~openagents.adapters.base.BaseAdapter`; only the
+Amp-specific subprocess invocation and output parsing live here.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import platform
+import shutil
+import signal
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from openagents.adapters.base import BaseAdapter
+from openagents.adapters.utils import format_attachments_for_prompt
+from openagents.adapters.workspace_prompt import build_openclaw_system_prompt
+from openagents.workspace_client import DEFAULT_ENDPOINT
+
+logger = logging.getLogger(__name__)
+
+# Per-read timeout while streaming Amp's stdout. A turn can pause for a while
+# (model latency, long tool runs), so we tolerate several idle reads before
+# treating the process as hung.
+_READ_TIMEOUT = 15.0
+# After this many consecutive idle reads (~5 min) with the process still alive
+# and no output, assume it is wedged and terminate it rather than block forever.
+_MAX_IDLE_READS = 20
+
+
+class AmpAdapter(BaseAdapter):
+    """Connects the Amp CLI to an OpenAgents workspace."""
+
+    def __init__(
+        self,
+        workspace_id: str,
+        channel_name: str,
+        token: str,
+        agent_name: str,
+        endpoint: str = DEFAULT_ENDPOINT,
+        disabled_modules: set | None = None,
+        working_dir: str | None = None,
+    ):
+        super().__init__(workspace_id, channel_name, token, agent_name, endpoint)
+        self.disabled_modules = disabled_modules or set()
+        self.working_dir = working_dir
+
+        # channel -> Amp thread id (for `amp threads continue <id>`)
+        self._channel_threads: dict[str, str] = {}
+        # channel -> running subprocess (for stop / cleanup)
+        self._channel_processes: dict[str, asyncio.subprocess.Process] = {}
+        # channels the user explicitly stopped (suppress "no response" noise)
+        self._stopping_channels: set[str] = set()
+
+        self._sessions_file = (
+            Path.home() / ".openagents" / "sessions"
+            / f"{workspace_id}_{agent_name}_amp.json"
+        )
+        self._load_sessions()
+
+        self._amp_binary = self._find_amp_binary()
+        if self._amp_binary:
+            logger.info("Using Amp CLI: %s", self._amp_binary)
+        else:
+            logger.warning(
+                "Amp binary not found. Install with: "
+                "curl -fsSL https://ampcode.com/install.sh | bash"
+            )
+
+    # ------------------------------------------------------------------
+    # Session (thread id) persistence
+    # ------------------------------------------------------------------
+
+    def _load_sessions(self):
+        try:
+            if self._sessions_file.exists():
+                data = json.loads(self._sessions_file.read_text())
+                if isinstance(data, dict):
+                    self._channel_threads.update(data)
+                    logger.info(
+                        "Loaded %d Amp thread(s) from %s",
+                        len(data), self._sessions_file.name,
+                    )
+        except Exception:
+            logger.debug("Could not load Amp sessions file, starting fresh")
+
+    def _save_sessions(self):
+        try:
+            self._sessions_file.parent.mkdir(parents=True, exist_ok=True)
+            self._sessions_file.write_text(json.dumps(self._channel_threads))
+        except Exception:
+            logger.debug("Could not save Amp sessions file")
+
+    # ------------------------------------------------------------------
+    # Binary resolution (cross-platform, mirrors the registry loader rules)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_amp_binary() -> Optional[str]:
+        """Locate the ``amp`` executable across platforms.
+
+        Detection order: PATH (preferring Windows ``.cmd``/``.exe`` shims, since
+        the bare name can resolve to a non-executable script) → npm global
+        prefix → the official installer's canonical ``~/.amp/bin`` plus its
+        symlink targets (``~/.local/bin``, ``~/bin``). The ``~/.amp/bin``
+        fallback is what makes detection work when a GUI- or daemon-spawned
+        process didn't inherit the user's interactive shell PATH — the common
+        "installed but not found" case.
+        """
+        home = Path.home()
+        if platform.system() == "Windows":
+            found = (
+                shutil.which("amp.cmd")
+                or shutil.which("amp.exe")
+                or shutil.which("amp")
+            )
+            if found:
+                return found
+            try:
+                npm_prefix = subprocess.check_output(
+                    ["npm", "config", "get", "prefix"],
+                    text=True, timeout=5,
+                ).strip()
+                if npm_prefix:
+                    for ext in (".cmd", ".exe", ""):
+                        candidate = os.path.join(npm_prefix, f"amp{ext}")
+                        if os.path.isfile(candidate):
+                            return candidate
+            except Exception:
+                pass
+            for candidate in (
+                home / ".amp" / "bin" / "amp.exe",
+                Path(os.environ.get("LOCALAPPDATA", str(home / "AppData" / "Local"))) / "amp" / "amp.exe",
+            ):
+                if candidate.is_file():
+                    return str(candidate)
+            return None
+
+        found = shutil.which("amp")
+        if found:
+            return found
+        for candidate in (
+            home / ".amp" / "bin" / "amp",
+            home / ".local" / "bin" / "amp",
+            home / "bin" / "amp",
+        ):
+            try:
+                if candidate.is_file() and os.access(candidate, os.X_OK):
+                    return str(candidate)
+            except OSError:
+                continue
+        return None
+
+    # ------------------------------------------------------------------
+    # Prompt / command construction
+    # ------------------------------------------------------------------
+
+    def _build_system_context(self, channel_name: str, browser_enabled: bool = False) -> str:
+        return build_openclaw_system_prompt(
+            agent_name=self.agent_name,
+            workspace_id=self.workspace_id,
+            channel_name=channel_name,
+            endpoint=self.endpoint,
+            token=self.token,
+            mode=self._mode,
+            disabled_modules=self.disabled_modules,
+            browser_enabled=browser_enabled,
+        )
+
+    def _build_amp_cmd(self, channel_name: str, resume: bool) -> list[str]:
+        """Build the Amp CLI argv for a channel.
+
+        ``resume`` continues this channel's existing Amp thread; otherwise a
+        fresh thread is started and its id captured from the stream output.
+        The prompt itself is supplied on stdin, not as an argument.
+        """
+        amp_bin = self._amp_binary or self._find_amp_binary()
+        if amp_bin:
+            self._amp_binary = amp_bin
+        if not amp_bin:
+            raise FileNotFoundError(
+                "amp CLI not found. Install with: "
+                "curl -fsSL https://ampcode.com/install.sh | bash"
+            )
+
+        thread_id = self._channel_threads.get(channel_name) if resume else None
+        if thread_id:
+            cmd = [amp_bin, "threads", "continue", thread_id, "-x", "--stream-json"]
+        else:
+            cmd = [amp_bin, "-x", "--stream-json"]
+        return cmd
+
+    # ------------------------------------------------------------------
+    # Control actions (stop)
+    # ------------------------------------------------------------------
+
+    async def _on_control_action(self, action: Optional[str], payload: dict):
+        if action == "stop":
+            await self._stop_all_processes()
+
+    async def _stop_all_processes(self):
+        """Terminate any running Amp subprocess (stop button)."""
+        for channel, proc in list(self._channel_processes.items()):
+            self._stopping_channels.add(channel)
+            await self._stop_process(proc)
+            self._channel_processes.pop(channel, None)
+            self._channel_queues.pop(channel, None)
+            await self._send_status(channel, "Execution stopped by user")
+
+    async def _stop_process(self, proc: asyncio.subprocess.Process):
+        """Kill a single Amp subprocess and its child process group."""
+        if not proc or proc.returncode is not None:
+            return
+        try:
+            if platform.system() == "Windows":
+                try:
+                    killer = await asyncio.create_subprocess_exec(
+                        "taskkill", "/F", "/T", "/PID", str(proc.pid),
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(killer.wait(), timeout=5)
+                except Exception:
+                    proc.kill()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+                return
+
+            # POSIX: kill the whole process group so child tool processes
+            # (started with start_new_session=True) are reaped too.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2)
+            except asyncio.TimeoutError:
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+                await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Message handler
+    # ------------------------------------------------------------------
+
+    async def _handle_message(self, msg: dict):
+        content = (msg.get("content") or "").strip()
+        attachments = msg.get("attachments", [])
+        att_text = format_attachments_for_prompt(attachments)
+        if att_text:
+            content = (content + att_text) if content else att_text.strip()
+        if not content:
+            return
+
+        msg_channel = msg.get("sessionId") or self.channel_name
+        sender = msg.get("senderName") or msg.get("senderType", "user")
+        logger.info(
+            "Processing message from %s in channel %s: %s...",
+            sender, msg_channel, content[:80],
+        )
+
+        await self._auto_title_channel(msg_channel, content)
+        self._stopping_channels.discard(msg_channel)
+        await self._send_status(msg_channel, "thinking...")
+
+        try:
+            response_text = await self._run_amp(content, msg_channel)
+        except FileNotFoundError as e:
+            await self._send_error(msg_channel, str(e))
+            return
+        except Exception as e:
+            logger.exception("Error handling message: %s", e)
+            await self._send_error(msg_channel, f"Error processing message: {e}")
+            return
+
+        if msg_channel in self._stopping_channels:
+            self._stopping_channels.discard(msg_channel)
+            return
+
+        if response_text:
+            await self._send_response(msg_channel, response_text)
+        else:
+            await self._send_response(
+                msg_channel, "No response generated. Please try again."
+            )
+
+    # ------------------------------------------------------------------
+    # Subprocess execution + stream-json parsing
+    # ------------------------------------------------------------------
+
+    async def _run_amp(self, content: str, msg_channel: str) -> str:
+        """Run Amp for a message, retrying once with a fresh thread if a
+        resumed thread turns out to be stale."""
+        browser_enabled = await self.get_browser_enabled()
+
+        for attempt in range(2):
+            resume = attempt == 0 and msg_channel in self._channel_threads
+            cmd = self._build_amp_cmd(msg_channel, resume=resume)
+
+            if resume:
+                # The Amp thread already carries the workspace context.
+                prompt = content
+            else:
+                context = self._build_system_context(
+                    msg_channel, browser_enabled=browser_enabled
+                )
+                prompt = f"{context}\n\n---\n\n{content}"
+
+            text, exit_code, stale = await self._spawn_amp(cmd, prompt, msg_channel)
+
+            if msg_channel in self._stopping_channels:
+                return ""
+            if text:
+                return text
+            if stale and resume:
+                logger.info(
+                    "Amp thread for channel %s appears stale — retrying fresh",
+                    msg_channel,
+                )
+                self._channel_threads.pop(msg_channel, None)
+                self._save_sessions()
+                continue
+            return ""
+        return ""
+
+    async def _spawn_amp(self, cmd: list[str], prompt: str, msg_channel: str):
+        """Spawn Amp, stream stdout, and return (final_text, exit_code, stale).
+
+        ``stale`` is True when the process failed in a way that suggests the
+        resumed thread id is no longer valid, so the caller can retry fresh.
+        """
+        # Pass a copy of the environment so AMP_API_KEY / AMP_URL flow through.
+        # We never log these values.
+        env = dict(os.environ)
+
+        is_windows = platform.system() == "Windows"
+        spawn_cmd = list(cmd)
+        if is_windows and spawn_cmd[0].lower().endswith(".cmd"):
+            spawn_cmd = ["cmd.exe", "/c"] + spawn_cmd
+
+        process = await asyncio.create_subprocess_exec(
+            *spawn_cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.working_dir,
+            env=env,
+            limit=10 * 1024 * 1024,  # 10 MB line buffer for large tool output
+            start_new_session=not is_windows,  # own process group for stop
+        )
+        self._channel_processes[msg_channel] = process
+
+        # Feed the prompt on stdin (documented `echo "..." | amp -x` path).
+        try:
+            if process.stdin:
+                process.stdin.write(prompt.encode("utf-8"))
+                await process.stdin.drain()
+                process.stdin.close()
+        except Exception:
+            pass
+
+        last_turn_text: list[str] = []
+        result_text = ""
+        has_tool_use_since_text = False
+        idle_reads = 0
+
+        try:
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        process.stdout.readline(), timeout=_READ_TIMEOUT
+                    )
+                    idle_reads = 0
+                except asyncio.TimeoutError:
+                    idle_reads += 1
+                    if process.returncode is not None:
+                        break
+                    if idle_reads > _MAX_IDLE_READS:
+                        logger.warning(
+                            "Amp produced no output for ~%ds — terminating",
+                            int(_MAX_IDLE_READS * _READ_TIMEOUT),
+                        )
+                        await self._stop_process(process)
+                        break
+                    continue
+
+                if not line:
+                    break
+                decoded = line.decode("utf-8", errors="replace").strip()
+                if not decoded:
+                    continue
+
+                try:
+                    event = json.loads(decoded)
+                except json.JSONDecodeError:
+                    logger.debug("Non-JSON line from Amp: %s", decoded[:100])
+                    continue
+
+                turn_text, is_result = await self._handle_event(
+                    event, msg_channel, last_turn_text, has_tool_use_since_text
+                )
+                last_turn_text = turn_text["last_turn_text"]
+                has_tool_use_since_text = turn_text["has_tool_use"]
+                if is_result:
+                    result_text = turn_text.get("result_text", "") or result_text
+
+            await process.wait()
+        finally:
+            self._channel_processes.pop(msg_channel, None)
+
+        exit_code = process.returncode or 0
+        stderr_text = ""
+        if exit_code != 0:
+            try:
+                stderr = await process.stderr.read()
+                stderr_text = stderr.decode("utf-8", errors="replace").strip()
+            except Exception:
+                stderr_text = ""
+            if stderr_text:
+                logger.warning("Amp stderr: %s", stderr_text[:300])
+
+        final = "\n".join(t for t in last_turn_text if t).strip() or result_text.strip()
+        # A non-zero exit with no usable output on a resumed thread most likely
+        # means the thread id is stale/invalid.
+        stale = bool(exit_code != 0 and not final)
+        return final, exit_code, stale
+
+    async def _handle_event(
+        self,
+        event: dict,
+        msg_channel: str,
+        last_turn_text: list[str],
+        has_tool_use_since_text: bool,
+    ):
+        """Process one stream-json event. Streams thinking/status to the
+        workspace and returns the running turn state."""
+        event_type = event.get("type")
+        result_text = ""
+
+        if event_type == "system":
+            # init event carries the Amp thread/session id
+            session_id = event.get("session_id")
+            if session_id:
+                self._remember_thread(msg_channel, session_id)
+
+        elif event_type == "assistant":
+            message_data = event.get("message", {}) or {}
+            for block in message_data.get("content", []) or []:
+                block_type = block.get("type")
+                if block_type == "text":
+                    text = (block.get("text") or "").strip()
+                    if not text:
+                        continue
+                    # A tool call since the last text starts a new reasoning
+                    # segment — reset so only the final turn is posted as chat.
+                    if has_tool_use_since_text:
+                        last_turn_text = []
+                        has_tool_use_since_text = False
+                    last_turn_text.append(text)
+                    await self._send_thinking(msg_channel, text)
+                elif block_type == "tool_use":
+                    has_tool_use_since_text = True
+                    last_turn_text = []
+                    tool_name = block.get("name", "")
+                    tool_input = str(block.get("input", {}))[:200]
+                    await self._send_status(
+                        msg_channel,
+                        f"**Using tool:** `{tool_name}`\n```\n{tool_input}\n```",
+                    )
+
+        elif event_type == "result":
+            session_id = event.get("session_id")
+            if session_id:
+                self._remember_thread(msg_channel, session_id)
+            if event.get("is_error"):
+                logger.warning("Amp result error: %s", str(event.get("result", ""))[:200])
+            result_text = event.get("result", "") or ""
+
+        return (
+            {
+                "last_turn_text": last_turn_text,
+                "has_tool_use": has_tool_use_since_text,
+                "result_text": result_text,
+            },
+            event_type == "result",
+        )
+
+    def _remember_thread(self, channel: str, thread_id: str):
+        if not thread_id:
+            return
+        if self._channel_threads.get(channel) != thread_id:
+            self._channel_threads[channel] = thread_id
+            self._save_sessions()
+            logger.info("Amp thread for channel %s: %s", channel, thread_id)
+
+    async def _send_thinking(self, channel: str, content: str):
+        """Stream intermediate reasoning as a 'thinking' message."""
+        try:
+            await self.client.send_message(
+                workspace_id=self.workspace_id,
+                channel_name=channel,
+                token=self.token,
+                content=content,
+                sender_type="agent",
+                sender_name=self.agent_name,
+                message_type="thinking",
+                metadata={"agent_mode": self._mode},
+            )
+        except Exception:
+            pass

--- a/sdk/src/openagents/registry/amp.yaml
+++ b/sdk/src/openagents/registry/amp.yaml
@@ -3,9 +3,34 @@ label: Amp (Sourcegraph)
 description: Sourcegraph's AI coding agent for CLI and VS Code
 homepage: https://ampcode.com
 tags: [coding, sourcegraph, cli, vscode]
+builtin: true
+support:
+  install: true
+  workspace: true
+  collaboration: true
 
 install:
   binary: amp
   macos: "curl -fsSL https://ampcode.com/install.sh | bash"
   linux: "curl -fsSL https://ampcode.com/install.sh | bash"
   windows: "powershell -c \"irm https://ampcode.com/install.ps1 | iex\""
+
+adapter:
+  module: openagents.adapters.amp
+  class: AmpAdapter
+
+launch:
+  args: []
+
+env_config:
+  - name: AMP_API_KEY
+    description: Amp API key (create one at https://ampcode.com/settings) — leave blank if you have run `amp login`
+    required: false
+    password: true
+  - name: AMP_URL
+    description: Amp server URL for enterprise/self-hosted deployments (leave blank for the default)
+    required: false
+
+check_ready:
+  login_command: "amp login"
+  not_ready_message: "Not installed — run: openagents install amp"

--- a/sdk/src/openagents/registry/loader.py
+++ b/sdk/src/openagents/registry/loader.py
@@ -109,7 +109,8 @@ def _find_in_known_install_dirs(binary_names: list) -> Optional[str]:
     is_windows = platform.system() == "Windows"
     extra_dirs = [
         home / ".cursor" / "bin",   # Cursor CLI native installer (curl|bash)
-        home / ".local" / "bin",    # pipx / user installs
+        home / ".amp" / "bin",      # Amp CLI native installer (curl|bash) — canonical dir
+        home / ".local" / "bin",    # pipx / user installs (also Amp's symlink target)
     ]
     if is_windows:
         # The Windows installer (irm 'https://cursor.com/install?win32=true' | iex)

--- a/tests/agents/test_amp.py
+++ b/tests/agents/test_amp.py
@@ -1,0 +1,411 @@
+"""Unit tests for Amp agent support (registry registration + AmpAdapter).
+
+These tests never require a real ``amp`` install or a live workspace: the CLI
+is simulated with a fake ``asyncio`` subprocess that emits Amp's
+Claude-compatible ``--stream-json`` events, and binary detection is exercised
+against a fake executable on an isolated PATH/HOME.
+
+Covered:
+- Amp agent-type registration (builtin plugin from the registry YAML)
+- Amp executable detection (PATH + ~/.local/bin fallback, missing binary)
+- Launch / execute command construction (new thread vs `threads continue`)
+- Working-directory passing (cwd of the spawned process)
+- Environment passing (AMP_API_KEY reaches the subprocess)
+- Sensitive info (AMP_API_KEY) never reaches logs
+- stream-json parsing → final text + per-channel thread persistence
+- Stop control updates process state
+- Existing agent types keep loading (no regression)
+
+Run:
+    pytest tests/agents/test_amp.py -v
+"""
+
+import asyncio
+import importlib
+import logging
+import os
+import stat
+
+import pytest
+
+import openagents.registry.loader as loader
+from openagents.adapters.amp import AmpAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_amp_plugin():
+    data = next(
+        d for d in loader.load_registry_yamls() if d.get("name") == "amp"
+    )
+    plugin = loader._make_plugin_from_yaml(data)
+    assert plugin is not None, "amp must be a builtin plugin"
+    return plugin
+
+
+def _write_executable(path, body="#!/bin/sh\necho ok\n"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_adapter(tmp_path, working_dir=None):
+    """Build an AmpAdapter without any network I/O (constructor is offline)."""
+    return AmpAdapter(
+        workspace_id="ws-test",
+        channel_name="general",
+        token="tok",
+        agent_name="amp-bot",
+        endpoint="https://example.invalid",
+        working_dir=working_dir or str(tmp_path / "proj"),
+    )
+
+
+class _FakeStreamReader:
+    """Minimal async stdout/stderr reader yielding pre-canned lines."""
+
+    def __init__(self, lines=None, blob=b""):
+        # lines: list[bytes] returned one-per-readline, then EOF (b"")
+        self._lines = list(lines or [])
+        self._blob = blob
+
+    async def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+    async def read(self):
+        return self._blob
+
+
+class _FakeStdin:
+    def __init__(self):
+        self.written = b""
+        self.closed = False
+
+    def write(self, data):
+        self.written += data
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeProcess:
+    def __init__(self, stdout_lines, returncode=0, stderr=b""):
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStreamReader(lines=stdout_lines)
+        self.stderr = _FakeStreamReader(blob=stderr)
+        self.returncode = returncode
+        self.pid = 4242
+
+    async def wait(self):
+        return self.returncode
+
+
+@pytest.fixture
+def patch_spawn(monkeypatch):
+    """Patch asyncio.create_subprocess_exec; capture call args, return a fake."""
+    captured = {}
+
+    def _factory(stdout_lines, returncode=0, stderr=b""):
+        async def fake_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            proc = _FakeProcess(stdout_lines, returncode=returncode, stderr=stderr)
+            captured["proc"] = proc
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        return captured
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# 1. Agent-type registration
+# ---------------------------------------------------------------------------
+
+class TestAmpRegistration:
+    def test_amp_is_builtin_plugin(self):
+        plugin = _make_amp_plugin()
+        assert plugin.name == "amp"
+        assert plugin.label == "Amp (Sourcegraph)"
+
+    def test_amp_adapter_module_imports(self):
+        data = next(d for d in loader.load_registry_yamls() if d["name"] == "amp")
+        mod = importlib.import_module(data["adapter"]["module"])
+        cls = getattr(mod, data["adapter"]["class"])
+        assert cls is AmpAdapter
+
+    def test_amp_env_config_exposes_api_key(self):
+        plugin = _make_amp_plugin()
+        names = [e.get("name") for e in plugin.required_env_vars()]
+        assert "AMP_API_KEY" in names
+        api_key = next(e for e in plugin.required_env_vars() if e["name"] == "AMP_API_KEY")
+        # The key must be flagged as a password field so UIs mask it.
+        assert api_key.get("password") is True
+
+    def test_amp_login_command(self):
+        assert _make_amp_plugin().login_command() == "amp login"
+
+
+# ---------------------------------------------------------------------------
+# 2. Executable detection
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    empty_bin = tmp_path / "empty_bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.setattr(
+        loader, "_INSTALLED_MARKERS_PATH", home / ".openagents" / "installed_agents.json"
+    )
+    return home
+
+
+class TestAmpDetection:
+    def test_not_installed_without_binary(self, isolated_home):
+        plugin = _make_amp_plugin()
+        assert plugin._which_binary() is None
+        assert plugin.is_installed() is False
+        ready, msg = plugin.check_ready()
+        assert ready is False
+        assert "install amp" in msg.lower()
+
+    def test_detects_binary_on_path(self, isolated_home, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "bin"
+        amp_path = bin_dir / "amp"
+        _write_executable(amp_path)
+        monkeypatch.setenv("PATH", str(bin_dir))
+        plugin = _make_amp_plugin()
+        assert plugin._which_binary() == str(amp_path)
+        assert plugin.is_installed() is True
+
+    def test_detects_binary_in_local_bin_fallback(self, isolated_home):
+        # The official installer drops `amp` into ~/.local/bin, which the
+        # native installer only exports to interactive shells.
+        amp_path = isolated_home / ".local" / "bin" / "amp"
+        _write_executable(amp_path)
+        plugin = _make_amp_plugin()
+        assert plugin._which_binary() == str(amp_path)
+
+    def test_detects_binary_in_amp_bin_fallback(self, isolated_home):
+        # Canonical install dir of the official installer: ~/.amp/bin. The
+        # symlink into ~/.local/bin is only made when that dir is already on
+        # PATH, so a GUI/daemon process must still find ~/.amp/bin. Regression
+        # guard for the "installed but Amp CLI not found" report.
+        amp_path = isolated_home / ".amp" / "bin" / "amp"
+        _write_executable(amp_path)
+        plugin = _make_amp_plugin()
+        assert plugin._which_binary() == str(amp_path)
+        assert plugin.is_installed() is True
+
+    def test_adapter_find_binary_in_amp_bin(self, isolated_home):
+        amp_path = isolated_home / ".amp" / "bin" / "amp"
+        _write_executable(amp_path)
+        # PATH is empty (isolated_home), so resolution must fall back to ~/.amp/bin.
+        assert AmpAdapter._find_amp_binary() == str(amp_path)
+
+    def test_adapter_find_binary_matches(self, isolated_home, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "bin"
+        amp_path = bin_dir / "amp"
+        _write_executable(amp_path)
+        monkeypatch.setenv("PATH", str(bin_dir))
+        assert AmpAdapter._find_amp_binary() == str(amp_path)
+
+    def test_windows_prefers_cmd_shim(self, monkeypatch):
+        """On Windows the .cmd shim must win over the bare name (npm/installer
+        drop a .cmd wrapper; the bare name can be a non-executable script)."""
+        import openagents.adapters.amp as amp_mod
+
+        monkeypatch.setattr(amp_mod.platform, "system", lambda: "Windows")
+        calls = []
+
+        def fake_which(name):
+            calls.append(name)
+            return f"C:\\bin\\{name}" if name == "amp.cmd" else None
+
+        monkeypatch.setattr(amp_mod.shutil, "which", fake_which)
+        assert AmpAdapter._find_amp_binary() == "C:\\bin\\amp.cmd"
+        # .cmd must be probed before the bare name.
+        assert calls[0] == "amp.cmd"
+
+
+# ---------------------------------------------------------------------------
+# 3. Command construction
+# ---------------------------------------------------------------------------
+
+class TestAmpCommand:
+    def test_new_thread_command(self, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        adapter._amp_binary = "/usr/bin/amp"
+        cmd = adapter._build_amp_cmd("general", resume=False)
+        assert cmd == ["/usr/bin/amp", "-x", "--stream-json"]
+
+    def test_resume_thread_command(self, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        adapter._amp_binary = "/usr/bin/amp"
+        adapter._channel_threads["general"] = "T-123"
+        cmd = adapter._build_amp_cmd("general", resume=True)
+        assert cmd == ["/usr/bin/amp", "threads", "continue", "T-123", "-x", "--stream-json"]
+
+    def test_missing_binary_raises(self, tmp_path, monkeypatch):
+        adapter = _make_adapter(tmp_path)
+        adapter._amp_binary = None
+        monkeypatch.setattr(AmpAdapter, "_find_amp_binary", staticmethod(lambda: None))
+        with pytest.raises(FileNotFoundError, match="amp CLI not found"):
+            adapter._build_amp_cmd("general", resume=False)
+
+
+# ---------------------------------------------------------------------------
+# 4-8. Subprocess flow: working dir, env, parsing, threads, secrets
+# ---------------------------------------------------------------------------
+
+def _stream_lines():
+    """A representative Amp --stream-json turn (Claude-compatible schema)."""
+    import json
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "T-thread-1"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "Looking into it"}]}},
+        {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}]}},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "All done!"}]}},
+        {"type": "result", "subtype": "success", "is_error": False, "result": "All done!", "session_id": "T-thread-1"},
+    ]
+    return [(json.dumps(e) + "\n").encode("utf-8") for e in events]
+
+
+class TestAmpSubprocessFlow:
+    def _run_spawn(self, adapter, captured_holder):
+        # Silence the thinking/status network calls.
+        sent = {"thinking": [], "status": []}
+
+        async def fake_thinking(channel, content):
+            sent["thinking"].append(content)
+
+        async def fake_status(channel, content):
+            sent["status"].append(content)
+
+        adapter._send_thinking = fake_thinking
+        adapter._send_status = fake_status
+
+        cmd = ["/usr/bin/amp", "-x", "--stream-json"]
+        result = asyncio.run(adapter._spawn_amp(cmd, "PROMPT-BODY", "general"))
+        return result, sent
+
+    def test_parses_final_text_and_persists_thread(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn(_stream_lines())
+        adapter = _make_adapter(tmp_path)
+        (text, exit_code, stale), sent = self._run_spawn(adapter, None)
+
+        assert text == "All done!", "final turn (after tool_use) should be the answer"
+        assert exit_code == 0
+        assert stale is False
+        # Process tracking is cleared once the turn ends (so the channel is no
+        # longer considered busy and a stuck thread is impossible).
+        assert "general" not in adapter._channel_processes
+        # Thread id captured + persisted per channel.
+        assert adapter._channel_threads["general"] == "T-thread-1"
+        # Intermediate text streamed as thinking.
+        assert "Looking into it" in sent["thinking"]
+        # Tool call surfaced as status.
+        assert any("Bash" in s for s in sent["status"])
+
+    def test_working_dir_is_process_cwd(self, isolated_home, tmp_path, patch_spawn):
+        captured = patch_spawn(_stream_lines())
+        wd = str(tmp_path / "myproject")
+        adapter = _make_adapter(tmp_path, working_dir=wd)
+        self._run_spawn(adapter, None)
+        assert captured["kwargs"].get("cwd") == wd
+
+    def test_prompt_sent_on_stdin(self, isolated_home, tmp_path, patch_spawn):
+        captured = patch_spawn(_stream_lines())
+        adapter = _make_adapter(tmp_path)
+        self._run_spawn(adapter, None)
+        assert captured["proc"].stdin.written == b"PROMPT-BODY"
+        assert captured["proc"].stdin.closed is True
+
+    def test_api_key_passed_to_subprocess_env(self, isolated_home, tmp_path, patch_spawn, monkeypatch):
+        monkeypatch.setenv("AMP_API_KEY", "sk-amp-secret-xyz")
+        captured = patch_spawn(_stream_lines())
+        adapter = _make_adapter(tmp_path)
+        self._run_spawn(adapter, None)
+        env = captured["kwargs"].get("env") or {}
+        assert env.get("AMP_API_KEY") == "sk-amp-secret-xyz"
+
+    def test_api_key_never_logged(self, isolated_home, tmp_path, patch_spawn, monkeypatch, caplog):
+        secret = "sk-amp-supersecret-should-not-log"
+        monkeypatch.setenv("AMP_API_KEY", secret)
+        patch_spawn(_stream_lines())
+        adapter = _make_adapter(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="openagents.adapters.amp"):
+            self._run_spawn(adapter, None)
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert secret not in joined, "AMP_API_KEY must never appear in logs"
+
+    def test_stale_thread_flagged_on_failure(self, isolated_home, tmp_path, patch_spawn):
+        # Non-zero exit with no usable output → caller should retry fresh.
+        patch_spawn([b'{"type":"result","is_error":true}\n'], returncode=1, stderr=b"thread not found")
+        adapter = _make_adapter(tmp_path)
+        adapter._channel_threads["general"] = "T-old"
+        (text, exit_code, stale), _ = self._run_spawn(adapter, None)
+        assert text == ""
+        assert exit_code == 1
+        assert stale is True
+
+
+# ---------------------------------------------------------------------------
+# 9. Stop control
+# ---------------------------------------------------------------------------
+
+class TestAmpStop:
+    def test_stop_terminates_and_clears_process(self, tmp_path, monkeypatch):
+        adapter = _make_adapter(tmp_path)
+
+        killed = {"count": 0}
+
+        async def fake_stop(proc):
+            killed["count"] += 1
+
+        async def fake_status(channel, content):
+            pass
+
+        adapter._stop_process = fake_stop
+        adapter._send_status = fake_status
+
+        class _P:
+            returncode = None
+            pid = 99
+        adapter._channel_processes["general"] = _P()
+
+        asyncio.run(adapter._on_control_action("stop", {}))
+
+        assert killed["count"] == 1
+        assert "general" not in adapter._channel_processes
+        assert "general" in adapter._stopping_channels
+
+
+# ---------------------------------------------------------------------------
+# 10. No regression for existing agents
+# ---------------------------------------------------------------------------
+
+class TestNoRegression:
+    @pytest.mark.parametrize("name", ["claude", "codex", "opencode", "cursor"])
+    def test_existing_builtins_still_load(self, name):
+        data = next(d for d in loader.load_registry_yamls() if d.get("name") == name)
+        plugin = loader._make_plugin_from_yaml(data)
+        assert plugin is not None
+        assert plugin.name == name
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds first-class support for the **Amp** (Sourcegraph) coding agent across the
whole stack, at parity with Claude Code / Codex / OpenCode: Amp can now be
installed, created, configured, connected to an OpenAgents Workspace, receive
tasks, execute them via the real Amp CLI, and stream results back — on Windows,
macOS and Linux.

It also hardens install-state detection so Amp can never again show as
"installed" when no runnable CLI is actually present.

## What's included

### Agent enablement
- `amp.yaml` promoted to a **builtin** registry entry (adapter / launch /
  `env_config` / `check_ready` / `support: workspace+collaboration`); bundled
  `registry.json` synced to match.
- **Python adapter** `openagents.adapters.amp.AmpAdapter` (auto-registered from
  the registry YAML).
- **Node adapter** `AmpAdapter` registered in the agent-connector
  `ADAPTER_MAP` (this is the runtime the Launcher daemon uses).
- Launcher: `amp` added to `CORE_AGENTS` → selectable when creating an agent,
  no longer shown as "Coming soon"; honest "Test connection" message (Amp signs
  in through its own service, like Cursor).
- README: Amp moved to the Supported table + a "Connecting Amp" section.

### How Amp is driven (official headless mode — not screen-scraping)
- New thread: `amp -x --stream-json`; follow-ups: `amp threads continue <id> -x
  --stream-json`. Prompt is fed on **stdin** (avoids ARG_MAX / quoting).
- Amp's `--stream-json` is Claude-Code-compatible, so events
  (`system`/`assistant`/`result`) are parsed like the Claude adapter; per-channel
  Amp thread IDs are persisted for context continuity.
- Runs with `cwd = <agent working dir>` (file changes land in the project dir).
- Auth via `AMP_API_KEY` (or `amp login`) and optional `AMP_URL`; secrets are
  never written to logs/errors/workspace messages.
- Stop/cleanup via process groups (POSIX `killpg` / Windows `taskkill /F /T`);
  idle watchdog guards against a hung subprocess. All shared connectivity,
  dispatch, queuing and state reuse `BaseAdapter`.

### Reliability hardening (Amp-only, low-risk)
- **Cross-platform binary resolution**: the Amp installer drops the CLI in
  `~/.amp/bin` (Windows: `%USERPROFILE%\.amp\bin\amp.exe`) and only adds it to
  PATH for *new* shells. `~/.amp/bin` is now part of the shared resolver
  (`whichBinary`) and the Python loader, so a GUI/daemon process finds Amp even
  before PATH refresh.
- **Post-install verification** (`install()` + `installStreaming()`): for Amp,
  the installed marker is written **only after** a real binary is resolved and
  exists on disk — the install script can exit 0 without landing a runnable
  binary. No marker / no "Done!" on failure; resolved absolute path is logged.
  `--version` is best-effort logging only, never the hard gate. Honors
  `AMP_HOME`.
- **Historical stale-marker reconciliation**: `getInstallInfo('amp')` now
  requires a real CLI — a leftover marker alone is no longer sufficient and is
  reported as `location: 'cli-missing'` (carried by the existing `location`
  field; no marker is deleted).
- Platform-aware "CLI not found" install hints in both adapters (Windows →
  `irm https://ampcode.com/install.ps1 | iex`).

## Tests
- Node: `test/amp.test.js` (12) + `test/amp-install.test.js` (11) — registration,
  command construction, stream-json parsing, thread persistence, working-dir/env
  passing, secret-not-logged, stop control, `~/.amp/bin` resolution, post-install
  verify (success/failure, both `install()` and `installStreaming()` via mocked
  spawn), and stale-marker reconciliation.
- Python: `tests/agents/test_amp.py` (25) — registration, detection (incl.
  Windows `.cmd`, `~/.amp/bin`), command build, working dir, env, secret hygiene,
  stream parse, stop.
- Full Node agent-connector suite: **220 pass / 0 fail**. No real Amp install or
  live workspace required (mocked CLI / fake executables).

## Compatibility
- Other agent types are **unchanged**: all installer/marker changes are guarded
  by `agentType === 'amp'`; the generic marker fallback, `getInstallInfo`,
  `healthCheck`, registries and UI state model for non-Amp agents are untouched.
- No renderer / i18n / global-status-enum changes.
- Windows / macOS / Linux covered for detection, launch and stop.
