### PR TITLE
fix(cli): import rich.progress symbols used by agentid commands

### DIFF
--- a/sdk/src/openagents/client/cli_identity.py
+++ b/sdk/src/openagents/client/cli_identity.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import requests
 import typer
 from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 from rich import box
 

--- a/tests/agentid/test_cli_identity_imports.py
+++ b/tests/agentid/test_cli_identity_imports.py
@@ -1,0 +1,47 @@
+"""Regression tests for the ``agentid`` CLI commands in cli_identity.py.
+
+The ``agentid`` subcommands (verify / info / resolve / verify-token /
+challenge / token / auth / claim) use ``Progress``, ``SpinnerColumn`` and
+``TextColumn`` from ``rich.progress`` inside a ``with Progress(...)`` block.
+Those names were never imported in ``cli_identity.py``, so every one of those
+commands crashed with ``NameError: name 'Progress' is not defined`` the moment
+it reached the progress block — before any network call.
+
+These tests stub out the network layer so no real request is made and assert
+that the command does not raise a ``NameError``.
+"""
+
+import openagents.agentid as agentid
+import openagents.client.cli_identity  # noqa: F401  -- registers agentid_app onto app
+from openagents.agentid.exceptions import AgentIDConnectionError
+from openagents.client.cli_shared import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_agentid_verify_does_not_raise_nameerror(monkeypatch):
+    """``agentid verify`` must reach the network layer without a NameError.
+
+    The verifier is stubbed to raise a connection error, so the command takes
+    its handled error path (exit code 1) instead of crashing with
+    ``NameError: name 'Progress' is not defined``.
+    """
+
+    class _OfflineVerifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def validate(self, agent_id):
+            raise AgentIDConnectionError("offline (test stub)")
+
+    monkeypatch.setattr(agentid, "AgentIDVerifier", _OfflineVerifier)
+
+    result = runner.invoke(app, ["agentid", "verify", "openagents:test-agent"])
+
+    assert not isinstance(result.exception, NameError), (
+        f"agentid verify raised NameError: {result.exception}"
+    )
+    assert "NameError" not in result.output
+    # Handled connection error -> typer.Exit(1)
+    assert result.exit_code == 1


### PR DESCRIPTION
## Bug

Every `agentid` subcommand in `sdk/src/openagents/client/cli_identity.py` crashes with `NameError: name 'Progress' is not defined`.

The commands use `Progress`, `SpinnerColumn` and `TextColumn` inside a `with Progress(...) as progress:` block, but `cli_identity.py` never imports them from `rich.progress`. The `NameError` is raised the moment the command reaches the progress block — before any network call — so the commands are completely unusable.

Affected subcommands: `verify`, `info`, `resolve`, `verify-token`, `challenge`, `token`, `auth`, `claim`.

The sibling `cli_agent.py` imports these symbols correctly; this just mirrors that import. (Same class of bug as the `cli_agent.py` missing-import fix.)

## Fix

Add the missing import to `cli_identity.py`:

```python
from rich.progress import Progress, SpinnerColumn, TextColumn
```

## Verification

Added `tests/agentid/test_cli_identity_imports.py`, which invokes `agentid verify` via `typer.testing.CliRunner` with the verifier stubbed to stay offline, and asserts the command does not raise `NameError` and takes its handled error path.

```
$ pytest tests/agentid/test_cli_identity_imports.py -q
1 passed
```

Before the fix this test fails with `NameError: name 'Progress' is not defined`. Full `tests/agentid` suite still passes (51 passed).
