### PR TITLE
Feature/workspace support aider

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,108 @@ agn connect my-agent <workspace-token>    # connect agent into workspace
 | **Hermes Agent** | ✅ Supported | Nous Hermes CLI with tools, profiles, and memory |
 | **Cursor** | ✅ Supported | AI code editor |
 | **OpenCode** | ✅ Supported | Open-source terminal agent |
-| Aider, Goose, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+| **Aider** | 🧪 Beta | AI pair programming in your terminal (multi-provider). Offline tests passed; real provider E2E pending |
+| Goose, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+
+> **Aider is Beta.** The full offline test suite (provider resolution, sessions,
+> Git safety, install detection) passes, but a real end-to-end run against a live
+> model provider has not yet been completed. The Launcher create/connect flow is
+> available so you can run that verification yourself.
+
+#### Connecting Aider
+
+Aider runs in its non-interactive scripting mode (`aider --message-file …`); the
+adapter keeps a separate Aider chat history per workspace channel for follow-up
+context and writes any file changes into the agent's configured working
+directory. Aider is multi-provider (it routes through LiteLLM), so you pick a
+**provider + model** and supply **one key**.
+
+```bash
+agn install aider                                  # install the Aider CLI (aider.chat)
+agn env aider --set AIDER_PROVIDER=anthropic       # which provider the key is for
+agn env aider --set AIDER_MODEL=sonnet             # a model for that provider
+agn env aider --set LLM_API_KEY=<your-key>         # one key, injected per provider
+agn create my-aider --type aider --path ~/code     # create an instance + working dir
+agn up                                              # start the daemon
+agn connect my-aider <workspace-token>              # connect Aider into a workspace
+```
+
+**Provider, model & key.** `AIDER_PROVIDER` decides which provider environment
+variable your `LLM_API_KEY` is injected into. It accepts `auto` (default),
+`openai`, `anthropic`, `openrouter`, `gemini`, `deepseek`, or
+`openai-compatible`:
+
+| `AIDER_PROVIDER` | Key injected as | Notes |
+|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` | e.g. `AIDER_MODEL=sonnet` / `opus` / `claude-3-5-sonnet-20241022` |
+| `openai` | `OPENAI_API_KEY` | e.g. `AIDER_MODEL=gpt-4o` |
+| `openrouter` | `OPENROUTER_API_KEY` | e.g. `AIDER_MODEL=openrouter/anthropic/claude-3.5-sonnet` |
+| `gemini` | `GEMINI_API_KEY` | e.g. `AIDER_MODEL=gemini/gemini-1.5-pro` |
+| `deepseek` | `DEEPSEEK_API_KEY` | e.g. `AIDER_MODEL=deepseek/deepseek-chat` |
+| `openai-compatible` | `OPENAI_API_KEY` + `OPENAI_API_BASE` | **requires `LLM_BASE_URL`**; the model is normalized to `openai/<model>` |
+| `auto` *(default)* | inferred from the model name | needs a model whose name identifies the provider |
+
+Config examples:
+
+```bash
+# Anthropic with the `sonnet` alias
+agn env aider --set AIDER_PROVIDER=anthropic --set AIDER_MODEL=sonnet --set LLM_API_KEY=sk-ant-…
+
+# OpenAI
+agn env aider --set AIDER_PROVIDER=openai --set AIDER_MODEL=gpt-4o --set LLM_API_KEY=sk-…
+
+# OpenRouter
+agn env aider --set AIDER_PROVIDER=openrouter \
+  --set AIDER_MODEL=openrouter/anthropic/claude-3.5-sonnet --set LLM_API_KEY=sk-or-…
+
+# OpenAI-compatible endpoint (self-hosted / relay / local)
+agn env aider --set AIDER_PROVIDER=openai-compatible \
+  --set AIDER_MODEL=llama3 --set LLM_BASE_URL=https://my-endpoint/v1 --set LLM_API_KEY=sk-…
+
+# Auto mode — reuse a native key already in your shell, no LLM_API_KEY
+export ANTHROPIC_API_KEY=sk-ant-…
+agn env aider --set AIDER_PROVIDER=auto --set AIDER_MODEL=sonnet
+```
+
+Rules:
+
+- **`AIDER_PROVIDER` decides where the generic `LLM_API_KEY` goes.** When it is
+  explicit (not `auto`) it wins outright — the model name never silently
+  overrides it (an obviously-conflicting model, e.g. `anthropic` + `openai/…`,
+  is rejected with a clear error rather than guessed).
+- **`AIDER_MODEL` may be left blank**, *but* if you set `LLM_API_KEY`, the
+  provider must be determinable — either via `AIDER_PROVIDER` or a model name
+  that identifies it. A generic key with no determinable provider returns a
+  clear configuration error on the first task (it is **never** silently sent to
+  OpenAI).
+- **`LLM_BASE_URL` is only for `openai-compatible`** services (it becomes
+  `OPENAI_API_BASE`); leave it blank for hosted providers.
+- **No `LLM_API_KEY`?** Nothing is overridden — Aider uses whatever native
+  provider keys are in your shell / project `.env` / `.aider.conf.yml`.
+  `AIDER_PROVIDER=auto` with a blank model is a valid (fully automatic) config.
+- **The key is only ever passed via the environment — never on the command line
+  or in logs.** Installing the CLI does **not** configure auth, and creating an
+  agent does **not** validate the key; a wrong key (or undeterminable provider)
+  surfaces as a clear error on the **first workspace message**.
+
+**File changes & Git — important.** Aider auto-commits by default; OpenAgents
+does **not**. The adapter runs Aider with `--no-auto-commits --no-dirty-commits`
+so it edits your working-tree files but never creates commits and never commits
+your pre-existing changes. It also passes `--no-gitignore` (your tracked
+`.gitignore` is left untouched) and adds `.aider*` to `.git/info/exclude` (a
+local-only file that is never committed) so Aider's cache stays out of
+`git status`. To opt **in** to Aider's automatic commits, set
+`AIDER_AUTO_COMMITS=true`. Aider works in both Git repos and non-Git
+directories. Per-channel chat history is stored under
+`~/.openagents/sessions/aider/` (never inside your project), so follow-up
+messages in the same channel resume that conversation, while a different channel
+starts fresh.
+
+**Verifying end to end.** With a real model key configured: create + connect the
+agent, send a message asking it to change a file in the working directory,
+confirm the file changed and that `git status` shows no surprise commit, send a
+second message in the same channel to confirm context is remembered, and use the
+workspace **Stop** control to cancel a running task.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ agn up                                              # start the daemon
 agn connect my-aider <workspace-token>              # connect Aider into a workspace
 ```
 
+> **Install detection.** The official installer (`aider.chat/install.{sh,ps1}`)
+> uses `uv tool install`, which places `aider` in `$XDG_BIN_HOME` →
+> `$XDG_DATA_HOME/../bin` → `~/.local/bin` (and always in the uv tools venv).
+> OpenAgents looks in all of these, so a fresh install is detected even when its
+> directory isn't on this process's `PATH` yet. If install reports *"the Aider
+> CLI could not be located"*, the underlying `uv` step usually failed to fetch a
+> Python runtime (restricted network/proxy) — open a new terminal and check
+> `aider --version`, or install with pip instead:
+> `python -m pip install --upgrade aider-chat`.
+
 **Provider, model & key.** `AIDER_PROVIDER` decides which provider environment
 variable your `LLM_API_KEY` is injected into. It accepts `auto` (default),
 `openai`, `anthropic`, `openrouter`, `gemini`, `deepseek`, or

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -9,11 +9,58 @@
       "pair-programming",
       "open-source"
     ],
+    "builtin": true,
+    "support": { "install": true, "workspace": true, "collaboration": true },
     "install": {
       "binary": "aider",
       "macos": "curl -LsSf https://aider.chat/install.sh | sh",
       "linux": "curl -LsSf https://aider.chat/install.sh | sh",
       "windows": "powershell -c \\\"irm https://aider.chat/install.ps1 | iex\\\""
+    },
+    "adapter": {
+      "module": "openagents.adapters.aider",
+      "class": "AiderAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "AIDER_PROVIDER",
+        "description": "Which provider the API key belongs to. One of: auto, openai, anthropic, openrouter, gemini, deepseek, openai-compatible. `auto` infers from the model name; set it explicitly when the model name doesn't identify the provider.",
+        "required": false,
+        "default": "auto",
+        "placeholder": "auto"
+      },
+      {
+        "name": "AIDER_MODEL",
+        "description": "Model to use, e.g. sonnet, gpt-4o, claude-3-5-sonnet-20241022, openrouter/anthropic/claude-3.5-sonnet, gemini/gemini-1.5-pro, deepseek/deepseek-chat. May be left blank to let Aider auto-select — but if you set LLM_API_KEY, the provider must be determinable (via AIDER_PROVIDER or the model name).",
+        "required": false,
+        "placeholder": "gpt-4o"
+      },
+      {
+        "name": "LLM_API_KEY",
+        "description": "API key for the selected provider. Injected into the provider env var chosen by AIDER_PROVIDER/model. Leave blank to reuse a provider key already in your shell or the project's .env / .aider.conf.yml.",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "LLM_BASE_URL",
+        "description": "Endpoint URL — ONLY for AIDER_PROVIDER=openai-compatible (self-hosted / relay / local). Becomes OPENAI_API_BASE; leave blank for hosted providers.",
+        "required": false,
+        "placeholder": "https://my-endpoint.example/v1"
+      }
+    ],
+    "check_ready": {
+      "env_vars": [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY"
+      ],
+      "saved_env_key": "LLM_API_KEY",
+      "not_ready_message": "No model API key — set a model + LLM_API_KEY (or a provider key such as OPENAI_API_KEY) — press e to configure"
     }
   },
   {

--- a/packages/agent-connector/src/adapters/aider.js
+++ b/packages/agent-connector/src/adapters/aider.js
@@ -1,0 +1,631 @@
+/**
+ * Aider adapter for OpenAgents workspace.
+ *
+ * Bridges Aider (https://aider.chat) to an OpenAgents workspace by running the
+ * CLI in its official non-interactive *scripting* mode:
+ *
+ *   aider --message-file <tmp> --yes-always --no-pretty --no-stream \
+ *         --no-auto-commits --no-dirty-commits --no-gitignore \
+ *         --chat-history-file <per-channel> --input-history-file <per-channel> \
+ *         [--restore-chat-history] [--model <model>]
+ *
+ * Differs from the Amp adapter in every Aider-specific dimension:
+ *  - Prompt is written to a private per-task message file (--message-file), so
+ *    a long prompt never hits ARG_MAX / shell quoting; never string-concatenated.
+ *  - Aider has no JSON event protocol — plain text is drained incrementally,
+ *    notable progress lines relayed as `status`, and the cleaned transcript sent
+ *    once as the final answer. The exit code decides success (non-zero is never
+ *    reported as success even with stdout).
+ *  - Per-channel `--chat-history-file` + `--restore-chat-history` give isolated,
+ *    resumable sessions stored under ~/.openagents/sessions/aider (never in the
+ *    project). A corrupt history file degrades to a fresh session.
+ *  - Git auto-commit is OFF by default (--no-auto-commits --no-dirty-commits)
+ *    and the tracked .gitignore is never rewritten (--no-gitignore); Aider's
+ *    local cache is excluded via .git/info/exclude.
+ *  - Multi-provider auth: a generic LLM_API_KEY is mapped to the right provider
+ *    env var from the model string; keys never reach the command line or logs.
+ *
+ * Reuses all shared connectivity / dispatch / state machinery in BaseAdapter.
+ *
+ * Mirrors the Python adapter: sdk/src/openagents/adapters/aider.py
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { whichBinary, getEnhancedEnv } = require('../paths');
+
+const IS_WINDOWS = process.platform === 'win32';
+// Terminate if Aider produces no output for this long (a wedged turn). Resets
+// on any stdout activity, so a slow-but-progressing task is never killed.
+const IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_STATUS_UPDATES = 60;
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const BLANKS_RE = /\n{3,}/g;
+const PROGRESS_RE =
+  /^(Applied edit|Edited |Wrote |Created |Added |Removed |Committing|Commit |Running |Scanning |Repo-map|Reformatting|Skipped |Renamed )/i;
+
+const ERROR_SIGNATURES = [
+  [['authenticationerror', 'invalid api key', 'incorrect api key', 'no api key',
+    'missing these environment variables', 'api key not found', '401',
+    'unauthorized', 'permission denied to access model'],
+    'Authentication failed — check the API key for the selected model/provider.'],
+  [['notfounderror', 'model_not_found', 'does not exist', 'unknown model',
+    'could not find model', 'you do not have access to model'],
+    'Model not found or not accessible — check the model name and that your key has access.'],
+  [['rate limit', 'ratelimiterror', '429', 'quota', 'insufficient_quota'],
+    'Rate-limited or out of quota at the model provider — try again later.'],
+  [['connectionerror', 'timeout', 'could not connect', 'getaddrinfo',
+    'temporary failure in name resolution', 'network is unreachable',
+    'failed to establish a new connection'],
+    'Network error reaching the model provider — check connectivity and the base URL.'],
+  [['permission denied', 'eacces', 'read-only file system', 'operation not permitted'],
+    'File permission error in the working directory.'],
+  [['gitcommanderror', 'fatal: not a git repository', 'git failed', 'not a git repo'],
+    'Git error while applying changes.'],
+];
+
+function aiderInstallHint() {
+  return IS_WINDOWS
+    ? 'powershell -NoProfile -Command "irm https://aider.chat/install.ps1 | iex"'
+    : 'curl -LsSf https://aider.chat/install.sh | sh';
+}
+
+function isTruthy(v) {
+  return ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
+}
+
+function cleanOutput(text) {
+  return String(text || '').replace(ANSI_RE, '').replace(BLANKS_RE, '\n\n').trim();
+}
+
+function classifyError(stderr, stdout) {
+  const blob = `${stderr}\n${stdout}`.toLowerCase();
+  for (const [needles, message] of ERROR_SIGNATURES) {
+    if (needles.some((n) => blob.includes(n))) return message;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Provider resolution — must stay behaviourally identical to the Python adapter
+// (sdk/src/openagents/adapters/aider.py). Aider routes through LiteLLM, so a
+// single generic LLM_API_KEY is injected into the provider-specific env var the
+// chosen model expects. Provider is chosen DETERMINISTICALLY:
+//   1. explicit AIDER_PROVIDER (not 'auto') wins;
+//   2. else infer from an unambiguous model name (case-insensitive);
+//   3. key set but provider undeterminable → config error (never silently OpenAI);
+//   4. no key → leave the inherited/native provider env untouched (auto mode).
+// Env var names verified against aider's official docs / `aider --help`.
+// ---------------------------------------------------------------------------
+
+const VALID_PROVIDERS = [
+  'auto', 'openai', 'anthropic', 'openrouter', 'gemini', 'deepseek',
+  'openai-compatible',
+];
+const PROVIDER_KEY_VAR = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+  'openai-compatible': 'OPENAI_API_KEY',
+};
+
+function explicitPrefixProvider(model) {
+  const m = String(model || '').trim().toLowerCase();
+  if (m.startsWith('openrouter/')) return 'openrouter';
+  if (m.startsWith('anthropic/')) return 'anthropic';
+  if (m.startsWith('openai/')) return 'openai';
+  if (m.startsWith('gemini/') || m.startsWith('google/')) return 'gemini';
+  if (m.startsWith('deepseek/')) return 'deepseek';
+  return null;
+}
+
+function inferProviderFromModel(model) {
+  const m = String(model || '').trim().toLowerCase();
+  if (!m) return null;
+  const prefixed = explicitPrefixProvider(m);
+  if (prefixed) return prefixed;
+  if (m.includes('claude') || m.includes('sonnet') || m.includes('opus') || m.includes('haiku')) return 'anthropic';
+  if (m.includes('deepseek')) return 'deepseek';
+  if (m.includes('gemini')) return 'gemini';
+  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3')
+      || m.startsWith('o4-') || m.startsWith('chatgpt') || m.includes('gpt-')) return 'openai';
+  return null;
+}
+
+function normalizeOpenAiModel(model) {
+  const m = String(model || '').trim();
+  if (!m) return m;
+  if (m.toLowerCase().startsWith('openai/')) return m;
+  return `openai/${m}`;
+}
+
+/**
+ * Deterministically resolve the provider env vars (and any model normalization)
+ * for a generic LLM_API_KEY.
+ * @returns {{ env: object, model: string, error: string|null }}
+ *   `env` is the provider vars to inject; `model` is the possibly-normalized
+ *   model; `error` is a clear message when the config is invalid/ambiguous (in
+ *   which case Aider must NOT start).
+ */
+function resolveAiderProvider(provider, model, apiKey, baseUrl) {
+  provider = String(provider || '').trim().toLowerCase();
+  model = String(model || '').trim();
+  apiKey = String(apiKey || '').trim();
+  baseUrl = String(baseUrl || '').trim();
+
+  if (provider && !VALID_PROVIDERS.includes(provider)) {
+    return {
+      env: {}, model,
+      error: `Unknown AIDER_PROVIDER '${provider}'. Valid values: auto, openai, `
+        + 'anthropic, openrouter, gemini, deepseek, openai-compatible.',
+    };
+  }
+  if (!provider) provider = 'auto';
+
+  // No generic key: auto mode — never fabricate/override provider keys.
+  if (!apiKey) {
+    if (provider === 'openai-compatible') {
+      if (!baseUrl) {
+        return { env: {}, model, error: 'AIDER_PROVIDER=openai-compatible requires LLM_BASE_URL (the OpenAI-compatible endpoint URL).' };
+      }
+      return { env: { OPENAI_API_BASE: baseUrl }, model: normalizeOpenAiModel(model), error: null };
+    }
+    return { env: {}, model, error: null };
+  }
+
+  // Generic key present: a concrete provider is required.
+  let resolved;
+  if (provider === 'auto') {
+    const inferred = inferProviderFromModel(model);
+    if (!inferred) {
+      return {
+        env: {}, model,
+        error: 'Could not determine the model provider for LLM_API_KEY. Set '
+          + 'AIDER_PROVIDER (openai, anthropic, openrouter, gemini, deepseek, or '
+          + 'openai-compatible), use an AIDER_MODEL whose name identifies the '
+          + 'provider, or set the native provider key directly.',
+      };
+    }
+    resolved = inferred;
+  } else {
+    resolved = provider;
+    const prefixProv = explicitPrefixProvider(model);
+    const effective = resolved === 'openai-compatible' ? 'openai' : resolved;
+    if (prefixProv && prefixProv !== effective) {
+      return {
+        env: {}, model,
+        error: `AIDER_PROVIDER=${provider} conflicts with AIDER_MODEL '${model}' `
+          + `(which targets ${prefixProv}). Fix the provider or the model.`,
+      };
+    }
+  }
+
+  if (resolved === 'openai-compatible') {
+    if (!baseUrl) {
+      return { env: {}, model, error: 'AIDER_PROVIDER=openai-compatible requires LLM_BASE_URL (the OpenAI-compatible endpoint URL).' };
+    }
+    return {
+      env: { OPENAI_API_KEY: apiKey, OPENAI_API_BASE: baseUrl },
+      model: normalizeOpenAiModel(model), error: null,
+    };
+  }
+
+  const env = { [PROVIDER_KEY_VAR[resolved]]: apiKey };
+  // A base URL only belongs to the OpenAI variable family.
+  if (baseUrl && resolved === 'openai') env.OPENAI_API_BASE = baseUrl;
+  return { env, model, error: null };
+}
+
+class AiderAdapter extends BaseAdapter {
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+
+    // channel -> running child process (for stop / cleanup)
+    this._channelProcesses = {};
+    // channels the user explicitly stopped (suppress "no response" noise)
+    this._stoppingChannels = new Set();
+    // git repos already given the local Aider exclude
+    this._gitExcludeDone = new Set();
+
+    this._sessionsDir = path.join(
+      os.homedir(), '.openagents', 'sessions', 'aider',
+      `${this.workspaceId}_${this.agentName}`,
+    );
+
+    this._aiderBin = this._findAiderBinary();
+    if (this._aiderBin) {
+      this._log(`Using Aider CLI: ${this._aiderBin}`);
+    } else {
+      this._log(`Warning: Aider CLI not found — install with: ${aiderInstallHint()}`);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Binary resolution
+  // ------------------------------------------------------------------
+
+  _findAiderBinary() {
+    const home = os.homedir();
+
+    // Shared cross-platform resolver runs `which`/`where` against an ENHANCED
+    // PATH (nvm/fnm/volta/homebrew, ~/.local/bin) — covers the GUI/daemon "not
+    // on PATH" case for the uv-tool / pipx / pip-user installs.
+    const resolved = whichBinary('aider');
+    if (resolved) return resolved;
+
+    const candidates = IS_WINDOWS ? [
+      path.join(home, '.local', 'bin', 'aider.exe'),
+      path.join(home, '.local', 'bin', 'aider.cmd'),
+      path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'),
+        'Programs', 'aider', 'aider.exe'),
+    ] : [
+      path.join(home, '.local', 'bin', 'aider'),
+      path.join(home, 'bin', 'aider'),
+      '/usr/local/bin/aider',
+      '/opt/homebrew/bin/aider',
+    ];
+    for (const c of candidates) {
+      if (c && fs.existsSync(c)) return c;
+    }
+    return null;
+  }
+
+  // ------------------------------------------------------------------
+  // Per-channel session storage
+  // ------------------------------------------------------------------
+
+  _safeChannelId(channel) {
+    let slug = String(channel || '').replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+/, '');
+    return slug || 'general';
+  }
+
+  _chatHistoryFile(channel) {
+    return path.join(this._sessionsDir, `${this._safeChannelId(channel)}.chat.history.md`);
+  }
+
+  _inputHistoryFile(channel) {
+    return path.join(this._sessionsDir, `${this._safeChannelId(channel)}.input.history`);
+  }
+
+  _hasHistory(channel) {
+    const p = this._chatHistoryFile(channel);
+    try {
+      const st = fs.statSync(p);
+      if (!st.size) return false;
+      fs.readFileSync(p, 'utf-8');
+      return true;
+    } catch (e) {
+      if (e && e.code === 'ENOENT') return false;
+      // Unreadable/corrupt → degrade to a fresh session.
+      this._log(`Aider chat history for ${this._safeChannelId(channel)} unreadable — starting fresh`);
+      try { fs.renameSync(p, `${p}.corrupt`); } catch {}
+      return false;
+    }
+  }
+
+  resetChannelSession(channel) {
+    for (const p of [this._chatHistoryFile(channel), this._inputHistoryFile(channel)]) {
+      try { fs.rmSync(p, { force: true }); } catch {}
+    }
+  }
+
+  clearAllSessions() {
+    try { fs.rmSync(this._sessionsDir, { recursive: true, force: true }); } catch {}
+  }
+
+  // ------------------------------------------------------------------
+  // Git hygiene — keep Aider's cache out of `git status` without touching the
+  // user's tracked .gitignore.
+  // ------------------------------------------------------------------
+
+  _ensureLocalGitExclude(workingDir) {
+    if (!workingDir || this._gitExcludeDone.has(workingDir)) return;
+    this._gitExcludeDone.add(workingDir);
+    try {
+      const gitDir = path.join(workingDir, '.git');
+      if (!fs.existsSync(gitDir) || !fs.statSync(gitDir).isDirectory()) return;
+      const infoDir = path.join(gitDir, 'info');
+      fs.mkdirSync(infoDir, { recursive: true });
+      const exclude = path.join(infoDir, 'exclude');
+      let existing = '';
+      try { existing = fs.readFileSync(exclude, 'utf-8'); } catch {}
+      if (!existing.includes('.aider')) {
+        const sep = (!existing || existing.endsWith('\n')) ? '' : '\n';
+        fs.writeFileSync(exclude, `${existing}${sep}# Added by OpenAgents Aider agent\n.aider*\n`);
+      }
+    } catch {}
+  }
+
+  // ------------------------------------------------------------------
+  // Command + env construction
+  // ------------------------------------------------------------------
+
+  _model() {
+    return String(this.agentEnv.AIDER_MODEL || this.agentEnv.LLM_MODEL || '').trim();
+  }
+
+  /**
+   * Deterministically resolve provider env + model from the agent config.
+   * Pure, so command/env builders and the pre-flight gate stay in sync.
+   * @returns {{ env: object, model: string, error: string|null }}
+   */
+  _resolveConfig() {
+    return resolveAiderProvider(
+      this.agentEnv.AIDER_PROVIDER,
+      this._model(),
+      this.agentEnv.LLM_API_KEY,
+      this.agentEnv.LLM_BASE_URL || this.agentEnv.OPENAI_API_BASE,
+    );
+  }
+
+  _buildAiderCmd(channel, msgFile, restore) {
+    const autoCommit = isTruthy(this.agentEnv.AIDER_AUTO_COMMITS);
+    const cmd = [
+      this._aiderBin,
+      '--message-file', msgFile,
+      '--yes-always',
+      '--no-pretty',
+      '--no-stream',
+      '--no-check-update',
+      '--no-gitignore',
+      '--no-dirty-commits',
+      '--chat-history-file', this._chatHistoryFile(channel),
+      '--input-history-file', this._inputHistoryFile(channel),
+    ];
+    cmd.push(autoCommit ? '--auto-commits' : '--no-auto-commits');
+    if (restore) cmd.push('--restore-chat-history');
+    // Use the resolved (possibly openai/-normalized) model, not the raw value.
+    const model = this._resolveConfig().model;
+    if (model) cmd.push('--model', model);
+    return cmd;
+  }
+
+  _buildSubprocessEnv() {
+    const base = getEnhancedEnv(this.agentEnv);
+    if (base.NO_COLOR === undefined) base.NO_COLOR = '1';
+    base.PYTHONUNBUFFERED = '1';
+    Object.assign(base, this._resolveConfig().env);
+    return base;
+  }
+
+  // ------------------------------------------------------------------
+  // Control actions (stop / reset)
+  // ------------------------------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      for (const [channel, proc] of Object.entries(this._channelProcesses)) {
+        this._stoppingChannels.add(channel);
+        await this._stopProcess(proc);
+        delete this._channelProcesses[channel];
+        try { await this.sendStatus(channel, 'Execution stopped by user'); } catch {}
+      }
+      return;
+    }
+    if (action === 'reset_session' || action === 'clear_session') {
+      const channel = (payload && payload.channel) || this.channelName;
+      this.resetChannelSession(channel);
+      return;
+    }
+    await super._onControlAction(action, payload);
+  }
+
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000 }); } catch {}
+        return;
+      }
+      try { process.kill(-proc.pid, 'SIGTERM'); } catch { proc.kill('SIGTERM'); }
+      await new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          try { process.kill(-proc.pid, 'SIGKILL'); } catch { proc.kill('SIGKILL'); }
+          resolve();
+        }, 5000);
+        proc.on('exit', () => { clearTimeout(timeout); resolve(); });
+      });
+    } catch {}
+  }
+
+  // ------------------------------------------------------------------
+  // Message handler
+  // ------------------------------------------------------------------
+
+  async _handleMessage(msg) {
+    const content = (msg.content || '').trim();
+    if (!content) return;
+
+    const msgChannel = msg.sessionId || this.channelName;
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${msgChannel}: ${content.length} chars`);
+
+    if (!this._aiderBin) this._aiderBin = this._findAiderBinary();
+    if (!this._aiderBin) {
+      await this.sendError(msgChannel, `Aider CLI not found. Install with: ${aiderInstallHint()}`);
+      return;
+    }
+
+    // Pre-flight: resolve the provider/key BEFORE starting Aider so a
+    // misconfiguration returns a crisp, actionable error (and never silently
+    // injects the key into the wrong provider).
+    const resolution = this._resolveConfig();
+    if (resolution.error) {
+      await this.sendError(msgChannel, `Configuration error: ${resolution.error}`);
+      return;
+    }
+
+    await this._autoTitleChannel(msgChannel, content);
+    this._stoppingChannels.delete(msgChannel);
+    this._ensureLocalGitExclude(this.workingDir);
+    await this.sendStatus(msgChannel, 'Aider is working...');
+
+    let result;
+    try {
+      result = await this._runAider(content, msgChannel);
+    } catch (e) {
+      this._log(`Error handling message: ${e.message}`);
+      await this.sendError(msgChannel, `Error processing message: ${e.message}`);
+      return;
+    }
+
+    if (this._stoppingChannels.has(msgChannel)) {
+      this._stoppingChannels.delete(msgChannel);
+      return;
+    }
+    const { text, error } = result;
+    if (error) {
+      await this.sendError(msgChannel, error);
+    } else if (text) {
+      await this.sendResponse(msgChannel, text);
+    } else {
+      await this.sendResponse(
+        msgChannel,
+        'Aider finished with no textual output (any file changes were applied to the working directory).',
+      );
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Subprocess execution
+  // ------------------------------------------------------------------
+
+  async _runAider(content, msgChannel) {
+    // Defensive re-check (the primary gate is in _handleMessage): never spawn
+    // Aider — nor create a temp file — on an invalid configuration.
+    const resolution = this._resolveConfig();
+    if (resolution.error) {
+      return { text: '', error: `Configuration error: ${resolution.error}` };
+    }
+
+    fs.mkdirSync(this._sessionsDir, { recursive: true });
+    const restore = this._hasHistory(msgChannel);
+
+    // Private per-task message file outside the project. The prompt body never
+    // appears on the command line or in a filename/log.
+    const msgFile = path.join(
+      this._sessionsDir,
+      `aider-msg-${process.pid}-${this._msgCounter = (this._msgCounter || 0) + 1}.txt`,
+    );
+    try {
+      fs.writeFileSync(msgFile, content, 'utf-8');
+      const cmd = this._buildAiderCmd(msgChannel, msgFile, restore);
+      return await this._spawnAider(cmd, msgChannel);
+    } finally {
+      try { fs.rmSync(msgFile, { force: true }); } catch {}
+    }
+  }
+
+  _spawnAider(cmd, msgChannel) {
+    return new Promise((resolve, reject) => {
+      const env = this._buildSubprocessEnv();
+
+      const proc = spawn(cmd[0], cmd.slice(1), {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env,
+        cwd: this.workingDir,
+        detached: !IS_WINDOWS,
+        windowsHide: true,
+        shell: IS_WINDOWS && String(cmd[0]).toLowerCase().endsWith('.cmd'),
+      });
+      this._channelProcesses[msgChannel] = proc;
+
+      let stdoutBuf = '';
+      let stderrBuf = '';
+      let lineBuffer = '';
+      let statusCount = 0;
+      let pending = Promise.resolve();
+
+      let idleTimer = null;
+      const armIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          this._log(`Aider produced no output for ${IDLE_TIMEOUT_MS / 1000}s — terminating`);
+          this._stopProcess(proc);
+        }, IDLE_TIMEOUT_MS);
+      };
+      armIdle();
+
+      if (proc.stderr) {
+        proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString('utf-8'); });
+      }
+
+      const handleLine = async (raw) => {
+        const stripped = raw.replace(ANSI_RE, '').trim();
+        if (stripped && statusCount < MAX_STATUS_UPDATES && PROGRESS_RE.test(stripped)) {
+          statusCount += 1;
+          try { await this.sendStatus(msgChannel, stripped.slice(0, 300)); } catch {}
+        }
+      };
+
+      proc.stdout.on('data', (chunk) => {
+        armIdle();
+        const s = chunk.toString('utf-8');
+        stdoutBuf += s;
+        lineBuffer += s;
+        const lines = lineBuffer.split('\n');
+        lineBuffer = lines.pop();
+        for (const line of lines) {
+          pending = pending.then(() => handleLine(line)).catch(() => {});
+        }
+      });
+
+      proc.on('exit', async (code) => {
+        if (idleTimer) clearTimeout(idleTimer);
+        if (lineBuffer) {
+          pending = pending.then(() => handleLine(lineBuffer)).catch(() => {});
+        }
+        try { await pending; } catch {}
+        delete this._channelProcesses[msgChannel];
+
+        if (this._stoppingChannels.has(msgChannel)) {
+          resolve({ text: '', error: null });
+          return;
+        }
+
+        const stdoutText = cleanOutput(stdoutBuf);
+        const stderrText = cleanOutput(stderrBuf);
+        if (stderrText) this._log(`Aider stderr: ${stderrText.length} chars`);
+
+        if (code !== 0) {
+          let diagnostic = classifyError(stderrText, stdoutText);
+          if (!diagnostic) {
+            const tail = (stderrText || stdoutText).split('\n');
+            const detail = tail.length ? tail[tail.length - 1] : '';
+            diagnostic = `Aider exited with code ${code}.${detail ? ` ${detail}` : ''}`;
+          }
+          resolve({ text: '', error: diagnostic });
+          return;
+        }
+
+        if (!stdoutText) {
+          const diagnostic = classifyError(stderrText, stdoutText);
+          if (diagnostic) {
+            resolve({ text: '', error: diagnostic });
+            return;
+          }
+        }
+        resolve({ text: stdoutText, error: null });
+      });
+
+      proc.on('error', (err) => {
+        if (idleTimer) clearTimeout(idleTimer);
+        delete this._channelProcesses[msgChannel];
+        reject(err);
+      });
+    });
+  }
+}
+
+module.exports = AiderAdapter;

--- a/packages/agent-connector/src/adapters/aider.js
+++ b/packages/agent-connector/src/adapters/aider.js
@@ -38,7 +38,7 @@ const path = require('path');
 const { execSync, spawn } = require('child_process');
 
 const BaseAdapter = require('./base');
-const { whichBinary, getEnhancedEnv } = require('../paths');
+const { whichBinary, getEnhancedEnv, aiderBinDirs } = require('../paths');
 
 const IS_WINDOWS = process.platform === 'win32';
 // Terminate if Aider produces no output for this long (a wedged turn). Resets
@@ -256,27 +256,21 @@ class AiderAdapter extends BaseAdapter {
   // ------------------------------------------------------------------
 
   _findAiderBinary() {
-    const home = os.homedir();
-
     // Shared cross-platform resolver runs `which`/`where` against an ENHANCED
-    // PATH (nvm/fnm/volta/homebrew, ~/.local/bin) — covers the GUI/daemon "not
-    // on PATH" case for the uv-tool / pipx / pip-user installs.
+    // PATH (nvm/fnm/volta/homebrew + the Aider install dirs added to paths.js)
+    // — covers the GUI/daemon "not on PATH" case for uv-tool / pipx / pip-user
+    // installs.
     const resolved = whichBinary('aider');
     if (resolved) return resolved;
 
-    const candidates = IS_WINDOWS ? [
-      path.join(home, '.local', 'bin', 'aider.exe'),
-      path.join(home, '.local', 'bin', 'aider.cmd'),
-      path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'),
-        'Programs', 'aider', 'aider.exe'),
-    ] : [
-      path.join(home, '.local', 'bin', 'aider'),
-      path.join(home, 'bin', 'aider'),
-      '/usr/local/bin/aider',
-      '/opt/homebrew/bin/aider',
-    ];
-    for (const c of candidates) {
-      if (c && fs.existsSync(c)) return c;
+    // Explicit fallback over every real install dir (XDG bin, XDG_DATA_HOME/../
+    // bin, ~/.local/bin, the uv tools venv) in the installer's own priority.
+    const names = IS_WINDOWS ? ['aider.exe', 'aider.cmd', 'aider'] : ['aider'];
+    for (const dir of aiderBinDirs()) {
+      for (const name of names) {
+        const c = path.join(dir, name);
+        if (fs.existsSync(c)) return c;
+      }
     }
     return null;
   }

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -14,6 +14,7 @@ const CursorAdapter = require('./cursor');
 const HermesAdapter = require('./hermes');
 const GeminiAdapter = require('./gemini');
 const KimiAdapter = require('./kimi');
+const AiderAdapter = require('./aider');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -25,11 +26,12 @@ const ADAPTER_MAP = {
   hermes: HermesAdapter,
   gemini: GeminiAdapter,
   kimi: KimiAdapter,
+  aider: AiderAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, aider)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -52,6 +54,7 @@ module.exports = {
   HermesAdapter,
   GeminiAdapter,
   KimiAdapter,
+  AiderAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execSync, exec } = require('child_process');
-const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache } = require('./paths');
+const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache, aiderBinDirs } = require('./paths');
 const { EnvManager } = require('./env');
 
 const STATUS_CACHE_TTL_MS = 10000;
@@ -184,15 +184,15 @@ class Installer {
     const isWin = process.platform === 'win32';
     const names = isWin ? ['aider.exe', 'aider.cmd', 'aider'] : ['aider'];
     const candidates = [];
+    // 1) Whatever the enhanced-PATH resolver finds (now includes the XDG and
+    //    uv-tools dirs added to paths.js).
     const resolved = this._whichBinary('aider');
     if (resolved) candidates.push(resolved);
-    const home = os.homedir();
-    const binDirs = [
-      path.join(home, '.local', 'bin'),  // uv tool / pipx / pip --user
-      path.join(home, 'bin'),
-    ];
-    if (!isWin) binDirs.push('/usr/local/bin', '/opt/homebrew/bin');
-    for (const dir of binDirs) {
+    // 2) Every real install dir the official installer can target — XDG bin,
+    //    XDG_DATA_HOME/../bin, ~/.local/bin, and the uv tools venv. This is the
+    //    fix for "install succeeded but landed outside ~/.local/bin" (e.g. the
+    //    user has XDG_* set, or only the uv-tools venv copy exists).
+    for (const dir of aiderBinDirs()) {
       for (const name of names) candidates.push(path.join(dir, name));
     }
 
@@ -223,16 +223,26 @@ class Installer {
   }
 
   /**
-   * Aider-only: message shown when the install command exits 0 but no runnable
-   * (and verified) aider binary can be found.
+   * Aider-only: actionable message when the install command exits 0 but no
+   * runnable (and verified) aider binary can be found anywhere we look. The most
+   * common real cause is the underlying `uv` step failing to download a Python
+   * runtime on a restricted network — so we point at both the PATH/new-terminal
+   * case and a pip fallback.
    */
   _aiderBinaryNotFoundMessage() {
     const isWin = process.platform === 'win32';
-    const expected = path.join(os.homedir(), '.local', 'bin', isWin ? 'aider.exe' : 'aider');
+    const name = isWin ? 'aider.exe' : 'aider';
+    const looked = aiderBinDirs().map((d) => `  ${path.join(d, name)}`).join('\n');
     return (
-      'Aider install command completed, but the Aider CLI binary could not be ' +
-      'found (or did not identify itself as Aider).\n\n' +
-      `Expected path:\n${expected}`
+      'Aider install command completed, but the Aider CLI could not be located ' +
+      'afterward. The underlying installer (uv) most likely could not finish — ' +
+      'often it cannot download a Python runtime on a restricted network/proxy.\n\n' +
+      `Looked in:\n${looked}\n\n` +
+      'Try one of:\n' +
+      '  1) Open a NEW terminal and run:  aider --version\n' +
+      '     (the install dir may simply not be on this process’s PATH yet)\n' +
+      '  2) Install with pip instead, then re-run detection:\n' +
+      '       python -m pip install --upgrade aider-chat'
     );
   }
 

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -90,6 +90,20 @@ class Installer {
     // Fallback: check if binary exists on PATH (system install)
     const binaryPath = this._whichBinary(agentType);
     if (!binaryPath) {
+      // Aider-only: a marker alone is NOT sufficient evidence of an install.
+      // Aider's CLI lives outside any npm package (curl/uv/pipx → ~/.local/bin),
+      // so a historical "installed" marker can outlive a missing/never-landed
+      // binary. Require a real resolvable binary; when only a stale marker
+      // remains, report not-installed with a 'cli-missing' diagnostic (carried
+      // by the existing `location` field — no new field/enum). The marker
+      // itself is left untouched.
+      if (agentType === 'aider') {
+        return {
+          installed: false,
+          managed: false,
+          location: this._hasMarker(agentType) ? 'cli-missing' : null,
+        };
+      }
       // If a successful install wrote a marker, surface installed=true even
       // when binary detection can't (yet) see the freshly-installed CLI —
       // e.g. PATH caches not yet picking up a brand-new ~/.cursor/bin. The
@@ -142,6 +156,84 @@ class Installer {
       } catch { return false; }
     }
     return this.isInstalled(agentType);
+  }
+
+  /**
+   * Aider-only post-install verification.
+   *
+   * Confirms a REAL aider binary exists on disk — AND that it is actually the
+   * Aider CLI rather than a same-named unrelated executable — before the
+   * install is recorded. The curl/uv/pipx installer can exit 0 without landing
+   * a runnable binary (blocked download, wrong $HOME, custom bin dir), which
+   * would otherwise leave a "marker says installed but CLI missing" state.
+   * Deliberately does NOT consult the install marker, so it can't be satisfied
+   * by its own about-to-be-written record.
+   *
+   * Hard condition: an absolute path resolves AND the file exists. `aider
+   * --version` is best-effort: a flaky/blocked probe does NOT fail the install,
+   * but a version string that is clearly NOT Aider (wrong same-named package)
+   * does — that is the whole point of the check.
+   *
+   * Scoped to Aider; never called for any other agent type.
+   *
+   * @returns {{ path: string, version: string|null } | null}
+   */
+  _verifyAiderBinary() {
+    try { clearBinaryLookupCache(); } catch {}
+
+    const isWin = process.platform === 'win32';
+    const names = isWin ? ['aider.exe', 'aider.cmd', 'aider'] : ['aider'];
+    const candidates = [];
+    const resolved = this._whichBinary('aider');
+    if (resolved) candidates.push(resolved);
+    const home = os.homedir();
+    const binDirs = [
+      path.join(home, '.local', 'bin'),  // uv tool / pipx / pip --user
+      path.join(home, 'bin'),
+    ];
+    if (!isWin) binDirs.push('/usr/local/bin', '/opt/homebrew/bin');
+    for (const dir of binDirs) {
+      for (const name of names) candidates.push(path.join(dir, name));
+    }
+
+    let found = null;
+    for (const c of candidates) {
+      try { if (c && fs.existsSync(c)) { found = c; break; } } catch {}
+    }
+    if (!found) return null;
+
+    let version = null;
+    try {
+      const raw = require('child_process').execSync(`"${found}" --version`, {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 8000,
+        env: getEnhancedEnv(),
+        windowsHide: true,
+        encoding: 'utf-8',
+      }).trim();
+      if (raw) {
+        // A confident mismatch means this `aider` is the wrong package.
+        if (!/aider/i.test(raw)) return null;
+        version = raw;
+      }
+    } catch {
+      // Best-effort only — file existence above is the hard condition.
+    }
+    return { path: found, version };
+  }
+
+  /**
+   * Aider-only: message shown when the install command exits 0 but no runnable
+   * (and verified) aider binary can be found.
+   */
+  _aiderBinaryNotFoundMessage() {
+    const isWin = process.platform === 'win32';
+    const expected = path.join(os.homedir(), '.local', 'bin', isWin ? 'aider.exe' : 'aider');
+    return (
+      'Aider install command completed, but the Aider CLI binary could not be ' +
+      'found (or did not identify itself as Aider).\n\n' +
+      `Expected path:\n${expected}`
+    );
   }
 
   /**
@@ -385,6 +477,23 @@ class Installer {
     }
 
     const output = await this._execShell(cmd);
+
+    // Aider-only: the curl/uv/pipx installer can exit 0 without landing a
+    // runnable (or genuine) binary, so verify the real CLI exists BEFORE
+    // recording the install. Other agent types keep the original
+    // "exit 0 → mark installed" behavior.
+    if (agentType === 'aider') {
+      const aider = this._verifyAiderBinary();
+      if (!aider) {
+        throw new Error(this._aiderBinaryNotFoundMessage());
+      }
+      this._markInstalled(agentType);
+      return {
+        success: true,
+        output: `${output}\nAider CLI resolved: ${aider.path}${aider.version ? ` (${aider.version})` : ''}`,
+      };
+    }
+
     this._markInstalled(agentType);
     return { success: true, output };
   }
@@ -502,6 +611,19 @@ class Installer {
       proc.on('error', (err) => reject(err));
       proc.on('close', (code) => {
         if (code === 0) {
+          // Aider-only: confirm a real, genuine binary exists before recording
+          // the install (verify-before-mark; never writes a marker on
+          // failure). Other agent types are unaffected.
+          if (agentType === 'aider') {
+            const aider = this._verifyAiderBinary();
+            if (!aider) {
+              const msg = this._aiderBinaryNotFoundMessage();
+              if (onData) onData(`\n${msg}\n`);
+              reject(new Error(msg));
+              return;
+            }
+            if (onData) onData(`\nAider CLI resolved: ${aider.path}${aider.version ? ` (${aider.version})` : ''}\n`);
+          }
           this._markInstalled(agentType);
           if (onData) onData(`\nDone! ${agentType} is now installed.\n`);
           resolve({ success: true, command: displayCmd });

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -50,6 +50,12 @@ function getExtraBinDirs() {
   // Common: ~/.local/bin (pipx, user installs)
   _push(dirs, path.join(HOME, '.local', 'bin'));
 
+  // Aider (uv tool install) — its executable honors XDG_BIN_HOME /
+  // XDG_DATA_HOME/../bin / ~/.local/bin and also always lands in the uv tools
+  // venv. A GUI/daemon process won't see the installer's PATH edit, so add the
+  // real install dirs explicitly (filtered to existing dirs by the caller).
+  for (const d of aiderBinDirs()) _push(dirs, d);
+
   // Also add the directory containing the current node binary
   try {
     const nodeDir = path.dirname(process.execPath);
@@ -396,6 +402,39 @@ function clearBinaryLookupCache() {
   whichBinaryCache.clear();
 }
 
+/**
+ * Directories where the Aider CLI executable can land, in the SAME priority the
+ * official installer (aider.chat/install.{sh,ps1} → `uv tool install`) uses, so
+ * detection matches reality on every platform:
+ *   1. $XDG_BIN_HOME
+ *   2. $XDG_DATA_HOME/../bin
+ *   3. ~/.local/bin              (the default uv-tool / pipx / pip --user bin)
+ *   4. the uv tools venv for aider-chat (Scripts on Windows, bin on Unix) — the
+ *      executable always lands here on a successful `uv tool install`, even if
+ *      the bin-dir copy/PATH edit didn't happen.
+ * Uses os.homedir()/live env so it reflects the current process (test-friendly).
+ * Returns directories only; callers join the platform binary names.
+ */
+function aiderBinDirs() {
+  const home = os.homedir();
+  const dirs = [];
+  if (process.env.XDG_BIN_HOME) dirs.push(process.env.XDG_BIN_HOME);
+  if (process.env.XDG_DATA_HOME) dirs.push(path.join(process.env.XDG_DATA_HOME, '..', 'bin'));
+  dirs.push(path.join(home, '.local', 'bin'));
+  if (IS_WINDOWS) {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    const uvTools = process.env.UV_TOOL_DIR || path.join(appData, 'uv', 'tools');
+    dirs.push(path.join(uvTools, 'aider-chat', 'Scripts'));
+    dirs.push(path.join(home, 'bin'));
+  } else {
+    const uvTools = process.env.UV_TOOL_DIR
+      || path.join(home, '.local', 'share', 'uv', 'tools');
+    dirs.push(path.join(uvTools, 'aider-chat', 'bin'));
+    dirs.push(path.join(home, 'bin'), '/usr/local/bin', '/opt/homebrew/bin');
+  }
+  return dirs;
+}
+
 module.exports = {
   getExtraBinDirs,
   getEnhancedPATH,
@@ -405,6 +444,7 @@ module.exports = {
   getRuntimePrefix,
   getCorePrefix,
   defaultAgentWorkdir,
+  aiderBinDirs,
   IS_WINDOWS,
   IS_MACOS,
   SEP,

--- a/packages/agent-connector/test/aider-install.test.js
+++ b/packages/agent-connector/test/aider-install.test.js
@@ -1,0 +1,255 @@
+'use strict';
+
+/**
+ * Aider-only post-install verification tests.
+ *
+ * Pins the "install command exited 0 but no runnable/genuine aider binary →
+ * Launcher must NOT show installed" behavior, plus stale-marker reconciliation.
+ * Verification is scoped to agentType === 'aider'; these tests also assert other
+ * agent types keep the original "exit 0 → mark installed" behavior.
+ *
+ * No real install runs: install() stubs _execShell, installStreaming() mocks
+ * child_process.spawn, and binary resolution is controlled via _whichBinary +
+ * an isolated HOME so the on-disk candidate checks (~/.local/bin) are
+ * deterministic.
+ *
+ * Run: node --test test/aider-install.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { EventEmitter } = require('node:events');
+const cp = require('child_process');
+
+const { Installer } = require('../src/installer');
+
+const mockRegistry = {
+  getEntry: (name) => {
+    if (name === 'aider') {
+      return {
+        name: 'aider',
+        install: {
+          binary: 'aider',
+          macos: 'curl -LsSf https://aider.chat/install.sh | sh',
+          linux: 'curl -LsSf https://aider.chat/install.sh | sh',
+          windows: 'powershell -c "irm https://aider.chat/install.ps1 | iex"',
+        },
+      };
+    }
+    // A non-npm "other agent" proving the non-aider path is unchanged.
+    if (name === 'otherapp') {
+      return {
+        name: 'otherapp',
+        install: { binary: 'otherapp', macos: 'echo install', linux: 'echo install', windows: 'echo install' },
+      };
+    }
+    return null;
+  },
+};
+
+let tmpDir;
+let tmpHome;
+let saved;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-inst-'));
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-home-'));
+  saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, spawn: cp.spawn };
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+});
+
+afterEach(() => {
+  cp.spawn = saved.spawn;
+  for (const k of ['HOME', 'USERPROFILE']) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+function markerHas(name) {
+  const f = path.join(tmpDir, 'installed_agents.json');
+  if (!fs.existsSync(f)) return false;
+  try { return JSON.parse(fs.readFileSync(f, 'utf-8')).includes(name); } catch { return false; }
+}
+
+function mockSpawnExit(code) {
+  cp.spawn = () => {
+    const proc = new EventEmitter();
+    const mkStream = () => { const e = new EventEmitter(); e.setEncoding = () => {}; return e; };
+    proc.stdout = mkStream();
+    proc.stderr = mkStream();
+    proc.pid = 4321;
+    setImmediate(() => proc.emit('close', code));
+    return proc;
+  };
+}
+
+// A real aider stub whose `--version` identifies itself as Aider.
+function writeAiderBinary(dir) {
+  const isWin = process.platform === 'win32';
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, isWin ? 'aider.exe' : 'aider');
+  fs.writeFileSync(p, isWin ? 'aider\n' : '#!/bin/sh\necho "aider 0.50.0"\n');
+  if (!isWin) fs.chmodSync(p, 0o755);
+  return p;
+}
+
+// A same-named WRONG binary whose `--version` does NOT mention aider.
+function writeWrongBinary(dir) {
+  const isWin = process.platform === 'win32';
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, isWin ? 'aider.exe' : 'aider');
+  fs.writeFileSync(p, isWin ? 'echo other\n' : '#!/bin/sh\necho "not-the-real-tool 9.9"\n');
+  if (!isWin) fs.chmodSync(p, 0o755);
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Verification failure → no marker
+// ---------------------------------------------------------------------------
+
+describe('Aider install — verification failure (no binary)', () => {
+  it('install(): exit 0 but binary missing → throws, writes no marker', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'install output';
+    inst._whichBinary = () => null; // not on PATH; ~/.local/bin absent in tmpHome
+
+    await assert.rejects(
+      () => inst.install('aider'),
+      /Aider CLI binary could not be found/,
+    );
+    assert.equal(markerHas('aider'), false);
+  });
+
+  it('installStreaming(): exit 0 but binary missing → rejects, no marker, no "Done"', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    mockSpawnExit(0);
+
+    const out = [];
+    await assert.rejects(
+      () => inst.installStreaming('aider', (d) => out.push(d)),
+      /Aider CLI binary could not be found/,
+    );
+    assert.equal(markerHas('aider'), false);
+    assert.ok(!out.join('').includes('Done!'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wrong same-named package is rejected
+// ---------------------------------------------------------------------------
+
+describe('Aider install — rejects a same-named non-Aider binary', () => {
+  it('install(): a binary whose --version is not Aider → verification fails', async () => {
+    const wrong = writeWrongBinary(path.join(tmpHome, '.local', 'bin'));
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'ok';
+    inst._whichBinary = () => wrong; // resolves, but it's the wrong tool
+
+    await assert.rejects(() => inst.install('aider'), /could not be found/);
+    assert.equal(markerHas('aider'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verification success (binary resolved off PATH)
+// ---------------------------------------------------------------------------
+
+describe('Aider install — verification success', () => {
+  it('install(): binary in ~/.local/bin (not on PATH) → marker + resolved path', async () => {
+    const aiderPath = writeAiderBinary(path.join(tmpHome, '.local', 'bin'));
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'install output';
+    inst._whichBinary = () => null; // force the ~/.local/bin candidate
+
+    const res = await inst.install('aider');
+    assert.equal(res.success, true);
+    assert.equal(markerHas('aider'), true);
+    assert.ok(res.output.includes(`Aider CLI resolved: ${aiderPath}`), res.output);
+  });
+
+  it('installStreaming(): binary in ~/.local/bin → marker + "Done!"', async () => {
+    const aiderPath = writeAiderBinary(path.join(tmpHome, '.local', 'bin'));
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    mockSpawnExit(0);
+
+    const out = [];
+    const res = await inst.installStreaming('aider', (d) => out.push(d));
+    assert.equal(res.success, true);
+    assert.equal(markerHas('aider'), true);
+    const joined = out.join('');
+    assert.ok(joined.includes(`Aider CLI resolved: ${aiderPath}`));
+    assert.ok(joined.includes('Done!'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No impact on other agent types
+// ---------------------------------------------------------------------------
+
+describe('Aider install — no impact on other agent types', () => {
+  it('install(): non-aider still marks installed on exit 0 without a binary', async () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'ok';
+    inst._whichBinary = () => null;
+
+    const res = await inst.install('otherapp');
+    assert.equal(res.success, true);
+    assert.equal(markerHas('otherapp'), true);
+    assert.ok(!String(res.output).includes('Aider CLI resolved'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale-marker reconciliation
+// ---------------------------------------------------------------------------
+
+describe('Aider install status — historical marker reconciliation', () => {
+  it('aider marker present but no real CLI → NOT installed, cli-missing, marker preserved', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._markInstalled('aider');
+    inst._whichBinary = () => null;
+
+    const info = inst.getInstallInfo('aider');
+    assert.equal(info.installed, false);
+    assert.equal(info.location, 'cli-missing');
+    assert.equal(inst.isInstalled('aider'), false);
+    assert.equal(markerHas('aider'), true, 'the historical marker must NOT be deleted');
+  });
+
+  it('aider marker AND real CLI present → installed (CLI wins)', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._markInstalled('aider');
+    inst._whichBinary = () => '/usr/bin/aider';
+
+    const info = inst.getInstallInfo('aider');
+    assert.equal(info.installed, true);
+    assert.equal(info.location, 'global');
+    assert.equal(inst.isInstalled('aider'), true);
+  });
+
+  it('aider without marker but real CLI present → installed', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => '/usr/bin/aider';
+    assert.equal(inst.getInstallInfo('aider').installed, true);
+    assert.equal(markerHas('aider'), false);
+  });
+
+  it('non-aider marker present but no CLI → still installed via marker (UNCHANGED)', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._markInstalled('otherapp');
+    inst._whichBinary = () => null;
+
+    const info = inst.getInstallInfo('otherapp');
+    assert.equal(info.installed, true);
+    assert.equal(info.location, 'marker');
+  });
+});

--- a/packages/agent-connector/test/aider-install.test.js
+++ b/packages/agent-connector/test/aider-install.test.js
@@ -57,14 +57,18 @@ let saved;
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-inst-'));
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-home-'));
-  saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, spawn: cp.spawn };
+  saved = { spawn: cp.spawn };
+  for (const k of ['HOME', 'USERPROFILE', 'APPDATA', 'XDG_BIN_HOME', 'XDG_DATA_HOME', 'UV_TOOL_DIR']) {
+    saved[k] = process.env[k];
+    if (!['HOME', 'USERPROFILE'].includes(k)) delete process.env[k];
+  }
   process.env.HOME = tmpHome;
   process.env.USERPROFILE = tmpHome;
 });
 
 afterEach(() => {
   cp.spawn = saved.spawn;
-  for (const k of ['HOME', 'USERPROFILE']) {
+  for (const k of ['HOME', 'USERPROFILE', 'APPDATA', 'XDG_BIN_HOME', 'XDG_DATA_HOME', 'UV_TOOL_DIR']) {
     if (saved[k] === undefined) delete process.env[k];
     else process.env[k] = saved[k];
   }
@@ -122,7 +126,7 @@ describe('Aider install — verification failure (no binary)', () => {
 
     await assert.rejects(
       () => inst.install('aider'),
-      /Aider CLI binary could not be found/,
+      /could not be located/,
     );
     assert.equal(markerHas('aider'), false);
   });
@@ -135,7 +139,7 @@ describe('Aider install — verification failure (no binary)', () => {
     const out = [];
     await assert.rejects(
       () => inst.installStreaming('aider', (d) => out.push(d)),
-      /Aider CLI binary could not be found/,
+      /could not be located/,
     );
     assert.equal(markerHas('aider'), false);
     assert.ok(!out.join('').includes('Done!'));
@@ -153,7 +157,7 @@ describe('Aider install — rejects a same-named non-Aider binary', () => {
     inst._execShell = async () => 'ok';
     inst._whichBinary = () => wrong; // resolves, but it's the wrong tool
 
-    await assert.rejects(() => inst.install('aider'), /could not be found/);
+    await assert.rejects(() => inst.install('aider'), /could not be located/);
     assert.equal(markerHas('aider'), false);
   });
 });
@@ -188,6 +192,43 @@ describe('Aider install — verification success', () => {
     const joined = out.join('');
     assert.ok(joined.includes(`Aider CLI resolved: ${aiderPath}`));
     assert.ok(joined.includes('Done!'));
+  });
+
+  it('install(): binary in the uv tools venv (not ~/.local/bin) → verified', async () => {
+    // The real-world Windows failure: `uv tool install` left the executable in
+    // its tools venv, not necessarily on ~/.local/bin. The Unix venv layout is
+    // ~/.local/share/uv/tools/aider-chat/bin; we must still detect it.
+    const isWin = process.platform === 'win32';
+    const venvBin = isWin
+      ? path.join(tmpHome, 'AppData', 'Roaming', 'uv', 'tools', 'aider-chat', 'Scripts')
+      : path.join(tmpHome, '.local', 'share', 'uv', 'tools', 'aider-chat', 'bin');
+    if (isWin) process.env.APPDATA = path.join(tmpHome, 'AppData', 'Roaming');
+    const aiderPath = writeAiderBinary(venvBin);
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._execShell = async () => 'ok';
+    inst._whichBinary = () => null;
+
+    const res = await inst.install('aider');
+    assert.equal(res.success, true);
+    assert.equal(markerHas('aider'), true);
+    assert.ok(res.output.includes(`Aider CLI resolved: ${aiderPath}`), res.output);
+  });
+
+  it('install(): respects XDG_BIN_HOME (installer\'s first-priority dir)', async () => {
+    const xdgBin = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-xdg-'));
+    process.env.XDG_BIN_HOME = xdgBin;
+    const aiderPath = writeAiderBinary(xdgBin);
+    try {
+      const inst = new Installer(mockRegistry, tmpDir);
+      inst._execShell = async () => 'ok';
+      inst._whichBinary = () => null;
+      const res = await inst.install('aider');
+      assert.equal(res.success, true);
+      assert.ok(res.output.includes(`Aider CLI resolved: ${aiderPath}`), res.output);
+    } finally {
+      delete process.env.XDG_BIN_HOME;
+      try { fs.rmSync(xdgBin, { recursive: true, force: true }); } catch {}
+    }
   });
 });
 

--- a/packages/agent-connector/test/aider.test.js
+++ b/packages/agent-connector/test/aider.test.js
@@ -109,6 +109,35 @@ describe('Aider adapter — registration', () => {
   });
 });
 
+describe('Aider — install-dir resolution (aiderBinDirs)', () => {
+  const { aiderBinDirs } = require('../src/paths');
+  const os = require('node:os');
+  const pathMod = require('node:path');
+
+  it('includes ~/.local/bin and the uv tools venv (the install targets)', () => {
+    const dirs = aiderBinDirs().map((d) => String(d));
+    assert.ok(dirs.includes(pathMod.join(os.homedir(), '.local', 'bin')));
+    // uv tool venv — Scripts on Windows, bin on Unix.
+    const hasVenv = dirs.some((d) => d.includes(pathMod.join('uv', 'tools', 'aider-chat')));
+    assert.ok(hasVenv, `expected a uv tools/aider-chat dir in ${JSON.stringify(dirs)}`);
+  });
+
+  it('honors XDG_BIN_HOME and UV_TOOL_DIR overrides', () => {
+    const savedXdg = process.env.XDG_BIN_HOME;
+    const savedUv = process.env.UV_TOOL_DIR;
+    try {
+      process.env.XDG_BIN_HOME = pathMod.join(os.tmpdir(), 'xdgbin');
+      process.env.UV_TOOL_DIR = pathMod.join(os.tmpdir(), 'uvtools');
+      const dirs = aiderBinDirs().map((d) => String(d));
+      assert.ok(dirs.includes(process.env.XDG_BIN_HOME), 'XDG_BIN_HOME first');
+      assert.ok(dirs.some((d) => d.startsWith(process.env.UV_TOOL_DIR)), 'UV_TOOL_DIR honored');
+    } finally {
+      if (savedXdg === undefined) delete process.env.XDG_BIN_HOME; else process.env.XDG_BIN_HOME = savedXdg;
+      if (savedUv === undefined) delete process.env.UV_TOOL_DIR; else process.env.UV_TOOL_DIR = savedUv;
+    }
+  });
+});
+
 describe('Aider adapter — command construction', () => {
   it('defaults to NO auto-commit and edits-only git safety', () => {
     const a = makeAdapter();

--- a/packages/agent-connector/test/aider.test.js
+++ b/packages/agent-connector/test/aider.test.js
@@ -1,0 +1,414 @@
+'use strict';
+
+/**
+ * Unit tests for the Aider adapter (Node / agent-connector runtime).
+ *
+ * No real `aider` binary, model key, or workspace is needed: `child_process.spawn`
+ * is faked to emit plain (non-JSON) terminal text, and the network helpers
+ * (sendStatus/sendResponse/sendError) are stubbed on the instance.
+ *
+ * Covered: registration in ADAPTER_MAP, non-interactive command construction
+ * (message-file, git-safety flags, model, auto-commit opt-in), multi-provider
+ * key→env mapping, secret never on the command line or in logs, exit-code
+ * decides success, error classification, per-channel chat-history isolation,
+ * stop control, git hygiene, and that existing adapters keep loading.
+ */
+
+const { describe, it, after, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const EventEmitter = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+// Swappable spawn shim installed BEFORE requiring the adapter so the
+// module-level `const { spawn } = require('child_process')` binds to it.
+const realSpawn = cp.spawn;
+let spawnImpl = null;
+let lastSpawn = null;
+cp.spawn = (...args) => spawnImpl(...args);
+
+const { createAdapter, ADAPTER_MAP, AiderAdapter } = require('../src/adapters');
+
+after(() => { cp.spawn = realSpawn; });
+
+function makeFakeSpawn(lines, exitCode = 0, stderr = '') {
+  return (cmd, args, opts) => {
+    const proc = new EventEmitter();
+    proc.pid = 4242;
+    proc.exitCode = null;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    lastSpawn = { cmd, args, opts };
+    setImmediate(() => {
+      for (const line of lines) proc.stdout.emit('data', Buffer.from(line + '\n', 'utf-8'));
+      if (stderr) proc.stderr.emit('data', Buffer.from(stderr, 'utf-8'));
+      proc.exitCode = exitCode;
+      proc.emit('exit', exitCode);
+    });
+    return proc;
+  };
+}
+
+let tmpHome;
+let savedHome;
+
+function isolateHome() {
+  savedHome = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-home-'));
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+}
+function restoreHome() {
+  if (savedHome) {
+    for (const k of ['HOME', 'USERPROFILE']) {
+      if (savedHome[k] === undefined) delete process.env[k];
+      else process.env[k] = savedHome[k];
+    }
+  }
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+}
+
+function makeAdapter(extra = {}) {
+  const adapter = createAdapter('aider', {
+    workspaceId: 'ws',
+    channelName: 'general',
+    token: 'tok',
+    agentName: 'aider-bot',
+    endpoint: 'https://example.invalid',
+    agentType: 'aider',
+    agentEnv: extra.agentEnv || {},
+    workingDir: extra.workingDir || '/tmp/proj',
+  });
+  adapter._aiderBin = '/usr/bin/aider';
+  // Stub network helpers — record what was streamed.
+  adapter._streamed = { status: [], response: [], error: [] };
+  adapter.sendStatus = async (_c, content) => adapter._streamed.status.push(content);
+  adapter.sendResponse = async (_c, content) => adapter._streamed.response.push(content);
+  adapter.sendError = async (_c, content) => adapter._streamed.error.push(content);
+  return adapter;
+}
+
+describe('Aider adapter — registration', () => {
+  it('is registered under the "aider" agent type', () => {
+    assert.equal('aider' in ADAPTER_MAP, true);
+    assert.equal(typeof AiderAdapter, 'function');
+  });
+
+  it('createAdapter("aider") returns an AiderAdapter', () => {
+    const a = makeAdapter();
+    assert.equal(a.constructor.name, 'AiderAdapter');
+    assert.equal(typeof a._handleMessage, 'function');
+  });
+
+  it('does not disturb the existing adapter map', () => {
+    for (const t of ['claude', 'codex', 'opencode', 'cursor', 'gemini', 'kimi']) {
+      assert.equal(t in ADAPTER_MAP, true, `${t} should still be registered`);
+    }
+  });
+});
+
+describe('Aider adapter — command construction', () => {
+  it('defaults to NO auto-commit and edits-only git safety', () => {
+    const a = makeAdapter();
+    const cmd = a._buildAiderCmd('general', '/tmp/m.txt', false);
+    assert.equal(cmd[0], '/usr/bin/aider');
+    assert.ok(cmd.includes('--message-file') && cmd.includes('/tmp/m.txt'));
+    assert.ok(cmd.includes('--yes-always'));
+    assert.ok(cmd.includes('--no-pretty'));
+    assert.ok(cmd.includes('--no-auto-commits'));
+    assert.ok(cmd.includes('--no-dirty-commits'));
+    assert.ok(cmd.includes('--no-gitignore'));
+    assert.ok(!cmd.includes('--auto-commits'));
+    assert.ok(!cmd.includes('--restore-chat-history'));
+  });
+
+  it('adds --restore-chat-history when resuming', () => {
+    const a = makeAdapter();
+    const cmd = a._buildAiderCmd('general', '/tmp/m.txt', true);
+    assert.ok(cmd.includes('--restore-chat-history'));
+  });
+
+  it('opts in to auto-commit via AIDER_AUTO_COMMITS', () => {
+    const a = makeAdapter({ agentEnv: { AIDER_AUTO_COMMITS: 'true' } });
+    const cmd = a._buildAiderCmd('general', '/tmp/m.txt', false);
+    assert.ok(cmd.includes('--auto-commits'));
+    assert.ok(!cmd.includes('--no-auto-commits'));
+  });
+
+  it('passes the configured model and never the key', () => {
+    const a = makeAdapter({ agentEnv: { AIDER_MODEL: 'gpt-4o', LLM_API_KEY: 'sk-secret' } });
+    const cmd = a._buildAiderCmd('general', '/tmp/m.txt', false);
+    const i = cmd.indexOf('--model');
+    assert.equal(cmd[i + 1], 'gpt-4o');
+    assert.ok(cmd.every((p) => !String(p).includes('sk-secret')));
+  });
+});
+
+describe('Aider adapter — provider resolution (explicit AIDER_PROVIDER)', () => {
+  const cfg = (env) => makeAdapter({ agentEnv: env })._resolveConfig();
+
+  it('maps each explicit provider to its env var (key wins over model)', () => {
+    assert.deepEqual(cfg({ AIDER_PROVIDER: 'openai', AIDER_MODEL: 'gpt-4o', LLM_API_KEY: 'k' }).env, { OPENAI_API_KEY: 'k' });
+    assert.deepEqual(cfg({ AIDER_PROVIDER: 'anthropic', AIDER_MODEL: 'sonnet', LLM_API_KEY: 'k' }).env, { ANTHROPIC_API_KEY: 'k' });
+    assert.deepEqual(cfg({ AIDER_PROVIDER: 'openrouter', AIDER_MODEL: 'x', LLM_API_KEY: 'k' }).env, { OPENROUTER_API_KEY: 'k' });
+    assert.deepEqual(cfg({ AIDER_PROVIDER: 'gemini', AIDER_MODEL: 'x', LLM_API_KEY: 'k' }).env, { GEMINI_API_KEY: 'k' });
+    assert.deepEqual(cfg({ AIDER_PROVIDER: 'deepseek', AIDER_MODEL: 'x', LLM_API_KEY: 'k' }).env, { DEEPSEEK_API_KEY: 'k' });
+  });
+
+  it('explicit provider beats model inference (no conflict for a bare model)', () => {
+    const r = cfg({ AIDER_PROVIDER: 'anthropic', AIDER_MODEL: 'gpt-4o', LLM_API_KEY: 'k' });
+    assert.equal(r.error, null);
+    assert.deepEqual(r.env, { ANTHROPIC_API_KEY: 'k' });
+  });
+
+  it('rejects an unknown AIDER_PROVIDER value', () => {
+    const r = cfg({ AIDER_PROVIDER: 'bogus', LLM_API_KEY: 'k' });
+    assert.ok(r.error && r.error.includes('Unknown AIDER_PROVIDER'));
+    assert.deepEqual(r.env, {});
+  });
+});
+
+describe('Aider adapter — provider resolution (auto inference, case-insensitive)', () => {
+  const env = (e) => makeAdapter({ agentEnv: e })._resolveConfig().env;
+
+  it('infers Anthropic from sonnet/opus/haiku/claude aliases', () => {
+    for (const m of ['sonnet', 'OPUS', 'Haiku', 'claude-3-5-sonnet-20241022', 'anthropic/claude-3']) {
+      assert.deepEqual(env({ AIDER_MODEL: m, LLM_API_KEY: 'k' }), { ANTHROPIC_API_KEY: 'k' }, m);
+    }
+  });
+
+  it('infers OpenAI from gpt/openai models', () => {
+    for (const m of ['gpt-4o', 'openai/gpt-4o', 'GPT-4O', 'o1-mini']) {
+      assert.deepEqual(env({ AIDER_MODEL: m, LLM_API_KEY: 'k' }), { OPENAI_API_KEY: 'k' }, m);
+    }
+  });
+
+  it('infers OpenRouter / Gemini / DeepSeek', () => {
+    assert.deepEqual(env({ AIDER_MODEL: 'openrouter/anthropic/claude-3.5-sonnet', LLM_API_KEY: 'k' }), { OPENROUTER_API_KEY: 'k' });
+    assert.deepEqual(env({ AIDER_MODEL: 'gemini/gemini-1.5-pro', LLM_API_KEY: 'k' }), { GEMINI_API_KEY: 'k' });
+    assert.deepEqual(env({ AIDER_MODEL: 'DeepSeek/deepseek-chat', LLM_API_KEY: 'k' }), { DEEPSEEK_API_KEY: 'k' });
+  });
+});
+
+describe('Aider adapter — ambiguity & conflict protection', () => {
+  const cfg = (e) => makeAdapter({ agentEnv: e })._resolveConfig();
+
+  it('empty model + key + no provider → config error (never silent OpenAI)', () => {
+    const r = cfg({ LLM_API_KEY: 'k' });
+    assert.deepEqual(r.env, {});
+    assert.ok(r.error && r.error.includes('Could not determine'));
+  });
+
+  it('unknown model + key + auto → config error', () => {
+    const r = cfg({ AIDER_MODEL: 'some-unknown-xyz', LLM_API_KEY: 'k', AIDER_PROVIDER: 'auto' });
+    assert.deepEqual(r.env, {});
+    assert.ok(r.error);
+  });
+
+  it('empty model + no key → allowed (auto mode)', () => {
+    const r = cfg({ AIDER_PROVIDER: 'auto' });
+    assert.equal(r.error, null);
+    assert.deepEqual(r.env, {});
+  });
+
+  it('no key does not override a native provider key', () => {
+    // resolver adds nothing; _buildSubprocessEnv keeps the inherited key.
+    const a = makeAdapter({ agentEnv: { AIDER_MODEL: 'claude-3', ANTHROPIC_API_KEY: 'preexisting' } });
+    assert.equal(a._buildSubprocessEnv().ANTHROPIC_API_KEY, 'preexisting');
+    assert.deepEqual(a._resolveConfig().env, {});
+  });
+
+  it('explicit provider conflicting with an explicit model prefix → error', () => {
+    assert.ok(cfg({ AIDER_PROVIDER: 'anthropic', AIDER_MODEL: 'openai/gpt-4o', LLM_API_KEY: 'k' }).error);
+    assert.ok(cfg({ AIDER_PROVIDER: 'openrouter', AIDER_MODEL: 'anthropic/claude-3', LLM_API_KEY: 'k' }).error);
+  });
+});
+
+describe('Aider adapter — OpenAI-compatible', () => {
+  const cfg = (e) => makeAdapter({ agentEnv: e })._resolveConfig();
+
+  it('maps base URL → OPENAI_API_BASE and key → OPENAI_API_KEY', () => {
+    const r = cfg({ AIDER_PROVIDER: 'openai-compatible', AIDER_MODEL: 'llama3', LLM_API_KEY: 'k', LLM_BASE_URL: 'https://host/v1' });
+    assert.equal(r.env.OPENAI_API_BASE, 'https://host/v1');
+    assert.equal(r.env.OPENAI_API_KEY, 'k');
+  });
+
+  it('normalizes a plain model to openai/<model> without doubling', () => {
+    assert.equal(cfg({ AIDER_PROVIDER: 'openai-compatible', AIDER_MODEL: 'llama3', LLM_API_KEY: 'k', LLM_BASE_URL: 'https://h/v1' }).model, 'openai/llama3');
+    assert.equal(cfg({ AIDER_PROVIDER: 'openai-compatible', AIDER_MODEL: 'openai/llama3', LLM_API_KEY: 'k', LLM_BASE_URL: 'https://h/v1' }).model, 'openai/llama3');
+  });
+
+  it('errors when Base URL is missing', () => {
+    const r = cfg({ AIDER_PROVIDER: 'openai-compatible', AIDER_MODEL: 'llama3', LLM_API_KEY: 'k' });
+    assert.deepEqual(r.env, {});
+    assert.ok(r.error && r.error.includes('LLM_BASE_URL'));
+  });
+
+  it('does not write Base URL into an unrelated provider env', () => {
+    const r = cfg({ AIDER_PROVIDER: 'anthropic', AIDER_MODEL: 'sonnet', LLM_API_KEY: 'k', LLM_BASE_URL: 'https://h/v1' });
+    assert.equal(r.env.OPENAI_API_BASE, undefined);
+    assert.deepEqual(r.env, { ANTHROPIC_API_KEY: 'k' });
+  });
+
+  it('normalized model reaches argv; key/base never do', () => {
+    const a = makeAdapter({ agentEnv: { AIDER_PROVIDER: 'openai-compatible', AIDER_MODEL: 'llama3', LLM_API_KEY: 'sk', LLM_BASE_URL: 'https://host/v1' } });
+    const cmd = a._buildAiderCmd('general', '/tmp/m', false);
+    const i = cmd.indexOf('--model');
+    assert.equal(cmd[i + 1], 'openai/llama3');
+    assert.ok(cmd.every((p) => String(p) !== 'sk' && !String(p).includes('https://host/v1')));
+  });
+});
+
+describe('Aider adapter — config gate', () => {
+  it('_runAider returns a config error without spawning', async () => {
+    let spawned = false;
+    const a = makeAdapter({ agentEnv: { LLM_API_KEY: 'k' } }); // key but no model/provider
+    a._spawnAider = async () => { spawned = true; return { text: '', error: null }; };
+    a._sessionsDir = require('node:os').tmpdir();
+    const r = await a._runAider('hi', 'general');
+    assert.equal(spawned, false);
+    assert.ok(r.error && r.error.includes('Configuration error'));
+  });
+});
+
+describe('Aider adapter — execution', () => {
+  beforeEach(() => { lastSpawn = null; });
+
+  it('returns cleaned stdout on success and streams progress', async () => {
+    spawnImpl = makeFakeSpawn(['Applied edit to foo.py', 'All done.']);
+    const a = makeAdapter();
+    const { text, error } = await a._spawnAider(['/usr/bin/aider'], 'general');
+    assert.equal(error, null);
+    assert.ok(text.includes('All done.'));
+    assert.ok(a._streamed.status.some((s) => s.includes('Applied edit')));
+  });
+
+  it('treats a non-zero exit as failure even with stdout', async () => {
+    spawnImpl = makeFakeSpawn(['partial output'], 1);
+    const a = makeAdapter();
+    const { text, error } = await a._spawnAider(['/usr/bin/aider'], 'general');
+    assert.equal(text, '');
+    assert.ok(error && /code 1|exit/i.test(error));
+  });
+
+  it('classifies an authentication failure', async () => {
+    spawnImpl = makeFakeSpawn(['litellm.AuthenticationError: invalid api key'], 1);
+    const a = makeAdapter();
+    const { error } = await a._spawnAider(['/usr/bin/aider'], 'general');
+    assert.ok(/Authentication failed/.test(error));
+  });
+
+  it('runs in the working directory and passes the key via env, not argv', async () => {
+    spawnImpl = makeFakeSpawn(['ok']);
+    const a = makeAdapter({ workingDir: '/tmp/myproject', agentEnv: { AIDER_MODEL: 'gpt-4o', LLM_API_KEY: 'sk-secret' } });
+    await a._spawnAider(['/usr/bin/aider', '--model', 'gpt-4o'], 'general');
+    assert.equal(lastSpawn.opts.cwd, '/tmp/myproject');
+    assert.equal(lastSpawn.opts.env.OPENAI_API_KEY, 'sk-secret');
+    assert.ok(lastSpawn.args.every((x) => !String(x).includes('sk-secret')));
+  });
+
+  it('never writes the key to the logs', async () => {
+    spawnImpl = makeFakeSpawn(['done'], 1, 'provider noise');
+    const a = makeAdapter({ agentEnv: { AIDER_MODEL: 'gpt-4o', LLM_API_KEY: 'sk-supersecret' } });
+    const logs = [];
+    a._log = (m) => logs.push(m);
+    await a._spawnAider(['/usr/bin/aider'], 'general');
+    assert.ok(!logs.join('\n').includes('sk-supersecret'));
+  });
+});
+
+describe('Aider adapter — sessions (isolated HOME)', () => {
+  beforeEach(isolateHome);
+  afterEach(restoreHome);
+
+  it('uses a separate, safe history file per channel', () => {
+    const a = makeAdapter();
+    const alpha = a._chatHistoryFile('alpha');
+    const beta = a._chatHistoryFile('beta');
+    assert.notEqual(alpha, beta);
+    assert.equal(path.dirname(alpha), a._sessionsDir);
+    const evil = a._chatHistoryFile('../../etc/passwd');
+    assert.equal(path.dirname(evil), a._sessionsDir);
+    assert.ok(!path.basename(evil).includes('/') && !path.basename(evil).includes('\\'));
+  });
+
+  it('resumes only when a non-empty history exists; corrupt → fresh', () => {
+    const a = makeAdapter();
+    assert.equal(a._hasHistory('general'), false);
+    fs.mkdirSync(a._sessionsDir, { recursive: true });
+    fs.writeFileSync(a._chatHistoryFile('general'), '# prior\n');
+    assert.equal(a._hasHistory('general'), true);
+  });
+
+  it('writes the message file under the sessions dir, not the project', async () => {
+    spawnImpl = makeFakeSpawn(['ok']);
+    const wd = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-proj-'));
+    const a = makeAdapter({ workingDir: wd });
+    a._streamed = { status: [] };
+    a.sendStatus = async () => {};
+    await a._runAider('a'.repeat(100000), 'general');
+    const mfIndex = lastSpawn.args.indexOf('--message-file');
+    const msgPath = lastSpawn.args[mfIndex + 1];
+    assert.ok(msgPath.startsWith(a._sessionsDir));
+    assert.ok(!msgPath.startsWith(wd));
+    fs.rmSync(wd, { recursive: true, force: true });
+  });
+
+  it('reset/clear remove stored history', () => {
+    const a = makeAdapter();
+    fs.mkdirSync(a._sessionsDir, { recursive: true });
+    fs.writeFileSync(a._chatHistoryFile('general'), 'x');
+    a.resetChannelSession('general');
+    assert.equal(fs.existsSync(a._chatHistoryFile('general')), false);
+    fs.writeFileSync(a._chatHistoryFile('general'), 'x');
+    a.clearAllSessions();
+    assert.equal(fs.existsSync(a._sessionsDir), false);
+  });
+});
+
+describe('Aider adapter — git hygiene (isolated HOME)', () => {
+  beforeEach(isolateHome);
+  afterEach(restoreHome);
+
+  it('adds .aider* to .git/info/exclude without touching .gitignore', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-repo-'));
+    fs.mkdirSync(path.join(repo, '.git', 'info'), { recursive: true });
+    const a = makeAdapter({ workingDir: repo });
+    a._ensureLocalGitExclude(repo);
+    const exclude = fs.readFileSync(path.join(repo, '.git', 'info', 'exclude'), 'utf-8');
+    assert.ok(exclude.includes('.aider*'));
+    assert.equal(fs.existsSync(path.join(repo, '.gitignore')), false);
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('is a no-op in a non-git directory', () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'aider-plain-'));
+    const a = makeAdapter({ workingDir: plain });
+    a._ensureLocalGitExclude(plain); // must not throw
+    assert.equal(fs.existsSync(path.join(plain, '.git')), false);
+    fs.rmSync(plain, { recursive: true, force: true });
+  });
+});
+
+describe('Aider adapter — stop control', () => {
+  it('terminates the running process and marks the channel stopped', async () => {
+    const a = makeAdapter();
+    const stopped = [];
+    a._stopProcess = async () => stopped.push('killed');
+    const statuses = [];
+    a.sendStatus = async (_c, content) => statuses.push(content);
+
+    const proc = new EventEmitter();
+    proc.pid = 99;
+    proc.exitCode = null;
+    a._channelProcesses.general = proc;
+
+    await a._onControlAction('stop', {});
+    assert.equal(stopped.length, 1);
+    assert.equal('general' in a._channelProcesses, false);
+    assert.equal(a._stoppingChannels.has('general'), true);
+    assert.deepEqual(statuses, ['Execution stopped by user']);
+  });
+});

--- a/packages/agent-connector/test/registry.test.js
+++ b/packages/agent-connector/test/registry.test.js
@@ -78,7 +78,9 @@ describe('Registry', () => {
 
   it('getEnvFields returns empty for agent without env_config', () => {
     const reg = new Registry(tmpDir);
-    const fields = reg.getEnvFields('aider');
+    // copilot is a catalog-only entry with no env_config (aider used to be the
+    // example here, but it now ships a multi-provider env_config).
+    const fields = reg.getEnvFields('copilot');
     assert.ok(Array.isArray(fields));
     assert.equal(fields.length, 0);
   });

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -306,6 +306,7 @@ const CORE_AGENTS: readonly string[] = [
   "hermes",
   "kimi",
   "gemini",
+  "aider",
 ]
 const CORE_AGENT_ORDER = new Map<string, number>(
   CORE_AGENTS.map((name, i) => [name, i]),
@@ -400,6 +401,40 @@ async function testLLMConnection(
   const trimSlash = (u: string): string => u.replace(/\/+$/, "")
 
   try {
+    // ── Aider: routes through LiteLLM, so the provider (and therefore the
+    // endpoint to probe) is decided by AIDER_PROVIDER / the model at run time.
+    // There is no single key endpoint to test here, and we must NOT report a
+    // fake "connected". Do only STATIC validation (provider value + the
+    // openai-compatible base-URL requirement); the real auth/model check happens
+    // on the first workspace task. Keyed on AIDER_PROVIDER/AIDER_MODEL, which
+    // only Aider configs carry. ──
+    const aiderProvider = pick("AIDER_PROVIDER").toLowerCase()
+    if (aiderProvider || pick("AIDER_MODEL")) {
+      const validProviders = [
+        "auto", "openai", "anthropic", "openrouter", "gemini", "deepseek",
+        "openai-compatible",
+      ]
+      if (aiderProvider && !validProviders.includes(aiderProvider)) {
+        return {
+          success: false,
+          error:
+            `Unknown AIDER_PROVIDER '${aiderProvider}'. Valid values: ${validProviders.join(", ")}.`,
+        }
+      }
+      if (aiderProvider === "openai-compatible" && !pick("LLM_BASE_URL")) {
+        return {
+          success: false,
+          error:
+            "AIDER_PROVIDER=openai-compatible requires LLM_BASE_URL (the OpenAI-compatible endpoint URL).",
+        }
+      }
+      return {
+        success: false,
+        error:
+          "Aider injects your key into the provider chosen by AIDER_PROVIDER (or the model name) and verifies it on its first run — there's no single endpoint to test here. Save the config and send a message in the workspace to confirm.",
+      }
+    }
+
     // ── Google Gemini ──
     const geminiKey = pick("GEMINI_API_KEY", "GOOGLE_API_KEY")
     if (geminiKey) {

--- a/sdk/src/openagents/adapters/aider.py
+++ b/sdk/src/openagents/adapters/aider.py
@@ -1,0 +1,860 @@
+"""
+Aider adapter for OpenAgents workspace.
+
+Bridges `Aider <https://aider.chat>`_ to an OpenAgents workspace by running the
+CLI in its official non-interactive *scripting* mode:
+
+    aider --message-file <tmp> --yes-always --no-pretty --no-stream \
+          --no-auto-commits --no-dirty-commits --no-gitignore \
+          --chat-history-file <per-channel> --input-history-file <per-channel> \
+          [--restore-chat-history] [--model <model>]
+
+Why this shape (and how it differs from the Amp adapter):
+
+* **Prompt delivery.** Aider has no stdin "execute" mode and no JSON event
+  protocol. The workspace task is written to a private temp *message file*
+  (``--message-file``) so an arbitrarily long prompt never hits ARG_MAX, shell
+  quoting, or Windows command-length limits, and is never built by string
+  concatenation. The file lives outside the project, is unique per task, is
+  deleted afterwards, and its contents never appear in a filename, log, or
+  error.
+* **Output.** Aider emits plain terminal text, not structured events, so we do
+  NOT fabricate ``tool_use``/``thinking`` semantics. ANSI/pretty output is
+  disabled, stdout and stderr are drained concurrently and incrementally (no
+  pipe deadlock, no blocking on large output), notable progress lines are
+  relayed as ``status``, and the cleaned transcript is sent once as the final
+  answer. Success/failure is decided by the **exit code** — a non-zero exit is
+  never reported as success even if stdout had content.
+* **Sessions.** Per (workspace, agent, channel) Aider keeps its own
+  ``--chat-history-file``; follow-up turns pass ``--restore-chat-history`` so
+  the model resumes that channel's conversation. History lives under
+  ``~/.openagents/sessions/aider/`` — never in the user's project — and a
+  corrupt history file degrades to a fresh session instead of wedging.
+* **Git.** Aider auto-commits by default; OpenAgents does NOT. We force
+  ``--no-auto-commits --no-dirty-commits --no-gitignore`` so the agent only
+  edits working-tree files, never commits the user's pre-existing changes, and
+  never rewrites the tracked ``.gitignore``. Auto-commit is an explicit opt-in
+  (``AIDER_AUTO_COMMITS=true``). Aider's local cache is excluded via
+  ``.git/info/exclude`` (local-only, never committed).
+* **Auth.** Aider is multi-provider (LiteLLM). A single generic ``LLM_API_KEY``
+  is mapped to the correct provider env var from the model string; keys travel
+  only through the environment, never on the command line or in logs.
+
+Reuses all shared connectivity / dispatch / state machinery in
+:class:`~openagents.adapters.base.BaseAdapter`; only the Aider-specific
+subprocess invocation, output handling, and session storage live here.
+
+Mirrors the Node adapter: packages/agent-connector/src/adapters/aider.js
+"""
+
+import asyncio
+import logging
+import os
+import platform
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from openagents.adapters.base import BaseAdapter
+from openagents.adapters.utils import format_attachments_for_prompt
+from openagents.workspace_client import DEFAULT_ENDPOINT
+
+logger = logging.getLogger(__name__)
+
+# Per-read timeout while draining Aider's stdout. A turn can pause for a while
+# (model latency on a long edit), so we tolerate many idle reads before
+# treating the process as wedged.
+_READ_TIMEOUT = 15.0
+# After this many consecutive idle reads (~10 min) with the process still alive
+# and producing nothing, assume it is hung and terminate it. Resets on ANY
+# output, so a slow-but-progressing task is never killed.
+_MAX_IDLE_READS = 40
+
+# Strip ANSI escape sequences defensively (we already pass --no-pretty).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+# Collapse 3+ consecutive blank lines down to a single blank line.
+_BLANKS_RE = re.compile(r"\n{3,}")
+
+# Lines worth surfacing as live progress. These are stable Aider status
+# prefixes (file edits / commits / shell runs), NOT a guess at the model's
+# natural-language intent.
+_PROGRESS_RE = re.compile(
+    r"^(Applied edit|Edited |Wrote |Created |Added |Removed |Committing|Commit |"
+    r"Running |Scanning |Repo-map|Reformatting|Skipped |Renamed )",
+    re.IGNORECASE,
+)
+# Cap status updates so a huge edit can't flood the channel.
+_MAX_STATUS_UPDATES = 60
+
+# Error signatures → human-readable diagnostics. Matched case-insensitively
+# against combined stderr+stdout. Order matters (first hit wins).
+_ERROR_SIGNATURES = [
+    (("authenticationerror", "invalid api key", "incorrect api key",
+      "no api key", "missing these environment variables", "api key not found",
+      "401", "unauthorized", "permission denied to access model"),
+     "Authentication failed — check the API key for the selected model/provider."),
+    (("notfounderror", "model_not_found", "does not exist", "unknown model",
+      "could not find model", "you do not have access to model"),
+     "Model not found or not accessible — check the model name and that your key has access."),
+    (("rate limit", "ratelimiterror", "429", "quota", "insufficient_quota"),
+     "Rate-limited or out of quota at the model provider — try again later."),
+    (("connectionerror", "timeout", "could not connect", "getaddrinfo",
+      "temporary failure in name resolution", "network is unreachable",
+      "failed to establish a new connection"),
+     "Network error reaching the model provider — check connectivity and the base URL."),
+    (("permission denied", "eacces", "read-only file system", "operation not permitted"),
+     "File permission error in the working directory."),
+    (("gitcommanderror", "fatal: not a git repository", "git failed", "not a git repo"),
+     "Git error while applying changes."),
+]
+
+
+def _aider_install_hint() -> str:
+    """Platform-appropriate Aider install command for 'not found' messages."""
+    if platform.system() == "Windows":
+        return 'powershell -NoProfile -Command "irm https://aider.chat/install.ps1 | iex"'
+    return "curl -LsSf https://aider.chat/install.sh | sh"
+
+
+# ---------------------------------------------------------------------------
+# Provider resolution
+#
+# Aider routes through LiteLLM, so a single generic LLM_API_KEY must be injected
+# into the provider-specific env var the model expects. The provider is chosen
+# DETERMINISTICALLY and IDENTICALLY in the Python and Node adapters:
+#
+#   1. explicit AIDER_PROVIDER (anything but ``auto``) wins outright;
+#   2. otherwise (``auto``/blank) infer from an unambiguous model name;
+#   3. if a key is set but the provider can't be determined → config error
+#      (we never silently dump the key into OPENAI_API_KEY);
+#   4. no key → leave the inherited/native provider env untouched (auto mode).
+#
+# The provider→env-var names below were verified against aider's official docs
+# and `aider --help` (GEMINI_API_KEY, DEEPSEEK_API_KEY, OPENAI_API_BASE, and the
+# `openai/<model>` prefix for OpenAI-compatible endpoints).
+# ---------------------------------------------------------------------------
+
+from collections import namedtuple  # noqa: E402
+
+ProviderResolution = namedtuple("ProviderResolution", ["env", "model", "error"])
+
+_VALID_PROVIDERS = (
+    "auto", "openai", "anthropic", "openrouter", "gemini", "deepseek",
+    "openai-compatible",
+)
+# provider -> the API-key env var aider/LiteLLM reads for it.
+_PROVIDER_KEY_VAR = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "openai-compatible": "OPENAI_API_KEY",
+}
+
+
+def _explicit_prefix_provider(model: str):
+    """Return the provider implied by an UNAMBIGUOUS ``provider/`` model prefix,
+    or None. Used for conflict detection against an explicit AIDER_PROVIDER."""
+    m = (model or "").strip().lower()
+    if m.startswith("openrouter/"):
+        return "openrouter"
+    if m.startswith("anthropic/"):
+        return "anthropic"
+    if m.startswith("openai/"):
+        return "openai"
+    if m.startswith("gemini/") or m.startswith("google/"):
+        return "gemini"
+    if m.startswith("deepseek/"):
+        return "deepseek"
+    return None
+
+
+def _infer_provider_from_model(model: str):
+    """Best-effort, case-insensitive provider inference from a model name.
+
+    Returns a provider key, or None when the name is empty/ambiguous (an unknown
+    model is NOT assumed to be OpenAI)."""
+    m = (model or "").strip().lower()
+    if not m:
+        return None
+    prefixed = _explicit_prefix_provider(m)
+    if prefixed:
+        return prefixed
+    # Bare names / aliases (aider exposes sonnet/opus/haiku as Claude shortcuts).
+    if "claude" in m or "sonnet" in m or "opus" in m or "haiku" in m:
+        return "anthropic"
+    if "deepseek" in m:
+        return "deepseek"
+    if "gemini" in m:
+        return "gemini"
+    if (m.startswith("gpt") or m.startswith("o1") or m.startswith("o3")
+            or m.startswith("o4-") or m.startswith("chatgpt") or "gpt-" in m):
+        return "openai"
+    return None
+
+
+def _normalize_openai_model(model: str) -> str:
+    """Ensure an OpenAI-compatible model carries the required ``openai/`` prefix
+    (added once, never duplicated)."""
+    m = (model or "").strip()
+    if not m:
+        return m
+    if m.lower().startswith("openai/"):
+        return m
+    return "openai/" + m
+
+
+def resolve_aider_provider(provider: str, model: str, api_key: str,
+                           base_url: str) -> ProviderResolution:
+    """Deterministically resolve the provider env vars (and any model
+    normalization) for a generic LLM_API_KEY. Returns ``env`` (the provider vars
+    to inject), the possibly-normalized ``model``, and an ``error`` string when
+    the configuration is invalid/ambiguous (in which case Aider must NOT start).
+    """
+    provider = (provider or "").strip().lower()
+    model = (model or "").strip()
+    api_key = (api_key or "").strip()
+    base_url = (base_url or "").strip()
+
+    if provider and provider not in _VALID_PROVIDERS:
+        return ProviderResolution(
+            {}, model,
+            f"Unknown AIDER_PROVIDER '{provider}'. Valid values: "
+            "auto, openai, anthropic, openrouter, gemini, deepseek, "
+            "openai-compatible.",
+        )
+    if not provider:
+        provider = "auto"
+
+    # ---- No generic key: auto mode — never fabricate/override provider keys ---
+    if not api_key:
+        if provider == "openai-compatible":
+            if not base_url:
+                return ProviderResolution(
+                    {}, model,
+                    "AIDER_PROVIDER=openai-compatible requires LLM_BASE_URL "
+                    "(the OpenAI-compatible endpoint URL).",
+                )
+            # Point aider at the endpoint and normalize the model, but inject no
+            # key (none was supplied — rely on the inherited env if the endpoint
+            # needs one).
+            return ProviderResolution(
+                {"OPENAI_API_BASE": base_url}, _normalize_openai_model(model), None,
+            )
+        # Native env / project .env / aider config select the model+key.
+        return ProviderResolution({}, model, None)
+
+    # ---- Generic key present: a concrete provider is required ---------------
+    if provider == "auto":
+        inferred = _infer_provider_from_model(model)
+        if inferred is None:
+            return ProviderResolution(
+                {}, model,
+                "Could not determine the model provider for LLM_API_KEY. Set "
+                "AIDER_PROVIDER (openai, anthropic, openrouter, gemini, deepseek, "
+                "or openai-compatible), use an AIDER_MODEL whose name identifies "
+                "the provider, or set the native provider key directly.",
+            )
+        resolved = inferred
+    else:
+        resolved = provider
+        # Explicit provider wins, but a clearly-conflicting model prefix is a
+        # configuration mistake — fail loudly rather than silently override.
+        prefix_prov = _explicit_prefix_provider(model)
+        effective = "openai" if resolved == "openai-compatible" else resolved
+        if prefix_prov and prefix_prov != effective:
+            return ProviderResolution(
+                {}, model,
+                f"AIDER_PROVIDER={provider} conflicts with AIDER_MODEL '{model}' "
+                f"(which targets {prefix_prov}). Fix the provider or the model.",
+            )
+
+    if resolved == "openai-compatible":
+        if not base_url:
+            return ProviderResolution(
+                {}, model,
+                "AIDER_PROVIDER=openai-compatible requires LLM_BASE_URL "
+                "(the OpenAI-compatible endpoint URL).",
+            )
+        return ProviderResolution(
+            {"OPENAI_API_KEY": api_key, "OPENAI_API_BASE": base_url},
+            _normalize_openai_model(model), None,
+        )
+
+    env = {_PROVIDER_KEY_VAR[resolved]: api_key}
+    # A base URL only belongs to the OpenAI variable family; never write it into
+    # an unrelated provider's env.
+    if base_url and resolved == "openai":
+        env["OPENAI_API_BASE"] = base_url
+    return ProviderResolution(env, model, None)
+
+
+def _clean_output(text: str) -> str:
+    """Strip ANSI and squeeze blank lines from captured Aider output."""
+    text = _ANSI_RE.sub("", text or "")
+    text = _BLANKS_RE.sub("\n\n", text)
+    return text.strip()
+
+
+def _classify_error(stderr: str, stdout: str) -> Optional[str]:
+    """Map known failure signatures to a friendly message, or None."""
+    blob = f"{stderr}\n{stdout}".lower()
+    for needles, message in _ERROR_SIGNATURES:
+        if any(n in blob for n in needles):
+            return message
+    return None
+
+
+def _is_truthy(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+class AiderAdapter(BaseAdapter):
+    """Connects the Aider CLI to an OpenAgents workspace."""
+
+    def __init__(
+        self,
+        workspace_id: str,
+        channel_name: str,
+        token: str,
+        agent_name: str,
+        endpoint: str = DEFAULT_ENDPOINT,
+        disabled_modules: set | None = None,
+        working_dir: str | None = None,
+    ):
+        super().__init__(workspace_id, channel_name, token, agent_name, endpoint)
+        self.disabled_modules = disabled_modules or set()
+        self.working_dir = working_dir
+
+        # channel -> running subprocess (for stop / cleanup)
+        self._channel_processes: dict[str, asyncio.subprocess.Process] = {}
+        # channels the user explicitly stopped (suppress "no response" noise)
+        self._stopping_channels: set[str] = set()
+        # git repos we've already added the local Aider exclude to (once each)
+        self._git_exclude_done: set[str] = set()
+
+        # Per-(workspace, agent) session dir holds the per-channel chat history
+        # and the transient message files. NEVER inside the user's project.
+        self._sessions_dir = (
+            Path.home() / ".openagents" / "sessions" / "aider"
+            / f"{workspace_id}_{agent_name}"
+        )
+
+        self._aider_binary = self._find_aider_binary()
+        if self._aider_binary:
+            logger.info("Using Aider CLI: %s", self._aider_binary)
+        else:
+            logger.warning(
+                "Aider binary not found. Install with: %s", _aider_install_hint()
+            )
+
+    # ------------------------------------------------------------------
+    # Binary resolution (cross-platform)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_aider_binary() -> Optional[str]:
+        """Locate the ``aider`` executable across platforms.
+
+        Detection order: PATH (preferring Windows ``.exe``/``.cmd`` shims) →
+        the user-install bin dirs that the official installer (uv tool), pipx,
+        and ``pip install --user`` all target but that a GUI/daemon process may
+        not have on PATH: ``~/.local/bin`` plus the common Homebrew/uv tool
+        locations. This is what makes detection work when the launcher didn't
+        inherit the interactive shell PATH — the "installed but not found" case.
+        """
+        home = Path.home()
+        if platform.system() == "Windows":
+            found = (
+                shutil.which("aider.exe")
+                or shutil.which("aider.cmd")
+                or shutil.which("aider")
+            )
+            if found:
+                return found
+            local_app_data = os.environ.get(
+                "LOCALAPPDATA", str(home / "AppData" / "Local")
+            )
+            for candidate in (
+                # uv tool / pipx / pip --user all target %USERPROFILE%\.local\bin
+                home / ".local" / "bin" / "aider.exe",
+                home / ".local" / "bin" / "aider.cmd",
+                Path(local_app_data) / "Programs" / "aider" / "aider.exe",
+            ):
+                if candidate.is_file():
+                    return str(candidate)
+            return None
+
+        found = shutil.which("aider")
+        if found:
+            return found
+        for candidate in (
+            home / ".local" / "bin" / "aider",   # uv tool / pipx / pip --user
+            home / "bin" / "aider",
+            Path("/usr/local/bin/aider"),
+            Path("/opt/homebrew/bin/aider"),
+        ):
+            try:
+                if candidate.is_file() and os.access(candidate, os.X_OK):
+                    return str(candidate)
+            except OSError:
+                continue
+        return None
+
+    @staticmethod
+    def is_real_aider(binary: str) -> bool:
+        """Best-effort check that ``binary`` is the Aider CLI, not a same-named
+        unrelated executable. Runs ``--version`` and looks for an Aider marker.
+        Returns True on a positive match; False only on a confident mismatch.
+        A flaky/blocked ``--version`` is treated as inconclusive → True, so we
+        never block a real install on a transient probe failure.
+        """
+        if not binary:
+            return False
+        try:
+            use_shell = (
+                platform.system() == "Windows" and binary.lower().endswith(".cmd")
+            )
+            result = subprocess.run(
+                [binary, "--version"],
+                capture_output=True, text=True, timeout=8, shell=use_shell,
+            )
+            out = f"{result.stdout}\n{result.stderr}".lower()
+            if not out.strip():
+                return True  # inconclusive — don't reject
+            return "aider" in out
+        except (OSError, subprocess.TimeoutExpired):
+            return True  # inconclusive
+        except Exception:
+            return True
+
+    # ------------------------------------------------------------------
+    # Per-channel session storage
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_channel_id(channel: str) -> str:
+        """Sanitize a channel name into a filesystem-safe slug (no traversal).
+
+        Any character outside ``[A-Za-z0-9._-]`` becomes ``_``; leading dots are
+        stripped so the result can't escape the sessions dir or be a dotfile.
+        Empty input falls back to ``general``.
+        """
+        slug = re.sub(r"[^A-Za-z0-9._-]", "_", channel or "")
+        slug = slug.lstrip(".")
+        return slug or "general"
+
+    def _chat_history_file(self, channel: str) -> Path:
+        return self._sessions_dir / f"{self._safe_channel_id(channel)}.chat.history.md"
+
+    def _input_history_file(self, channel: str) -> Path:
+        return self._sessions_dir / f"{self._safe_channel_id(channel)}.input.history"
+
+    def _has_history(self, channel: str) -> bool:
+        """A channel has resumable history when its chat-history file exists and
+        is non-empty and readable. A corrupt/unreadable file degrades to a fresh
+        session (we move it aside) rather than wedging restore forever."""
+        path = self._chat_history_file(channel)
+        try:
+            if not path.exists() or path.stat().st_size == 0:
+                return False
+            path.read_text(encoding="utf-8", errors="strict")
+            return True
+        except (OSError, UnicodeDecodeError):
+            logger.warning(
+                "Aider chat history for channel %s is unreadable — starting fresh",
+                self._safe_channel_id(channel),
+            )
+            try:
+                path.rename(path.with_suffix(path.suffix + ".corrupt"))
+            except OSError:
+                pass
+            return False
+
+    def reset_channel_session(self, channel: str):
+        """Forget a single channel's Aider conversation history."""
+        for path in (self._chat_history_file(channel), self._input_history_file(channel)):
+            try:
+                if path.exists():
+                    path.unlink()
+            except OSError:
+                pass
+
+    def clear_all_sessions(self):
+        """Remove all stored Aider session state for this agent (used when the
+        agent is deleted or fully reset)."""
+        try:
+            if self._sessions_dir.exists():
+                shutil.rmtree(self._sessions_dir, ignore_errors=True)
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Git hygiene — keep Aider's local cache out of `git status` WITHOUT
+    # touching the user's tracked .gitignore.
+    # ------------------------------------------------------------------
+
+    def _ensure_local_git_exclude(self, working_dir: Optional[str]):
+        """Append ``.aider*`` to ``.git/info/exclude`` (local-only, never
+        committed) so Aider's tags cache doesn't show up in ``git status``.
+        We pass ``--no-gitignore`` so Aider won't edit the tracked .gitignore;
+        this is the clean alternative. Best-effort and idempotent."""
+        if not working_dir:
+            return
+        if working_dir in self._git_exclude_done:
+            return
+        self._git_exclude_done.add(working_dir)
+        try:
+            git_dir = Path(working_dir) / ".git"
+            if not git_dir.is_dir():
+                return  # not a git repo root — nothing to exclude
+            info_dir = git_dir / "info"
+            info_dir.mkdir(parents=True, exist_ok=True)
+            exclude = info_dir / "exclude"
+            existing = exclude.read_text(encoding="utf-8") if exclude.exists() else ""
+            if ".aider" not in existing:
+                sep = "" if existing.endswith("\n") or not existing else "\n"
+                exclude.write_text(
+                    existing + sep + "# Added by OpenAgents Aider agent\n.aider*\n",
+                    encoding="utf-8",
+                )
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Command + environment construction
+    # ------------------------------------------------------------------
+
+    def _build_aider_cmd(self, channel: str, msg_file: str, restore: bool) -> list[str]:
+        """Build the Aider argv for a channel (prompt comes from ``msg_file``)."""
+        aider_bin = self._aider_binary or self._find_aider_binary()
+        if aider_bin:
+            self._aider_binary = aider_bin
+        if not aider_bin:
+            raise FileNotFoundError(
+                f"aider CLI not found. Install with: {_aider_install_hint()}"
+            )
+
+        auto_commit = _is_truthy(self.agent_env_value("AIDER_AUTO_COMMITS"))
+        cmd = [
+            aider_bin,
+            "--message-file", msg_file,
+            "--yes-always",          # non-interactive: auto-confirm prompts
+            "--no-pretty",           # plain output (no ANSI / live UI)
+            "--no-stream",           # capture a clean, complete final block
+            "--no-check-update",     # no PyPI version probe on every run
+            "--no-gitignore",        # never rewrite the user's tracked .gitignore
+            "--no-dirty-commits",    # never commit the user's pre-existing changes
+            "--chat-history-file", str(self._chat_history_file(channel)),
+            "--input-history-file", str(self._input_history_file(channel)),
+        ]
+        # OpenAgents default: edit files but do NOT auto-commit. Opt-in only.
+        cmd.append("--auto-commits" if auto_commit else "--no-auto-commits")
+        if restore:
+            cmd.append("--restore-chat-history")
+        # Use the resolved (possibly openai/-normalized) model, not the raw value.
+        model = self._resolve_config().model
+        if model:
+            cmd += ["--model", model]
+        return cmd
+
+    def agent_env_value(self, name: str) -> str:
+        """Read a config/env value (os.environ is the source for the Python
+        connect path; subclass-friendly indirection for tests)."""
+        return os.environ.get(name, "")
+
+    def _model(self) -> str:
+        return (self.agent_env_value("AIDER_MODEL")
+                or self.agent_env_value("LLM_MODEL")).strip()
+
+    def _resolve_config(self) -> ProviderResolution:
+        """Deterministically resolve provider env + model from the agent config.
+
+        Pure/deterministic, so it can be called from the command builder, the
+        env builder, and the pre-flight gate without divergence."""
+        return resolve_aider_provider(
+            self.agent_env_value("AIDER_PROVIDER"),
+            self._model(),
+            self.agent_env_value("LLM_API_KEY"),
+            self.agent_env_value("LLM_BASE_URL") or self.agent_env_value("OPENAI_API_BASE"),
+        )
+
+    def _build_subprocess_env(self) -> dict:
+        """Inherited env + the resolved provider key/base (never logged)."""
+        base = dict(os.environ)
+        # Make output prompt+unbuffered and colourless regardless of TTY.
+        base.setdefault("NO_COLOR", "1")
+        base["PYTHONUNBUFFERED"] = "1"
+        base.update(self._resolve_config().env)
+        return base
+
+    # ------------------------------------------------------------------
+    # Control actions (stop / reset)
+    # ------------------------------------------------------------------
+
+    async def _on_control_action(self, action: Optional[str], payload: dict):
+        if action == "stop":
+            await self._stop_all_processes()
+        elif action in ("reset_session", "clear_session"):
+            channel = (payload or {}).get("channel") or self.channel_name
+            self.reset_channel_session(channel)
+
+    async def _stop_all_processes(self):
+        """Terminate any running Aider subprocess (stop button)."""
+        for channel, proc in list(self._channel_processes.items()):
+            self._stopping_channels.add(channel)
+            await self._stop_process(proc)
+            self._channel_processes.pop(channel, None)
+            self._channel_queues.pop(channel, None)
+            await self._send_status(channel, "Execution stopped by user")
+
+    async def _stop_process(self, proc: asyncio.subprocess.Process):
+        """Kill a single Aider subprocess and its child process group."""
+        if not proc or proc.returncode is not None:
+            return
+        try:
+            if platform.system() == "Windows":
+                try:
+                    killer = await asyncio.create_subprocess_exec(
+                        "taskkill", "/F", "/T", "/PID", str(proc.pid),
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(killer.wait(), timeout=5)
+                except Exception:
+                    proc.kill()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+                return
+
+            # POSIX: kill the whole process group so any child the CLI spawned
+            # (started with start_new_session=True) is reaped too.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2)
+            except asyncio.TimeoutError:
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+                await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Message handler
+    # ------------------------------------------------------------------
+
+    async def _handle_message(self, msg: dict):
+        content = (msg.get("content") or "").strip()
+        attachments = msg.get("attachments", [])
+        att_text = format_attachments_for_prompt(attachments)
+        if att_text:
+            content = (content + att_text) if content else att_text.strip()
+        if not content:
+            return
+
+        msg_channel = msg.get("sessionId") or self.channel_name
+        sender = msg.get("senderName") or msg.get("senderType", "user")
+        logger.info(
+            "Processing message from %s in channel %s: %d chars",
+            sender, msg_channel, len(content),
+        )
+
+        if not self._aider_binary:
+            self._aider_binary = self._find_aider_binary()
+        if not self._aider_binary:
+            await self._send_error(
+                msg_channel,
+                f"Aider CLI not found. Install with: {_aider_install_hint()}",
+            )
+            return
+
+        # Pre-flight: resolve the provider/key BEFORE starting Aider so a
+        # misconfiguration returns a crisp, actionable error (and never silently
+        # injects the key into the wrong provider).
+        resolution = self._resolve_config()
+        if resolution.error:
+            await self._send_error(msg_channel, f"Configuration error: {resolution.error}")
+            return
+
+        await self._auto_title_channel(msg_channel, content)
+        self._stopping_channels.discard(msg_channel)
+        self._ensure_local_git_exclude(self.working_dir)
+        await self._send_status(msg_channel, "Aider is working...")
+
+        try:
+            text, error = await self._run_aider(content, msg_channel)
+        except FileNotFoundError as e:
+            await self._send_error(msg_channel, str(e))
+            return
+        except Exception as e:
+            logger.exception("Error handling message: %s", e)
+            await self._send_error(msg_channel, f"Error processing message: {e}")
+            return
+
+        if msg_channel in self._stopping_channels:
+            self._stopping_channels.discard(msg_channel)
+            return
+
+        if error:
+            await self._send_error(msg_channel, error)
+        elif text:
+            await self._send_response(msg_channel, text)
+        else:
+            await self._send_response(
+                msg_channel,
+                "Aider finished with no textual output (any file changes were applied "
+                "to the working directory).",
+            )
+
+    # ------------------------------------------------------------------
+    # Subprocess execution
+    # ------------------------------------------------------------------
+
+    async def _run_aider(self, content: str, msg_channel: str) -> tuple[str, Optional[str]]:
+        """Write the message file, run Aider once, return (final_text, error)."""
+        # Defensive re-check (the primary gate is in _handle_message): never
+        # spawn Aider — nor create a temp file — on an invalid configuration.
+        resolution = self._resolve_config()
+        if resolution.error:
+            return "", f"Configuration error: {resolution.error}"
+
+        self._sessions_dir.mkdir(parents=True, exist_ok=True)
+        restore = self._has_history(msg_channel)
+
+        # Private, per-task message file outside the project. The prompt body is
+        # never placed on the command line or echoed into a filename/log.
+        fd, msg_path = tempfile.mkstemp(
+            prefix="aider-msg-", suffix=".txt", dir=str(self._sessions_dir)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+
+            cmd = self._build_aider_cmd(msg_channel, msg_path, restore=restore)
+            return await self._spawn_aider(cmd, msg_channel)
+        finally:
+            # Windows-safe cleanup: the process has exited by the time we get
+            # here, so the file is no longer open.
+            try:
+                os.unlink(msg_path)
+            except OSError:
+                pass
+
+    async def _spawn_aider(self, cmd: list[str], msg_channel: str) -> tuple[str, Optional[str]]:
+        """Spawn Aider, drain stdout/stderr concurrently and incrementally, and
+        return (final_text, error_message). Exit code is authoritative for
+        success: a non-zero exit yields an error even if stdout had content."""
+        env = self._build_subprocess_env()
+
+        is_windows = platform.system() == "Windows"
+        spawn_cmd = list(cmd)
+        if is_windows and spawn_cmd[0].lower().endswith(".cmd"):
+            spawn_cmd = ["cmd.exe", "/c"] + spawn_cmd
+
+        process = await asyncio.create_subprocess_exec(
+            *spawn_cmd,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.working_dir,
+            env=env,
+            limit=10 * 1024 * 1024,  # 10 MB line buffer for large edits
+            start_new_session=not is_windows,
+        )
+        self._channel_processes[msg_channel] = process
+
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+        status_count = 0
+
+        async def drain_stderr():
+            while True:
+                line = await process.stderr.readline()
+                if not line:
+                    break
+                stderr_chunks.append(line.decode("utf-8", errors="replace"))
+
+        stderr_task = asyncio.create_task(drain_stderr())
+
+        try:
+            idle_reads = 0
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        process.stdout.readline(), timeout=_READ_TIMEOUT
+                    )
+                    idle_reads = 0
+                except asyncio.TimeoutError:
+                    idle_reads += 1
+                    if process.returncode is not None:
+                        break
+                    if idle_reads > _MAX_IDLE_READS:
+                        logger.warning(
+                            "Aider produced no output for ~%ds — terminating",
+                            int(_MAX_IDLE_READS * _READ_TIMEOUT),
+                        )
+                        await self._stop_process(process)
+                        break
+                    continue
+
+                if not line:
+                    break
+                decoded = line.decode("utf-8", errors="replace")
+                stdout_chunks.append(decoded)
+
+                stripped = _ANSI_RE.sub("", decoded).strip()
+                if (stripped and status_count < _MAX_STATUS_UPDATES
+                        and _PROGRESS_RE.match(stripped)):
+                    status_count += 1
+                    await self._send_status(msg_channel, stripped[:300])
+
+            await process.wait()
+        finally:
+            self._channel_processes.pop(msg_channel, None)
+            try:
+                await asyncio.wait_for(stderr_task, timeout=5)
+            except (asyncio.TimeoutError, Exception):
+                stderr_task.cancel()
+
+        if msg_channel in self._stopping_channels:
+            return "", None
+
+        exit_code = process.returncode or 0
+        stdout_text = _clean_output("".join(stdout_chunks))
+        stderr_text = _clean_output("".join(stderr_chunks))
+        if stderr_text:
+            # stderr may carry secrets in provider error bodies — never log it
+            # verbatim; log only its length.
+            logger.debug("Aider stderr: %d chars", len(stderr_text))
+
+        if exit_code != 0:
+            diagnostic = _classify_error(stderr_text, stdout_text)
+            if not diagnostic:
+                tail = (stderr_text or stdout_text).splitlines()
+                detail = tail[-1] if tail else ""
+                diagnostic = (
+                    f"Aider exited with code {exit_code}."
+                    + (f" {detail}" if detail else "")
+                )
+            return "", diagnostic
+
+        # Exit 0 → success. Surface a clear auth/model diagnostic only if Aider
+        # printed a hard provider error without producing any answer.
+        if not stdout_text:
+            diagnostic = _classify_error(stderr_text, stdout_text)
+            if diagnostic:
+                return "", diagnostic
+        return stdout_text, None

--- a/sdk/src/openagents/adapters/aider.py
+++ b/sdk/src/openagents/adapters/aider.py
@@ -358,52 +358,67 @@ class AiderAdapter(BaseAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _aider_bin_dirs() -> list[Path]:
+        """Directories where the Aider executable can land, in the SAME priority
+        the official installer (``uv tool install``) uses, so detection matches
+        reality: ``$XDG_BIN_HOME`` → ``$XDG_DATA_HOME/../bin`` → ``~/.local/bin``
+        → the uv tools venv for ``aider-chat`` (which always contains the
+        executable after a successful install, even if the bin-dir copy/PATH
+        edit didn't happen). Mirrors ``aiderBinDirs()`` in the Node paths.js."""
+        home = Path.home()
+        dirs: list[Path] = []
+        if os.environ.get("XDG_BIN_HOME"):
+            dirs.append(Path(os.environ["XDG_BIN_HOME"]))
+        if os.environ.get("XDG_DATA_HOME"):
+            dirs.append(Path(os.environ["XDG_DATA_HOME"]).parent / "bin")
+        dirs.append(home / ".local" / "bin")
+        if platform.system() == "Windows":
+            app_data = os.environ.get("APPDATA", str(home / "AppData" / "Roaming"))
+            uv_tools = os.environ.get("UV_TOOL_DIR", str(Path(app_data) / "uv" / "tools"))
+            dirs.append(Path(uv_tools) / "aider-chat" / "Scripts")
+            dirs.append(home / "bin")
+        else:
+            uv_tools = os.environ.get(
+                "UV_TOOL_DIR", str(home / ".local" / "share" / "uv" / "tools")
+            )
+            dirs.append(Path(uv_tools) / "aider-chat" / "bin")
+            dirs += [home / "bin", Path("/usr/local/bin"), Path("/opt/homebrew/bin")]
+        return dirs
+
+    @staticmethod
     def _find_aider_binary() -> Optional[str]:
         """Locate the ``aider`` executable across platforms.
 
         Detection order: PATH (preferring Windows ``.exe``/``.cmd`` shims) →
-        the user-install bin dirs that the official installer (uv tool), pipx,
-        and ``pip install --user`` all target but that a GUI/daemon process may
-        not have on PATH: ``~/.local/bin`` plus the common Homebrew/uv tool
-        locations. This is what makes detection work when the launcher didn't
-        inherit the interactive shell PATH — the "installed but not found" case.
+        every real install dir the official installer (uv tool), pipx, and ``pip
+        install --user`` can target but that a GUI/daemon process may not have on
+        PATH. This is what makes detection work when the launcher didn't inherit
+        the interactive shell PATH — the "installed but not found" case.
         """
-        home = Path.home()
-        if platform.system() == "Windows":
+        is_windows = platform.system() == "Windows"
+        if is_windows:
             found = (
                 shutil.which("aider.exe")
                 or shutil.which("aider.cmd")
                 or shutil.which("aider")
             )
-            if found:
-                return found
-            local_app_data = os.environ.get(
-                "LOCALAPPDATA", str(home / "AppData" / "Local")
-            )
-            for candidate in (
-                # uv tool / pipx / pip --user all target %USERPROFILE%\.local\bin
-                home / ".local" / "bin" / "aider.exe",
-                home / ".local" / "bin" / "aider.cmd",
-                Path(local_app_data) / "Programs" / "aider" / "aider.exe",
-            ):
-                if candidate.is_file():
-                    return str(candidate)
-            return None
-
-        found = shutil.which("aider")
+            names = ("aider.exe", "aider.cmd", "aider")
+        else:
+            found = shutil.which("aider")
+            names = ("aider",)
         if found:
             return found
-        for candidate in (
-            home / ".local" / "bin" / "aider",   # uv tool / pipx / pip --user
-            home / "bin" / "aider",
-            Path("/usr/local/bin/aider"),
-            Path("/opt/homebrew/bin/aider"),
-        ):
-            try:
-                if candidate.is_file() and os.access(candidate, os.X_OK):
-                    return str(candidate)
-            except OSError:
-                continue
+
+        for directory in AiderAdapter._aider_bin_dirs():
+            for name in names:
+                candidate = directory / name
+                try:
+                    if not candidate.is_file():
+                        continue
+                    if is_windows or os.access(candidate, os.X_OK):
+                        return str(candidate)
+                except OSError:
+                    continue
         return None
 
     @staticmethod

--- a/sdk/src/openagents/registry/aider.yaml
+++ b/sdk/src/openagents/registry/aider.yaml
@@ -3,9 +3,59 @@ label: Aider
 description: AI pair programming in your terminal
 homepage: https://aider.chat
 tags: [coding, pair-programming, open-source]
+builtin: true
+support:
+  install: true
+  workspace: true
+  collaboration: true
 
 install:
   binary: aider
+  # Official one-line installer (bootstraps uv, then `uv tool install aider-chat`).
+  # Lands the launcher in ~/.local/bin/aider on every platform.
   macos: "curl -LsSf https://aider.chat/install.sh | sh"
   linux: "curl -LsSf https://aider.chat/install.sh | sh"
   windows: "powershell -c \"irm https://aider.chat/install.ps1 | iex\""
+
+adapter:
+  module: openagents.adapters.aider
+  class: AiderAdapter
+
+launch:
+  args: []
+
+# Aider is multi-provider (it routes through LiteLLM), so it is NOT modelled with
+# a single fixed key. The user picks a provider + model and supplies one key; the
+# adapter injects that generic key into the correct provider env var (OpenAI /
+# Anthropic / OpenRouter / Gemini / DeepSeek / OpenAI-compatible) at run time.
+# AIDER_PROVIDER decides which provider the key belongs to (default `auto` infers
+# from the model name). The key only ever travels via the environment — never on
+# the command line or in logs.
+env_config:
+  - name: AIDER_PROVIDER
+    description: "Which provider the API key belongs to. One of: auto, openai, anthropic, openrouter, gemini, deepseek, openai-compatible. `auto` infers from the model name; set it explicitly when the model name doesn't identify the provider."
+    required: false
+    default: "auto"
+    placeholder: "auto"
+  - name: AIDER_MODEL
+    description: "Model to use, e.g. sonnet, gpt-4o, claude-3-5-sonnet-20241022, openrouter/anthropic/claude-3.5-sonnet, gemini/gemini-1.5-pro, deepseek/deepseek-chat. May be left blank to let Aider auto-select — but if you set LLM_API_KEY, the provider must be determinable (via AIDER_PROVIDER or the model name)."
+    required: false
+    placeholder: "gpt-4o"
+  - name: LLM_API_KEY
+    description: "API key for the selected provider. Injected into the provider env var chosen by AIDER_PROVIDER/model. Leave blank to reuse a provider key already in your shell or the project's .env / .aider.conf.yml."
+    required: false
+    password: true
+  - name: LLM_BASE_URL
+    description: "Endpoint URL — ONLY for AIDER_PROVIDER=openai-compatible (self-hosted / relay / local). Becomes OPENAI_API_BASE; leave blank for hosted providers."
+    required: false
+    placeholder: "https://my-endpoint.example/v1"
+
+check_ready:
+  env_vars:
+    - OPENAI_API_KEY
+    - ANTHROPIC_API_KEY
+    - OPENROUTER_API_KEY
+    - GEMINI_API_KEY
+    - DEEPSEEK_API_KEY
+  saved_env_key: LLM_API_KEY
+  not_ready_message: "No model API key — set a model + LLM_API_KEY (or a provider key such as OPENAI_API_KEY) — press e to configure"

--- a/tests/agents/test_aider.py
+++ b/tests/agents/test_aider.py
@@ -1,0 +1,726 @@
+"""Unit tests for Aider agent support (registry registration + AiderAdapter).
+
+None of these require a real ``aider`` install, a model API key, or a live
+workspace: the CLI is simulated with a fake ``asyncio`` subprocess that emits
+plain (non-JSON) terminal text, binary detection runs against a fake executable
+on an isolated PATH/HOME, and the network helpers are stubbed on the instance.
+
+Covered (maps to the PR's test matrix):
+- Aider agent-type registration (builtin plugin from the registry YAML)
+- Executable detection (PATH + ~/.local/bin fallback, missing, wrong binary)
+- Non-interactive command construction (message-file, safety flags, model)
+- Default git safety (--no-auto-commits/--no-dirty-commits) + opt-in auto-commit
+- Multi-provider key→env mapping (OpenAI/Anthropic/OpenRouter/Gemini/DeepSeek/base-url)
+- API key never on the command line and never logged
+- Long prompt delivered via a private message file outside the project
+- stdout/stderr handling, ANSI stripping, exit-code-decides-success
+- Auth / model / network / git / permission error classification
+- Per-channel chat-history isolation, restore, path-traversal safety, corruption
+- Stop control, session reset/clear, working directory
+- No regression for existing agent types
+
+Run:
+    pytest tests/agents/test_aider.py -v
+"""
+
+import asyncio
+import importlib
+import logging
+import os
+import stat
+
+import pytest
+
+import openagents.registry.loader as loader
+import openagents.adapters.aider as aider_mod
+from openagents.adapters.aider import (
+    AiderAdapter,
+    resolve_aider_provider,
+    _classify_error,
+    _clean_output,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_aider_plugin():
+    data = next(
+        d for d in loader.load_registry_yamls() if d.get("name") == "aider"
+    )
+    plugin = loader._make_plugin_from_yaml(data)
+    assert plugin is not None, "aider must be a builtin plugin"
+    return plugin
+
+
+def _write_executable(path, body="#!/bin/sh\necho 'aider 0.50.0'\n"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_adapter(tmp_path, working_dir=None):
+    """Build an AiderAdapter without any network I/O (constructor is offline)."""
+    return AiderAdapter(
+        workspace_id="ws-test",
+        channel_name="general",
+        token="tok",
+        agent_name="aider-bot",
+        endpoint="https://example.invalid",
+        working_dir=working_dir or str(tmp_path / "proj"),
+    )
+
+
+class _FakeStreamReader:
+    """Minimal async reader yielding pre-canned lines, then EOF (b"")."""
+
+    def __init__(self, lines=None):
+        self._lines = list(lines or [])
+
+    async def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+
+class _FakeProcess:
+    def __init__(self, stdout_lines, returncode=0, stderr_lines=None):
+        self.stdout = _FakeStreamReader(stdout_lines)
+        self.stderr = _FakeStreamReader(stderr_lines or [])
+        self.returncode = returncode
+        self.pid = 4242
+
+    async def wait(self):
+        return self.returncode
+
+
+@pytest.fixture
+def patch_spawn(monkeypatch):
+    """Patch asyncio.create_subprocess_exec; capture call args, return a fake."""
+    captured = {}
+
+    def _factory(stdout_lines, returncode=0, stderr_lines=None):
+        async def fake_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            proc = _FakeProcess(stdout_lines, returncode, stderr_lines)
+            captured["proc"] = proc
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        return captured
+
+    return _factory
+
+
+def _lines(*texts):
+    return [(t + "\n").encode("utf-8") for t in texts]
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    empty_bin = tmp_path / "empty_bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.setattr(
+        loader, "_INSTALLED_MARKERS_PATH", home / ".openagents" / "installed_agents.json"
+    )
+    # No provider keys / config leak in from the developer's shell.
+    for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                "GEMINI_API_KEY", "DEEPSEEK_API_KEY", "LLM_API_KEY",
+                "AIDER_PROVIDER", "AIDER_MODEL", "LLM_MODEL", "LLM_BASE_URL",
+                "OPENAI_API_BASE", "AIDER_AUTO_COMMITS"):
+        monkeypatch.delenv(var, raising=False)
+    return home
+
+
+# ---------------------------------------------------------------------------
+# 1. Registration
+# ---------------------------------------------------------------------------
+
+class TestAiderRegistration:
+    def test_aider_is_builtin_plugin(self):
+        plugin = _make_aider_plugin()
+        assert plugin.name == "aider"
+        assert plugin.label == "Aider"
+
+    def test_adapter_module_imports(self):
+        data = next(d for d in loader.load_registry_yamls() if d["name"] == "aider")
+        mod = importlib.import_module(data["adapter"]["module"])
+        cls = getattr(mod, data["adapter"]["class"])
+        assert cls is AiderAdapter
+
+    def test_env_config_is_multiprovider(self):
+        plugin = _make_aider_plugin()
+        fields = plugin.required_env_vars()
+        names = [e.get("name") for e in fields]
+        assert "AIDER_PROVIDER" in names
+        assert "AIDER_MODEL" in names
+        assert "LLM_API_KEY" in names
+        assert "LLM_BASE_URL" in names
+        # Provider defaults to auto.
+        provider = next(e for e in fields if e["name"] == "AIDER_PROVIDER")
+        assert provider.get("default") == "auto"
+        # The key must be flagged password so the launcher masks it; and there
+        # is NOT a fixed single AIDER_API_KEY (Aider is multi-provider).
+        api_key = next(e for e in fields if e["name"] == "LLM_API_KEY")
+        assert api_key.get("password") is True
+        assert "AIDER_API_KEY" not in names
+
+    def test_workspace_support_flag(self):
+        data = next(d for d in loader.load_registry_yamls() if d["name"] == "aider")
+        assert data.get("builtin") is True
+        assert data.get("support", {}).get("workspace") is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Detection
+# ---------------------------------------------------------------------------
+
+class TestAiderDetection:
+    def test_not_installed_without_binary(self, isolated_home):
+        plugin = _make_aider_plugin()
+        assert plugin._which_binary() is None
+        assert plugin.is_installed() is False
+        ready, msg = plugin.check_ready()
+        assert ready is False
+        assert "install aider" in msg.lower()
+
+    def test_detects_binary_on_path(self, isolated_home, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "bin"
+        aider_path = bin_dir / "aider"
+        _write_executable(aider_path)
+        monkeypatch.setenv("PATH", str(bin_dir))
+        plugin = _make_aider_plugin()
+        assert plugin._which_binary() == str(aider_path)
+        assert plugin.is_installed() is True
+
+    def test_detects_binary_in_local_bin_fallback(self, isolated_home):
+        # uv tool / pipx / pip --user all install into ~/.local/bin, which a
+        # GUI/daemon process may not have on PATH.
+        aider_path = isolated_home / ".local" / "bin" / "aider"
+        _write_executable(aider_path)
+        plugin = _make_aider_plugin()
+        assert plugin._which_binary() == str(aider_path)
+
+    def test_adapter_find_binary_in_local_bin(self, isolated_home):
+        aider_path = isolated_home / ".local" / "bin" / "aider"
+        _write_executable(aider_path)
+        assert AiderAdapter._find_aider_binary() == str(aider_path)
+
+    def test_adapter_find_binary_missing(self, isolated_home):
+        assert AiderAdapter._find_aider_binary() is None
+
+    def test_windows_prefers_exe_shim(self, monkeypatch):
+        monkeypatch.setattr(aider_mod.platform, "system", lambda: "Windows")
+        calls = []
+
+        def fake_which(name):
+            calls.append(name)
+            return f"C:\\bin\\{name}" if name == "aider.exe" else None
+
+        monkeypatch.setattr(aider_mod.shutil, "which", fake_which)
+        assert AiderAdapter._find_aider_binary() == "C:\\bin\\aider.exe"
+        assert calls[0] == "aider.exe"
+
+    def test_is_real_aider_accepts_aider(self, monkeypatch):
+        class _R:
+            stdout = "aider 0.50.0"
+            stderr = ""
+        monkeypatch.setattr(aider_mod.subprocess, "run", lambda *a, **k: _R())
+        assert AiderAdapter.is_real_aider("/usr/bin/aider") is True
+
+    def test_is_real_aider_rejects_wrong_binary(self, monkeypatch):
+        class _R:
+            stdout = "some-other-tool 1.2.3"
+            stderr = ""
+        monkeypatch.setattr(aider_mod.subprocess, "run", lambda *a, **k: _R())
+        assert AiderAdapter.is_real_aider("/usr/bin/aider") is False
+
+    def test_is_real_aider_inconclusive_on_error(self, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("cannot exec")
+        monkeypatch.setattr(aider_mod.subprocess, "run", boom)
+        # A flaky probe must not block a real install.
+        assert AiderAdapter.is_real_aider("/usr/bin/aider") is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Command construction + config
+# ---------------------------------------------------------------------------
+
+class TestAiderCommand:
+    def test_new_session_command_defaults_to_no_commits(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        cmd = adapter._build_aider_cmd("general", "/tmp/msg.txt", restore=False)
+        assert cmd[0] == "/usr/bin/aider"
+        assert "--message-file" in cmd and "/tmp/msg.txt" in cmd
+        assert "--yes-always" in cmd
+        assert "--no-pretty" in cmd
+        # Git safety defaults — never auto-commit, never commit pre-existing work,
+        # never touch the tracked .gitignore.
+        assert "--no-auto-commits" in cmd
+        assert "--no-dirty-commits" in cmd
+        assert "--no-gitignore" in cmd
+        assert "--auto-commits" not in cmd
+        # New session → no restore.
+        assert "--restore-chat-history" not in cmd
+
+    def test_resume_when_history_exists(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        # Materialize a non-empty, readable chat history for this channel.
+        hist = adapter._chat_history_file("general")
+        hist.parent.mkdir(parents=True, exist_ok=True)
+        hist.write_text("# prior turn\n")
+        restore = adapter._has_history("general")
+        cmd = adapter._build_aider_cmd("general", "/tmp/msg.txt", restore=restore)
+        assert "--restore-chat-history" in cmd
+
+    def test_auto_commit_opt_in(self, isolated_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIDER_AUTO_COMMITS", "true")
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        cmd = adapter._build_aider_cmd("general", "/tmp/msg.txt", restore=False)
+        assert "--auto-commits" in cmd
+        assert "--no-auto-commits" not in cmd
+
+    def test_model_flag_passed(self, isolated_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIDER_MODEL", "claude-3-5-sonnet-20241022")
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        cmd = adapter._build_aider_cmd("general", "/tmp/msg.txt", restore=False)
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "claude-3-5-sonnet-20241022"
+
+    def test_missing_binary_raises(self, isolated_home, tmp_path, monkeypatch):
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = None
+        monkeypatch.setattr(AiderAdapter, "_find_aider_binary", staticmethod(lambda: None))
+        with pytest.raises(FileNotFoundError, match="aider CLI not found"):
+            adapter._build_aider_cmd("general", "/tmp/msg.txt", restore=False)
+
+    def test_api_key_never_in_command_args(self, isolated_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("LLM_API_KEY", "sk-secret-zzz")
+        monkeypatch.setenv("AIDER_MODEL", "gpt-4o")
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        cmd = adapter._build_aider_cmd("general", "/tmp/msg.txt", restore=False)
+        assert all("sk-secret-zzz" not in str(part) for part in cmd)
+
+
+# ---------------------------------------------------------------------------
+# 4. Provider resolution (deterministic resolver)
+# ---------------------------------------------------------------------------
+
+class TestExplicitProvider:
+    """§III.1 — explicit AIDER_PROVIDER wins and maps to the right env var."""
+
+    def test_openai(self):
+        r = resolve_aider_provider("openai", "gpt-4o", "sk", "")
+        assert r.error is None and r.env == {"OPENAI_API_KEY": "sk"}
+
+    def test_anthropic(self):
+        r = resolve_aider_provider("anthropic", "sonnet", "sk", "")
+        assert r.error is None and r.env == {"ANTHROPIC_API_KEY": "sk"}
+
+    def test_openrouter(self):
+        r = resolve_aider_provider("openrouter", "anything", "sk", "")
+        assert r.error is None and r.env == {"OPENROUTER_API_KEY": "sk"}
+
+    def test_gemini(self):
+        r = resolve_aider_provider("gemini", "gemini-1.5-pro", "sk", "")
+        assert r.error is None and r.env == {"GEMINI_API_KEY": "sk"}
+
+    def test_deepseek(self):
+        r = resolve_aider_provider("deepseek", "deepseek-chat", "sk", "")
+        assert r.error is None and r.env == {"DEEPSEEK_API_KEY": "sk"}
+
+    def test_openai_compatible(self):
+        r = resolve_aider_provider("openai-compatible", "my-model", "sk", "https://relay/v1")
+        assert r.error is None
+        assert r.env == {"OPENAI_API_KEY": "sk", "OPENAI_API_BASE": "https://relay/v1"}
+        assert r.model == "openai/my-model"
+
+    def test_explicit_beats_model_inference(self):
+        # §III.1 + test 21: provider wins; a bare gpt model under anthropic is
+        # NOT a conflict (no provider prefix) so anthropic is honoured.
+        r = resolve_aider_provider("anthropic", "gpt-4o", "sk", "")
+        assert r.error is None and r.env == {"ANTHROPIC_API_KEY": "sk"}
+
+    def test_unknown_provider_value_errors(self):
+        r = resolve_aider_provider("bogus", "gpt-4o", "sk", "")
+        assert r.error is not None and "Unknown AIDER_PROVIDER" in r.error
+
+
+class TestModelInference:
+    """§III.2 — auto/blank provider infers from an unambiguous model name."""
+
+    @pytest.mark.parametrize("model", ["sonnet", "opus", "haiku", "claude-3-5-sonnet-20241022",
+                                       "anthropic/claude-3", "SONNET", "Claude-3"])
+    def test_anthropic_models(self, model):
+        r = resolve_aider_provider("auto", model, "sk", "")
+        assert r.error is None and r.env == {"ANTHROPIC_API_KEY": "sk"}
+
+    @pytest.mark.parametrize("model", ["gpt-4o", "openai/gpt-4o", "GPT-4O", "o1-mini", "chatgpt-4o-latest"])
+    def test_openai_models(self, model):
+        r = resolve_aider_provider("auto", model, "sk", "")
+        assert r.error is None and r.env == {"OPENAI_API_KEY": "sk"}
+
+    def test_openrouter_prefix(self):
+        r = resolve_aider_provider("auto", "openrouter/anthropic/claude-3.5-sonnet", "sk", "")
+        assert r.env == {"OPENROUTER_API_KEY": "sk"}
+
+    @pytest.mark.parametrize("model", ["gemini/gemini-1.5-pro", "gemini-1.5-flash", "GEMINI/gemini-2.0"])
+    def test_gemini_models(self, model):
+        r = resolve_aider_provider("auto", model, "sk", "")
+        assert r.env == {"GEMINI_API_KEY": "sk"}
+
+    @pytest.mark.parametrize("model", ["deepseek/deepseek-chat", "deepseek-coder", "DeepSeek/x"])
+    def test_deepseek_models(self, model):
+        r = resolve_aider_provider("auto", model, "sk", "")
+        assert r.env == {"DEEPSEEK_API_KEY": "sk"}
+
+    def test_blank_provider_treated_as_auto(self):
+        r = resolve_aider_provider("", "sonnet", "sk", "")
+        assert r.env == {"ANTHROPIC_API_KEY": "sk"}
+
+
+class TestAmbiguityProtection:
+    """§III.3 / §III.4 — never silently dump the key into OPENAI_API_KEY."""
+
+    def test_empty_model_with_key_and_no_provider_errors(self):
+        r = resolve_aider_provider("auto", "", "sk", "")
+        assert r.env == {} and r.error is not None
+        assert "Could not determine" in r.error
+
+    def test_unknown_model_with_key_auto_errors(self):
+        r = resolve_aider_provider("auto", "some-random-model-xyz", "sk", "")
+        assert r.env == {} and r.error is not None
+
+    def test_empty_model_no_key_is_allowed(self):
+        # §III.4 + test 19 — auto + blank model + no key is a valid (auto) config.
+        r = resolve_aider_provider("auto", "", "", "")
+        assert r.error is None and r.env == {}
+
+    def test_no_key_does_not_override_native_env(self):
+        # The resolver only returns vars to ADD; with no key it adds nothing, so
+        # the inherited native provider key is preserved by the caller.
+        r = resolve_aider_provider("auto", "claude-3", "", "")
+        assert r.error is None and r.env == {}
+
+    def test_conflict_provider_vs_model_prefix(self):
+        # §V — explicit provider conflicting with an explicit model prefix errors.
+        r = resolve_aider_provider("anthropic", "openai/gpt-4o", "sk", "")
+        assert r.env == {} and r.error is not None and "conflicts" in r.error
+        r2 = resolve_aider_provider("openrouter", "anthropic/claude-3", "sk", "")
+        assert r2.env == {} and r2.error is not None and "conflicts" in r2.error
+
+
+class TestOpenAiCompatible:
+    """§IV — OpenAI-compatible endpoint handling."""
+
+    def test_base_url_and_key_mapping(self):
+        r = resolve_aider_provider("openai-compatible", "llama3", "sk", "https://host/v1")
+        assert r.env["OPENAI_API_BASE"] == "https://host/v1"   # test 23
+        assert r.env["OPENAI_API_KEY"] == "sk"                 # test 24
+
+    def test_plain_model_normalized(self):
+        r = resolve_aider_provider("openai-compatible", "llama3", "sk", "https://host/v1")
+        assert r.model == "openai/llama3"                      # test 25
+
+    def test_existing_prefix_not_doubled(self):
+        r = resolve_aider_provider("openai-compatible", "openai/llama3", "sk", "https://host/v1")
+        assert r.model == "openai/llama3"                      # test 26
+
+    def test_missing_base_url_errors(self):
+        r = resolve_aider_provider("openai-compatible", "llama3", "sk", "")
+        assert r.env == {} and r.error is not None             # test 27
+        assert "LLM_BASE_URL" in r.error
+
+    def test_base_url_not_written_to_unrelated_provider(self):
+        # §IV.6 — a base URL with anthropic must NOT leak into OPENAI_API_BASE.
+        r = resolve_aider_provider("anthropic", "sonnet", "sk", "https://host/v1")
+        assert "OPENAI_API_BASE" not in r.env
+        assert r.env == {"ANTHROPIC_API_KEY": "sk"}
+
+
+class TestSubprocessEnvIntegration:
+    def test_build_subprocess_env_maps_and_keeps_secret(self, isolated_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("LLM_API_KEY", "sk-anthropic-secret")
+        monkeypatch.setenv("AIDER_MODEL", "claude-3-5-sonnet-20241022")
+        adapter = _make_adapter(tmp_path)
+        env = adapter._build_subprocess_env()
+        assert env["ANTHROPIC_API_KEY"] == "sk-anthropic-secret"
+        assert env.get("NO_COLOR") == "1"
+
+    def test_explicit_provider_via_config(self, isolated_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIDER_PROVIDER", "openrouter")
+        monkeypatch.setenv("AIDER_MODEL", "anything/model")
+        monkeypatch.setenv("LLM_API_KEY", "sk-or")
+        adapter = _make_adapter(tmp_path)
+        # openrouter explicit, model has no conflicting prefix → no error.
+        res = adapter._resolve_config()
+        assert res.error is None
+        assert adapter._build_subprocess_env()["OPENROUTER_API_KEY"] == "sk-or"
+
+    def test_openai_compatible_model_normalized_in_cmd(self, isolated_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("AIDER_PROVIDER", "openai-compatible")
+        monkeypatch.setenv("AIDER_MODEL", "llama3")
+        monkeypatch.setenv("LLM_API_KEY", "sk")
+        monkeypatch.setenv("LLM_BASE_URL", "https://host/v1")
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        cmd = adapter._build_aider_cmd("general", "/tmp/m.txt", restore=False)
+        i = cmd.index("--model")
+        assert cmd[i + 1] == "openai/llama3"
+        env = adapter._build_subprocess_env()
+        assert env["OPENAI_API_BASE"] == "https://host/v1"
+        # test 28 — neither key nor base URL ever appears in argv.
+        assert all("sk" != str(p) for p in cmd)
+        assert all("https://host/v1" not in str(p) for p in cmd)
+
+    def test_config_gate_blocks_run(self, isolated_home, tmp_path, monkeypatch):
+        # Ambiguous config → _run_aider returns an error WITHOUT spawning.
+        monkeypatch.setenv("LLM_API_KEY", "sk")  # key but no model/provider
+        adapter = _make_adapter(tmp_path)
+        adapter._aider_binary = "/usr/bin/aider"
+        spawned = {"called": False}
+
+        async def fake_spawn(cmd, ch):
+            spawned["called"] = True
+            return "", None
+
+        adapter._spawn_aider = fake_spawn
+        text, error = asyncio.run(adapter._run_aider("hi", "general"))
+        assert spawned["called"] is False
+        assert error is not None and "Configuration error" in error
+
+
+# ---------------------------------------------------------------------------
+# 5. Subprocess flow — output, working dir, message file, errors, secrets
+# ---------------------------------------------------------------------------
+
+def _run_spawn(adapter, msg_channel="general"):
+    sent = {"status": [], "response": [], "error": []}
+
+    async def fake_status(channel, content):
+        sent["status"].append(content)
+
+    adapter._send_status = fake_status
+    cmd = ["/usr/bin/aider", "--message-file", "/tmp/m", "--no-pretty"]
+    result = asyncio.run(adapter._spawn_aider(cmd, msg_channel))
+    return result, sent
+
+
+class TestAiderSubprocessFlow:
+    def test_success_returns_cleaned_stdout(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn(_lines("Applied edit to foo.py", "All done — added the function."))
+        adapter = _make_adapter(tmp_path)
+        (text, error), sent = _run_spawn(adapter)
+        assert error is None
+        assert "All done" in text
+        # Progress line streamed as a status during the run.
+        assert any("Applied edit" in s for s in sent["status"])
+        # Process tracking cleared once the turn ends.
+        assert "general" not in adapter._channel_processes
+
+    def test_nonzero_exit_is_failure_even_with_stdout(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn(_lines("partial output here"), returncode=1)
+        adapter = _make_adapter(tmp_path)
+        (text, error), _ = _run_spawn(adapter)
+        assert text == ""
+        assert error is not None
+        assert "code 1" in error or "exit" in error.lower()
+
+    def test_auth_error_classified(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn(_lines("litellm.AuthenticationError: invalid api key"), returncode=1)
+        adapter = _make_adapter(tmp_path)
+        (text, error), _ = _run_spawn(adapter)
+        assert "Authentication failed" in error
+
+    def test_model_error_classified(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn(_lines("NotFoundError: model_not_found: the model does not exist"), returncode=1)
+        adapter = _make_adapter(tmp_path)
+        (_, error), _ = _run_spawn(adapter)
+        assert "Model not found" in error
+
+    def test_network_error_classified(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn([], returncode=1, stderr_lines=_lines("ConnectionError: could not connect"))
+        adapter = _make_adapter(tmp_path)
+        (_, error), _ = _run_spawn(adapter)
+        assert "Network error" in error
+
+    def test_permission_error_classified(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn([], returncode=1, stderr_lines=_lines("PermissionError: [Errno 13] Permission denied"))
+        adapter = _make_adapter(tmp_path)
+        (_, error), _ = _run_spawn(adapter)
+        assert "permission" in error.lower()
+
+    def test_working_dir_is_process_cwd(self, isolated_home, tmp_path, patch_spawn):
+        captured = patch_spawn(_lines("ok"))
+        wd = str(tmp_path / "myproject")
+        adapter = _make_adapter(tmp_path, working_dir=wd)
+        asyncio.run(adapter._spawn_aider(["/usr/bin/aider"], "general"))
+        assert captured["kwargs"].get("cwd") == wd
+
+    def test_api_key_in_env_not_logged(self, isolated_home, tmp_path, patch_spawn, monkeypatch, caplog):
+        secret = "sk-aider-supersecret"
+        monkeypatch.setenv("LLM_API_KEY", secret)
+        monkeypatch.setenv("AIDER_MODEL", "gpt-4o")
+        patch_spawn(_lines("done"), stderr_lines=_lines("some provider noise"))
+        adapter = _make_adapter(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="openagents.adapters.aider"):
+            _run_spawn(adapter)
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert secret not in joined
+
+    def test_long_prompt_goes_to_message_file_outside_project(self, isolated_home, tmp_path, patch_spawn):
+        captured = patch_spawn(_lines("done"))
+        wd = str(tmp_path / "proj")
+        os.makedirs(wd, exist_ok=True)
+        adapter = _make_adapter(tmp_path, working_dir=wd)
+        adapter._aider_binary = "/usr/bin/aider"
+        big = "please refactor " * 5000  # well past any ARG_MAX concern
+        text, error = asyncio.run(adapter._run_aider(big, "general"))
+        argv = captured["args"]
+        mf_index = argv.index("--message-file")
+        msg_path = argv[mf_index + 1]
+        # The message file lives under the sessions dir, NOT inside the project.
+        assert str(adapter._sessions_dir) in msg_path
+        assert wd not in msg_path
+        # The prompt text is never an argv element.
+        assert all(big not in str(a) for a in argv)
+
+    def test_ansi_is_stripped(self):
+        assert _clean_output("\x1b[31mred\x1b[0m text") == "red text"
+
+    def test_empty_output_success_has_fallback(self, isolated_home, tmp_path, patch_spawn):
+        patch_spawn([])  # exit 0, no output
+        adapter = _make_adapter(tmp_path)
+        (text, error), _ = _run_spawn(adapter)
+        assert error is None
+        assert text == ""  # _spawn returns empty; _handle_message supplies the fallback
+
+
+# ---------------------------------------------------------------------------
+# 6. Sessions — per-channel isolation, restore, traversal safety, corruption
+# ---------------------------------------------------------------------------
+
+class TestAiderSessions:
+    def test_channels_use_separate_history_files(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        a = adapter._chat_history_file("alpha")
+        b = adapter._chat_history_file("beta")
+        assert a != b
+        assert a.parent == adapter._sessions_dir
+
+    def test_channel_id_is_traversal_safe(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        evil = adapter._chat_history_file("../../etc/passwd")
+        # Sanitized to a single filename inside the sessions dir — no path
+        # separators survive, so it cannot escape the sessions dir (the leftover
+        # literal ".." chars are inert without a separator).
+        assert evil.parent == adapter._sessions_dir
+        assert "/" not in evil.name and "\\" not in evil.name
+        assert evil.resolve().parent == adapter._sessions_dir.resolve()
+
+    def test_corrupt_history_degrades_to_fresh(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        hist = adapter._chat_history_file("general")
+        hist.parent.mkdir(parents=True, exist_ok=True)
+        hist.write_bytes(b"\xff\xfe\x00invalid-utf8")
+        assert adapter._has_history("general") is False
+        # The bad file is moved aside rather than re-read forever.
+        assert hist.with_suffix(hist.suffix + ".corrupt").exists()
+
+    def test_reset_channel_session_removes_files(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        hist = adapter._chat_history_file("general")
+        hist.parent.mkdir(parents=True, exist_ok=True)
+        hist.write_text("x")
+        adapter.reset_channel_session("general")
+        assert not hist.exists()
+
+    def test_clear_all_sessions(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        hist = adapter._chat_history_file("general")
+        hist.parent.mkdir(parents=True, exist_ok=True)
+        hist.write_text("x")
+        adapter.clear_all_sessions()
+        assert not adapter._sessions_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# 7. Git hygiene
+# ---------------------------------------------------------------------------
+
+class TestAiderGit:
+    def test_local_git_exclude_added_without_touching_gitignore(self, isolated_home, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / ".git" / "info").mkdir(parents=True)
+        adapter = _make_adapter(tmp_path, working_dir=str(repo))
+        adapter._ensure_local_git_exclude(str(repo))
+        exclude = (repo / ".git" / "info" / "exclude").read_text()
+        assert ".aider*" in exclude
+        # The tracked .gitignore must NOT be created/modified by us.
+        assert not (repo / ".gitignore").exists()
+
+    def test_non_git_dir_is_noop(self, isolated_home, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        adapter = _make_adapter(tmp_path, working_dir=str(plain))
+        adapter._ensure_local_git_exclude(str(plain))  # must not raise
+        assert not (plain / ".git").exists()
+
+
+# ---------------------------------------------------------------------------
+# 8. Stop control
+# ---------------------------------------------------------------------------
+
+class TestAiderStop:
+    def test_stop_terminates_and_clears_process(self, isolated_home, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        killed = {"count": 0}
+
+        async def fake_stop(proc):
+            killed["count"] += 1
+
+        async def fake_status(channel, content):
+            pass
+
+        adapter._stop_process = fake_stop
+        adapter._send_status = fake_status
+
+        class _P:
+            returncode = None
+            pid = 99
+        adapter._channel_processes["general"] = _P()
+
+        asyncio.run(adapter._on_control_action("stop", {}))
+        assert killed["count"] == 1
+        assert "general" not in adapter._channel_processes
+        assert "general" in adapter._stopping_channels
+
+
+# ---------------------------------------------------------------------------
+# 9. No regression for existing agents
+# ---------------------------------------------------------------------------
+
+class TestNoRegression:
+    @pytest.mark.parametrize("name", ["claude", "codex", "opencode", "cursor"])
+    def test_existing_builtins_still_load(self, name):
+        data = next(d for d in loader.load_registry_yamls() if d.get("name") == name)
+        plugin = loader._make_plugin_from_yaml(data)
+        assert plugin is not None
+        assert plugin.name == name
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/agents/test_aider.py
+++ b/tests/agents/test_aider.py
@@ -130,11 +130,12 @@ def isolated_home(tmp_path, monkeypatch):
     monkeypatch.setattr(
         loader, "_INSTALLED_MARKERS_PATH", home / ".openagents" / "installed_agents.json"
     )
-    # No provider keys / config leak in from the developer's shell.
+    # No provider keys / config / install-dir overrides leak in from the shell.
     for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
                 "GEMINI_API_KEY", "DEEPSEEK_API_KEY", "LLM_API_KEY",
                 "AIDER_PROVIDER", "AIDER_MODEL", "LLM_MODEL", "LLM_BASE_URL",
-                "OPENAI_API_BASE", "AIDER_AUTO_COMMITS"):
+                "OPENAI_API_BASE", "AIDER_AUTO_COMMITS",
+                "XDG_BIN_HOME", "XDG_DATA_HOME", "UV_TOOL_DIR", "APPDATA"):
         monkeypatch.delenv(var, raising=False)
     return home
 
@@ -212,6 +213,21 @@ class TestAiderDetection:
         aider_path = isolated_home / ".local" / "bin" / "aider"
         _write_executable(aider_path)
         assert AiderAdapter._find_aider_binary() == str(aider_path)
+
+    def test_adapter_find_binary_in_uv_tools_venv(self, isolated_home):
+        # The real Windows failure mode: `uv tool install` left the executable
+        # only in its tools venv. Unix layout: ~/.local/share/uv/tools/<pkg>/bin.
+        aider_path = (isolated_home / ".local" / "share" / "uv" / "tools"
+                      / "aider-chat" / "bin" / "aider")
+        _write_executable(aider_path)
+        assert AiderAdapter._find_aider_binary() == str(aider_path)
+
+    def test_adapter_find_binary_honors_xdg_bin_home(self, isolated_home, tmp_path, monkeypatch):
+        # The official installer's first-priority dir.
+        xdg = tmp_path / "xdg_bin"
+        _write_executable(xdg / "aider")
+        monkeypatch.setenv("XDG_BIN_HOME", str(xdg))
+        assert AiderAdapter._find_aider_binary() == str(xdg / "aider")
 
     def test_adapter_find_binary_missing(self, isolated_home):
         assert AiderAdapter._find_aider_binary() is None


### PR DESCRIPTION
## Summary

This PR adds beta Workspace support for Aider in OpenAgents.

It introduces Python and Node.js Aider adapters, Launcher integration, cross-platform installation validation, deterministic model provider resolution, per-channel conversation persistence, and Git-safe defaults.

Aider is marked as Beta because all offline tests pass, but a real provider end-to-end test has not yet been completed.

## What changed

* Registered Aider as a built-in Workspace agent
* Added Python and Node.js Aider adapters
* Added Aider to the adapter registry and Launcher agent list
* Added non-interactive execution using `--message-file`
* Added incremental stdout and stderr handling
* Added per-Workspace-channel chat history isolation and restoration
* Added support for:

  * OpenAI
  * Anthropic
  * OpenRouter
  * Gemini
  * DeepSeek
  * OpenAI-compatible endpoints
* Added explicit `AIDER_PROVIDER` configuration
* Prevented unknown or ambiguous models from silently defaulting to OpenAI
* Added correct `OPENAI_API_BASE` and `openai/<model>` handling for OpenAI-compatible services
* Disabled Aider automatic commits, dirty commits, and `.gitignore` modification by default
* Added cross-platform Aider binary validation
* Added stale installation marker reconciliation
* Added README setup, authentication, provider, and validation documentation

## Provider resolution

Provider resolution now follows deterministic rules:

1. An explicit `AIDER_PROVIDER` takes priority.
2. When provider is `auto`, known model names and prefixes may be used for inference.
3. Anthropic aliases such as `sonnet`, `opus`, and `haiku` are correctly recognized.
4. Unknown models with a generic API key return a configuration error.
5. A generic key is never silently injected as `OPENAI_API_KEY`.
6. When no generic key is provided, existing native provider environment variables and Aider configuration remain untouched.

OpenAI-compatible endpoints are normalized to:

* `LLM_BASE_URL` → `OPENAI_API_BASE`
* `LLM_API_KEY` → `OPENAI_API_KEY`
* `<model>` → `openai/<model>`

## Git behavior

Aider normally creates commits automatically. OpenAgents disables this behavior by default using:

* `--no-auto-commits`
* `--no-dirty-commits`
* `--no-gitignore`

Automatic commits remain available as an explicit opt-in configuration.

## Tests

The following checks pass:

* Python Aider tests: `84 passed`
* Node.js Aider and installer tests: `46 passed`
* Full agent-connector suite: `243 passed, 0 failed`
* Python/Node provider resolution parity checks passed
* Existing session, Git safety, message-file cleanup, registry, and adapter tests remain passing

The broader Python test selection still contains 50 pre-existing failures. A clean-HEAD comparison produced the same 50 failures, confirming this PR introduces no new failures.

## Known limitations

* Real provider end-to-end validation has not yet been completed because the test environment does not have Aider installed or an available model API key.
* Launcher TypeScript compilation was not run because Launcher dependencies are not installed in the current environment.
* `AIDER_PROVIDER` currently uses the existing text-field configuration UI instead of a dedicated select control.

## Manual validation

To validate with a real provider:

```bash
agn install aider
agn env aider --set AIDER_PROVIDER=anthropic
agn env aider --set AIDER_MODEL=sonnet
agn env aider --set LLM_API_KEY=<your-key>
agn create my-aider --type aider --path ~/project
agn up
agn connect my-aider <workspace-token>
```

Then verify that:

* Aider replies to a Workspace message
* file changes are written to the configured project directory
* follow-up messages restore context in the same channel
* different channels remain isolated
* no unexpected Git commits are created
* Stop terminates the active task
* invalid credentials return a clear Workspace error
* reconnecting does not replay completed tasks
