### PR TITLE
add beta Goose workspace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,101 @@ agn connect my-agent <workspace-token>    # connect agent into workspace
 | **Hermes Agent** | ✅ Supported | Nous Hermes CLI with tools, profiles, and memory |
 | **Cursor** | ✅ Supported | AI code editor |
 | **OpenCode** | ✅ Supported | Open-source terminal agent |
-| Aider, Goose, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+| **Goose** | 🧪 Beta | Block's open-source agent (CLI, headless) — see [Goose (Beta)](#goose-beta) |
+| Aider, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+
+---
+
+### Goose (Beta)
+
+[Goose](https://github.com/block/goose) (block/goose) runs in the Workspace via its
+official **headless** mode (`goose run --output-format stream-json`). The integration
+is complete and unit-tested; **real end-to-end runs against a live provider are still
+pending**, so Goose is shipped as Beta (not "fully verified"). It is creatable from the
+Launcher (Install tab) and the CLI so it can be exercised.
+
+**Minimum version: Goose CLI ≥ 1.37.0.** Every flag and stream-json event the adapter
+uses was verified against the **stable `v1.37.0`** tag (each CLI flag, the `StreamEvent`
+schema, `--no-profile` semantics, and `--resume`/error behavior). Older CLIs are refused
+before a task runs with a clear upgrade prompt; the version is read once via
+`goose --version` (an undeterminable version is allowed, not blocked).
+
+**Install the CLI** (the OpenAgents installer does this for you, non-interactively):
+
+```bash
+# macOS / Linux — CONFIGURE=false keeps it non-interactive (no `goose configure`)
+curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+# Windows (PowerShell)
+powershell -c "$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/block/goose/main/download_cli.ps1 | iex"
+```
+
+The CLI installs to `~/.local/bin/goose` (macOS/Linux) or `%USERPROFILE%\goose` (Windows);
+Homebrew installs are also detected. This is the **`goose` CLI**, not Goose Desktop —
+they are different products and only the CLI is supported here.
+
+**Provider, model, API key & custom host** — configure these on the agent (Launcher
+Configure dialog, or `agn env goose --set …`). They map 1:1 to Goose's native env vars:
+
+| Field | Goose env var | Notes |
+|-------|---------------|-------|
+| Provider | `GOOSE_PROVIDER` | e.g. `openai`, `anthropic`, `google`, `openrouter`, `ollama` |
+| Model | `GOOSE_MODEL` | e.g. `gpt-4o`, `claude-sonnet-4-6` |
+| API key | `GOOSE_PROVIDER__API_KEY` | generic provider key; stored as a password, never in argv/logs |
+| Custom host | `GOOSE_PROVIDER__HOST` | proxy / self-hosted / OpenAI-compatible endpoint |
+| Tool mode | `GOOSE_MODE` | defaults to `auto` (see below) |
+
+**Existing login is reused.** Leave the fields blank to fall back to your existing Goose
+config (`~/.config/goose/config.yaml`), keyring, OAuth provider, or local provider
+(e.g. Ollama). OpenAgents never edits your global `config.yaml`/`secrets.yaml`, never
+writes plaintext secrets, and never runs `goose configure`. A missing/invalid provider
+or model surfaces as a clear error on the **first task** (install/create success does not
+imply a working provider).
+
+**Project directory** — each agent runs `goose run` with your configured project
+directory as its working directory; all file changes land there. Sessions and OpenAgents
+state are stored under `~/.openagents`, never in your repo. Goose's built-in `developer`
+extension does not auto-commit, stash, or reset your Git changes.
+
+**Headless permission mode (important).** Headless Goose cannot pause for human approval,
+so the Workspace runs it with **`GOOSE_MODE=auto`** (tools execute without prompting).
+Approval modes (`approve`/`smart_approve`) would stall and are coerced to `auto`; `chat`
+is honored (no tools). Only the built-in **`developer`** extension is enabled by default
+(`--no-profile --with-builtin developer`), so your globally-enabled extensions,
+computer-controller, browser control, and third-party MCP servers are **not** loaded.
+Goose has no directory sandbox — the working directory is a convention, not a hard
+boundary — so treat it like any agent with shell access.
+
+**Sessions & channel isolation.** Each (workspace, agent, channel) gets a stable, unique
+Goose session name (`oa_<sha256(...)[:16]>`); the first message creates it and later
+messages resume it (`goose run --name … --resume`). Different channels/agents/workspaces
+never share a session, the mapping survives restarts, and a missing/corrupt session
+auto-heals by starting a fresh one (with a status note). Tasks on one channel run
+serially.
+
+**Stop & cleanup.** Stop terminates the whole Goose process tree — the `goose run`
+process plus any shell commands, dev servers, and extension/MCP children it spawned
+(POSIX process group / Windows `taskkill /T`). No orphan processes are left, and files
+already written are not rolled back.
+
+**Limits / long tasks.** Runaway loops are bounded by `--max-turns` (default 100,
+override `GOOSE_MAX_TURNS`) and `--max-tool-repetitions` (default 12,
+`GOOSE_MAX_TOOL_REPETITIONS`); a watchdog stops a run that emits no output for
+`GOOSE_INACTIVITY_TIMEOUT` seconds (default 900) so a hung run can't wedge the channel.
+
+**Troubleshooting**
+- *Authentication failed* — check `GOOSE_PROVIDER__API_KEY` / `GOOSE_PROVIDER__HOST`.
+- *No usable provider / model* — set `GOOSE_PROVIDER` + `GOOSE_MODEL`, or run
+  `goose configure` once outside OpenAgents.
+- *"Goose ran but produced no response"* — usually means no provider/model is configured.
+- *CLI not found after install* — ensure `~/.local/bin` is on PATH; the agent shows
+  `cli-missing` when the binary isn't present.
+
+**Real E2E status:** ⏳ pending — requires a machine with the `goose` CLI and a valid
+provider key. To verify manually: `goose --version`; create a Goose agent with a provider
++ model + key; connect it to a Workspace; send a message and confirm the reply, tool
+status, and that file edits land in the project directory; send a second message in the
+same channel and confirm context is retained; open a new channel and confirm it does not
+inherit context; press Stop mid-task and confirm no leftover processes.
 
 ---
 

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -302,18 +302,66 @@
   {
     "name": "goose",
     "label": "Goose",
-    "description": "An open-source AI developer agent by Block",
+    "description": "An open-source AI developer agent by Block (CLI — Beta)",
     "homepage": "https://github.com/block/goose",
     "tags": [
       "coding",
       "developer",
-      "open-source"
+      "open-source",
+      "cli"
     ],
+    "order": 9,
+    "support": {
+      "install": true,
+      "workspace": true,
+      "collaboration": true
+    },
+    "builtin": true,
     "install": {
       "binary": "goose",
-      "macos": "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash",
-      "linux": "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash",
-      "windows": "powershell -c \\\"irm https://raw.githubusercontent.com/block/goose/main/download_cli.ps1 | iex\\\""
+      "macos": "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash",
+      "linux": "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash",
+      "windows": "powershell -c \"$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/block/goose/main/download_cli.ps1 | iex\""
+    },
+    "adapter": {
+      "module": "openagents.adapters.goose",
+      "class": "GooseAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "GOOSE_PROVIDER",
+        "description": "Goose provider id (e.g. openai, anthropic, google, openrouter, ollama). Leave blank to reuse your existing Goose config.",
+        "required": false
+      },
+      {
+        "name": "GOOSE_MODEL",
+        "description": "Model name for the selected provider (e.g. gpt-4o, claude-sonnet-4-6). Leave blank to reuse your existing Goose config.",
+        "required": false
+      },
+      {
+        "name": "GOOSE_PROVIDER__API_KEY",
+        "description": "Provider API key (generic Goose provider key). Leave blank to reuse the Goose keyring/config, an OAuth provider, or a local provider.",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "GOOSE_PROVIDER__HOST",
+        "description": "Custom provider endpoint/host URL (optional — for proxies or self-hosted/OpenAI-compatible endpoints).",
+        "required": false
+      },
+      {
+        "name": "GOOSE_MODE",
+        "description": "Headless tool-permission mode. 'auto' runs tools without approval (required for the workspace); 'chat' disables tools. Approval modes are coerced to 'auto'.",
+        "required": false,
+        "default": "auto"
+      }
+    ],
+    "check_ready": {
+      "require_binary": true,
+      "not_ready_message": "Goose CLI not found. Install it: openagents install goose — then set a provider/model (or run `goose configure` once)."
     }
   },
   {

--- a/packages/agent-connector/src/adapters/goose-stream.js
+++ b/packages/agent-connector/src/adapters/goose-stream.js
@@ -1,0 +1,268 @@
+/**
+ * Pure, line-oriented parser for Goose's `goose run --output-format stream-json`
+ * output, plus helpers for secret redaction and error classification.
+ *
+ * No I/O / process code lives here so it can be unit-tested in isolation and
+ * kept behaviourally identical to the Python port
+ * (sdk/src/openagents/adapters/goose_stream.py).
+ *
+ * Verified against block/goose v1.38.0. The CLI emits one JSON object per line
+ * (NDJSON). StreamEvent is `#[serde(tag="type", rename_all="snake_case")]`:
+ *
+ *   {"type":"message","message":{"role":"assistant"|"user","created":N,"content":[...]}}
+ *   {"type":"notification","extension_id":"...","log":{"message":"..."}}   // or "progress"
+ *   {"type":"error","error":"..."}
+ *   {"type":"complete","total_tokens":N,"input_tokens":N,"output_tokens":N}
+ *
+ * Content items are `#[serde(tag="type", rename_all="camelCase")]`:
+ *   text {text}, thinking {thinking,signature}, redactedThinking {data},
+ *   toolRequest {id, toolCall:{status:"success", value:{name, arguments}}|{status:"error", error}},
+ *   toolResponse {id, toolResult:{status, ...}}, image / systemNotification / ...
+ *
+ * Important: an agent/provider error during a run is emitted as an `error`
+ * event but `goose run` still exits 0. Callers MUST treat `hadError` (or any
+ * event of kind `error`) as a failure regardless of the process exit code.
+ */
+
+'use strict';
+
+// Hard cap on a single un-terminated line we will buffer before giving up.
+const MAX_LINE_BYTES = 8 * 1024 * 1024;
+// Cap on how much of a tool-argument preview we surface as workspace status.
+const TOOL_PREVIEW_LIMIT = 160;
+
+/**
+ * Mask credentials in arbitrary text.
+ * @param {string} text
+ * @param {string[]} [secrets] exact secret values to mask (e.g. the API key)
+ * @returns {string}
+ */
+function redactSecrets(text, secrets) {
+  if (!text) return '';
+  let out = String(text);
+  for (const secret of secrets || []) {
+    if (secret && typeof secret === 'string' && secret.length >= 4) {
+      out = out.split(secret).join('***');
+    }
+  }
+  out = out.replace(
+    /\b(api[_-]?key|secret|token|authorization|auth|bearer)\b\s*[:=]?\s*['"]?([A-Za-z0-9._-]{8,})['"]?/gi,
+    (_m, label) => `${label}=***`,
+  );
+  out = out.replace(/\bsk-[A-Za-z0-9._-]{6,}\b/g, 'sk-***');
+  return out;
+}
+
+/**
+ * Map a raw Goose stderr/error string to a readable, actionable message, or
+ * null when there's nothing useful. Callers should still pass the result
+ * through redactSecrets.
+ * @param {string} text
+ * @returns {string|null}
+ */
+function classifyGooseError(text) {
+  if (!text || !String(text).trim()) return null;
+  const low = String(text).toLowerCase();
+  const has = (...needles) => needles.some((n) => low.includes(n));
+
+  if (has('401', '403', 'unauthorized', 'invalid api key', 'invalid_api_key',
+    'authentication', 'incorrect api key', 'no api key', 'missing api key')) {
+    return "Goose authentication failed. Check this agent's provider API key "
+      + '(GOOSE_PROVIDER__API_KEY) and host — the key may be missing, invalid, or expired.';
+  }
+  if (has('429', 'rate limit', 'rate_limit', 'too many requests', 'quota', 'overloaded')) {
+    return "Goose hit the provider's rate limit or quota. Wait and retry, or use a "
+      + 'different key/provider.';
+  }
+  if (has('no such model', 'unknown model', 'model not found', 'does not exist') || has('model')) {
+    if (has('model')) {
+      return 'Goose could not use the configured model. Check GOOSE_MODEL is valid for '
+        + 'the selected GOOSE_PROVIDER.';
+    }
+  }
+  if (has('provider', 'unknown provider', 'no provider', 'provider not', 'configure')) {
+    return 'Goose has no usable provider configured. Set GOOSE_PROVIDER (and a key/host), '
+      + 'or run `goose configure` once outside OpenAgents.';
+  }
+  if (has('permission denied', 'not permitted', 'tool execution denied', 'denied by')) {
+    return 'A Goose tool call was denied. The workspace runs Goose headless with '
+      + 'GOOSE_MODE=auto; check the project directory permissions.';
+  }
+  if (has('extension', 'mcp', 'failed to start', 'failed to load')) {
+    return 'A Goose extension failed to start. The workspace only enables the built-in '
+      + 'developer extension by default; check your Goose extension config.';
+  }
+  if (has('connection', 'network', 'timed out', 'timeout', 'dns', 'could not resolve',
+    'connection refused', 'unreachable')) {
+    return 'Goose could not reach the provider endpoint. Check the network and the '
+      + 'GOOSE_PROVIDER__HOST URL.';
+  }
+  if (has('no such file', 'not a directory', 'os error 13')) {
+    return 'Goose hit a filesystem error. Check the agent\'s project directory exists and '
+      + 'is writable.';
+  }
+  return null;
+}
+
+class GooseStreamParser {
+  constructor() {
+    this._buf = '';
+    this._pendingFinal = null;
+    this._finalText = null;
+    this._finalEmitted = false;
+    this.hadError = false;
+    this.errorMessage = null;
+  }
+
+  get finalText() {
+    return this._finalText;
+  }
+
+  /**
+   * Feed a raw stdout chunk; returns semantic events parsed from completed lines.
+   * @param {string} chunk
+   * @returns {Array<object>}
+   */
+  feed(chunk) {
+    const events = [];
+    if (!chunk) return events;
+    this._buf += chunk;
+    if (this._buf.length > MAX_LINE_BYTES && !this._buf.includes('\n')) {
+      this._buf = this._buf.slice(-MAX_LINE_BYTES);
+    }
+    let idx;
+    while ((idx = this._buf.indexOf('\n')) >= 0) {
+      const line = this._buf.slice(0, idx);
+      this._buf = this._buf.slice(idx + 1);
+      this._handleLine(line, events);
+    }
+    return events;
+  }
+
+  /** Flush at EOF; emits the final answer if the stream ended without `complete`. */
+  finish() {
+    const events = [];
+    const leftover = this._buf;
+    this._buf = '';
+    if (leftover.trim()) this._handleLine(leftover, events);
+    if (!this._finalEmitted && !this.hadError) this._emitFinal(events);
+    return events;
+  }
+
+  _emitFinal(events) {
+    if (this._pendingFinal) {
+      this._finalText = this._pendingFinal;
+      this._pendingFinal = null;
+    }
+    if (!this._finalEmitted && this._finalText) {
+      events.push({ kind: 'final', text: this._finalText });
+      this._finalEmitted = true;
+    }
+  }
+
+  _handleLine(line, events) {
+    line = line.trim();
+    if (!line) return;
+    let ev;
+    try {
+      ev = JSON.parse(line);
+    } catch {
+      return; // half-line / non-JSON noise: ignore defensively
+    }
+    if (!ev || typeof ev !== 'object' || Array.isArray(ev)) return;
+    const etype = ev.type;
+    if (etype === 'message') {
+      if (ev.message && typeof ev.message === 'object') this._handleMessage(ev.message, events);
+    } else if (etype === 'error') {
+      const msg = ev.error || 'Goose reported an error';
+      this.hadError = true;
+      this.errorMessage = String(msg);
+      events.push({ kind: 'error', message: String(msg) });
+    } else if (etype === 'complete') {
+      if (!this.hadError) this._emitFinal(events);
+      events.push({ kind: 'complete', tokens: ev.total_tokens ?? null });
+    } else if (etype === 'notification') {
+      const text = GooseStreamParser._notificationText(ev);
+      if (text) events.push({ kind: 'notification', text });
+    }
+    // Unknown event types are ignored on purpose (forward-compatible).
+  }
+
+  static _notificationText(ev) {
+    if (ev.progress && typeof ev.progress === 'object' && ev.progress.message) {
+      return String(ev.progress.message);
+    }
+    if (ev.log && typeof ev.log === 'object' && ev.log.message) {
+      return String(ev.log.message);
+    }
+    return null;
+  }
+
+  _handleMessage(message, events) {
+    const role = String(message.role || '').toLowerCase();
+    const content = message.content;
+    if (!Array.isArray(content)) return;
+    const texts = [];
+    for (const item of content) {
+      if (!item || typeof item !== 'object') continue;
+      const itype = item.type;
+      if (itype === 'text') {
+        if (item.text) texts.push(String(item.text));
+      } else if (itype === 'thinking') {
+        if (item.thinking) events.push({ kind: 'thinking', text: String(item.thinking) });
+      } else if (itype === 'toolRequest') {
+        events.push(GooseStreamParser._toolEvent(item));
+      } else if (itype === 'toolResponse') {
+        events.push(GooseStreamParser._toolResultEvent(item));
+      }
+      // image / redactedThinking / systemNotification / etc → ignore
+    }
+    if (role === 'assistant' && texts.length) {
+      const joined = texts.filter(Boolean).join('\n').trim();
+      if (joined) {
+        // Intermediate assistant text is interim narration (assistant output),
+        // not model-internal reasoning — surface it as `progress` (→ status),
+        // NOT `thinking`. Only genuine `thinking` content items emit `thinking`.
+        if (this._pendingFinal) events.push({ kind: 'progress', text: this._pendingFinal });
+        this._pendingFinal = joined;
+      }
+    }
+  }
+
+  static _toolEvent(item) {
+    const toolCall = item.toolCall;
+    if (!toolCall || typeof toolCall !== 'object') {
+      return { kind: 'tool', name: 'tool', summary: '' };
+    }
+    if (toolCall.status === 'error') {
+      return { kind: 'tool', name: 'tool', summary: '(tool call could not be parsed)' };
+    }
+    const value = toolCall.value;
+    if (!value || typeof value !== 'object') {
+      return { kind: 'tool', name: 'tool', summary: '' };
+    }
+    const name = String(value.name || 'tool');
+    return { kind: 'tool', name, summary: GooseStreamParser._summarizeArgs(name, value.arguments) };
+  }
+
+  static _toolResultEvent(item) {
+    const tr = item.toolResult;
+    const ok = !!(tr && typeof tr === 'object' && tr.status === 'success');
+    return { kind: 'tool_result', ok };
+  }
+
+  static _summarizeArgs(_name, args) {
+    if (!args || typeof args !== 'object') return '';
+    for (const key of ['command', 'path', 'file_path', 'file', 'pattern', 'query', 'uri', 'url']) {
+      const val = args[key];
+      if (typeof val === 'string' && val) {
+        let preview = val.split(/\s+/).join(' ');
+        if (preview.length > TOOL_PREVIEW_LIMIT) preview = preview.slice(0, TOOL_PREVIEW_LIMIT) + '…';
+        return preview;
+      }
+    }
+    return Object.keys(args).filter((k) => typeof k === 'string').slice(0, 6).join(', ');
+  }
+}
+
+module.exports = { GooseStreamParser, redactSecrets, classifyGooseError };

--- a/packages/agent-connector/src/adapters/goose.js
+++ b/packages/agent-connector/src/adapters/goose.js
@@ -1,0 +1,640 @@
+/**
+ * Goose adapter for OpenAgents workspace.
+ *
+ * Bridges the Goose CLI (block/goose) to an OpenAgents workspace via Goose's
+ * official headless mode:
+ *
+ *   goose run --output-format stream-json --name <session> [--resume] \
+ *             --no-profile --with-builtin developer \
+ *             --max-turns N --max-tool-repetitions M --system <ctx> -i -
+ *
+ * - The task prompt is written to the child's stdin (`-i -`), never argv.
+ * - stdout is parsed incrementally as NDJSON stream-json (goose-stream.js);
+ *   stderr is drained concurrently.
+ * - Each (workspace, agent, channel) maps to a stable, unique Goose session
+ *   name so conversations resume per-channel and never cross-talk.
+ * - Provider/model/key/host come from native Goose env vars (this.agentEnv);
+ *   the key is never placed on the command line or in logs.
+ * - GOOSE_MODE=auto runs tools without interactive approval (required for
+ *   headless); only the built-in `developer` extension is enabled by default.
+ *
+ * Port of sdk/src/openagents/adapters/goose.py. Verified against block/goose
+ * v1.38.0. Goose is currently Beta — real end-to-end runs are pending.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const { spawn, execSync, execFileSync } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { GooseStreamParser, classifyGooseError, redactSecrets } = require('./goose-stream');
+const {
+  buildWorkspaceIdentity,
+  buildCollaborationPrompt,
+  buildModePrompt,
+} = require('./workspace-prompt');
+const { whichBinary, getEnhancedEnv, defaultAgentWorkdir } = require('../paths');
+
+const IS_WINDOWS = process.platform === 'win32';
+
+const DEFAULT_INACTIVITY_TIMEOUT = 900; // seconds
+const DEFAULT_MAX_TURNS = 100;
+const DEFAULT_MAX_TOOL_REPETITIONS = 12;
+const STDERR_CAP = 64 * 1024;
+const STATUS_PREVIEW = 280;
+
+// Minimum Goose CLI version verified against the stable tag (block/goose
+// v1.37.0). Older releases may lack stream-json / the flags used here, so we
+// refuse them with a clear upgrade prompt rather than failing obscurely.
+const MIN_GOOSE_VERSION = [1, 37, 0];
+
+/** Parse `goose --version` output (e.g. "goose 1.37.0") → [1,37,0], or null. */
+function parseGooseVersion(text) {
+  if (!text) return null;
+  const m = String(text).match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** True if parsed >= minimum (or unknown — lenient). */
+function gooseVersionMeetsMinimum(parsed, minimum = MIN_GOOSE_VERSION) {
+  if (!parsed) return true;
+  for (let i = 0; i < 3; i++) {
+    const a = parsed[i] || 0;
+    const b = minimum[i] || 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return true;
+}
+
+function tooOldMessage(parsed) {
+  const cur = parsed ? parsed.join('.') : 'unknown';
+  const minv = MIN_GOOSE_VERSION.join('.');
+  return `Goose CLI ${cur} is too old — OpenAgents requires Goose >= ${minv} `
+    + '(headless stream-json support). Upgrade it: curl -fsSL '
+    + 'https://github.com/block/goose/releases/download/stable/download_cli.sh '
+    + '| CONFIGURE=false bash';
+}
+
+/**
+ * Stable, unique, filesystem-safe Goose session name for a channel.
+ * Mirrors goose_session_name() in goose_stream.py / goose.py.
+ */
+function gooseSessionName(workspaceId, agentName, channel) {
+  const digest = crypto
+    .createHash('sha256')
+    .update(`${workspaceId}|${agentName}|${channel}`)
+    .digest('hex');
+  return `oa_${digest.slice(0, 16)}`;
+}
+
+/** Locate the real `goose` CLI across platforms (PATH + well-known dirs). */
+function findGooseBinary() {
+  const home = os.homedir();
+  // PATH (enriched with nvm/homebrew/etc), windowsHide avoids a console flash.
+  try {
+    const env = getEnhancedEnv();
+    if (IS_WINDOWS) {
+      const r = execSync('where goose.exe 2>nul || where goose.cmd 2>nul || where goose 2>nul', {
+        encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
+      });
+      const hit = r.split(/\r?\n/)[0].trim();
+      if (hit) return hit;
+    } else {
+      const hit = execSync('command -v goose', {
+        encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
+      }).trim();
+      if (hit) return hit;
+    }
+  } catch {}
+
+  const candidates = IS_WINDOWS ? [
+    path.join(process.env.USERPROFILE || home, 'goose', 'goose.exe'),
+    path.join(home, '.local', 'bin', 'goose.exe'),
+  ] : [
+    path.join(home, '.local', 'bin', 'goose'),  // official installer default
+    '/opt/homebrew/bin/goose',                  // macOS Homebrew (Apple silicon)
+    '/usr/local/bin/goose',                     // macOS Homebrew (Intel) / Linux
+    path.join(home, 'bin', 'goose'),
+  ];
+  for (const c of candidates) {
+    try { if (fs.existsSync(c)) return c; } catch {}
+  }
+
+  // Deep scan of every known bin dir (nvm/fnm/volta/homebrew/…).
+  const viaWhich = whichBinary('goose');
+  if (viaWhich) return viaWhich;
+  return null;
+}
+
+class GooseAdapter extends BaseAdapter {
+  /**
+   * @param {object} opts BaseAdapter opts plus { disabledModules, workingDir }
+   */
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+
+    // channel → Goose session name. Persisted so the mapping survives a daemon
+    // restart (Goose stores the conversation itself in its SQLite session DB).
+    this._channelSessions = {};
+    this._sessionsFile = path.join(
+      os.homedir(), '.openagents', 'sessions',
+      `${this.workspaceId}_${this.agentName}_goose.json`,
+    );
+    this._loadSessions();
+
+    this._channelProcesses = {};
+    this._stoppingChannels = new Set();
+
+    // One-time minimum-version pre-flight (cached for the adapter lifetime).
+    this._versionChecked = false;
+    this._versionTooOld = null;
+
+    this._gooseBinary = findGooseBinary();
+    if (this._gooseBinary) {
+      this._log(`Using Goose CLI: ${this._gooseBinary}`);
+    } else {
+      this._log('goose CLI not found. Install (non-interactively): '
+        + 'curl -fsSL '
+        + 'https://github.com/block/goose/releases/download/stable/download_cli.sh '
+        + '| CONFIGURE=false bash');
+    }
+
+    this._secrets = this._collectSecretValues();
+  }
+
+  // -- session mapping persistence ----------------------------------------
+
+  _loadSessions() {
+    try {
+      if (fs.existsSync(this._sessionsFile)) {
+        const data = JSON.parse(fs.readFileSync(this._sessionsFile, 'utf-8'));
+        if (data && typeof data === 'object') {
+          for (const [k, v] of Object.entries(data)) {
+            if (typeof v === 'string') this._channelSessions[k] = v;
+          }
+          this._log(`Loaded ${Object.keys(this._channelSessions).length} Goose session mapping(s)`);
+        }
+      }
+    } catch {
+      this._log('Could not load Goose sessions file, starting fresh');
+    }
+  }
+
+  _saveSessions() {
+    try {
+      fs.mkdirSync(path.dirname(this._sessionsFile), { recursive: true });
+      fs.writeFileSync(this._sessionsFile, JSON.stringify(this._channelSessions));
+    } catch {}
+  }
+
+  // -- environment / provider config --------------------------------------
+
+  _collectSecretValues() {
+    const env = this.agentEnv || process.env;
+    const secrets = [];
+    for (const [key, val] of Object.entries(env)) {
+      if (!val || typeof val !== 'string' || val.length < 4) continue;
+      const upper = key.toUpperCase();
+      if (upper.includes('API_KEY') || upper.includes('TOKEN') || upper.includes('SECRET')) {
+        secrets.push(val);
+      }
+    }
+    return secrets;
+  }
+
+  _buildEnv() {
+    const env = { ...(this.agentEnv || process.env) };
+    const mode = String(env.GOOSE_MODE || '').trim().toLowerCase();
+    if (mode === 'auto' || mode === 'chat') {
+      env.GOOSE_MODE = mode;
+    } else {
+      if (mode === 'approve' || mode === 'smart_approve') {
+        this._log(`GOOSE_MODE=${mode} waits for interactive approval and cannot run `
+          + "headless; overriding to 'auto' for this agent.");
+      }
+      env.GOOSE_MODE = 'auto';
+    }
+    return env;
+  }
+
+  _maxTurns() {
+    const env = this.agentEnv || process.env;
+    const n = parseInt(env.GOOSE_MAX_TURNS, 10);
+    return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_TURNS;
+  }
+
+  _maxToolRepetitions() {
+    const env = this.agentEnv || process.env;
+    const n = parseInt(env.GOOSE_MAX_TOOL_REPETITIONS, 10);
+    return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_TOOL_REPETITIONS;
+  }
+
+  _inactivityTimeout() {
+    const env = this.agentEnv || process.env;
+    const n = parseFloat(env.GOOSE_INACTIVITY_TIMEOUT);
+    return Number.isFinite(n) && n >= 30 ? n : DEFAULT_INACTIVITY_TIMEOUT;
+  }
+
+  _buildSystemPrompt(channelName) {
+    let prompt = buildWorkspaceIdentity(this.agentName, this.workspaceId, channelName, this._mode)
+      + buildCollaborationPrompt()
+      + buildModePrompt(this._mode);
+    if (this.workingDir) {
+      prompt += `\n## Project Directory\nYou are working in: ${this.workingDir}\n`
+        + 'Make all file changes within this directory.\n';
+    }
+    return prompt;
+  }
+
+  _resolveCwd() {
+    if (!this.workingDir) return defaultAgentWorkdir(this.agentName);
+    let stat;
+    try {
+      stat = fs.statSync(this.workingDir);
+    } catch {
+      throw new Error(`Project directory does not exist: ${this.workingDir}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`Project path is not a directory: ${this.workingDir}`);
+    }
+    return this.workingDir;
+  }
+
+  _safe(text) {
+    return redactSecrets(text, this._secrets);
+  }
+
+  // -- control actions (stop) ---------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      const channel = (payload && typeof payload === 'object') ? payload.channel : null;
+      if (channel) {
+        await this._stopChannel(channel, 'Execution stopped by user.');
+      } else {
+        await this._stopAll('Execution stopped by user.');
+      }
+      return;
+    }
+    await super._onControlAction(action, payload);
+  }
+
+  async _stopChannel(channel, message) {
+    const proc = this._channelProcesses[channel];
+    const hadQueue = !!(this._channelQueues[channel] && this._channelQueues[channel].length);
+    if (proc) {
+      this._stoppingChannels.add(channel);
+      await this._stopProcess(proc);
+      delete this._channelProcesses[channel];
+    }
+    delete this._channelQueues[channel];
+    if (proc || hadQueue) {
+      try { await this.sendStatus(channel, message); } catch {}
+    }
+  }
+
+  async _stopAll(message) {
+    for (const channel of Object.keys(this._channelProcesses)) {
+      // eslint-disable-next-line no-await-in-loop
+      await this._stopChannel(channel, message);
+    }
+  }
+
+  /** Override BaseAdapter.stop so daemon shutdown tears down in-flight runs. */
+  stop() {
+    this._stopAll('Task interrupted — daemon restarting. Send another message to continue.')
+      .catch(() => {});
+    super.stop();
+  }
+
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { proc.kill('SIGINT'); } catch {}
+        const exited = await new Promise((resolve) => {
+          if (proc.exitCode !== null) { resolve(true); return; }
+          const timeout = setTimeout(() => resolve(false), 1500);
+          proc.once('exit', () => { clearTimeout(timeout); resolve(true); });
+        });
+        if (!exited) {
+          try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000 }); } catch {}
+        }
+      } else {
+        // Kill the whole process group (Goose's shell commands, dev servers and
+        // any MCP/extension children share it — we spawn detached).
+        try { process.kill(-proc.pid, 'SIGTERM'); } catch {
+          proc.kill('SIGTERM');
+        }
+        await new Promise((resolve) => {
+          let done = false;
+          const finish = () => { if (!done) { done = true; resolve(); } };
+          const timeout = setTimeout(() => {
+            try { process.kill(-proc.pid, 'SIGKILL'); } catch {
+              proc.kill('SIGKILL');
+            }
+            const reap = setTimeout(finish, 1000);
+            proc.once('exit', () => { clearTimeout(reap); finish(); });
+          }, 1500);
+          proc.once('exit', () => { clearTimeout(timeout); finish(); });
+        });
+      }
+    } catch {}
+  }
+
+  // -- message handler ----------------------------------------------------
+
+  async _handleMessage(msg) {
+    const content = (msg.content || '').trim();
+    if (!content) return;
+
+    const msgChannel = msg.sessionId || this.channelName;
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${msgChannel}: ${content.slice(0, 80)}...`);
+
+    await this._autoTitleChannel(msgChannel, content);
+    await this.sendStatus(msgChannel, 'thinking...');
+
+    try {
+      // null → stopped or a failure already reported; '' → empty success; str → answer.
+      const result = await this._runGoose(content, msgChannel);
+      if (result === null) return;
+      if (result) {
+        await this.sendResponse(msgChannel, result);
+      } else {
+        await this.sendResponse(
+          msgChannel,
+          'Goose ran but produced no response. This usually means no provider/model is '
+          + 'configured — set GOOSE_PROVIDER and GOOSE_MODEL (and a key) for this agent, '
+          + 'or run `goose configure` once outside OpenAgents.',
+        );
+      }
+    } catch (e) {
+      if (this._stoppingChannels.has(msgChannel)) {
+        this._stoppingChannels.delete(msgChannel);
+        return;
+      }
+      this._log(`Error handling message: ${e.message}`);
+      await this.sendError(msgChannel, `Error processing message: ${this._safe(e.message)}`);
+    } finally {
+      this._stoppingChannels.delete(msgChannel);
+    }
+  }
+
+  // -- subprocess execution ----------------------------------------------
+
+  _buildCmd(sessionName, resume, systemPrompt) {
+    const binary = this._gooseBinary || findGooseBinary();
+    if (!binary) {
+      throw new Error('goose CLI not found. Install (non-interactively): '
+        + 'curl -fsSL '
+        + 'https://github.com/block/goose/releases/download/stable/download_cli.sh '
+        + '| CONFIGURE=false bash');
+    }
+    this._gooseBinary = binary;
+    const cmd = [
+      binary, 'run',
+      '--output-format', 'stream-json',
+      '--name', sessionName,
+      '--no-profile',
+      '--with-builtin', 'developer',
+      '--max-turns', String(this._maxTurns()),
+      '--max-tool-repetitions', String(this._maxToolRepetitions()),
+    ];
+    if (resume) cmd.push('--resume');
+    cmd.push('--system', systemPrompt, '-i', '-');
+    return cmd;
+  }
+
+  /**
+   * Run one headless `goose run`. Resolves null (stopped/failure already
+   * reported), '' (empty success), or the answer text.
+   */
+  /**
+   * Check the installed Goose CLI meets MIN_GOOSE_VERSION once (cached).
+   * Returns an upgrade-prompt string if it is definitively too old, else null
+   * (new enough, missing, or undeterminable — lenient).
+   */
+  _versionTooOldMessage() {
+    if (this._versionChecked) return this._versionTooOld;
+    this._versionChecked = true;
+    this._versionTooOld = null;
+    const binary = this._gooseBinary || findGooseBinary();
+    if (!binary) return null;
+    let parsed = null;
+    try {
+      const out = execFileSync(binary, ['--version'], {
+        encoding: 'utf-8', timeout: 10000, windowsHide: true,
+      });
+      parsed = parseGooseVersion(out);
+    } catch {
+      return null; // can't determine → don't block
+    }
+    if (!gooseVersionMeetsMinimum(parsed)) this._versionTooOld = tooOldMessage(parsed);
+    return this._versionTooOld;
+  }
+
+  _runGoose(content, channel, retry = false) {
+    let cwd;
+    try {
+      cwd = this._resolveCwd();
+    } catch (e) {
+      return this.sendError(channel, e.message).then(() => null, () => null);
+    }
+
+    // Refuse a Goose CLI older than the verified-stable minimum.
+    const tooOld = this._versionTooOldMessage();
+    if (tooOld) return this.sendError(channel, tooOld).then(() => null, () => null);
+
+    const sessionName = this._channelSessions[channel]
+      || gooseSessionName(this.workspaceId, this.agentName, channel);
+    const resume = Object.prototype.hasOwnProperty.call(this._channelSessions, channel);
+    const systemPrompt = this._buildSystemPrompt(channel);
+
+    let cmd;
+    try {
+      cmd = this._buildCmd(sessionName, resume, systemPrompt);
+    } catch (e) {
+      return this.sendError(channel, e.message).then(() => null, () => null);
+    }
+
+    const env = this._buildEnv();
+    const parser = new GooseStreamParser();
+    const captured = { finalText: null };
+    let stderr = '';
+    let lastActivity = Date.now();
+
+    this._log(`CLI: goose run --output-format stream-json --name ${sessionName}`
+      + `${resume ? ' --resume' : ''} --no-profile --with-builtin developer`);
+
+    return new Promise((resolve) => {
+      let proc;
+      try {
+        proc = spawn(cmd[0], cmd.slice(1), {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+          cwd,
+          detached: !IS_WINDOWS, // own process group for tree kill
+          windowsHide: true,
+        });
+      } catch (e) {
+        this.sendError(channel, `Failed to start Goose: ${this._safe(e.message)}`)
+          .then(() => resolve(null), () => resolve(null));
+        return;
+      }
+
+      this._channelProcesses[channel] = proc;
+
+      let settled = false;
+      let pending = Promise.resolve();
+      const dispatch = (ev) => {
+        pending = pending.then(() => this._dispatchEvent(channel, ev, captured)).catch(() => {});
+      };
+
+      // Inactivity watchdog: kill a truly hung run (no output for a long time).
+      const timeoutSec = this._inactivityTimeout();
+      const watchdog = setInterval(() => {
+        if (proc.exitCode !== null) return;
+        if ((Date.now() - lastActivity) / 1000 > timeoutSec) {
+          this._log(`Goose produced no output for ${timeoutSec}s — treating as hung, killing.`);
+          this._stoppingChannels.add(channel);
+          this._stopProcess(proc).catch(() => {});
+          this.sendError(
+            channel,
+            'Goose appears to have hung (no output for a long time) and was stopped. '
+            + 'Try a smaller task or check the provider.',
+          ).catch(() => {});
+        }
+      }, Math.min(30000, timeoutSec * 1000));
+
+      if (proc.stdout) {
+        proc.stdout.on('data', (chunk) => {
+          lastActivity = Date.now();
+          for (const ev of parser.feed(chunk.toString('utf-8'))) dispatch(ev);
+        });
+      }
+      if (proc.stderr) {
+        proc.stderr.on('data', (chunk) => {
+          lastActivity = Date.now();
+          if (stderr.length < STDERR_CAP) stderr += chunk.toString('utf-8');
+        });
+      }
+
+      // Write the prompt via stdin, then close it. Goose reads stdin to EOF
+      // before processing, so writing+closing here is required and safe.
+      if (proc.stdin) {
+        proc.stdin.on('error', () => {});
+        try {
+          proc.stdin.write(content, 'utf-8');
+          proc.stdin.end();
+        } catch { /* child gone — close handler reports it */ }
+      }
+
+      proc.on('error', (err) => {
+        if (settled) return;
+        settled = true;
+        clearInterval(watchdog);
+        if (this._channelProcesses[channel] === proc) delete this._channelProcesses[channel];
+        this.sendError(channel, `Failed to run Goose: ${this._safe(err.message)}`)
+          .then(() => resolve(null), () => resolve(null));
+      });
+
+      // 'close' fires after stdout/stderr drain — never parse a truncated stream.
+      proc.on('close', async (code) => {
+        if (settled) return;
+        settled = true;
+        clearInterval(watchdog);
+        if (this._channelProcesses[channel] === proc) delete this._channelProcesses[channel];
+
+        for (const ev of parser.finish()) dispatch(ev);
+        await pending;
+
+        if (this._stoppingChannels.has(channel)) {
+          resolve(null);
+          return;
+        }
+
+        const stderrText = stderr.trim();
+
+        // Auto-heal a stale/missing session (Goose exits non-zero when --resume
+        // names a session it can't find). Recreate once.
+        if (resume && code && !retry && stderrText.toLowerCase().includes('no session found')) {
+          this._log(`Goose session ${sessionName} missing; creating a fresh one.`);
+          delete this._channelSessions[channel];
+          this._saveSessions();
+          await this.sendStatus(
+            channel,
+            'Previous Goose session was unavailable — starting a new one (earlier context is reset).',
+          );
+          resolve(await this._runGoose(content, channel, true));
+          return;
+        }
+
+        // Failure: non-zero exit OR an error event (Goose can exit 0 after an
+        // agent error). A non-zero exit is never a success, even with partial text.
+        if (code !== 0 || parser.hadError) {
+          const detail = parser.errorMessage || stderrText;
+          const message = classifyGooseError(detail)
+            || (detail ? this._safe(detail).slice(0, 500) : `Goose exited with code ${code}.`);
+          await this.sendError(channel, this._safe(message));
+          resolve(null);
+          return;
+        }
+
+        if (!Object.prototype.hasOwnProperty.call(this._channelSessions, channel)) {
+          this._channelSessions[channel] = sessionName;
+          this._saveSessions();
+        }
+        resolve(captured.finalText || '');
+      });
+    });
+  }
+
+  async _dispatchEvent(channel, event, captured) {
+    const kind = event.kind;
+    if (kind === 'final') {
+      captured.finalText = event.text || '';
+      return;
+    }
+    if (kind === 'tool') {
+      const name = event.name || 'tool';
+      const summary = this._safe(event.summary || '');
+      await this.sendStatus(channel, `🔧 ${name}${summary ? ` — ${summary}` : ''}`);
+    } else if (kind === 'progress') {
+      // Intermediate assistant narration is assistant output, not internal
+      // reasoning — post it as transient status, never as a "thinking" message.
+      let text = this._safe(event.text || '').trim();
+      if (text) {
+        if (text.length > STATUS_PREVIEW) text = text.slice(0, STATUS_PREVIEW) + '…';
+        await this.sendStatus(channel, text);
+      }
+    } else if (kind === 'thinking') {
+      // Genuine model thinking content (ThinkingContent) — legitimately a
+      // thinking message.
+      let text = this._safe(event.text || '').trim();
+      if (text) {
+        if (text.length > STATUS_PREVIEW) text = text.slice(0, STATUS_PREVIEW) + '…';
+        await this.sendThinking(channel, text);
+      }
+    } else if (kind === 'notification') {
+      const text = this._safe(event.text || '').trim();
+      if (text) await this.sendStatus(channel, text.slice(0, STATUS_PREVIEW));
+    }
+    // tool_result / complete / error → no direct status (error handled by caller)
+  }
+}
+
+GooseAdapter.gooseSessionName = gooseSessionName;
+GooseAdapter.findGooseBinary = findGooseBinary;
+GooseAdapter.parseGooseVersion = parseGooseVersion;
+GooseAdapter.gooseVersionMeetsMinimum = gooseVersionMeetsMinimum;
+GooseAdapter.MIN_GOOSE_VERSION = MIN_GOOSE_VERSION;
+
+module.exports = GooseAdapter;

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -14,6 +14,7 @@ const CursorAdapter = require('./cursor');
 const HermesAdapter = require('./hermes');
 const GeminiAdapter = require('./gemini');
 const KimiAdapter = require('./kimi');
+const GooseAdapter = require('./goose');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -25,6 +26,7 @@ const ADAPTER_MAP = {
   hermes: HermesAdapter,
   gemini: GeminiAdapter,
   kimi: KimiAdapter,
+  goose: GooseAdapter,
 };
 
 /**
@@ -52,6 +54,7 @@ module.exports = {
   HermesAdapter,
   GeminiAdapter,
   KimiAdapter,
+  GooseAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/test/goose.test.js
+++ b/packages/agent-connector/test/goose.test.js
@@ -1,0 +1,508 @@
+'use strict';
+
+/**
+ * Tests for the Goose adapter and its stream-json parser. No real goose binary
+ * and no model credits: a fake `goose` Node script emits stream-json, and the
+ * parser is tested as a pure unit. Mirrors tests/agents/test_goose_stream.py
+ * and tests/agents/test_goose_adapter.py.
+ *
+ * Run: node --test test/goose.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const { GooseStreamParser, classifyGooseError, redactSecrets } = require('../src/adapters/goose-stream');
+const GooseAdapter = require('../src/adapters/goose');
+const { ADAPTER_MAP } = require('../src/adapters/index');
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+function isPidAlive(pid) { try { process.kill(pid, 0); return true; } catch { return false; } }
+
+function msg(role, content) {
+  return JSON.stringify({ type: 'message', message: { role, created: 1, content } });
+}
+function feedAll(p, ...lines) {
+  const out = [];
+  for (const l of lines) out.push(...p.feed(l + '\n'));
+  out.push(...p.finish());
+  return out;
+}
+function kinds(events) { return events.map((e) => e.kind); }
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+describe('GooseStreamParser', () => {
+  it('emits the final assistant text once on complete', () => {
+    const p = new GooseStreamParser();
+    const events = feedAll(p,
+      msg('assistant', [{ type: 'text', text: 'Hello world' }]),
+      JSON.stringify({ type: 'complete', total_tokens: 10 }));
+    assert.equal(p.finalText, 'Hello world');
+    assert.equal(kinds(events).filter((k) => k === 'final').length, 1);
+    assert.equal(p.hadError, false);
+  });
+
+  it('maps tool requests and results', () => {
+    const p = new GooseStreamParser();
+    const events = feedAll(p,
+      msg('assistant', [{ type: 'toolRequest', id: 't1', toolCall: { status: 'success', value: { name: 'developer__shell', arguments: { command: 'ls -la' } } } }]),
+      msg('user', [{ type: 'toolResponse', id: 't1', toolResult: { status: 'success', value: [] } }]),
+      msg('assistant', [{ type: 'text', text: 'done' }]),
+      JSON.stringify({ type: 'complete' }));
+    const tool = events.find((e) => e.kind === 'tool');
+    assert.equal(tool.name, 'developer__shell');
+    assert.equal(tool.summary, 'ls -la');
+    assert.ok(events.some((e) => e.kind === 'tool_result' && e.ok));
+    assert.equal(p.finalText, 'done');
+  });
+
+  it('surfaces intermediate assistant text as progress (not thinking), last as final', () => {
+    const p = new GooseStreamParser();
+    const events = feedAll(p,
+      msg('assistant', [{ type: 'text', text: 'step 1' }]),
+      msg('assistant', [{ type: 'text', text: 'final answer' }]),
+      JSON.stringify({ type: 'complete' }));
+    assert.ok(events.some((e) => e.kind === 'progress' && e.text === 'step 1'));
+    assert.ok(!events.some((e) => e.kind === 'thinking')); // interim text never mislabeled
+    assert.equal(p.finalText, 'final answer');
+    assert.equal(kinds(events).filter((k) => k === 'final').length, 1);
+  });
+
+  it('keeps genuine thinking content distinct from interim progress', () => {
+    const p = new GooseStreamParser();
+    const events = feedAll(p,
+      msg('assistant', [{ type: 'text', text: 'interim narration' }]),
+      msg('assistant', [{ type: 'thinking', thinking: 'real chain of thought', signature: 's' }, { type: 'text', text: 'answer' }]),
+      JSON.stringify({ type: 'complete' }));
+    assert.ok(events.some((e) => e.kind === 'progress' && e.text.includes('interim')));
+    assert.ok(events.some((e) => e.kind === 'thinking' && e.text.includes('real chain')));
+    assert.equal(p.finalText, 'answer');
+  });
+
+  it('parses the canonical v1.37.0 stream-json sequence', () => {
+    // Derived from the verified serde defs in block/goose v1.37.0 (StreamEvent /
+    // MessageContent / tool_result_serde) — identical to tests/agents STABLE_V137_STREAM.
+    const STABLE = [
+      '{"type":"message","message":{"role":"assistant","created":1718000000,"content":'
+      + '[{"type":"text","text":"I\'ll check the files."},'
+      + '{"type":"toolRequest","id":"req_1","toolCall":{"status":"success","value":'
+      + '{"name":"developer__shell","arguments":{"command":"ls"}}}}]}}',
+      '{"type":"message","message":{"role":"user","created":1718000001,"content":'
+      + '[{"type":"toolResponse","id":"req_1","toolResult":{"status":"success","value":'
+      + '[{"type":"text","text":"README.md\\nsrc"}]}}]}}',
+      '{"type":"message","message":{"role":"assistant","created":1718000002,"content":'
+      + '[{"type":"text","text":"There are 2 entries: README.md and src."}]}}',
+      '{"type":"complete","total_tokens":1234,"input_tokens":1000,"output_tokens":234}',
+    ];
+    const p = new GooseStreamParser();
+    const events = feedAll(p, ...STABLE);
+    assert.ok(events.some((e) => e.kind === 'progress' && e.text.includes('check the files')));
+    assert.ok(!events.some((e) => e.kind === 'thinking'));
+    const tool = events.find((e) => e.kind === 'tool');
+    assert.equal(tool.name, 'developer__shell');
+    assert.equal(tool.summary, 'ls');
+    assert.ok(events.some((e) => e.kind === 'tool_result' && e.ok));
+    assert.equal(p.finalText, 'There are 2 entries: README.md and src.');
+    assert.equal(kinds(events).filter((k) => k === 'final').length, 1);
+    assert.ok(events.some((e) => e.kind === 'complete' && e.tokens === 1234));
+    assert.equal(p.hadError, false);
+  });
+
+  it('handles JSON split across chunks', () => {
+    const p = new GooseStreamParser();
+    const line = msg('assistant', [{ type: 'text', text: 'chunked' }]);
+    const events = [];
+    events.push(...p.feed(line.slice(0, 12)));
+    events.push(...p.feed(line.slice(12) + '\n'));
+    events.push(...p.feed(JSON.stringify({ type: 'complete' }) + '\n'));
+    events.push(...p.finish());
+    assert.equal(p.finalText, 'chunked');
+  });
+
+  it('ignores blank, invalid, and unknown lines without crashing', () => {
+    const p = new GooseStreamParser();
+    const events = [];
+    events.push(...p.feed('\n'));
+    events.push(...p.feed('not json\n'));
+    events.push(...p.feed('{ broken\n'));
+    events.push(...p.feed(JSON.stringify({ type: 'brand_new_event', x: 1 }) + '\n'));
+    events.push(...p.feed(msg('assistant', [{ type: 'text', text: 'ok' }]) + '\n'));
+    events.push(...p.finish());
+    assert.equal(p.finalText, 'ok');
+    assert.equal(p.hadError, false);
+  });
+
+  it('treats an error event as failure and suppresses final', () => {
+    const p = new GooseStreamParser();
+    const events = [];
+    events.push(...p.feed(msg('assistant', [{ type: 'text', text: 'partial' }]) + '\n'));
+    events.push(...p.feed(JSON.stringify({ type: 'error', error: '401 Unauthorized' }) + '\n'));
+    events.push(...p.feed(JSON.stringify({ type: 'complete' }) + '\n'));
+    events.push(...p.finish());
+    assert.equal(p.hadError, true);
+    assert.equal(kinds(events).filter((k) => k === 'final').length, 0);
+  });
+
+  it('emits final on EOF when complete is missing', () => {
+    const p = new GooseStreamParser();
+    const events = feedAll(p, msg('assistant', [{ type: 'text', text: 'partial' }]));
+    assert.ok(events.some((e) => e.kind === 'final' && e.text === 'partial'));
+  });
+
+  it('surfaces notification progress messages', () => {
+    const p = new GooseStreamParser();
+    const events = feedAll(p, JSON.stringify({
+      type: 'notification', extension_id: 'developer', progress: { progress: 0.5, total: 1, message: 'halfway' },
+    }));
+    assert.ok(events.some((e) => e.kind === 'notification' && e.text === 'halfway'));
+  });
+
+  it('does not blow up on very large output', () => {
+    const p = new GooseStreamParser();
+    const big = 'x'.repeat(200000);
+    feedAll(p, msg('assistant', [{ type: 'text', text: big }]), JSON.stringify({ type: 'complete' }));
+    assert.equal(p.finalText, big);
+  });
+});
+
+describe('classifyGooseError', () => {
+  const cases = [
+    ['Error: 401 Unauthorized invalid api key', 'authentication'],
+    ['429 too many requests', 'rate limit'],
+    ['model gpt-x does not exist', 'model'],
+    ['no provider configured', 'provider'],
+    ['tool execution denied: permission denied', 'denied'],
+    ['extension failed to start', 'extension'],
+    ['connection refused', 'reach the provider'],
+  ];
+  for (const [text, needle] of cases) {
+    it(`classifies: ${text.slice(0, 24)}`, () => {
+      const out = classifyGooseError(text);
+      assert.ok(out && out.toLowerCase().includes(needle));
+    });
+  }
+  it('returns null for empty', () => {
+    assert.equal(classifyGooseError(''), null);
+    assert.equal(classifyGooseError(null), null);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('masks explicit secrets and bearer/api keys', () => {
+    const out = redactSecrets('Authorization: Bearer sk-abc123def456 key=topsecret999', ['topsecret999']);
+    assert.ok(!out.includes('sk-abc123def456'));
+    assert.ok(!out.includes('topsecret999'));
+  });
+  it('leaves short strings alone', () => {
+    assert.equal(redactSecrets('hello world', ['ab']), 'hello world');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter: registry / session names / command / env
+// ---------------------------------------------------------------------------
+
+function makeAdapter(opts = {}) {
+  const base = {
+    workspaceId: 'ws1', channelName: 'general', token: 'tok',
+    agentName: 'agentA', endpoint: 'http://x', agentEnv: { PATH: process.env.PATH },
+  };
+  const a = new GooseAdapter({ ...base, ...opts });
+  a._gooseBinary = '/fake/goose'; // pretend goose exists
+  return a;
+}
+
+describe('Goose adapter map + session names', () => {
+  it('is registered in the adapter map', () => {
+    assert.ok(ADAPTER_MAP.goose === GooseAdapter);
+  });
+  it('session name is stable and isolated', () => {
+    const { gooseSessionName } = GooseAdapter;
+    assert.equal(gooseSessionName('w', 'a', 'c'), gooseSessionName('w', 'a', 'c'));
+    assert.notEqual(gooseSessionName('w', 'a', 'c'), gooseSessionName('w', 'a', 'c2'));
+    assert.notEqual(gooseSessionName('w', 'a', 'c'), gooseSessionName('w', 'a2', 'c'));
+    assert.notEqual(gooseSessionName('w', 'a', 'c'), gooseSessionName('w2', 'a', 'c'));
+  });
+  it('session name is filesystem-safe and leaks nothing', () => {
+    const name = GooseAdapter.gooseSessionName('ws/../x', 'a b', '../../etc/passwd');
+    assert.ok(/^oa_[a-f0-9]{16}$/.test(name));
+  });
+});
+
+describe('Goose minimum version', () => {
+  it('minimum is the verified stable tag 1.37.0', () => {
+    assert.deepEqual(GooseAdapter.MIN_GOOSE_VERSION, [1, 37, 0]);
+  });
+  it('parses goose --version output', () => {
+    assert.deepEqual(GooseAdapter.parseGooseVersion('goose 1.37.0'), [1, 37, 0]);
+    assert.deepEqual(GooseAdapter.parseGooseVersion('goose-cli 1.40.2 (abc)'), [1, 40, 2]);
+    assert.equal(GooseAdapter.parseGooseVersion('no version'), null);
+  });
+  it('compares against the minimum (lenient on unknown)', () => {
+    assert.equal(GooseAdapter.gooseVersionMeetsMinimum([1, 37, 0]), true);
+    assert.equal(GooseAdapter.gooseVersionMeetsMinimum([2, 0, 0]), true);
+    assert.equal(GooseAdapter.gooseVersionMeetsMinimum([1, 36, 9]), false);
+    assert.equal(GooseAdapter.gooseVersionMeetsMinimum(null), true);
+  });
+
+  it('blocks a too-old CLI with an upgrade prompt and never runs the task', async () => {
+    if (process.platform === 'win32') return; // shell-script fake is POSIX-only
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-'));
+    const proj = path.join(tmp, 'proj'); fs.mkdirSync(proj);
+    // A real executable that reports an ancient version.
+    const verBin = path.join(tmp, 'old-goose.sh');
+    fs.writeFileSync(verBin, '#!/bin/sh\necho "goose 1.10.0"\n');
+    fs.chmodSync(verBin, 0o755);
+    const a = makeAdapter({ workingDir: proj, agentEnv: { PATH: process.env.PATH } });
+    a._gooseBinary = verBin; // version check runs this
+    a._sessionsFile = path.join(tmp, 'sessions.json');
+    let ran = false;
+    a._buildCmd = () => { ran = true; return [process.execPath, '-e', '0']; };
+    const sent = instrument(a);
+
+    await a._handleMessage({ content: 'hi', sessionId: 'general' });
+
+    assert.equal(ran, false); // task never built/spawned
+    assert.equal(sent.response.length, 0);
+    assert.equal(sent.error.length, 1);
+    assert.ok(sent.error[0].includes('>= 1.37.0') && /too old/i.test(sent.error[0]));
+  });
+});
+
+describe('Goose command building', () => {
+  it('builds a new-session command with stream-json + stdin', () => {
+    const a = makeAdapter();
+    const name = GooseAdapter.gooseSessionName('ws1', 'agentA', 'general');
+    const cmd = a._buildCmd(name, false, 'SYS');
+    assert.equal(cmd[0], '/fake/goose');
+    assert.equal(cmd[1], 'run');
+    assert.equal(cmd[cmd.indexOf('--output-format') + 1], 'stream-json');
+    assert.equal(cmd[cmd.indexOf('--name') + 1], name);
+    assert.ok(cmd.includes('--no-profile'));
+    assert.equal(cmd[cmd.indexOf('--with-builtin') + 1], 'developer');
+    assert.ok(!cmd.includes('--resume'));
+    assert.deepEqual(cmd.slice(-2), ['-i', '-']);
+    assert.ok(cmd.includes('--max-turns'));
+    assert.ok(cmd.includes('--max-tool-repetitions'));
+  });
+
+  it('adds --resume when resuming', () => {
+    const a = makeAdapter();
+    const cmd = a._buildCmd('oa_x', true, 'SYS');
+    assert.ok(cmd.includes('--resume'));
+  });
+
+  it('never puts the key or prompt in argv', () => {
+    const a = makeAdapter({ agentEnv: { PATH: process.env.PATH, GOOSE_PROVIDER__API_KEY: 'sk-zzz-secret' } });
+    const cmd = a._buildCmd('oa_x', false, 'SYS');
+    assert.ok(cmd.every((p) => !String(p).includes('sk-zzz-secret')));
+  });
+});
+
+describe('Goose env / provider', () => {
+  it('defaults GOOSE_MODE to auto and coerces blocking modes', () => {
+    assert.equal(makeAdapter({ agentEnv: { PATH: '' } })._buildEnv().GOOSE_MODE, 'auto');
+    assert.equal(makeAdapter({ agentEnv: { PATH: '', GOOSE_MODE: 'smart_approve' } })._buildEnv().GOOSE_MODE, 'auto');
+    assert.equal(makeAdapter({ agentEnv: { PATH: '', GOOSE_MODE: 'approve' } })._buildEnv().GOOSE_MODE, 'auto');
+    assert.equal(makeAdapter({ agentEnv: { PATH: '', GOOSE_MODE: 'chat' } })._buildEnv().GOOSE_MODE, 'chat');
+  });
+
+  it('passes provider/model/key/host through and keeps existing env', () => {
+    const a = makeAdapter({ agentEnv: {
+      PATH: '', GOOSE_PROVIDER: 'openai', GOOSE_MODEL: 'gpt-4o',
+      GOOSE_PROVIDER__API_KEY: 'sk-secret', GOOSE_PROVIDER__HOST: 'https://proxy/v1',
+      OPENAI_API_KEY: 'existing',
+    } });
+    const env = a._buildEnv();
+    assert.equal(env.GOOSE_PROVIDER, 'openai');
+    assert.equal(env.GOOSE_MODEL, 'gpt-4o');
+    assert.equal(env.GOOSE_PROVIDER__API_KEY, 'sk-secret');
+    assert.equal(env.GOOSE_PROVIDER__HOST, 'https://proxy/v1');
+    assert.equal(env.OPENAI_API_KEY, 'existing'); // not cleared
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Process-tree termination (stop) — real subprocess that spawns a child
+// ---------------------------------------------------------------------------
+
+function readFirstLine(stream) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    const t = setTimeout(() => reject(new Error('timed out reading pid')), 3000);
+    stream.on('data', (c) => {
+      buf += c.toString('utf-8');
+      const i = buf.indexOf('\n');
+      if (i >= 0) { clearTimeout(t); resolve(buf.slice(0, i).trim()); }
+    });
+  });
+}
+
+describe('Goose stop terminates the process tree', () => {
+  it('kills the spawned process and its children', async () => {
+    const a = makeAdapter();
+    const script = [
+      "const { spawn } = require('node:child_process');",
+      "const child = spawn(process.execPath, ['-e', 'setInterval(()=>{},1000)'], { stdio:'ignore' });",
+      'console.log(child.pid);',
+      'setInterval(()=>{}, 1000);',
+    ].join('\n');
+    const proc = spawn(process.execPath, ['-e', script], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      detached: process.platform !== 'win32',
+      windowsHide: true,
+    });
+    try {
+      const childPid = Number(await readFirstLine(proc.stdout));
+      assert.equal(isPidAlive(proc.pid), true);
+      assert.equal(isPidAlive(childPid), true);
+      await a._stopProcess(proc);
+      await sleep(500);
+      assert.equal(isPidAlive(proc.pid), false);
+      assert.equal(isPidAlive(childPid), false); // tree termination
+    } finally {
+      await a._stopProcess(proc);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end run against a fake goose (Node script emitting stream-json)
+// ---------------------------------------------------------------------------
+
+function makeFakeGoose(dir, streamLines, { exitCode = 0, stderr = '' } = {}) {
+  const file = path.join(dir, 'fake-goose.js');
+  const body = `
+const chunks = [];
+process.stdin.on('data', (d) => chunks.push(d));
+process.stdin.on('end', () => {
+  for (const line of ${JSON.stringify(streamLines)}) process.stdout.write(line + '\\n');
+  if (${JSON.stringify(stderr)}) process.stderr.write(${JSON.stringify(stderr)} + '\\n');
+  process.exit(${exitCode});
+});
+`;
+  fs.writeFileSync(file, body);
+  // Return an argv-style wrapper: the adapter spawns cmd[0] with cmd.slice(1).
+  return file;
+}
+
+function instrument(a) {
+  const sent = { status: [], thinking: [], response: [], error: [] };
+  a.sendStatus = async (_ch, c) => { sent.status.push(c); };
+  a.sendThinking = async (_ch, c) => { sent.thinking.push(c); };
+  a.sendResponse = async (_ch, c) => { sent.response.push(c); };
+  a.sendError = async (_ch, c) => { sent.error.push(c); };
+  a._autoTitleChannel = async () => {};
+  return sent;
+}
+
+describe('Goose end-to-end (fake binary)', () => {
+  it('runs a successful turn, posts final once, records the session', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-'));
+    const proj = path.join(tmp, 'proj'); fs.mkdirSync(proj);
+    const lines = [
+      msg('assistant', [{ type: 'toolRequest', id: 't1', toolCall: { status: 'success', value: { name: 'developer__shell', arguments: { command: 'echo hi' } } } }]),
+      msg('assistant', [{ type: 'text', text: 'All done!' }]),
+      JSON.stringify({ type: 'complete', total_tokens: 7 }),
+    ];
+    const fake = makeFakeGoose(tmp, lines);
+    const a = makeAdapter({ workingDir: proj, agentEnv: { PATH: process.env.PATH } });
+    a._sessionsFile = path.join(tmp, 'sessions.json');
+    // Spawn `node fake-goose.js …` instead of a real goose binary.
+    a._buildCmd = (name, resume) => [process.execPath, fake, name, resume ? '--resume' : ''];
+    const sent = instrument(a);
+
+    await a._handleMessage({ content: 'do the thing', sessionId: 'general' });
+
+    assert.deepEqual(sent.response, ['All done!']);
+    assert.deepEqual(sent.error, []);
+    assert.ok(sent.status.some((s) => s.includes('developer__shell')));
+    assert.ok(Object.prototype.hasOwnProperty.call(a._channelSessions, 'general'));
+  });
+
+  it('treats a non-zero exit as failure even with partial stdout', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-'));
+    const proj = path.join(tmp, 'proj'); fs.mkdirSync(proj);
+    const lines = [msg('assistant', [{ type: 'text', text: 'partial' }])];
+    const fake = makeFakeGoose(tmp, lines, { exitCode: 1, stderr: 'Error: 401 Unauthorized invalid api key' });
+    const a = makeAdapter({ workingDir: proj, agentEnv: { PATH: process.env.PATH } });
+    a._sessionsFile = path.join(tmp, 'sessions.json');
+    a._buildCmd = () => [process.execPath, fake];
+    const sent = instrument(a);
+
+    await a._handleMessage({ content: 'hi', sessionId: 'general' });
+
+    assert.deepEqual(sent.response, []);
+    assert.equal(sent.error.length, 1);
+    assert.ok(sent.error[0].toLowerCase().includes('authentication'));
+    assert.ok(!Object.prototype.hasOwnProperty.call(a._channelSessions, 'general'));
+  });
+
+  it('second message resumes the same channel session', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-'));
+    const proj = path.join(tmp, 'proj'); fs.mkdirSync(proj);
+    const lines = [msg('assistant', [{ type: 'text', text: 'ok' }]), JSON.stringify({ type: 'complete' })];
+    const fake = makeFakeGoose(tmp, lines);
+    const a = makeAdapter({ workingDir: proj, agentEnv: { PATH: process.env.PATH } });
+    a._sessionsFile = path.join(tmp, 'sessions.json');
+    const seen = [];
+    a._buildCmd = (name, resume) => { seen.push({ name, resume }); return [process.execPath, fake]; };
+    instrument(a);
+
+    await a._handleMessage({ content: 'first', sessionId: 'general' });
+    await a._handleMessage({ content: 'second', sessionId: 'general' });
+
+    assert.equal(seen[0].resume, false);
+    assert.equal(seen[1].resume, true);
+    assert.equal(seen[0].name, seen[1].name);
+  });
+
+  it('auto-heals a missing session (resume fails → recreate)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-'));
+    const proj = path.join(tmp, 'proj'); fs.mkdirSync(proj);
+    // Fake goose: fail "No session found" when --resume is present, else succeed.
+    const fake = path.join(tmp, 'heal-goose.js');
+    const success = msg('assistant', [{ type: 'text', text: 'fresh' }]);
+    const complete = JSON.stringify({ type: 'complete' });
+    fs.writeFileSync(fake, `
+const chunks = [];
+process.stdin.on('data', (d) => chunks.push(d));
+process.stdin.on('end', () => {
+  if (process.argv.includes('--resume')) {
+    process.stderr.write("Error: No session found with name oa_x\\n");
+    process.exit(1);
+  }
+  process.stdout.write(${JSON.stringify(success)} + '\\n');
+  process.stdout.write(${JSON.stringify(complete)} + '\\n');
+  process.exit(0);
+});
+`);
+    const a = makeAdapter({ workingDir: proj, agentEnv: { PATH: process.env.PATH } });
+    a._sessionsFile = path.join(tmp, 'sessions.json');
+    a._channelSessions.general = GooseAdapter.gooseSessionName('ws1', 'agentA', 'general'); // stale
+    a._buildCmd = (name, resume) => [process.execPath, fake, ...(resume ? ['--resume'] : [])];
+    const sent = instrument(a);
+
+    await a._handleMessage({ content: 'hi', sessionId: 'general' });
+
+    assert.deepEqual(sent.response, ['fresh']);
+    assert.ok(sent.status.some((s) => /new one|reset/i.test(s)));
+    assert.deepEqual(sent.error, []);
+  });
+
+  it('reports an error for an invalid working directory', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-'));
+    const a = makeAdapter({ workingDir: path.join(tmp, 'missing'), agentEnv: { PATH: process.env.PATH } });
+    a._sessionsFile = path.join(tmp, 'sessions.json');
+    const sent = instrument(a);
+    await a._handleMessage({ content: 'hi', sessionId: 'general' });
+    assert.ok(sent.error.length === 1 && sent.error[0].includes('does not exist'));
+  });
+});

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -311,7 +311,7 @@ const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
  * an API key, so they're a rougher first-run experience than the key-only
  * agents; keep onboarding to the smoother options.
  */
-const ONBOARDING_HIDDEN = new Set<string>(["cursor", "hermes"])
+const ONBOARDING_HIDDEN = new Set<string>(["cursor", "hermes", "goose"])
 
 /**
  * The agents the launcher/workspace core officially supports today, in the
@@ -332,6 +332,12 @@ const CORE_AGENTS: readonly string[] = [
   "hermes",
   "kimi",
   "gemini",
+  // Goose is supported as a creatable Workspace agent but is BETA: the Headless
+  // stream-json integration is complete and unit-tested, real end-to-end runs
+  // are still pending. It's kept out of the first-run onboarding wizard via
+  // ONBOARDING_HIDDEN (like cursor/hermes) but is installable/creatable from the
+  // Install tab so it can be exercised. Marked Beta in its registry description.
+  "goose",
 ]
 const CORE_AGENT_ORDER = new Map<string, number>(
   CORE_AGENTS.map((name, i) => [name, i]),

--- a/sdk/src/openagents/adapters/goose.py
+++ b/sdk/src/openagents/adapters/goose.py
@@ -1,0 +1,756 @@
+"""
+Goose adapter for OpenAgents workspace.
+
+Bridges the Goose CLI (block/goose) to an OpenAgents workspace using Goose's
+official **headless** mode:
+
+    goose run --output-format stream-json --name <session> [--resume] \
+              --no-profile --with-builtin developer \
+              --max-turns N --max-tool-repetitions M --system <ctx> -i -
+
+- The task prompt is written to the child's **stdin** (`-i -`), never argv.
+- stdout is parsed incrementally as NDJSON ``stream-json`` (see
+  :mod:`openagents.adapters.goose_stream`); stderr is drained concurrently.
+- Each (workspace, agent, channel) maps to a **stable, unique** Goose session
+  name so conversations resume per-channel and never cross-talk.
+- Providers/models/keys/host come from native Goose env vars; the key is never
+  placed on the command line or in logs.
+- ``GOOSE_MODE=auto`` makes tools run without interactive approval (required for
+  headless); only the built-in ``developer`` extension is enabled by default.
+
+Verified against block/goose v1.38.0. See goose_stream.py for the exact event
+schema. Goose is currently marked **Beta** — real end-to-end runs are pending.
+"""
+
+import asyncio
+import hashlib
+import logging
+import os
+import platform
+import re
+import shutil
+import signal
+from pathlib import Path
+from typing import Optional
+
+from openagents.adapters.base import BaseAdapter
+from openagents.adapters.goose_stream import (
+    GooseStreamParser,
+    classify_goose_error,
+    redact_secrets,
+)
+from openagents.adapters.workspace_prompt import (
+    build_collaboration_prompt,
+    build_mode_prompt,
+    build_workspace_identity,
+)
+from openagents.workspace_client import DEFAULT_ENDPOINT
+
+logger = logging.getLogger(__name__)
+
+IS_WINDOWS = platform.system() == "Windows"
+
+# Backstop for a truly hung run: if Goose emits nothing on stdout *or* stderr for
+# this long while the process is alive, treat it as hung and kill it. Long but
+# legitimate tasks keep emitting tool/assistant events, so this distinguishes a
+# real hang from a long task. Override with GOOSE_INACTIVITY_TIMEOUT (seconds).
+_DEFAULT_INACTIVITY_TIMEOUT = 900
+# Bound runaway loops via Goose's own limits (preferred over a wall-clock cap).
+_DEFAULT_MAX_TURNS = 100
+_DEFAULT_MAX_TOOL_REPETITIONS = 12
+# Cap how much stderr we retain for error classification.
+_STDERR_CAP = 64 * 1024
+# Truncate noisy intermediate reasoning we surface as workspace status.
+_STATUS_PREVIEW = 280
+
+# Minimum Goose CLI version verified against the stable tag (block/goose v1.37.0):
+# every flag used here (`-i -`, `--output-format stream-json`, `--name`,
+# `--resume`, `--no-profile`, `--with-builtin`, `--max-turns`,
+# `--max-tool-repetitions`) and the stream-json event schema exist there. Older
+# releases may lack stream-json / these flags, so we refuse them with a clear
+# upgrade prompt rather than failing obscurely.
+MIN_GOOSE_VERSION = (1, 37, 0)
+
+
+def parse_goose_version(text: Optional[str]) -> Optional[tuple]:
+    """Parse ``goose --version`` output (e.g. ``"goose 1.37.0"``) → ``(1, 37, 0)``.
+
+    Returns ``None`` when no ``X.Y.Z`` can be found so callers can stay lenient
+    (an undeterminable version must not block a working setup).
+    """
+    if not text:
+        return None
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def goose_version_meets_minimum(parsed: Optional[tuple],
+                                minimum: tuple = MIN_GOOSE_VERSION) -> bool:
+    """True if ``parsed`` >= ``minimum`` (or unknown — lenient)."""
+    if parsed is None:
+        return True
+    return tuple(parsed) >= tuple(minimum)
+
+
+def _too_old_message(parsed: Optional[tuple]) -> str:
+    cur = ".".join(map(str, parsed)) if parsed else "unknown"
+    minv = ".".join(map(str, MIN_GOOSE_VERSION))
+    return (
+        f"Goose CLI {cur} is too old — OpenAgents requires Goose >= {minv} "
+        "(headless stream-json support). Upgrade it: curl -fsSL "
+        "https://github.com/block/goose/releases/download/stable/download_cli.sh "
+        "| CONFIGURE=false bash"
+    )
+
+
+def goose_session_name(workspace_id: str, agent_name: str, channel: str) -> str:
+    """Return a stable, unique, filesystem-safe Goose session name for a channel.
+
+    The name is a short SHA-256 of ``workspace_id|agent_name|channel`` so it:
+    - is unique per (workspace, agent, channel) — no cross-talk, no reuse;
+    - is stable across restarts (deterministic from the same inputs);
+    - leaks no raw token/workspace id/channel/user content;
+    - contains only ``[a-z0-9_]`` — no path traversal or shell metacharacters.
+    """
+    digest = hashlib.sha256(
+        f"{workspace_id}|{agent_name}|{channel}".encode("utf-8")
+    ).hexdigest()
+    return f"oa_{digest[:16]}"
+
+
+def find_goose_binary() -> Optional[str]:
+    """Locate the real ``goose`` CLI across platforms.
+
+    Uses the standard PATH lookup first, then well-known install locations that
+    the official installer uses but which may be absent from a GUI/daemon PATH:
+    ``~/.local/bin`` (Linux/macOS default), Homebrew, ``/usr/local/bin``, and on
+    Windows ``%USERPROFILE%\\goose`` plus ``.exe``. Does NOT validate that the
+    binary is the CLI vs. the Desktop app — call :func:`goose_cli_version` for
+    that (it runs ``goose --version``).
+    """
+    home = Path.home()
+    if IS_WINDOWS:
+        for name in ("goose.exe", "goose.cmd", "goose"):
+            found = shutil.which(name)
+            if found:
+                return found
+        candidates = [
+            home / "goose" / "goose.exe",
+            Path(os.environ.get("USERPROFILE", str(home))) / "goose" / "goose.exe",
+            home / ".local" / "bin" / "goose.exe",
+        ]
+    else:
+        found = shutil.which("goose")
+        if found:
+            return found
+        candidates = [
+            home / ".local" / "bin" / "goose",            # official installer default
+            Path("/opt/homebrew/bin/goose"),              # macOS Homebrew (Apple silicon)
+            Path("/usr/local/bin/goose"),                 # macOS Homebrew (Intel) / Linux
+            home / "bin" / "goose",
+        ]
+    for cand in candidates:
+        try:
+            if cand.is_file() and (IS_WINDOWS or os.access(cand, os.X_OK)):
+                return str(cand)
+        except OSError:
+            continue
+    return None
+
+
+class GooseAdapter(BaseAdapter):
+    """Connects the Goose CLI to an OpenAgents workspace via headless ``goose run``."""
+
+    def __init__(
+        self,
+        workspace_id: str,
+        channel_name: str,
+        token: str,
+        agent_name: str,
+        endpoint: str = DEFAULT_ENDPOINT,
+        disabled_modules: set | None = None,
+        working_dir: str | None = None,
+    ):
+        super().__init__(workspace_id, channel_name, token, agent_name, endpoint)
+        self.disabled_modules = disabled_modules or set()
+        self.working_dir = working_dir
+
+        # channel → Goose session name. Presence ⇒ a session has been created,
+        # so subsequent turns resume it. Persisted so the mapping survives an
+        # agent restart (Goose itself stores the conversation in its SQLite DB).
+        self._channel_sessions: dict[str, str] = {}
+        self._sessions_file = (
+            Path.home() / ".openagents" / "sessions"
+            / f"{workspace_id}_{agent_name}_goose.json"
+        )
+        self._load_sessions()
+
+        # Per-channel process tracking for stop / cleanup.
+        self._channel_processes: dict[str, asyncio.subprocess.Process] = {}
+        self._stopping_channels: set[str] = set()
+
+        # One-time minimum-version pre-flight (cached for the adapter lifetime).
+        self._version_checked = False
+        self._version_ok = True
+
+        self._goose_binary = find_goose_binary()
+        if self._goose_binary:
+            logger.info("Using Goose CLI: %s", self._goose_binary)
+        else:
+            logger.warning(
+                "goose CLI not found. Install it (non-interactively): "
+                "curl -fsSL "
+                "https://github.com/block/goose/releases/download/stable/download_cli.sh "
+                "| CONFIGURE=false bash"
+            )
+
+        # Collect secret values present in the environment so we can redact them
+        # from any stderr/error text before logging or posting to the workspace.
+        self._secrets = self._collect_secret_values()
+
+    # ------------------------------------------------------------------
+    # Session mapping persistence
+    # ------------------------------------------------------------------
+
+    def _load_sessions(self):
+        try:
+            if self._sessions_file.exists():
+                import json
+                data = json.loads(self._sessions_file.read_text())
+                if isinstance(data, dict):
+                    self._channel_sessions.update(
+                        {k: v for k, v in data.items() if isinstance(v, str)}
+                    )
+                    logger.info(
+                        "Loaded %d Goose session mapping(s) from %s",
+                        len(self._channel_sessions), self._sessions_file.name,
+                    )
+        except Exception:
+            logger.debug("Could not load Goose sessions file, starting fresh")
+
+    def _save_sessions(self):
+        try:
+            import json
+            self._sessions_file.parent.mkdir(parents=True, exist_ok=True)
+            self._sessions_file.write_text(json.dumps(self._channel_sessions))
+        except Exception:
+            logger.debug("Could not save Goose sessions file")
+
+    # ------------------------------------------------------------------
+    # Environment / provider configuration
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _collect_secret_values() -> list:
+        secrets = []
+        for key, val in os.environ.items():
+            if not val or len(val) < 4:
+                continue
+            upper = key.upper()
+            if ("API_KEY" in upper or "TOKEN" in upper or "SECRET" in upper
+                    or upper.endswith("__API_KEY")):
+                secrets.append(val)
+        return secrets
+
+    def _build_env(self) -> dict:
+        """Build the subprocess environment.
+
+        Provider/model/key/host are inherited from the parent environment
+        (the launcher sets GOOSE_PROVIDER, GOOSE_MODEL, GOOSE_PROVIDER__API_KEY,
+        GOOSE_PROVIDER__HOST from the agent's saved config). We do NOT clear any
+        existing provider env, so an unconfigured agent can still fall back to
+        the user's global Goose config/keyring. We only force a headless-safe
+        tool-permission mode, scoped to this child process.
+        """
+        env = dict(os.environ)
+        mode = (env.get("GOOSE_MODE") or "").strip().lower()
+        if mode in ("auto", "chat"):
+            env["GOOSE_MODE"] = mode
+        else:
+            if mode in ("approve", "smart_approve"):
+                logger.warning(
+                    "GOOSE_MODE=%s waits for interactive approval and cannot run "
+                    "headless; overriding to 'auto' for this agent.", mode,
+                )
+            env["GOOSE_MODE"] = "auto"
+        return env
+
+    def _max_turns(self) -> int:
+        try:
+            return max(1, int(os.environ.get("GOOSE_MAX_TURNS", _DEFAULT_MAX_TURNS)))
+        except (TypeError, ValueError):
+            return _DEFAULT_MAX_TURNS
+
+    def _max_tool_repetitions(self) -> int:
+        try:
+            return max(1, int(os.environ.get(
+                "GOOSE_MAX_TOOL_REPETITIONS", _DEFAULT_MAX_TOOL_REPETITIONS)))
+        except (TypeError, ValueError):
+            return _DEFAULT_MAX_TOOL_REPETITIONS
+
+    def _inactivity_timeout(self) -> float:
+        try:
+            return max(30.0, float(os.environ.get(
+                "GOOSE_INACTIVITY_TIMEOUT", _DEFAULT_INACTIVITY_TIMEOUT)))
+        except (TypeError, ValueError):
+            return float(_DEFAULT_INACTIVITY_TIMEOUT)
+
+    def _build_system_prompt(self, channel_name: str) -> str:
+        """Compact, stable system context passed via ``--system`` every turn.
+
+        It is a *system* prompt (replaced each run), not appended to the
+        conversation, so re-passing it on resume does not bloat context. No
+        workspace token is included.
+        """
+        parts = [
+            build_workspace_identity(
+                self.agent_name, self.workspace_id, channel_name, self._mode,
+            ),
+            build_collaboration_prompt(),
+            build_mode_prompt(self._mode),
+        ]
+        if self.working_dir:
+            parts.append(
+                f"\n## Project Directory\nYou are working in: {self.working_dir}\n"
+                "Make all file changes within this directory.\n"
+            )
+        return "".join(parts)
+
+    # ------------------------------------------------------------------
+    # Working directory validation
+    # ------------------------------------------------------------------
+
+    def _resolve_cwd(self) -> str:
+        """Return a validated project working directory, or raise.
+
+        Goose runs with this as its cwd — the only place its developer extension
+        should read/write. We validate it exists and is a directory before
+        spawning (Goose offers no path flag and no sandbox).
+        """
+        if not self.working_dir:
+            # Fall back to a guaranteed-writable per-agent directory.
+            d = Path.home() / ".openagents" / "workspaces" / _safe_name(self.agent_name)
+            d.mkdir(parents=True, exist_ok=True)
+            return str(d)
+        p = Path(self.working_dir)
+        if not p.exists():
+            raise NotADirectoryError(
+                f"Project directory does not exist: {self.working_dir}"
+            )
+        if not p.is_dir():
+            raise NotADirectoryError(
+                f"Project path is not a directory: {self.working_dir}"
+            )
+        return str(p)
+
+    # ------------------------------------------------------------------
+    # Control actions (stop)
+    # ------------------------------------------------------------------
+
+    async def _on_control_action(self, action: Optional[str], payload: dict):
+        if action == "stop":
+            channel = payload.get("channel") if isinstance(payload, dict) else None
+            if channel:
+                await self._stop_channel(channel, "Execution stopped by user.")
+            else:
+                await self._stop_all("Execution stopped by user.")
+            return
+        await super()._on_control_action(action, payload)
+
+    async def _stop_channel(self, channel: str, message: str):
+        proc = self._channel_processes.get(channel)
+        had_queue = bool(self._channel_queues.get(channel))
+        if proc:
+            self._stopping_channels.add(channel)
+            await self._stop_process(proc)
+            self._channel_processes.pop(channel, None)
+        self._channel_queues.pop(channel, None)
+        if proc or had_queue:
+            try:
+                await self._send_status(channel, message)
+            except Exception:
+                pass
+
+    async def _stop_all(self, message: str):
+        for channel in list(self._channel_processes.keys()):
+            await self._stop_channel(channel, message)
+
+    async def _stop_process(self, proc: asyncio.subprocess.Process):
+        """Terminate a Goose subprocess and every child it spawned.
+
+        POSIX: signal the whole process group (Goose's shell commands, dev
+        servers, and any MCP/extension children share it because we spawn with
+        ``start_new_session=True``). Windows: ``taskkill /F /T`` kills the tree.
+        """
+        if not proc or proc.returncode is not None:
+            return
+        try:
+            if IS_WINDOWS:
+                try:
+                    proc.send_signal(signal.SIGINT)
+                except Exception:
+                    pass
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=1.5)
+                    return
+                except asyncio.TimeoutError:
+                    pass
+                try:
+                    killer = await asyncio.create_subprocess_exec(
+                        "taskkill", "/F", "/T", "/PID", str(proc.pid),
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(killer.wait(), timeout=5)
+                except Exception:
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+                    await proc.wait()
+                return
+
+            # POSIX: kill the process group.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                try:
+                    proc.terminate()
+                except ProcessLookupError:
+                    pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2)
+            except asyncio.TimeoutError:
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except (ProcessLookupError, PermissionError, OSError):
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+                await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Message handler
+    # ------------------------------------------------------------------
+
+    async def _handle_message(self, msg: dict):
+        content = (msg.get("content") or "").strip()
+        if not content:
+            return
+
+        msg_channel = msg.get("sessionId") or self.channel_name
+        sender = msg.get("senderName") or msg.get("senderType", "user")
+        logger.info(
+            "Processing message from %s in channel %s: %s...",
+            sender, msg_channel, content[:80],
+        )
+
+        await self._auto_title_channel(msg_channel, content)
+        await self._send_status(msg_channel, "thinking...")
+
+        try:
+            # _run_goose returns: None → stopped or a failure it already reported
+            # (stay silent); "" → success but no answer text; str → the answer.
+            result = await self._run_goose(content, msg_channel)
+            if result is None:
+                return
+            if result:
+                await self._send_response(msg_channel, result)
+            else:
+                await self._send_response(
+                    msg_channel,
+                    "Goose ran but produced no response. This usually means no "
+                    "provider/model is configured — set GOOSE_PROVIDER and GOOSE_MODEL "
+                    "(and a key) for this agent, or run `goose configure` once outside "
+                    "OpenAgents.",
+                )
+        except FileNotFoundError as e:
+            await self._send_error(msg_channel, str(e))
+        except NotADirectoryError as e:
+            await self._send_error(msg_channel, str(e))
+        except Exception as e:
+            logger.exception("Error handling message: %s", e)
+            if msg_channel not in self._stopping_channels:
+                await self._send_error(
+                    msg_channel, f"Error processing message: {self._safe(str(e))}",
+                )
+        finally:
+            self._stopping_channels.discard(msg_channel)
+
+    def _safe(self, text: str) -> str:
+        return redact_secrets(text, self._secrets)
+
+    # ------------------------------------------------------------------
+    # Subprocess execution
+    # ------------------------------------------------------------------
+
+    def _build_cmd(self, session_name: str, resume: bool, system_prompt: str) -> list:
+        binary = self._goose_binary or find_goose_binary()
+        if not binary:
+            raise FileNotFoundError(
+                "goose CLI not found. Install it (non-interactively): "
+                "curl -fsSL "
+                "https://github.com/block/goose/releases/download/stable/download_cli.sh "
+                "| CONFIGURE=false bash"
+            )
+        self._goose_binary = binary
+        cmd = [
+            binary, "run",
+            "--output-format", "stream-json",
+            "--name", session_name,
+            "--no-profile",                 # ignore globally-enabled extensions
+            "--with-builtin", "developer",  # enable ONLY the developer extension
+            "--max-turns", str(self._max_turns()),
+            "--max-tool-repetitions", str(self._max_tool_repetitions()),
+        ]
+        if resume:
+            cmd.append("--resume")
+        cmd.extend(["--system", system_prompt, "-i", "-"])
+        return cmd
+
+    async def _ensure_version_ok(self, channel: str) -> bool:
+        """Check the installed Goose CLI meets :data:`MIN_GOOSE_VERSION` once.
+
+        Runs ``goose --version`` (cached for the adapter's lifetime). Returns
+        True when the version is new enough OR cannot be determined (lenient —
+        an undeterminable version must not block a working setup); returns False
+        and posts a clear upgrade error only when the CLI is definitively too old.
+        """
+        if self._version_checked:
+            return self._version_ok
+        self._version_checked = True
+        binary = self._goose_binary or find_goose_binary()
+        if not binary:
+            return True  # a missing binary is surfaced separately by _build_cmd
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                binary, "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            parsed = parse_goose_version(out.decode("utf-8", errors="replace"))
+        except Exception as e:
+            logger.debug("Could not determine Goose version: %s", e)
+            return True
+        if not goose_version_meets_minimum(parsed):
+            self._version_ok = False
+            await self._send_error(channel, _too_old_message(parsed))
+            return False
+        return True
+
+    async def _run_goose(self, content: str, channel: str, _retry: bool = False):
+        """Run one headless ``goose run``.
+
+        Returns ``None`` if the run was stopped or failed (an error was already
+        posted), ``""`` on an empty success, or the final answer text.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            cwd = self._resolve_cwd()
+        except NotADirectoryError as e:
+            await self._send_error(channel, str(e))
+            return None
+
+        # Refuse a Goose CLI older than the verified-stable minimum, with a
+        # clear upgrade prompt (lenient when the version can't be determined).
+        if not await self._ensure_version_ok(channel):
+            return None
+
+        session_name = self._channel_sessions.get(channel) or goose_session_name(
+            self.workspace_id, self.agent_name, channel,
+        )
+        resume = channel in self._channel_sessions
+        system_prompt = self._build_system_prompt(channel)
+        cmd = self._build_cmd(session_name, resume, system_prompt)
+
+        env = self._build_env()
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+                limit=10 * 1024 * 1024,  # 10 MB line buffer for big tool output
+                start_new_session=not IS_WINDOWS,  # own process group for tree kill
+            )
+        except Exception as e:
+            await self._send_error(
+                channel, f"Failed to start Goose: {self._safe(str(e))}",
+            )
+            return None
+
+        self._channel_processes[channel] = process
+
+        parser = GooseStreamParser()
+        final_text: Optional[str] = None
+        stderr_chunks: list = []
+        stderr_len = 0
+        last_activity = loop.time()
+
+        async def write_stdin():
+            try:
+                process.stdin.write(content.encode("utf-8"))
+                await process.stdin.drain()
+            except Exception as e:
+                logger.debug("Goose stdin write failed: %s", e)
+            finally:
+                try:
+                    process.stdin.close()
+                except Exception:
+                    pass
+
+        async def read_stderr():
+            nonlocal stderr_len, last_activity
+            while True:
+                try:
+                    line = await process.stderr.readline()
+                except Exception:
+                    break
+                if not line:
+                    break
+                last_activity = loop.time()
+                if stderr_len < _STDERR_CAP:
+                    chunk = line.decode("utf-8", errors="replace")
+                    stderr_chunks.append(chunk)
+                    stderr_len += len(chunk)
+
+        async def watchdog():
+            timeout = self._inactivity_timeout()
+            while True:
+                await asyncio.sleep(min(30.0, timeout))
+                if process.returncode is not None:
+                    return
+                if loop.time() - last_activity > timeout:
+                    logger.warning(
+                        "Goose produced no output for %ss — treating as hung, killing.",
+                        timeout,
+                    )
+                    self._stopping_channels.add(channel)
+                    await self._stop_process(process)
+                    try:
+                        await self._send_error(
+                            channel,
+                            "Goose appears to have hung (no output for a long time) "
+                            "and was stopped. Try a smaller task or check the provider.",
+                        )
+                    except Exception:
+                        pass
+                    return
+
+        stdin_task = asyncio.create_task(write_stdin())
+        stderr_task = asyncio.create_task(read_stderr())
+        watchdog_task = asyncio.create_task(watchdog())
+
+        try:
+            while True:
+                try:
+                    line = await process.stdout.readline()
+                except (asyncio.LimitOverrunError, ValueError):
+                    # Line longer than the buffer limit — skip it defensively.
+                    continue
+                except Exception:
+                    break
+                if not line:
+                    break
+                last_activity = loop.time()
+                text = line.decode("utf-8", errors="replace")
+                for event in parser.feed(text):
+                    ft = await self._dispatch_event(channel, event)
+                    if ft is not None:
+                        final_text = ft
+            for event in parser.finish():
+                ft = await self._dispatch_event(channel, event)
+                if ft is not None:
+                    final_text = ft
+        finally:
+            watchdog_task.cancel()
+            await asyncio.gather(stdin_task, stderr_task, watchdog_task,
+                                 return_exceptions=True)
+            await process.wait()
+            self._channel_processes.pop(channel, None)
+
+        stderr_text = "".join(stderr_chunks).strip()
+        returncode = process.returncode
+
+        if channel in self._stopping_channels:
+            return None
+
+        # Auto-heal a stale/missing session: Goose exits non-zero with this
+        # message when --resume names a session it can't find. Recreate once.
+        if (resume and returncode and not _retry
+                and "no session found" in stderr_text.lower()):
+            logger.info("Goose session %s missing; creating a fresh one.", session_name)
+            self._channel_sessions.pop(channel, None)
+            self._save_sessions()
+            await self._send_status(
+                channel,
+                "Previous Goose session was unavailable — starting a new one "
+                "(earlier context is reset).",
+            )
+            return await self._run_goose(content, channel, _retry=True)
+
+        # Failure: non-zero exit OR an error event (Goose can exit 0 after an
+        # agent error). Never report success on a non-zero exit even if some
+        # text was produced.
+        if returncode != 0 or parser.had_error:
+            detail = parser.error_message or stderr_text
+            message = classify_goose_error(detail) or (
+                self._safe(detail)[:500] if detail
+                else f"Goose exited with code {returncode}."
+            )
+            await self._send_error(channel, self._safe(message))
+            return None
+
+        # First successful run for this channel created the session — record it
+        # so future turns resume instead of starting over.
+        if channel not in self._channel_sessions:
+            self._channel_sessions[channel] = session_name
+            self._save_sessions()
+
+        return final_text or ""
+
+    async def _dispatch_event(self, channel: str, event: dict) -> Optional[str]:
+        """Map a parser event to workspace status, or return the final answer text."""
+        kind = event.get("kind")
+        if kind == "final":
+            return event.get("text") or ""
+        if kind == "tool":
+            name = event.get("name") or "tool"
+            summary = self._safe(event.get("summary") or "")
+            label = f"🔧 {name}" + (f" — {summary}" if summary else "")
+            await self._send_status(channel, label)
+        elif kind in ("progress", "thinking"):
+            # Intermediate assistant narration (progress) and genuine model
+            # thinking are both surfaced as transient workspace status (the
+            # Python BaseAdapter has no separate "thinking" channel).
+            text = self._safe(event.get("text") or "").strip()
+            if text:
+                if len(text) > _STATUS_PREVIEW:
+                    text = text[:_STATUS_PREVIEW] + "…"
+                await self._send_status(channel, text)
+        elif kind == "notification":
+            text = self._safe(event.get("text") or "").strip()
+            if text:
+                await self._send_status(channel, text[:_STATUS_PREVIEW])
+        # tool_result / complete / error → no direct status (error handled by caller)
+        return None
+
+
+def _safe_name(name: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in (name or "default")) or "default"

--- a/sdk/src/openagents/adapters/goose_stream.py
+++ b/sdk/src/openagents/adapters/goose_stream.py
@@ -1,0 +1,303 @@
+"""
+Pure, line-oriented parser for Goose's ``goose run --output-format stream-json``
+output, plus helpers for secret redaction and error classification.
+
+This module is intentionally free of any I/O, asyncio, or subprocess code so it
+can be unit-tested in isolation and kept behaviourally identical to the Node
+port (``packages/agent-connector/src/adapters/goose-stream.js``).
+
+Verified against block/goose v1.38.0. The CLI emits one JSON object per line
+(NDJSON). The ``StreamEvent`` enum is ``#[serde(tag="type", rename_all="snake_case")]``:
+
+    {"type":"message","message":{"role":"assistant"|"user","created":N,"content":[...]}}
+    {"type":"notification","extension_id":"...","log":{"message":"..."}}     # or "progress"
+    {"type":"error","error":"..."}
+    {"type":"complete","total_tokens":N,"input_tokens":N,"output_tokens":N}
+
+Message content items are ``#[serde(tag="type", rename_all="camelCase")]``:
+``text`` {text}, ``thinking`` {thinking,signature}, ``redactedThinking`` {data},
+``toolRequest`` {id, toolCall:{status:"success", value:{name, arguments}}|{status:"error", error}},
+``toolResponse`` {id, toolResult:{status, ...}}, plus image / systemNotification / etc.
+
+Important: an agent/provider error during a run is emitted as a ``error`` event
+but ``goose run`` still exits 0. Callers MUST treat ``had_error`` (or any event
+of kind ``error``) as a failure regardless of the process exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Optional
+
+# Hard cap on a single un-terminated line we will buffer before giving up on it.
+# Guards against a pathological/garbage stream pinning memory (req: bounded output).
+_MAX_LINE_BYTES = 8 * 1024 * 1024
+# Cap on how much of a tool-argument preview we surface as workspace status.
+# Keeps large tool inputs from flooding the channel and avoids dumping full
+# file bodies / arguments into chat.
+_TOOL_PREVIEW_LIMIT = 160
+
+
+def redact_secrets(text: Optional[str], secrets: Optional[list] = None) -> str:
+    """Return ``text`` with credentials masked.
+
+    - Masks explicit ``secrets`` values (e.g. the configured provider API key)
+      by exact substring match — the most reliable redaction.
+    - Masks common ``key=value`` / ``Bearer <token>`` / ``Authorization: ...``
+      shapes heuristically so leaked credentials in arbitrary CLI output don't
+      reach logs or the workspace.
+    """
+    if not text:
+        return ""
+    out = str(text)
+    for secret in secrets or []:
+        if secret and isinstance(secret, str) and len(secret) >= 4:
+            out = out.replace(secret, "***")
+    # api_key=..., token: ..., authorization ..., bearer ..., sk-...
+    out = re.sub(
+        r"(?i)\b(api[_-]?key|secret|token|authorization|auth|bearer)\b\s*[:=]?\s*"
+        r"['\"]?([A-Za-z0-9._\-]{8,})['\"]?",
+        lambda m: f"{m.group(1)}=***",
+        out,
+    )
+    out = re.sub(r"\bsk-[A-Za-z0-9._\-]{6,}\b", "sk-***", out)
+    return out
+
+
+def classify_goose_error(text: Optional[str]) -> Optional[str]:
+    """Map a raw Goose stderr/error string to a readable, actionable message.
+
+    Returns ``None`` when ``text`` is empty. Never returns the raw secret —
+    callers should still pass the result through :func:`redact_secrets`.
+    """
+    if not text or not str(text).strip():
+        return None
+    raw = str(text).strip()
+    low = raw.lower()
+
+    def has(*needles: str) -> bool:
+        return any(n in low for n in needles)
+
+    if has("401", "403", "unauthorized", "invalid api key", "invalid_api_key",
+           "authentication", "incorrect api key", "no api key", "missing api key"):
+        return ("Goose authentication failed. Check this agent's provider API key "
+                "(GOOSE_PROVIDER__API_KEY) and host — the key may be missing, invalid, or expired.")
+    if has("429", "rate limit", "rate_limit", "too many requests", "quota", "overloaded"):
+        return ("Goose hit the provider's rate limit or quota. Wait and retry, or use a "
+                "different key/provider.")
+    if has("model", "no such model", "unknown model", "model not found", "does not exist"):
+        if has("model"):
+            return ("Goose could not use the configured model. Check GOOSE_MODEL is valid for "
+                    "the selected GOOSE_PROVIDER.")
+    if has("provider", "unknown provider", "no provider", "provider not", "configure"):
+        return ("Goose has no usable provider configured. Set GOOSE_PROVIDER (and a key/host), "
+                "or run `goose configure` once outside OpenAgents.")
+    if has("permission denied", "not permitted", "tool execution denied", "denied by"):
+        return ("A Goose tool call was denied. The workspace runs Goose headless with "
+                "GOOSE_MODE=auto; check the project directory permissions.")
+    if has("extension", "mcp", "failed to start", "failed to load"):
+        return ("A Goose extension failed to start. The workspace only enables the built-in "
+                "developer extension by default; check your Goose extension config.")
+    if has("connection", "network", "timed out", "timeout", "dns", "could not resolve",
+           "connection refused", "unreachable"):
+        return ("Goose could not reach the provider endpoint. Check the network and the "
+                "GOOSE_PROVIDER__HOST URL.")
+    if has("no such file", "not a directory", "permission denied (os error 13)"):
+        return ("Goose hit a filesystem error. Check the agent's project directory exists and "
+                "is writable.")
+    return None
+
+
+class GooseStreamParser:
+    """Incremental NDJSON parser that turns Goose stream-json into semantic events.
+
+    Feed raw stdout chunks (``feed``) and flush at EOF (``finish``). Each call
+    returns a list of event dicts with a ``kind`` field:
+
+    - ``{"kind": "progress", "text": str}``   — intermediate assistant text (interim narration → status)
+    - ``{"kind": "thinking", "text": str}``   — genuine model thinking content (ThinkingContent)
+    - ``{"kind": "tool", "name": str, "summary": str}``  — a tool invocation (progress)
+    - ``{"kind": "tool_result", "ok": bool}`` — a tool completed
+    - ``{"kind": "notification", "text": str}`` — extension progress note
+    - ``{"kind": "error", "message": str}``   — Goose reported an error (FAILURE)
+    - ``{"kind": "final", "text": str}``      — the final answer (emitted at most once)
+    - ``{"kind": "complete", "tokens": int|None}`` — run finished
+
+    Final-answer semantics: the *last* assistant text message is the answer
+    (emitted once on ``complete``/EOF). Any earlier assistant text is surfaced
+    as ``thinking`` so nothing is sent to chat twice.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+        self._pending_final: Optional[str] = None
+        self._final_text: Optional[str] = None
+        self._final_emitted = False
+        self.had_error = False
+        self.error_message: Optional[str] = None
+
+    # -- public API ----------------------------------------------------------
+
+    def feed(self, chunk: str) -> list:
+        events: list = []
+        if not chunk:
+            return events
+        self._buf += chunk
+        # Defensive: a single line that never terminates must not grow unbounded.
+        if len(self._buf) > _MAX_LINE_BYTES and "\n" not in self._buf:
+            self._buf = self._buf[-_MAX_LINE_BYTES:]
+        while True:
+            idx = self._buf.find("\n")
+            if idx < 0:
+                break
+            line = self._buf[:idx]
+            self._buf = self._buf[idx + 1:]
+            self._handle_line(line, events)
+        return events
+
+    def finish(self) -> list:
+        events: list = []
+        leftover = self._buf
+        self._buf = ""
+        if leftover.strip():
+            self._handle_line(leftover, events)
+        # Promote any pending assistant text to the final answer if Goose ended
+        # without an explicit `complete` line (e.g. it crashed mid-stream).
+        if not self._final_emitted and not self.had_error:
+            self._emit_final(events)
+        return events
+
+    @property
+    def final_text(self) -> Optional[str]:
+        return self._final_text
+
+    # -- internals -----------------------------------------------------------
+
+    def _emit_final(self, events: list) -> None:
+        if self._pending_final:
+            self._final_text = self._pending_final
+            self._pending_final = None
+        if not self._final_emitted and self._final_text:
+            events.append({"kind": "final", "text": self._final_text})
+            self._final_emitted = True
+
+    def _handle_line(self, line: str, events: list) -> None:
+        line = line.strip()
+        if not line:
+            return
+        try:
+            ev = json.loads(line)
+        except Exception:
+            # Half-lines / non-JSON noise: ignore defensively, never crash.
+            return
+        if not isinstance(ev, dict):
+            return
+        etype = ev.get("type")
+        if etype == "message":
+            msg = ev.get("message")
+            if isinstance(msg, dict):
+                self._handle_message(msg, events)
+        elif etype == "error":
+            msg = ev.get("error") or "Goose reported an error"
+            self.had_error = True
+            self.error_message = str(msg)
+            events.append({"kind": "error", "message": str(msg)})
+        elif etype == "complete":
+            if not self.had_error:
+                self._emit_final(events)
+            events.append({"kind": "complete", "tokens": ev.get("total_tokens")})
+        elif etype == "notification":
+            text = self._notification_text(ev)
+            if text:
+                events.append({"kind": "notification", "text": text})
+        # Unknown event types are ignored on purpose (forward-compatible).
+
+    @staticmethod
+    def _notification_text(ev: dict) -> Optional[str]:
+        progress = ev.get("progress")
+        if isinstance(progress, dict):
+            msg = progress.get("message")
+            if msg:
+                return str(msg)
+        log = ev.get("log")
+        if isinstance(log, dict):
+            msg = log.get("message")
+            if msg:
+                return str(msg)
+        return None
+
+    def _handle_message(self, message: dict, events: list) -> None:
+        role = str(message.get("role") or "").lower()
+        content = message.get("content")
+        if not isinstance(content, list):
+            return
+        texts: list = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            itype = item.get("type")
+            if itype == "text":
+                txt = item.get("text")
+                if txt:
+                    texts.append(str(txt))
+            elif itype == "thinking":
+                th = item.get("thinking")
+                if th:
+                    events.append({"kind": "thinking", "text": str(th)})
+            elif itype == "toolRequest":
+                events.append(self._tool_event(item))
+            elif itype == "toolResponse":
+                events.append(self._tool_result_event(item))
+            # image / redactedThinking / systemNotification / etc → ignore.
+        if role == "assistant" and texts:
+            joined = "\n".join(t for t in texts if t).strip()
+            if joined:
+                # The previous candidate is now known to be intermediate. It is
+                # assistant *output* (interim narration), not model-internal
+                # reasoning, so surface it as ``progress`` (→ workspace status),
+                # NOT ``thinking`` — only genuine ``thinking`` content items above
+                # are emitted as ``thinking``.
+                if self._pending_final:
+                    events.append({"kind": "progress", "text": self._pending_final})
+                self._pending_final = joined
+
+    @classmethod
+    def _tool_event(cls, item: dict) -> dict:
+        tool_call = item.get("toolCall")
+        if not isinstance(tool_call, dict):
+            return {"kind": "tool", "name": "tool", "summary": ""}
+        status = tool_call.get("status")
+        if status == "error":
+            return {"kind": "tool", "name": "tool", "summary": "(tool call could not be parsed)"}
+        value = tool_call.get("value")
+        if not isinstance(value, dict):
+            return {"kind": "tool", "name": "tool", "summary": ""}
+        name = str(value.get("name") or "tool")
+        summary = cls._summarize_args(name, value.get("arguments"))
+        return {"kind": "tool", "name": name, "summary": summary}
+
+    @staticmethod
+    def _tool_result_event(item: dict) -> dict:
+        tr = item.get("toolResult")
+        ok = isinstance(tr, dict) and tr.get("status") == "success"
+        return {"kind": "tool_result", "ok": bool(ok)}
+
+    @staticmethod
+    def _summarize_args(name: str, args) -> str:
+        """Short, single-line preview of a tool's most salient argument.
+
+        Never dumps the full argument object (it can contain large file bodies).
+        """
+        if not isinstance(args, dict):
+            return ""
+        for key in ("command", "path", "file_path", "file", "pattern", "query", "uri", "url"):
+            val = args.get(key)
+            if isinstance(val, str) and val:
+                preview = " ".join(val.split())
+                if len(preview) > _TOOL_PREVIEW_LIMIT:
+                    preview = preview[:_TOOL_PREVIEW_LIMIT] + "…"
+                return preview
+        # Fall back to the list of argument keys (names only, no values).
+        keys = [k for k in args.keys() if isinstance(k, str)]
+        return ", ".join(keys[:6])

--- a/sdk/src/openagents/registry/goose.yaml
+++ b/sdk/src/openagents/registry/goose.yaml
@@ -1,11 +1,47 @@
 name: goose
 label: Goose
-description: An open-source AI developer agent by Block
+description: An open-source AI developer agent by Block (CLI — Beta)
 homepage: https://github.com/block/goose
-tags: [coding, developer, open-source]
+tags: [coding, developer, open-source, cli]
+builtin: true
 
 install:
   binary: goose
-  macos: "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash"
-  linux: "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash"
-  windows: "powershell -c \"irm https://raw.githubusercontent.com/block/goose/main/download_cli.ps1 | iex\""
+  # CONFIGURE=false keeps the official installer non-interactive (it otherwise
+  # launches `goose configure`). It must be set on the shell that runs the
+  # script (the `bash`/`iex` side), not on curl.
+  macos: "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"
+  linux: "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"
+  windows: "powershell -c \"$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/block/goose/main/download_cli.ps1 | iex\""
+
+adapter:
+  module: openagents.adapters.goose
+  class: GooseAdapter
+
+launch:
+  args: []
+
+env_config:
+  - name: GOOSE_PROVIDER
+    description: "Goose provider id (e.g. openai, anthropic, google, openrouter, ollama). Leave blank to reuse your existing Goose config."
+    required: false
+  - name: GOOSE_MODEL
+    description: "Model name for the selected provider (e.g. gpt-4o, claude-sonnet-4-6). Leave blank to reuse your existing Goose config."
+    required: false
+  - name: GOOSE_PROVIDER__API_KEY
+    description: "Provider API key (generic Goose provider key). Leave blank to reuse the Goose keyring/config, an OAuth provider, or a local provider."
+    required: false
+    password: true
+  - name: GOOSE_PROVIDER__HOST
+    description: "Custom provider endpoint/host URL (optional — for proxies or self-hosted/OpenAI-compatible endpoints)."
+    required: false
+  - name: GOOSE_MODE
+    description: "Headless tool-permission mode. 'auto' runs tools without approval (required for the workspace); 'chat' disables tools. Approval modes are coerced to 'auto'."
+    required: false
+    default: "auto"
+
+check_ready:
+  # Goose is a real binary with no API-only mode — readiness must reflect the
+  # actual CLI being present, not just an install marker (cli-missing reconcile).
+  require_binary: true
+  not_ready_message: "Goose CLI not found. Install it: openagents install goose — then set a provider/model (or run `goose configure` once)."

--- a/sdk/src/openagents/registry/loader.py
+++ b/sdk/src/openagents/registry/loader.py
@@ -443,6 +443,14 @@ def _make_plugin_from_yaml(data: dict):
             return env
 
         def check_ready(self) -> tuple[bool, str]:
+            # Opt-in: agents whose readiness must reflect the actual binary (not
+            # just an install marker) set ``require_binary: true``. This reconciles
+            # a stale marker when the CLI was uninstalled/moved (cli-missing).
+            if check_cfg.get("require_binary") and self._which_binary() is None:
+                return False, check_cfg.get(
+                    "not_ready_message",
+                    f"{data['name']} CLI not found on PATH. Reinstall: openagents install {data['name']}",
+                )
             if not self.is_installed():
                 return False, f"Not installed. Run: openagents install {data['name']}"
             # If no readiness checks are configured, being installed is enough

--- a/tests/agents/test_goose_adapter.py
+++ b/tests/agents/test_goose_adapter.py
@@ -1,0 +1,559 @@
+"""Unit tests for the Goose adapter, registry wiring, and install detection.
+
+No real Goose binary is installed and no model credits are used: a fake
+``goose`` executable plus monkeypatching cover command building, session
+isolation, provider env, working-dir validation, and an end-to-end stream-json
+run. Mirrors packages/agent-connector/test/goose.test.js.
+
+Run:
+    pytest tests/agents/test_goose_adapter.py -v
+"""
+
+import asyncio
+import functools
+import json
+import os
+import stat
+
+import pytest
+
+import openagents.registry.loader as loader
+from openagents.adapters import goose as goose_mod
+from openagents.adapters.goose import (
+    GooseAdapter,
+    MIN_GOOSE_VERSION,
+    find_goose_binary,
+    goose_session_name,
+    goose_version_meets_minimum,
+    parse_goose_version,
+)
+
+
+def _aiorun(coro_fn):
+    """Run an async test body via asyncio.run so the suite doesn't depend on a
+    pytest async plugin being installed (pytest still injects fixtures via the
+    preserved signature)."""
+    @functools.wraps(coro_fn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(coro_fn(*args, **kwargs))
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+def _goose_data():
+    return next(d for d in loader.load_registry_yamls() if d.get("name") == "goose")
+
+
+class TestRegistry:
+    def test_goose_is_builtin(self):
+        data = _goose_data()
+        assert data.get("builtin") is True
+        assert data["adapter"]["module"] == "openagents.adapters.goose"
+        assert data["adapter"]["class"] == "GooseAdapter"
+
+    def test_env_config_fields(self):
+        data = _goose_data()
+        names = [f["name"] for f in data.get("env_config", [])]
+        assert names == [
+            "GOOSE_PROVIDER", "GOOSE_MODEL", "GOOSE_PROVIDER__API_KEY",
+            "GOOSE_PROVIDER__HOST", "GOOSE_MODE",
+        ]
+        # The API key must be a password field and not required.
+        key = next(f for f in data["env_config"] if f["name"] == "GOOSE_PROVIDER__API_KEY")
+        assert key.get("password") is True
+        assert key.get("required") is False
+
+    def test_install_is_non_interactive(self):
+        data = _goose_data()
+        install = data["install"]
+        assert "CONFIGURE=false" in install["macos"]
+        assert "CONFIGURE=false" in install["linux"]
+        assert "CONFIGURE=false" in install["windows"] or "$env:CONFIGURE" in install["windows"]
+        # CONFIGURE belongs on the shell side, not on curl.
+        assert "CONFIGURE=false curl" not in install["macos"]
+        assert "| CONFIGURE=false bash" in install["linux"]
+        # Never run goose configure during install.
+        assert "goose configure" not in install["macos"]
+
+    def test_create_adapter_returns_goose_adapter(self):
+        data = _goose_data()
+        plugin = loader._make_plugin_from_yaml(data)
+        adapter = plugin.create_adapter("ws", "chan", "tok", "agent", "http://x")
+        assert isinstance(adapter, GooseAdapter)
+
+    def test_other_agents_unaffected(self):
+        names = {d["name"] for d in loader.load_registry_yamls()}
+        # Amp/Aider must remain catalog-only; their builtin status is unchanged.
+        for n in ("amp", "aider"):
+            data = next(d for d in loader.load_registry_yamls() if d["name"] == n)
+            assert not data.get("builtin"), f"{n} must stay catalog-only"
+        for n in ("claude", "codex", "opencode"):
+            data = next(d for d in loader.load_registry_yamls() if d["name"] == n)
+            assert data.get("builtin") is True
+
+
+# ---------------------------------------------------------------------------
+# Install detection / marker reconciliation
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    empty_bin = tmp_path / "empty_bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    markers_path = home / ".openagents" / "installed_agents.json"
+    monkeypatch.setattr(loader, "_INSTALLED_MARKERS_PATH", markers_path)
+    return home
+
+
+def _write_exe(path, body="#!/bin/sh\necho goose 1.38.0\n"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class TestInstallDetection:
+    def test_finds_goose_in_local_bin(self, isolated_home, monkeypatch):
+        goose_bin = isolated_home / ".local" / "bin" / "goose"
+        _write_exe(goose_bin)
+        # find_goose_binary's fallback list checks ~/.local/bin
+        assert find_goose_binary() == str(goose_bin)
+
+    def test_finds_goose_on_path(self, isolated_home, monkeypatch):
+        bindir = isolated_home / "pathbin"
+        goose_bin = bindir / "goose"
+        _write_exe(goose_bin)
+        monkeypatch.setenv("PATH", str(bindir))
+        assert find_goose_binary() == str(goose_bin)
+
+    def test_missing_binary_returns_none(self, isolated_home):
+        assert find_goose_binary() is None
+
+    def test_check_ready_cli_missing_with_stale_marker(self, isolated_home):
+        # require_binary: a stale marker must NOT mask a missing CLI.
+        plugin = loader._make_plugin_from_yaml(_goose_data())
+        loader.mark_installed("goose")  # marker exists
+        assert plugin._which_binary() is None
+        ready, msg = plugin.check_ready()
+        assert ready is False
+        assert "not found" in msg.lower()
+
+    def test_check_ready_ok_when_binary_present(self, isolated_home, monkeypatch):
+        bindir = isolated_home / "pathbin"
+        _write_exe(bindir / "goose")
+        monkeypatch.setenv("PATH", str(bindir))
+        plugin = loader._make_plugin_from_yaml(_goose_data())
+        ready, _ = plugin.check_ready()
+        assert ready is True
+
+
+# ---------------------------------------------------------------------------
+# Adapter construction + command/env/session
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    # Make the adapter believe goose exists at a fake path (no detection noise).
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: "/fake/goose")
+    proj = tmp_path / "project"
+    proj.mkdir()
+    a = GooseAdapter("ws1", "general", "tok", "agentA", "http://x",
+                     working_dir=str(proj))
+    return a
+
+
+class TestVersion:
+    def test_minimum_is_stable_137(self):
+        # Verified against block/goose v1.37.0 (the stable tag).
+        assert MIN_GOOSE_VERSION == (1, 37, 0)
+
+    def test_parse(self):
+        assert parse_goose_version("goose 1.37.0") == (1, 37, 0)
+        assert parse_goose_version("goose-cli 1.40.2 (abc1234)") == (1, 40, 2)
+        assert parse_goose_version("1.37.0\n") == (1, 37, 0)
+        assert parse_goose_version("no version here") is None
+        assert parse_goose_version("") is None
+
+    def test_meets_minimum(self):
+        assert goose_version_meets_minimum((1, 37, 0)) is True
+        assert goose_version_meets_minimum((1, 40, 1)) is True
+        assert goose_version_meets_minimum((2, 0, 0)) is True
+        assert goose_version_meets_minimum((1, 36, 9)) is False
+        assert goose_version_meets_minimum((1, 0, 0)) is False
+        # Unknown version must be lenient (don't block a working setup).
+        assert goose_version_meets_minimum(None) is True
+
+
+class TestSessionNaming:
+    def test_stable(self):
+        assert goose_session_name("w", "a", "c") == goose_session_name("w", "a", "c")
+
+    def test_isolated_across_dimensions(self):
+        base = goose_session_name("w", "a", "c")
+        assert base != goose_session_name("w", "a", "c2")   # channel
+        assert base != goose_session_name("w", "a2", "c")   # agent
+        assert base != goose_session_name("w2", "a", "c")   # workspace
+
+    def test_safe_characters_only(self):
+        name = goose_session_name("ws/../x", "a b", "../../etc/passwd")
+        assert name.startswith("oa_")
+        assert all(c.isalnum() or c == "_" for c in name)
+
+    def test_does_not_leak_inputs(self):
+        name = goose_session_name("workspace-token-abc", "agentA", "secret-channel")
+        assert "workspace-token-abc" not in name
+        assert "secret-channel" not in name
+
+
+class TestCommandBuilding:
+    def test_new_session_command(self, adapter):
+        name = goose_session_name("ws1", "agentA", "general")
+        cmd = adapter._build_cmd(name, resume=False, system_prompt="SYS")
+        assert cmd[0] == "/fake/goose"
+        assert cmd[1] == "run"
+        assert "--output-format" in cmd and cmd[cmd.index("--output-format") + 1] == "stream-json"
+        assert "--name" in cmd and cmd[cmd.index("--name") + 1] == name
+        assert "--no-profile" in cmd
+        assert cmd[cmd.index("--with-builtin") + 1] == "developer"
+        assert "--resume" not in cmd
+        assert cmd[-2:] == ["-i", "-"]  # prompt comes from stdin
+        assert "--max-turns" in cmd and "--max-tool-repetitions" in cmd
+
+    def test_resume_session_command(self, adapter):
+        name = goose_session_name("ws1", "agentA", "general")
+        cmd = adapter._build_cmd(name, resume=True, system_prompt="SYS")
+        assert "--resume" in cmd
+
+    def test_prompt_never_in_argv(self, adapter):
+        cmd = adapter._build_cmd("oa_x", resume=False, system_prompt="SYS")
+        # The user prompt is fed via stdin; only the system prompt is an arg.
+        assert "-i" in cmd and cmd[cmd.index("-i") + 1] == "-"
+        # No element equals a user prompt placeholder
+        assert "USER_PROMPT" not in cmd
+
+    def test_missing_binary_raises(self, adapter, monkeypatch):
+        adapter._goose_binary = None
+        monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: None)
+        with pytest.raises(FileNotFoundError):
+            adapter._build_cmd("oa_x", resume=False, system_prompt="SYS")
+
+
+class TestEnvProvider:
+    def test_mode_defaults_to_auto(self, adapter, monkeypatch):
+        monkeypatch.delenv("GOOSE_MODE", raising=False)
+        env = adapter._build_env()
+        assert env["GOOSE_MODE"] == "auto"
+
+    def test_blocking_mode_coerced_to_auto(self, adapter, monkeypatch):
+        monkeypatch.setenv("GOOSE_MODE", "smart_approve")
+        assert adapter._build_env()["GOOSE_MODE"] == "auto"
+        monkeypatch.setenv("GOOSE_MODE", "approve")
+        assert adapter._build_env()["GOOSE_MODE"] == "auto"
+
+    def test_chat_mode_respected(self, adapter, monkeypatch):
+        monkeypatch.setenv("GOOSE_MODE", "chat")
+        assert adapter._build_env()["GOOSE_MODE"] == "chat"
+
+    def test_provider_env_passthrough(self, adapter, monkeypatch):
+        monkeypatch.setenv("GOOSE_PROVIDER", "openai")
+        monkeypatch.setenv("GOOSE_MODEL", "gpt-4o")
+        monkeypatch.setenv("GOOSE_PROVIDER__API_KEY", "sk-secret")
+        monkeypatch.setenv("GOOSE_PROVIDER__HOST", "https://proxy.example/v1")
+        env = adapter._build_env()
+        assert env["GOOSE_PROVIDER"] == "openai"
+        assert env["GOOSE_MODEL"] == "gpt-4o"
+        assert env["GOOSE_PROVIDER__API_KEY"] == "sk-secret"  # passed via env, not argv
+        assert env["GOOSE_PROVIDER__HOST"] == "https://proxy.example/v1"
+
+    def test_existing_provider_env_not_cleared(self, adapter, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "existing")
+        env = adapter._build_env()
+        assert env["OPENAI_API_KEY"] == "existing"
+
+    def test_key_not_in_argv(self, adapter, monkeypatch):
+        monkeypatch.setenv("GOOSE_PROVIDER__API_KEY", "sk-zzz-secret")
+        cmd = adapter._build_cmd("oa_x", resume=False, system_prompt="SYS")
+        assert all("sk-zzz-secret" not in str(part) for part in cmd)
+
+    def test_secret_redacted_in_safe(self, adapter, monkeypatch):
+        # _collect_secret_values runs in __init__; build a fresh adapter so it
+        # sees the key.
+        monkeypatch.setenv("GOOSE_PROVIDER__API_KEY", "sk-zzz-supersecret")
+        a = GooseAdapter("ws1", "general", "tok", "agentA", "http://x")
+        masked = a._safe("error using sk-zzz-supersecret here")
+        assert "sk-zzz-supersecret" not in masked
+
+
+class TestWorkingDir:
+    def test_valid_dir(self, adapter):
+        assert adapter._resolve_cwd() == adapter.working_dir
+
+    def test_missing_dir_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: "/fake/goose")
+        a = GooseAdapter("ws", "c", "t", "ag", "http://x",
+                         working_dir=str(tmp_path / "nope"))
+        with pytest.raises(NotADirectoryError):
+            a._resolve_cwd()
+
+    def test_file_not_dir_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: "/fake/goose")
+        f = tmp_path / "afile"
+        f.write_text("x")
+        a = GooseAdapter("ws", "c", "t", "ag", "http://x", working_dir=str(f))
+        with pytest.raises(NotADirectoryError):
+            a._resolve_cwd()
+
+
+class TestSessionPersistence:
+    def test_save_and_reload(self, adapter, monkeypatch):
+        adapter._channel_sessions["general"] = "oa_abc"
+        adapter._save_sessions()
+        # New adapter instance reloads the mapping (survives restart).
+        a2 = GooseAdapter("ws1", "general", "tok", "agentA", "http://x",
+                          working_dir=adapter.working_dir)
+        assert a2._channel_sessions.get("general") == "oa_abc"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end stream-json run against a FAKE goose (no real binary, no model)
+# ---------------------------------------------------------------------------
+
+def _make_fake_goose(tmp_path, stream_lines, exit_code=0, stderr="", version="1.37.0"):
+    """Write a fake goose script that answers --version then emits stream-json."""
+    script = tmp_path / "fake_goose.sh"
+    body = [
+        "#!/bin/sh",
+        'for a in "$@"; do',
+        f'  if [ "$a" = "--version" ]; then echo "goose {version}"; exit 0; fi',
+        "done",
+        "cat >/dev/null",  # consume stdin (the prompt)
+    ]
+    for line in stream_lines:
+        esc = line.replace("'", "'\\''")
+        body.append(f"printf '%s\\n' '{esc}'")
+    if stderr:
+        esc = stderr.replace("'", "'\\''")
+        body.append(f"printf '%s\\n' '{esc}' 1>&2")
+    body.append(f"exit {exit_code}")
+    script.write_text("\n".join(body) + "\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script)
+
+
+def _instrument(adapter):
+    """Capture status/response/error instead of hitting the network."""
+    sent = {"status": [], "response": [], "error": []}
+    async def _status(ch, content): sent["status"].append(content)
+    async def _response(ch, content): sent["response"].append(content)
+    async def _error(ch, content): sent["error"].append(content)
+    async def _title(ch, content): pass
+    adapter._send_status = _status
+    adapter._send_response = _response
+    adapter._send_error = _error
+    adapter._auto_title_channel = _title
+    return sent
+
+
+@_aiorun
+async def test_e2e_success_run(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"; proj.mkdir()
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    lines = [
+        json.dumps({"type": "message", "message": {"role": "assistant", "created": 1,
+            "content": [{"type": "toolRequest", "id": "t1", "toolCall": {"status": "success",
+                "value": {"name": "developer__shell", "arguments": {"command": "echo hi"}}}}]}}),
+        json.dumps({"type": "message", "message": {"role": "assistant", "created": 2,
+            "content": [{"type": "text", "text": "All done!"}]}}),
+        json.dumps({"type": "complete", "total_tokens": 7}),
+    ]
+    fake = _make_fake_goose(tmp_path, lines)
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x", working_dir=str(proj))
+    a._goose_binary = fake
+    sent = _instrument(a)
+
+    await a._handle_message({"content": "do the thing", "sessionId": "general"})
+
+    assert sent["response"] == ["All done!"]   # final answer sent exactly once
+    assert sent["error"] == []
+    assert any("developer__shell" in s for s in sent["status"])  # tool progress shown
+    # session recorded for resume
+    assert "general" in a._channel_sessions
+
+
+@_aiorun
+async def test_e2e_nonzero_exit_is_failure(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"; proj.mkdir()
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    # Some text on stdout, but exit 1 + an auth error on stderr.
+    lines = [json.dumps({"type": "message", "message": {"role": "assistant", "created": 1,
+        "content": [{"type": "text", "text": "partial"}]}})]
+    fake = _make_fake_goose(tmp_path, lines, exit_code=1,
+                            stderr="Error: 401 Unauthorized invalid api key")
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x", working_dir=str(proj))
+    a._goose_binary = fake
+    sent = _instrument(a)
+
+    await a._handle_message({"content": "hi", "sessionId": "general"})
+
+    assert sent["response"] == []           # never report partial text as success
+    assert len(sent["error"]) == 1
+    assert "authentication" in sent["error"][0].lower()
+    assert "general" not in a._channel_sessions  # failed run does not record a session
+
+
+@_aiorun
+async def test_e2e_error_event_with_exit_zero_is_failure(tmp_path, monkeypatch):
+    # Goose can emit an error event then still exit 0 — must be treated as failure.
+    proj = tmp_path / "proj"; proj.mkdir()
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    lines = [
+        json.dumps({"type": "error", "error": "model gpt-x does not exist"}),
+        json.dumps({"type": "complete"}),
+    ]
+    fake = _make_fake_goose(tmp_path, lines, exit_code=0)
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x", working_dir=str(proj))
+    a._goose_binary = fake
+    sent = _instrument(a)
+
+    await a._handle_message({"content": "hi", "sessionId": "general"})
+    assert sent["response"] == []
+    assert len(sent["error"]) == 1
+    assert "model" in sent["error"][0].lower()
+
+
+@_aiorun
+async def test_e2e_second_message_resumes(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"; proj.mkdir()
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    lines = [
+        json.dumps({"type": "message", "message": {"role": "assistant", "created": 1,
+            "content": [{"type": "text", "text": "ok"}]}}),
+        json.dumps({"type": "complete"}),
+    ]
+    fake = _make_fake_goose(tmp_path, lines)
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x", working_dir=str(proj))
+    a._goose_binary = fake
+    _instrument(a)
+
+    captured_cmds = []
+    orig_build = a._build_cmd
+    def spy(name, resume, system_prompt):
+        captured_cmds.append({"name": name, "resume": resume})
+        return orig_build(name, resume, system_prompt)
+    a._build_cmd = spy
+
+    await a._handle_message({"content": "first", "sessionId": "general"})
+    await a._handle_message({"content": "second", "sessionId": "general"})
+
+    assert captured_cmds[0]["resume"] is False   # first creates
+    assert captured_cmds[1]["resume"] is True    # second resumes
+    assert captured_cmds[0]["name"] == captured_cmds[1]["name"]  # same channel → same session
+
+
+def _make_heal_goose(tmp_path):
+    """Fake goose that fails 'No session found' on --resume, succeeds on create."""
+    script = tmp_path / "heal_goose.sh"
+    success = json.dumps({"type": "message", "message": {"role": "assistant",
+        "created": 1, "content": [{"type": "text", "text": "fresh"}]}})
+    complete = json.dumps({"type": "complete"})
+    s_esc = success.replace("'", "'\\''")
+    c_esc = complete.replace("'", "'\\''")
+    body = [
+        "#!/bin/sh",
+        'for a in "$@"; do',
+        '  if [ "$a" = "--version" ]; then echo "goose 1.37.0"; exit 0; fi',
+        "done",
+        "cat >/dev/null",
+        'for a in "$@"; do',
+        '  if [ "$a" = "--resume" ]; then',
+        "    printf 'Error: No session found with name oa_x\\n' 1>&2; exit 1",
+        "  fi",
+        "done",
+        f"printf '%s\\n' '{s_esc}'",
+        f"printf '%s\\n' '{c_esc}'",
+        "exit 0",
+    ]
+    script.write_text("\n".join(body) + "\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script)
+
+
+@_aiorun
+async def test_e2e_too_old_version_blocks(tmp_path, monkeypatch):
+    # A Goose CLI older than the minimum is refused with an upgrade prompt and
+    # the task never runs.
+    proj = tmp_path / "proj"; proj.mkdir()
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    lines = [json.dumps({"type": "message", "message": {"role": "assistant",
+        "created": 1, "content": [{"type": "text", "text": "should not run"}]}}),
+        json.dumps({"type": "complete"})]
+    fake = _make_fake_goose(tmp_path, lines, version="1.10.0")
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x", working_dir=str(proj))
+    a._goose_binary = fake
+    sent = _instrument(a)
+
+    await a._handle_message({"content": "hi", "sessionId": "general"})
+
+    assert sent["response"] == []  # task did not run
+    assert len(sent["error"]) == 1
+    assert ">= 1.37.0" in sent["error"][0] and "too old" in sent["error"][0].lower()
+
+
+@_aiorun
+async def test_e2e_missing_session_auto_heals(tmp_path, monkeypatch):
+    # A persisted mapping points at a session Goose no longer has: --resume fails
+    # with "No session found", and the adapter recreates it instead of erroring.
+    proj = tmp_path / "proj"; proj.mkdir()
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    fake = _make_heal_goose(tmp_path)
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x", working_dir=str(proj))
+    a._goose_binary = fake
+    a._channel_sessions["general"] = goose_session_name("ws", "agentA", "general")  # stale
+    sent = _instrument(a)
+
+    await a._handle_message({"content": "hi", "sessionId": "general"})
+
+    assert sent["response"] == ["fresh"]  # recovered via a fresh session
+    assert any("new one" in s.lower() or "reset" in s.lower() for s in sent["status"])
+    assert sent["error"] == []
+
+
+@_aiorun
+async def test_e2e_invalid_working_dir_reports_error(tmp_path, monkeypatch):
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    fake = _make_fake_goose(tmp_path, [json.dumps({"type": "complete"})])
+    monkeypatch.setattr(goose_mod, "find_goose_binary", lambda: fake)
+    a = GooseAdapter("ws", "general", "tok", "agentA", "http://x",
+                     working_dir=str(tmp_path / "missing"))
+    a._goose_binary = fake
+    sent = _instrument(a)
+    await a._handle_message({"content": "hi", "sessionId": "general"})
+    assert sent["error"] and "does not exist" in sent["error"][0]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/agents/test_goose_stream.py
+++ b/tests/agents/test_goose_stream.py
@@ -1,0 +1,286 @@
+"""Unit tests for the Goose stream-json parser, redaction, and error
+classification (``openagents.adapters.goose_stream``).
+
+These are pure-function tests — no subprocess, no network. They pin the event
+schema verified against block/goose v1.38.0 and must stay behaviourally
+identical to the Node port (packages/agent-connector/test/goose.test.js).
+
+Run:
+    pytest tests/agents/test_goose_stream.py -v
+"""
+
+import json
+
+import pytest
+
+from openagents.adapters.goose_stream import (
+    GooseStreamParser,
+    classify_goose_error,
+    redact_secrets,
+)
+
+
+def _msg(role, content):
+    return json.dumps({"type": "message", "message": {"role": role, "created": 1, "content": content}})
+
+
+def _feed_all(parser, *lines):
+    events = []
+    for line in lines:
+        events.extend(parser.feed(line + "\n"))
+    events.extend(parser.finish())
+    return events
+
+
+def _kinds(events):
+    return [e["kind"] for e in events]
+
+
+class TestNormalStream:
+    def test_simple_assistant_final(self):
+        p = GooseStreamParser()
+        events = _feed_all(p, _msg("assistant", [{"type": "text", "text": "Hello world"}]),
+                           json.dumps({"type": "complete", "total_tokens": 10}))
+        assert {"kind": "final", "text": "Hello world"} in events
+        assert p.final_text == "Hello world"
+        assert not p.had_error
+        # final emitted exactly once
+        assert _kinds(events).count("final") == 1
+
+    def test_tool_call_and_result(self):
+        p = GooseStreamParser()
+        tool_req = {"type": "toolRequest", "id": "t1", "toolCall": {
+            "status": "success", "value": {"name": "developer__shell",
+                                           "arguments": {"command": "ls -la"}}}}
+        tool_resp = {"type": "toolResponse", "id": "t1",
+                     "toolResult": {"status": "success", "value": []}}
+        events = _feed_all(
+            p,
+            _msg("assistant", [tool_req]),
+            _msg("user", [tool_resp]),
+            _msg("assistant", [{"type": "text", "text": "done"}]),
+            json.dumps({"type": "complete", "total_tokens": 5}),
+        )
+        tool_events = [e for e in events if e["kind"] == "tool"]
+        assert tool_events and tool_events[0]["name"] == "developer__shell"
+        assert tool_events[0]["summary"] == "ls -la"
+        assert any(e["kind"] == "tool_result" and e["ok"] for e in events)
+        assert p.final_text == "done"
+
+    def test_thinking_event(self):
+        p = GooseStreamParser()
+        events = _feed_all(p, _msg("assistant", [
+            {"type": "thinking", "thinking": "reasoning...", "signature": "x"},
+            {"type": "text", "text": "answer"},
+        ]), json.dumps({"type": "complete"}))
+        assert any(e["kind"] == "thinking" and e["text"] == "reasoning..." for e in events)
+        assert p.final_text == "answer"
+
+    def test_intermediate_assistant_text_is_progress_not_thinking(self):
+        # Two assistant text messages: the earlier one is intermediate. It is
+        # assistant *output*, so it must be surfaced as ``progress`` (→ status),
+        # NOT fabricated as model-internal ``thinking``. The last is the final
+        # answer (sent once).
+        p = GooseStreamParser()
+        events = _feed_all(
+            p,
+            _msg("assistant", [{"type": "text", "text": "step 1 reasoning"}]),
+            _msg("assistant", [{"type": "text", "text": "final answer"}]),
+            json.dumps({"type": "complete"}),
+        )
+        progress = [e["text"] for e in events if e["kind"] == "progress"]
+        assert "step 1 reasoning" in progress
+        assert not any(e["kind"] == "thinking" for e in events)  # never mislabeled
+        assert p.final_text == "final answer"
+        assert _kinds(events).count("final") == 1
+
+    def test_genuine_thinking_vs_intermediate_progress(self):
+        # A real `thinking` content item is `thinking`; interim assistant text is
+        # `progress`. The two are kept distinct.
+        p = GooseStreamParser()
+        events = _feed_all(
+            p,
+            _msg("assistant", [{"type": "text", "text": "interim narration"}]),
+            _msg("assistant", [
+                {"type": "thinking", "thinking": "real chain of thought", "signature": "s"},
+                {"type": "text", "text": "answer"},
+            ]),
+            json.dumps({"type": "complete"}),
+        )
+        assert any(e["kind"] == "progress" and "interim" in e["text"] for e in events)
+        assert any(e["kind"] == "thinking" and "real chain" in e["text"] for e in events)
+        assert p.final_text == "answer"
+
+
+class TestChunkingAndRobustness:
+    def test_split_json_across_chunks(self):
+        p = GooseStreamParser()
+        line = _msg("assistant", [{"type": "text", "text": "chunked"}])
+        events = []
+        events += p.feed(line[:15])
+        events += p.feed(line[15:] + "\n")
+        events += p.feed(json.dumps({"type": "complete"}) + "\n")
+        events += p.finish()
+        assert p.final_text == "chunked"
+
+    def test_multiple_events_one_chunk(self):
+        p = GooseStreamParser()
+        blob = (_msg("assistant", [{"type": "text", "text": "a"}]) + "\n"
+                + _msg("assistant", [{"type": "text", "text": "b"}]) + "\n"
+                + json.dumps({"type": "complete"}) + "\n")
+        events = p.feed(blob) + p.finish()
+        assert p.final_text == "b"
+
+    def test_blank_and_invalid_lines_ignored(self):
+        p = GooseStreamParser()
+        events = []
+        events += p.feed("\n")
+        events += p.feed("not json at all\n")
+        events += p.feed("{ broken json\n")
+        events += p.feed(_msg("assistant", [{"type": "text", "text": "ok"}]) + "\n")
+        events += p.finish()
+        assert p.final_text == "ok"
+        assert not p.had_error  # invalid lines must never set the error flag
+
+    def test_unknown_event_type_ignored(self):
+        p = GooseStreamParser()
+        events = []
+        events += p.feed(json.dumps({"type": "brand_new_future_event", "x": 1}) + "\n")
+        events += p.feed(_msg("assistant", [{"type": "text", "text": "ok"}]) + "\n")
+        events += p.finish()
+        assert p.final_text == "ok"
+        assert not p.had_error
+
+    def test_unknown_content_item_ignored(self):
+        p = GooseStreamParser()
+        events = _feed_all(p, _msg("assistant", [
+            {"type": "image", "data": "..."},
+            {"type": "redactedThinking", "data": "..."},
+            {"type": "text", "text": "kept"},
+        ]), json.dumps({"type": "complete"}))
+        assert p.final_text == "kept"
+
+    def test_finish_without_complete_emits_final(self):
+        # Goose crashed mid-stream (no `complete`): still surface the last answer.
+        p = GooseStreamParser()
+        events = _feed_all(p, _msg("assistant", [{"type": "text", "text": "partial"}]))
+        assert {"kind": "final", "text": "partial"} in events
+
+    def test_large_output_does_not_blow_up(self):
+        p = GooseStreamParser()
+        big = "x" * 200000
+        events = _feed_all(p, _msg("assistant", [{"type": "text", "text": big}]),
+                           json.dumps({"type": "complete"}))
+        assert p.final_text == big
+
+
+class TestErrorEvents:
+    def test_error_event_sets_failure(self):
+        p = GooseStreamParser()
+        events = []
+        events += p.feed(json.dumps({"type": "error", "error": "boom"}) + "\n")
+        events += p.feed(json.dumps({"type": "complete"}) + "\n")
+        events += p.finish()
+        assert p.had_error
+        assert p.error_message == "boom"
+        assert any(e["kind"] == "error" for e in events)
+
+    def test_error_suppresses_final(self):
+        # Even if some assistant text arrived, an error must not be reported as
+        # a successful final answer.
+        p = GooseStreamParser()
+        events = []
+        events += p.feed(_msg("assistant", [{"type": "text", "text": "partial"}]) + "\n")
+        events += p.feed(json.dumps({"type": "error", "error": "401 Unauthorized"}) + "\n")
+        events += p.feed(json.dumps({"type": "complete"}) + "\n")
+        events += p.finish()
+        assert p.had_error
+        assert _kinds(events).count("final") == 0
+
+    def test_notification_progress_surfaced(self):
+        p = GooseStreamParser()
+        events = _feed_all(p, json.dumps({
+            "type": "notification", "extension_id": "developer",
+            "progress": {"progress": 0.5, "total": 1.0, "message": "halfway"}}))
+        assert any(e["kind"] == "notification" and e["text"] == "halfway" for e in events)
+
+
+# Canonical v1.37.0 stream-json sequence. Each line is exactly what
+# `goose run --output-format stream-json` emits, derived from the verified serde
+# definitions in block/goose v1.37.0:
+#   - StreamEvent: crates/goose-cli/src/session/mod.rs  (#[serde(tag="type", rename_all="snake_case")])
+#   - MessageContent: crates/goose/src/conversation/message.rs (#[serde(tag="type", rename_all="camelCase")])
+#   - ToolRequest.toolCall / ToolResponse.toolResult: crates/goose/src/conversation/tool_result_serde.rs
+#     ({"status":"success","value":…} | {"status":"error","error":…})
+STABLE_V137_STREAM = [
+    '{"type":"message","message":{"role":"assistant","created":1718000000,"content":'
+    '[{"type":"text","text":"I\'ll check the files."},'
+    '{"type":"toolRequest","id":"req_1","toolCall":{"status":"success","value":'
+    '{"name":"developer__shell","arguments":{"command":"ls"}}}}]}}',
+    '{"type":"message","message":{"role":"user","created":1718000001,"content":'
+    '[{"type":"toolResponse","id":"req_1","toolResult":{"status":"success","value":'
+    '[{"type":"text","text":"README.md\\nsrc"}]}}]}}',
+    '{"type":"message","message":{"role":"assistant","created":1718000002,"content":'
+    '[{"type":"text","text":"There are 2 entries: README.md and src."}]}}',
+    '{"type":"complete","total_tokens":1234,"input_tokens":1000,"output_tokens":234}',
+]
+
+
+class TestStableV137Fixture:
+    def test_full_sequence(self):
+        p = GooseStreamParser()
+        events = _feed_all(p, *STABLE_V137_STREAM)
+        # interim narration → progress (not thinking)
+        assert any(e["kind"] == "progress" and "check the files" in e["text"] for e in events)
+        assert not any(e["kind"] == "thinking" for e in events)
+        # tool call mapped with a concise preview
+        tool = next(e for e in events if e["kind"] == "tool")
+        assert tool["name"] == "developer__shell" and tool["summary"] == "ls"
+        assert any(e["kind"] == "tool_result" and e["ok"] for e in events)
+        # final answer once, complete with tokens
+        assert p.final_text == "There are 2 entries: README.md and src."
+        assert _kinds(events).count("final") == 1
+        assert any(e["kind"] == "complete" and e["tokens"] == 1234 for e in events)
+        assert not p.had_error
+
+
+class TestClassifyError:
+    @pytest.mark.parametrize("text,needle", [
+        ("Error: 401 Unauthorized invalid api key", "authentication"),
+        ("request error: 429 too many requests", "rate limit"),
+        ("model gpt-x does not exist", "model"),
+        ("no provider configured, run goose configure", "provider"),
+        ("tool execution denied: permission denied", "denied"),
+        ("extension failed to start: mcp server crashed", "extension"),
+        ("connection refused while reaching host", "reach the provider"),
+        ("rate_limit exceeded", "rate limit"),
+    ])
+    def test_classification(self, text, needle):
+        msg = classify_goose_error(text)
+        assert msg is not None
+        assert needle.lower() in msg.lower()
+
+    def test_empty_returns_none(self):
+        assert classify_goose_error("") is None
+        assert classify_goose_error(None) is None
+
+
+class TestRedaction:
+    def test_explicit_secret_masked(self):
+        out = redact_secrets("the key is supersecretvalue123 ok", ["supersecretvalue123"])
+        assert "supersecretvalue123" not in out
+        assert "***" in out
+
+    def test_bearer_and_apikey_masked(self):
+        out = redact_secrets("Authorization: Bearer sk-abc123def456ghi api_key=zzzttoppp999")
+        assert "sk-abc123def456ghi" not in out
+        assert "zzzttoppp999" not in out
+
+    def test_short_strings_not_masked(self):
+        # Don't mask trivially short values to avoid garbling normal text.
+        out = redact_secrets("hello world", ["ab"])
+        assert out == "hello world"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

This PR adds Beta Workspace support for Goose in OpenAgents.

## What changed

* Added Python and Node.js Goose adapters
* Added Headless execution with stdin and `stream-json`
* Added isolated session resume per Workspace channel
* Added Goose-native provider and model configuration
* Enabled the built-in `developer` extension with Headless-safe defaults
* Added cross-platform installation checks and process-tree cleanup
* Added Goose CLI minimum-version validation (`>= 1.37.0`)
* Added Launcher integration and README documentation
* Added Python and Node.js test coverage

## Validation

* Python Goose tests: `67 passed`
* Full Python Agent suite: `208 passed, 9 skipped`
* Node.js Goose tests: `39 passed`
* Full Node.js suite: `236 passed`
* Launcher build: passed
* Goose v1.37.0 CLI compatibility: verified from source

## Status

Real provider end-to-end testing is still pending, so Goose remains marked as Beta.
