### PR TITLE
fix(inbox): navigate notifications by channel

### DIFF
--- a/workspace/frontend/components/inbox/inbox-view.tsx
+++ b/workspace/frontend/components/inbox/inbox-view.tsx
@@ -154,9 +154,8 @@ export function InboxView() {
     markAllNotificationsRead,
     dismissNotification,
     setCurrentSessionId,
-    sessions,
   } = useWorkspace();
-  const { setViewMode } = useLayout();
+  const { isMobile, setViewMode, openMobileDetail } = useLayout();
 
   useEffect(() => {
     refreshNotifications();
@@ -188,11 +187,9 @@ export function InboxView() {
       markNotificationRead(notification.id);
     }
     if (notification.channelName) {
-      const session = sessions.find((s) => s.sessionId === notification.channelName);
-      if (session) {
-        setCurrentSessionId(notification.channelName);
-        setViewMode('threads');
-      }
+      setCurrentSessionId(notification.channelName);
+      setViewMode('threads');
+      if (isMobile) openMobileDetail();
     }
   };
 


### PR DESCRIPTION
## Summary
- Fix Inbox notification navigation when the target thread is not present in the currently loaded session list.
- Navigate directly from the notification channel and open the mobile detail pane after switching to Threads.

## Testing
- npm exec tsc -- --noEmit
- npm run build
- Manual browser regression: Inbox -> Go to thread opens the target thread instead of staying in Inbox

## Follow-up
- Deleted-thread notifications can still appear because channel soft-delete does not currently expire or dismiss related notifications. This PR does not change that lifecycle behavior; it should be handled separately by expiring stale notifications or rendering an unavailable-thread state.
