### PR TITLE
add Cline CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ agn connect my-agent <workspace-token>    # connect agent into workspace
 | **Hermes Agent** | ✅ Supported | Nous Hermes CLI with tools, profiles, and memory |
 | **Cursor** | ✅ Supported | AI code editor |
 | **OpenCode** | ✅ Supported | Open-source terminal agent |
-| Aider, Goose, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+| **Gemini CLI** | ✅ Supported | Google's open-source CLI agent |
+| **Cline** | ✅ Supported (Beta) | Autonomous coding agent CLI — see [docs/guides/cline.md](docs/guides/cline.md) |
+| Aider, Goose, Copilot, Amp | 🔜 Coming soon | |
 
 ---
 

--- a/docs/guides/cline.md
+++ b/docs/guides/cline.md
@@ -1,0 +1,203 @@
+# Cline (CLI) in OpenAgents
+
+[Cline](https://github.com/cline/cline) is an autonomous coding agent. OpenAgents
+drives its **command-line interface** (`cline`, npm package
+[`cline`](https://www.npmjs.com/package/cline)) — *not* the VS Code extension —
+to run tasks inside a workspace channel and stream the results back.
+
+> **Status: Beta.** Verified end-to-end against Cline CLI **v3.0.26 / v3.0.27**
+> on Linux. It is intentionally kept out of the first-run onboarding wizard
+> (still installable from the Install tab). See [Known limitations](#known-limitations).
+
+## Supported platforms & minimum version
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| macOS | ✅ Verified (manual E2E) | `npm install -g cline` |
+| Linux | ✅ Verified (manual E2E) | `npm install -g cline` |
+| Windows | ⚠️ Implemented, automated tests only | `npm install -g cline` (ships a native `cline.exe`). Command parsing, `.cmd`/exe/Node-wrapper resolution, and process-tree termination have unit tests, but a real Windows end-to-end run has **not** yet been done. |
+
+- **Minimum CLI version: `3.0.0`** (HARD minimum; constant `MIN_CLINE_VERSION`,
+  and registry `check_ready.min_version`).
+  - A **confirmed-older** CLI (`< 3.0.0`) is treated as **incompatible**: the
+    Launcher reports `installed: true`, `compatible: false`, `ready: false`,
+    and the agent **refuses to start**, returning an upgrade prompt
+    (`npm install -g cline@latest`). It is **never** shown as "not installed".
+  - An **undetermined** version (`cline --version` unparseable or failing) is
+    reported as unknown (`compatible: null`) and the agent proceeds leniently —
+    we don't lock users out on a future `--version` format change.
+  - The version is cached (per binary path) so status refreshes don't re-spawn
+    `cline --version`; the cache is cleared on install/upgrade so a new version
+    is reflected promptly.
+- Requires **Node.js** to install (the published binary is a self-contained
+  bun build, so Node is not needed to *run* it).
+
+## Install
+
+From the OpenAgents **Launcher → Install** tab, choose **Cline** (runs
+`npm install -g cline` into an isolated runtime prefix at
+`~/.openagents/runtimes/cline/`). Or install it yourself:
+
+```bash
+npm install -g cline
+cline --version   # 3.0.x
+```
+
+> **Windows PATH / `.cmd` note.** npm installs a native `cline.exe` plus a
+> `cline` Node wrapper. The adapter resolves the binary across nvm/fnm/volta,
+> npm-global, and the OpenAgents runtime prefix. Because Cline declares its
+> `bin` as `"./bin/cline"`, a local prefix install does **not** create a
+> `node_modules/.bin/cline` shim — the installer/adapter fall back to the
+> package's own `bin/cline` (run under Node), so detection works regardless.
+
+## Configure & authenticate
+
+Cline supports many providers (its own Cline account, Anthropic, OpenAI,
+OpenRouter, …). There are two ways to authenticate:
+
+1. **Sign in with Cline's own flow** (recommended for the Cline account or a
+   provider's OAuth):
+   ```bash
+   cline auth                 # interactive
+   cline auth -p anthropic -k <key> -m claude-sonnet-4-6   # non-interactive
+   ```
+   Credentials are stored in `~/.cline/data/settings/providers.json`.
+
+2. **Let the Launcher manage an API key.** In the agent's config, set:
+   - `CLINE_API_KEY` — the provider key (passed to Cline via `-k`)
+   - `CLINE_PROVIDER` — e.g. `anthropic`, `openai`, `openrouter` (passed via `-P`)
+   - `CLINE_MODEL` — e.g. `anthropic/claude-sonnet-4.6` (passed via `-m`)
+
+   These are optional — leave them blank to use whatever `cline auth` configured.
+
+### How readiness is reported
+
+Config detection is a **heuristic** — `providers.json` is a Cline-version-specific
+internal file, so the real authority is the run result, not the file.
+
+- The Launcher badge shows **ready** when an API key env var is configured
+  (`CLINE_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY`).
+- Otherwise the adapter classifies auth conservatively from `providers.json`:
+  - **ready** only on a positive signal (a credential field is present, or an env key is set);
+  - **no_credentials** only when it can confirm a key-based provider is selected with no credential anywhere;
+  - **unknown** for everything it cannot confirm — file missing, unparseable, structure changed, or an account/OAuth provider (e.g. the `cline` account) whose credential lives outside `providers.json`.
+- **Config state never blocks startup** (only an incompatible version does). If
+  you authenticated via `cline auth` or an env var the adapter doesn't recognize,
+  the agent still runs and the run result decides. When detection is `unknown`
+  and a run fails on auth, the error message says detection couldn't confirm and
+  points you at the fix.
+- The adapter never reads, returns, or logs your API key value, and never writes
+  `providers.json` contents to a log — only whether the file exists, parses, and
+  what kind of config it is. Auth state is derived only from the *presence* of a
+  credential field.
+
+## Run from the Launcher / use in the Workspace
+
+1. Create a **Cline** agent and pick its **working directory** (the project to
+   work in). The directory must exist — there is no silent fallback.
+2. Connect it to a workspace and send a task in a channel.
+3. You'll see streamed **thinking**, **tool** activity (file edits, commands,
+   searches), and a final **answer**. File edits and shell commands run in the
+   chosen working directory.
+
+Each user message runs one `cline --json -c <dir> [...] <prompt>` process. The
+prompt is passed as a positional argument (an args array — never a shell
+string), so quotes, newlines, Chinese text, and shell metacharacters are
+delivered verbatim with no injection risk, and OpenAgents does not write the
+task text to its own logs.
+
+> **Process-argument visibility.** Cline's CLI requires the prompt as a
+> positional argument, so while the args array avoids any shell-injection risk
+> and OpenAgents redacts it from its logs, the prompt **can still appear in the
+> operating system's process list** (e.g. `ps`/Task Manager) and in diagnostic
+> tooling for the lifetime of the run, and Cline records it in its own session
+> history. Don't assume the prompt is fully private.
+
+## Permissions & auto-approve
+
+In normal (act) mode the agent runs **non-interactively with auto-approval on**
+(`--auto-approve true`). This is required for headless operation — there is no
+TTY to confirm each step — so **Cline will automatically run the tools and shell
+commands it decides to use** inside the working directory, without per-step
+confirmation. Plan/Act gating from the interactive TUI does not apply here.
+
+What this means in practice:
+
+- Point the agent at a working directory whose contents you're comfortable
+  having an autonomous agent edit and run commands in.
+- You can **interrupt** at any time from the Workspace (see *Stopping a task*).
+- Use **plan mode** for a read-only run: when the channel/agent is in plan mode
+  the adapter passes `-p` (plan) instead of `--auto-approve`, so Cline
+  investigates and proposes a plan rather than modifying files.
+
+Auto-approval is fixed-on for act mode (a headless requirement) and is **not**
+configurable to "confirm each step" from OpenAgents — that's a known, documented
+behavior, not a hidden default.
+
+## Sessions / resume
+
+Cline supports resuming a conversation with `--id <session-id>`, and OpenAgents
+uses it for per-channel continuity. Because Cline does **not** emit the session
+id in its `--json` stream, the adapter correlates the run's session via a
+**before/after snapshot** of `cline history --json`: it records the existing
+session ids *before* spawning, reads history again *after*, and considers only
+records that are new since then, in the same working directory, within the run
+window. It binds the **real** Cline session id (bound to the working directory)
+**only when exactly one candidate remains** — if two runs in the same directory
+finish close together (ambiguous), it declines and starts fresh next turn rather
+than risk binding the wrong session. It never resumes another project's session,
+and a stored session that can't be resumed degrades gracefully to a fresh
+session seeded with a short channel recap. Correlation failure never fails the
+task, and the prompt is never written to logs (only candidate counts are).
+
+## Stopping a task
+
+Use the workspace **Stop** control (or `/stop`). The adapter sends `SIGINT`
+(Cline's graceful abort), then escalates to `SIGTERM`/`SIGKILL` on the whole
+process group (POSIX) or `taskkill /F /T` (Windows). The UI returns to idle and
+no Cline worker process is left running.
+
+> Cline also starts a shared, long-lived `cline --cline-hub-daemon` per working
+> directory (like a language server). It is **not** killed on task stop because
+> it is shared infrastructure, not the task. Clean up stale ones with
+> `cline doctor fix`.
+
+## Common errors
+
+| Symptom | Meaning | Fix |
+|---------|---------|-----|
+| "Cline CLI not found" | Not installed / not on PATH | `npm install -g cline` |
+| "Cline is not authenticated … re-authenticate" | No valid credential | Set `CLINE_API_KEY` in the Launcher, or run `cline auth` |
+| "The configured model is unavailable" | Bad `CLINE_MODEL` | Pick a valid model for the provider |
+| "The selected provider is unavailable" | Bad/unknown `CLINE_PROVIDER` | Use a supported provider id |
+| "rate-limiting or over quota" | Provider 429 | Retry shortly |
+| "Working directory does not exist" | Bad agent working dir | Point the agent at an existing folder |
+| "Cline became unresponsive" | No output for ~5 min | The watchdog killed a hung run; retry |
+
+Error messages shown to users are friendly summaries; full (secret-redacted)
+detail goes only to the daemon log.
+
+## Known limitations
+
+- **No native multi-agent collaboration.** Cline runs as a **standalone coding
+  agent** — it can join a workspace, receive a task, and stream results back,
+  but it has no agent-to-agent messaging or `@mention` delegation. Its registry
+  capability is therefore `support.collaboration: false` (vs `workspace: true`).
+- **Workspace MCP tools.** The OpenAgents workspace MCP toolset (browser, file
+  sharing, todos, `@mention`) is not wired into Cline yet — it works only within
+  its working directory.
+- **Auto-approval is always on in act mode** (headless requirement; see
+  *Permissions & auto-approve*). Use plan mode for a read-only run.
+- **Interactive questions.** If Cline calls `ask_question` / `ask_followup_question`
+  mid-task, the question is surfaced to the channel, but a headless run cannot
+  round-trip an answer back into the same process — answer in your next message
+  (a new run).
+- **Prompt visibility.** The prompt may appear in the OS process list / Cline's
+  own history while a run is in flight (see *Run from the Launcher*).
+- **Windows** is implemented and unit-tested but not yet verified with a real
+  end-to-end run.
+- **Authenticated end-to-end** runs depend on you providing a provider key; CI
+  uses a mock CLI fixture rather than a real account.
+- The shared `cline-hub-daemon` persists per working directory (see *Stopping a
+  task*). It is shared infrastructure, not a leaked task process; clear stale
+  ones with `cline doctor fix`.

--- a/packages/agent-connector/CLAUDE.md
+++ b/packages/agent-connector/CLAUDE.md
@@ -29,12 +29,14 @@ src/
     cursor.js         CursorAdapter — extends LlmDirectAdapter for Cursor CLI
     hermes.js         HermesAdapter — Nous Research Hermes bridge
     gemini.js         GeminiAdapter — Google Gemini CLI bridge
+    cline.js          ClineAdapter — Cline CLI bridge (`cline --json`, one run per message)
+    cline-stream.js   Pure helpers for ClineAdapter (NDJSON parser, event mapping, redaction, error/auth/version classify, arg builder, session correlation) — unit-tested
     llm-direct.js     LlmDirectAdapter — base for adapters that call LLM APIs directly (SSE streaming)
     index.js          Adapter registry mapping type names to classes
     utils.js          Shared adapter utilities
     workspace-prompt.js  System prompt generation for workspace-connected agents
 
-registry.json        Bundled catalog of 14 agents with metadata, install commands, env config, readiness checks
+registry.json        Bundled catalog of agents with metadata, install commands, env config, readiness checks
 ```
 
 ## How the daemon works

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -84,20 +84,64 @@
   {
     "name": "cline",
     "label": "Cline",
-    "description": "Autonomous coding agent (VS Code extension)",
+    "description": "Autonomous coding agent CLI by Cline Bot",
     "homepage": "https://github.com/cline/cline",
     "tags": [
       "coding",
-      "vscode",
+      "cli",
       "autonomous"
     ],
+    "builtin": true,
+    "support": { "install": true, "workspace": true, "collaboration": false },
     "install": {
-      "binary": "code",
-      "verify": "code --list-extensions 2>/dev/null | grep -qi claude-dev",
-      "verify_win": "code --list-extensions 2>nul | findstr /i claude-dev",
-      "macos": "code --install-extension saoudrizwan.claude-dev",
-      "linux": "code --install-extension saoudrizwan.claude-dev",
-      "windows": "code --install-extension saoudrizwan.claude-dev"
+      "binary": "cline",
+      "requires": [
+        "nodejs"
+      ],
+      "verify": "cline --version",
+      "verify_win": "cline --version",
+      "macos": "npm install -g cline",
+      "linux": "npm install -g cline",
+      "windows": "npm install -g cline"
+    },
+    "adapter": {
+      "module": "openagents.adapters.cline",
+      "class": "ClineAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "CLINE_API_KEY",
+        "description": "API key for the selected provider (passed to Cline with -k). Leave blank to use `cline auth` (account or provider sign-in).",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "CLINE_PROVIDER",
+        "description": "Cline provider id (e.g. cline, anthropic, openai, openrouter). Leave blank to use Cline's configured default.",
+        "required": false,
+        "placeholder": "openrouter"
+      },
+      {
+        "name": "CLINE_MODEL",
+        "description": "Model id for the selected provider.",
+        "required": false,
+        "placeholder": "anthropic/claude-sonnet-4.6"
+      }
+    ],
+    "check_ready": {
+      "min_version": "3.0.0",
+      "env_vars": [
+        "CLINE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY"
+      ],
+      "saved_env_key": "CLINE_API_KEY",
+      "login_command": "cline auth",
+      "not_ready_message": "Not configured — set an API key (press e) or run: cline auth"
     }
   },
   {

--- a/packages/agent-connector/scripts/deploy-goose-core.js
+++ b/packages/agent-connector/scripts/deploy-goose-core.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Dev helper: overlay the Goose adapter into the *installed*
+ * `@openagents-org/agent-launcher` core — the copy the daemon actually loads
+ * (the Launcher auto-installs/updates it from npm via `ensureCoreLibrary`).
+ *
+ * Goose support lives in this repo's source, but until a core version that
+ * includes it is published to npm, a running daemon resolves an older published
+ * core and throws `Unknown agent type: goose`. Run this to deploy Goose into
+ * that core so it works before publishing, then restart the daemon.
+ *
+ * - Idempotent: re-running is a no-op.
+ * - Preserves every other adapter already in the core (e.g. `aider`).
+ * - `--pin <version>` sets the core's package.json version (use the current
+ *   `npm view @openagents-org/agent-launcher version`) so the Launcher's
+ *   auto-updater treats it as "already latest" and won't revert the overlay.
+ *
+ * Usage:
+ *   node scripts/deploy-goose-core.js [coreDir] [--pin <version>]
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SRC = path.resolve(__dirname, '..'); // packages/agent-connector
+
+function findCore(explicit) {
+  const candidates = [
+    explicit,
+    path.join(os.homedir(), '.openagents', 'nodejs', 'node_modules', '@openagents-org', 'agent-launcher'),
+    path.join(os.homedir(), '.openagents', 'core', 'node_modules', '@openagents-org', 'agent-launcher'),
+  ].filter(Boolean);
+  for (const c of candidates) {
+    if (fs.existsSync(path.join(c, 'src', 'adapters', 'index.js'))) return c;
+  }
+  try {
+    return path.dirname(require.resolve('@openagents-org/agent-launcher/package.json'));
+  } catch { /* not resolvable from here */ }
+  return null;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const pinIdx = args.indexOf('--pin');
+  const pinVersion = pinIdx >= 0 ? args[pinIdx + 1] : null;
+  const explicit = args.find((a) => !a.startsWith('--') && a !== pinVersion);
+
+  const core = findCore(explicit);
+  if (!core) {
+    console.error('Could not find an installed @openagents-org/agent-launcher core.');
+    console.error('Pass its directory as the first argument.');
+    process.exit(1);
+  }
+  const adir = path.join(core, 'src', 'adapters');
+
+  // 1) Copy the Goose adapter + its parser (deps base/workspace-prompt/paths
+  //    already exist in the core).
+  for (const f of ['goose.js', 'goose-stream.js']) {
+    fs.copyFileSync(path.join(SRC, 'src', 'adapters', f), path.join(adir, f));
+  }
+
+  // 2) Register it in the adapter map (idempotent, preserves other adapters).
+  const idxPath = path.join(adir, 'index.js');
+  let idx = fs.readFileSync(idxPath, 'utf-8');
+  if (!/require\(['"]\.\/goose['"]\)/.test(idx)) {
+    idx = idx.replace(
+      /(const BaseAdapter = require\(['"]\.\/base['"]\);\n)/,
+      "$1const GooseAdapter = require('./goose');\n",
+    );
+  }
+  if (!/\bgoose:\s*GooseAdapter\b/.test(idx)) {
+    idx = idx.replace(/(const ADAPTER_MAP = \{\n)/, '$1  goose: GooseAdapter,\n');
+  }
+  fs.writeFileSync(idxPath, idx);
+
+  // 3) Inject the registry.json entry (idempotent). Optional for createAdapter,
+  //    but keeps the core's catalog/env metadata complete.
+  const goose = JSON.parse(fs.readFileSync(path.join(SRC, 'registry.json'), 'utf-8'))
+    .find((e) => e.name === 'goose');
+  const regPath = path.join(core, 'registry.json');
+  if (goose && fs.existsSync(regPath)) {
+    let reg = JSON.parse(fs.readFileSync(regPath, 'utf-8'));
+    reg = reg.filter((e) => e.name !== 'goose');
+    const at = reg.findIndex((e) => e.name === 'opencode');
+    reg.splice(at >= 0 ? at + 1 : reg.length, 0, goose);
+    fs.writeFileSync(regPath, JSON.stringify(reg, null, 2) + '\n');
+  }
+
+  // 4) Optionally pin the version so the Launcher's auto-updater won't revert.
+  if (pinVersion) {
+    const pkgPath = path.join(core, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    pkg.version = pinVersion;
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
+
+  // Verify the deployed core can build a Goose adapter.
+  delete require.cache[require.resolve(idxPath)];
+  const { ADAPTER_MAP } = require(idxPath);
+  const ok = !!ADAPTER_MAP.goose;
+
+  console.log(`Goose deployed to core: ${core}`);
+  console.log(`  adapter map has goose: ${ok}`);
+  if (pinVersion) console.log(`  version pinned to: ${pinVersion}`);
+  console.log('Restart the daemon to load it (quit & relaunch the Launcher, or `agn down && agn up`).');
+  process.exit(ok ? 0 : 2);
+}
+
+main();

--- a/packages/agent-connector/src/adapters/cline-stream.js
+++ b/packages/agent-connector/src/adapters/cline-stream.js
@@ -1,0 +1,632 @@
+/**
+ * Pure, side-effect-free helpers for the Cline CLI adapter.
+ *
+ * Everything here is I/O-free and deterministic so it can be unit-tested
+ * without spawning the `cline` binary or touching the network: the NDJSON
+ * stream parser, the event interpreter, secret redaction, error/auth/version
+ * classification, the (shell-safe) argument builder, and the session-id
+ * correlation used for `--id` resume.
+ *
+ * Verified against Cline CLI v3.0.26 (`cline --json`). The `--json` stream is
+ * NDJSON on stdout where each line is an envelope:
+ *   {ts, type:"hook_event", hookEventName, agentId, taskId, parentAgentId}
+ *   {ts, type:"run_start", providerId, modelId, catalog, thinking, mode}   (verbose)
+ *   {ts, type:"agent_event", event:{...}}     <- the model's activity
+ *   {ts, type:"team_event",  event:{...}}     <- only when teams/spawn enabled
+ *   {ts, type:"run_result", finishReason, iterations, usage, durationMs, text, model}
+ * and stderr carries {ts, type:"error", message} on fatal errors.
+ *
+ * The inner agent_event `event.type` is one of nine variants; text, reasoning
+ * and tool activity are multiplexed through content_start/content_update/
+ * content_end keyed by `contentType` ("text" | "reasoning" | "tool").
+ */
+
+'use strict';
+
+// Minimum Cline CLI version whose headless `--json` / `-c` / `--id` interface
+// matches what this adapter drives. Cline's CLI changed its surface across
+// majors (v1 preview → v2 → v3); the v3 line is what we target.
+//
+// Policy is a HARD minimum: a CONFIRMED-older version (parseable, < 3.0.0) is
+// incompatible and the agent must not start. Only an UNDETERMINED version
+// (output unparseable, or `cline --version` failed) is treated leniently as
+// "unknown" — we proceed rather than lock users out on a future `--version`
+// format change — but it is never reported as compatible.
+const MIN_CLINE_VERSION = '3.0.0';
+
+// ---------------------------------------------------------------------------
+// Version handling
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull a dotted version (e.g. "3.0.26") out of `cline --version` output.
+ * Returns null when nothing version-like is present.
+ */
+function parseClineVersion(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const m = raw.match(/(\d+)\.(\d+)\.(\d+)(?:[-.][0-9A-Za-z.]+)?/);
+  return m ? m[0] : null;
+}
+
+/** Compare two dotted versions. Returns -1, 0, or 1. */
+function compareVersions(a, b) {
+  const pa = String(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Classify an installed Cline version against MIN_CLINE_VERSION.
+ * @returns {{version: string|null, supported: boolean|null}}
+ *   supported === true  → meets the minimum (>= 3.0.0) → may start
+ *   supported === false → CONFIRMED too old → incompatible, must NOT start
+ *   supported === null  → version undetermined (unparseable) → unknown, proceed
+ *                         leniently but never claim compatible
+ */
+function classifyClineVersion(rawVersion) {
+  const version = parseClineVersion(rawVersion);
+  if (!version) return { version: null, supported: null };
+  return { version, supported: compareVersions(version, MIN_CLINE_VERSION) >= 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Secret redaction
+// ---------------------------------------------------------------------------
+
+// Redaction is applied to anything that could reach a log line: stderr text,
+// error messages, and the spawn argv we echo for debugging. We never log the
+// user's prompt or raw env, but defense-in-depth keeps key material out of the
+// daemon log even if an upstream message echoes it back.
+const SECRET_PATTERNS = [
+  // Provider API keys: sk-..., sk-ant-..., sk-or-..., etc.
+  /\bsk-[A-Za-z0-9._-]{8,}\b/g,
+  // OpenRouter / generic long opaque tokens prefixed with a vendor tag
+  /\b(?:or|rk|gsk|ghp|gho|ghu|ghs|github_pat)[-_][A-Za-z0-9._-]{12,}\b/g,
+  // Bearer / Authorization header values
+  /\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+  // AWS access key ids
+  /\bAKIA[0-9A-Z]{16}\b/g,
+];
+
+// Sensitive keys we scrub when serializing an arbitrary object (e.g. a tool
+// input) for a preview/log line.
+const SENSITIVE_KEY_RE = /(api[_-]?key|secret|token|password|passwd|authorization|cookie|credential)/i;
+
+/** Redact obvious secret material from a free-text string. */
+function redactSecrets(text) {
+  if (text == null) return text;
+  let out = String(text);
+  for (const re of SECRET_PATTERNS) out = out.replace(re, '«redacted»');
+  return out;
+}
+
+/**
+ * Redact an arbitrary value for previews: any object key matching
+ * SENSITIVE_KEY_RE has its value masked, and remaining strings are run through
+ * redactSecrets. Returns a JSON-safe clone (never mutates the input).
+ */
+function redactValue(value, depth = 0) {
+  if (depth > 6) return '…';
+  if (value == null) return value;
+  if (typeof value === 'string') return redactSecrets(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (Array.isArray(value)) return value.map((v) => redactValue(v, depth + 1));
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = SENSITIVE_KEY_RE.test(k) ? '«redacted»' : redactValue(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a raw Cline error string to a coarse category plus a user-facing message.
+ * Frontends should show `userMessage`; the raw (redacted) text goes to logs.
+ *
+ * @returns {{kind: string, userMessage: string}}
+ *   kind ∈ auth | provider | model | rate_limit | network | config | timeout | unknown
+ */
+function classifyClineError(rawMessage) {
+  const msg = redactSecrets(String(rawMessage || '').trim());
+  const low = msg.toLowerCase();
+
+  if (/unauthorized|authenticat|invalid.*(api[ _-]?key|token|credential)|\b401\b|\b403\b|re-authenticate|not signed in|no api key|api key (is )?(missing|required|not)/i.test(low)) {
+    return {
+      kind: 'auth',
+      userMessage:
+        'Cline is not authenticated. Configure an API key for this agent in the launcher, ' +
+        'or run `cline auth` to sign in. (' + truncate(msg, 160) + ')',
+    };
+  }
+  if (/rate.?limit|too many requests|\b429\b|quota|overloaded/i.test(low)) {
+    return {
+      kind: 'rate_limit',
+      userMessage: 'The provider is rate-limiting or over quota. Please retry shortly. (' + truncate(msg, 160) + ')',
+    };
+  }
+  if (/\bmodel\b.*(not found|unavailable|invalid|does not exist|unknown)|no such model|unsupported model/i.test(low)) {
+    return {
+      kind: 'model',
+      userMessage: 'The configured model is unavailable. Pick a valid model for this provider. (' + truncate(msg, 160) + ')',
+    };
+  }
+  if (/provider.*(not|un)(available|configured|supported|known)|unknown provider|no provider/i.test(low)) {
+    return {
+      kind: 'provider',
+      userMessage: 'The selected provider is unavailable or unconfigured. Check the provider/model settings. (' + truncate(msg, 160) + ')',
+    };
+  }
+  if (/timed?\s?out|timeout|deadline exceeded/i.test(low)) {
+    return { kind: 'timeout', userMessage: 'The task timed out. (' + truncate(msg, 160) + ')' };
+  }
+  if (/econn|enotfound|etimedout|network|fetch failed|socket|dns|tls|certificate|getaddrinfo/i.test(low)) {
+    return { kind: 'network', userMessage: 'A network error occurred reaching the provider. (' + truncate(msg, 160) + ')' };
+  }
+  if (/config|settings|providers\.json|parse|malformed|invalid json/i.test(low)) {
+    return { kind: 'config', userMessage: 'Cline configuration looks invalid. (' + truncate(msg, 160) + ')' };
+  }
+  return { kind: 'unknown', userMessage: msg ? 'Cline error: ' + truncate(msg, 200) : 'Cline returned an error.' };
+}
+
+function truncate(s, n) {
+  s = String(s || '');
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+// ---------------------------------------------------------------------------
+// Auth / config classification (from a parsed providers.json object)
+// ---------------------------------------------------------------------------
+
+// Field names that, when present and non-empty inside a provider's `settings`,
+// indicate a stored credential. We only ever test for PRESENCE — values are
+// never read into the return value or logged.
+const CREDENTIAL_FIELDS = ['apiKey', 'apikey', 'token', 'accessToken', 'access_token', 'refreshToken', 'sessionToken'];
+
+// Env vars Cline reads natively (a key here means the run can authenticate even
+// when providers.json has no stored credential).
+const CLINE_AUTH_ENV_VARS = [
+  'CLINE_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'AI_GATEWAY_API_KEY',
+  'V0_API_KEY',
+];
+
+// Providers that authenticate WITHOUT an apiKey in providers.json (account /
+// OAuth — the credential lives elsewhere). For these, a missing apiKey is NOT
+// evidence of "no credentials" — we must report unknown, not no_credentials.
+const ACCOUNT_PROVIDERS = new Set(['cline']);
+
+function hasCredential(settings) {
+  if (!settings || typeof settings !== 'object') return false;
+  return CREDENTIAL_FIELDS.some(
+    (f) => typeof settings[f] === 'string' && settings[f].trim().length > 0,
+  );
+}
+
+/**
+ * Classify Cline auth/config from a parsed providers.json object and the agent
+ * env. Pure: never reads files, never exposes secret values.
+ *
+ * providers.json is a Cline-version-specific internal file, so this is a
+ * HEURISTIC, never an absolute auth verdict — the real authority is the run
+ * result. The classification is deliberately conservative:
+ *   - `ready`         only on a POSITIVE signal: a credential field is present,
+ *                     or a native env key is set.
+ *   - `no_credentials` only when we can CONFIRM a key-based provider is selected
+ *                     with no credential anywhere (and it isn't an account/OAuth
+ *                     provider). Used for a softer hint, never to block startup.
+ *   - `unknown`       everything we cannot confirm: file missing, unparseable,
+ *                     unrecognized shape, an account/OAuth provider without a
+ *                     stored key, or no identifiable provider. Never reported as
+ *                     ready, and never blocks startup.
+ *
+ * @param {object|null} providersJson  parsed providers.json, or null (missing),
+ *                                      or a non-plain value (unparseable/changed)
+ * @param {object} env                 the agent env (checked for native key vars)
+ * @returns {{state: string, provider: string|null, model: string|null, detail: string}}
+ *   state ∈ ready | no_credentials | unknown
+ */
+function classifyClineAuth(providersJson, env = {}) {
+  const envKey = CLINE_AUTH_ENV_VARS.find((k) => (env[k] || '').trim());
+  if (envKey) {
+    return { state: 'ready', provider: null, model: null, detail: `API key via ${envKey}` };
+  }
+
+  // No config file → cannot confirm anything (could be env/OAuth/custom data-dir).
+  if (providersJson === undefined || providersJson === null) {
+    return { state: 'unknown', provider: null, model: null, detail: 'No providers.json; auth undetermined' };
+  }
+  // Unparseable / not a recognizable object → undetermined, NOT a hard "no creds".
+  if (typeof providersJson !== 'object' || Array.isArray(providersJson) || providersJson.__parse_error) {
+    return { state: 'unknown', provider: null, model: null, detail: 'providers.json unparseable or unrecognized' };
+  }
+
+  const providers = providersJson.providers && typeof providersJson.providers === 'object' && !Array.isArray(providersJson.providers)
+    ? providersJson.providers
+    : null;
+  if (!providers) {
+    return { state: 'unknown', provider: null, model: null, detail: 'providers.json shape unrecognized' };
+  }
+  const active = providersJson.lastUsedProvider || null;
+
+  // Positive signal: any provider carries a stored credential.
+  for (const id of Object.keys(providers)) {
+    if (hasCredential((providers[id] || {}).settings)) {
+      return { state: 'ready', provider: id, model: (providers[id].settings || {}).model || null, detail: 'Provider credential present' };
+    }
+  }
+
+  // No credential anywhere. Decide between no_credentials (confident) vs unknown.
+  const activeEntry = active && providers[active] ? providers[active] : null;
+  if (activeEntry && activeEntry.settings && !ACCOUNT_PROVIDERS.has(active)) {
+    // A key-based provider is selected with no stored credential → confident.
+    return { state: 'no_credentials', provider: active, model: activeEntry.settings.model || null, detail: 'Key-based provider selected but no credential stored' };
+  }
+  // Account/OAuth provider without a stored key, empty providers, or no active
+  // provider → cannot confirm; the credential may live outside providers.json.
+  return { state: 'unknown', provider: active, model: (activeEntry && activeEntry.settings && activeEntry.settings.model) || null, detail: 'No stored credential found; auth undetermined' };
+}
+
+// ---------------------------------------------------------------------------
+// Argument building (shell-safe — consumed as a spawn args array, never a string)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the argv (after the binary) for a one-shot headless Cline run.
+ * The prompt is always the LAST positional so any leading dashes in user text
+ * cannot be parsed as flags. Returns a flat string array suitable for
+ * child_process.spawn(bin, args) — there is NO shell, so quotes/newlines/$()
+ * in the prompt are passed verbatim and safely.
+ *
+ * @param {object} o
+ * @param {string} o.prompt        required — the task text (positional)
+ * @param {string} [o.cwd]         working directory (-c)
+ * @param {string} [o.sessionId]   resume an existing session (--id)
+ * @param {boolean} [o.planMode]   plan mode (-p) vs default act+auto-approve
+ * @param {string} [o.provider]    provider id (-P)
+ * @param {string} [o.model]       model id (-m)
+ * @param {string} [o.apiKey]      per-run API key (-k) — caller must keep out of logs
+ * @param {string} [o.thinking]    reasoning level none|low|medium|high|xhigh (--thinking)
+ * @param {number} [o.timeoutSec]  run timeout in seconds (-t); 0/undefined = no timeout
+ */
+function buildClineArgs(o) {
+  if (!o || typeof o.prompt !== 'string') {
+    throw new Error('buildClineArgs: prompt (string) is required');
+  }
+  const args = ['--json'];
+  if (o.cwd) args.push('-c', o.cwd);
+  if (o.sessionId) args.push('--id', o.sessionId);
+  // Default (no -p) is "act mode with auto-approve enabled" per `cline --help`.
+  // We make auto-approval explicit so a future change to Cline's default can't
+  // silently start blocking on tool prompts in our non-interactive context.
+  if (o.planMode) {
+    args.push('-p');
+  } else {
+    args.push('--auto-approve', 'true');
+  }
+  if (o.provider) args.push('-P', o.provider);
+  if (o.model) args.push('-m', o.model);
+  if (o.apiKey) args.push('-k', o.apiKey);
+  if (o.thinking) args.push('--thinking', o.thinking);
+  if (o.timeoutSec && Number(o.timeoutSec) > 0) args.push('-t', String(Math.floor(Number(o.timeoutSec))));
+  // Prompt LAST and positional so it is never mistaken for an option.
+  args.push(o.prompt);
+  return args;
+}
+
+/** Return a copy of an args array with the value after `-k` redacted, for logging. */
+function redactArgs(args) {
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    out.push(args[i]);
+    if (args[i] === '-k' || args[i] === '--key') {
+      out.push('«redacted»');
+      i++; // skip the real key
+    } else if (i === args.length - 1) {
+      // last positional is the prompt — don't echo user content to logs
+      out[out.length - 1] = '«prompt»';
+    } else {
+      out[out.length - 1] = redactSecrets(args[i]);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// NDJSON stream parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Incremental NDJSON parser. Handles:
+ *  - chunked input where one JSON object is split across many chunks
+ *  - a single chunk that contains several complete lines
+ *  - mixed "\n" and "\r\n" line endings and a trailing incomplete line
+ *  - stray non-JSON lines (skipped, surfaced via `garbage` for optional logging)
+ *
+ * Usage:
+ *   const p = new ClineStreamParser();
+ *   for (const chunk of chunks) for (const env of p.push(chunk)) handle(env);
+ *   for (const env of p.flush()) handle(env);   // trailing buffer at EOF
+ */
+class ClineStreamParser {
+  constructor() {
+    this._buf = '';
+    this.garbage = []; // lines that failed JSON.parse (for debugging only)
+  }
+
+  push(chunk) {
+    if (chunk == null) return [];
+    this._buf += chunk.toString('utf-8');
+    const out = [];
+    let nl;
+    while ((nl = this._buf.indexOf('\n')) !== -1) {
+      const line = this._buf.slice(0, nl);
+      this._buf = this._buf.slice(nl + 1);
+      const env = this._parseLine(line);
+      if (env !== undefined) out.push(env);
+    }
+    return out;
+  }
+
+  flush() {
+    const out = [];
+    if (this._buf.trim()) {
+      const env = this._parseLine(this._buf);
+      if (env !== undefined) out.push(env);
+    }
+    this._buf = '';
+    return out;
+  }
+
+  _parseLine(line) {
+    const trimmed = line.replace(/\r$/, '').trim();
+    if (!trimmed) return undefined;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      if (this.garbage.length < 50) this.garbage.push(trimmed.slice(0, 500));
+      return undefined;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Envelope → normalized event interpretation
+// ---------------------------------------------------------------------------
+
+// Tools that represent a question for the human rather than an autonomous action.
+const ASK_TOOLS = new Set(['ask_question', 'ask_followup_question']);
+
+/** Human-friendly verb for a Cline tool name (best-effort; unknown → the name). */
+function friendlyToolLabel(toolName) {
+  switch (toolName) {
+    case 'editor':
+    case 'apply_patch':
+      return 'Editing file';
+    case 'read_files':
+      return 'Reading files';
+    case 'run_commands':
+      return 'Running command';
+    case 'search_codebase':
+      return 'Searching codebase';
+    case 'fetch_web_content':
+      return 'Fetching web content';
+    case 'skills':
+      return 'Using skill';
+    case 'spawn_agent':
+      return 'Spawning subagent';
+    default:
+      return toolName || 'Tool';
+  }
+}
+
+/** Best-effort one-line preview of a tool's input, with secrets scrubbed. */
+function toolInputPreview(input) {
+  if (input == null) return '';
+  if (typeof input === 'string') return truncate(redactSecrets(input), 160);
+  if (typeof input !== 'object') return truncate(String(input), 160);
+  const i = input;
+  let v =
+    (Array.isArray(i.commands) && i.commands.join('; ')) ||
+    i.command ||
+    (Array.isArray(i.file_paths) && i.file_paths.join(', ')) ||
+    i.file_path || i.path ||
+    (Array.isArray(i.queries) && i.queries.join(', ')) ||
+    i.query || i.pattern ||
+    (Array.isArray(i.requests) && i.requests.map((r) => r && r.url).filter(Boolean).join(', ')) ||
+    i.url || i.skill || i.question || '';
+  if (!v) {
+    try { v = JSON.stringify(redactValue(i)); } catch { v = ''; }
+  }
+  return truncate(redactSecrets(String(v)), 160);
+}
+
+/**
+ * Interpret one stream envelope into zero or more normalized events the adapter
+ * can act on. Stateless: relies on Cline emitting whole text/output in the
+ * `content_end` events (so we never double-count streamed deltas).
+ *
+ * Normalized event kinds:
+ *   {kind:'text', text}                 final assistant text block for a turn
+ *   {kind:'reasoning', text}            a thinking/reasoning block
+ *   {kind:'tool_start', toolName, toolCallId, label, preview, input}
+ *   {kind:'tool_end', toolName, toolCallId, ok, error, durationMs}
+ *   {kind:'ask', question, options, toolCallId}
+ *   {kind:'notice', noticeType, reason, text}
+ *   {kind:'error', message, recoverable}     (from agent_event error)
+ *   {kind:'done', reason, text}              inner "done" event
+ *   {kind:'result', finishReason, text, model, ok}   terminal run_result
+ *   {kind:'aborted', reason, text}           run_aborted
+ *   {kind:'session', taskId, agentId}        hook_event agent_start (informational)
+ */
+function interpretClineEnvelope(env) {
+  if (!env || typeof env !== 'object') return [];
+  const type = env.type;
+
+  if (type === 'run_result') {
+    const reason = env.finishReason || 'unknown';
+    return [{
+      kind: 'result',
+      finishReason: reason,
+      ok: reason === 'completed',
+      text: typeof env.text === 'string' ? env.text : '',
+      model: env.model && env.model.id ? env.model.id : null,
+    }];
+  }
+  if (type === 'run_aborted') {
+    return [{ kind: 'aborted', reason: env.reason || 'aborted', text: env.message || '' }];
+  }
+  if (type === 'hook_event') {
+    if (env.hookEventName === 'agent_start') {
+      return [{ kind: 'session', taskId: env.taskId || null, agentId: env.agentId || null }];
+    }
+    return [];
+  }
+  if (type !== 'agent_event') return []; // run_start/team_event/unknown → no UI action
+
+  const ev = env.event;
+  if (!ev || typeof ev !== 'object') return [];
+
+  switch (ev.type) {
+    case 'content_end': {
+      // The whole, final content for a block. Deltas (content_start/_update)
+      // are intentionally ignored to avoid duplicate output.
+      if (ev.contentType === 'text') {
+        const t = (ev.text || '').trim();
+        return t ? [{ kind: 'text', text: t }] : [];
+      }
+      if (ev.contentType === 'reasoning') {
+        const t = (ev.reasoning || '').trim();
+        return t ? [{ kind: 'reasoning', text: t }] : [];
+      }
+      if (ev.contentType === 'tool') {
+        return [{
+          kind: 'tool_end',
+          toolName: ev.toolName || '',
+          toolCallId: ev.toolCallId || null,
+          ok: !ev.error,
+          error: ev.error ? redactSecrets(String(ev.error)) : null,
+          durationMs: typeof ev.durationMs === 'number' ? ev.durationMs : null,
+        }];
+      }
+      return [];
+    }
+    case 'content_start': {
+      // We only surface tool *starts* (text/reasoning starts are deltas we skip).
+      if (ev.contentType !== 'tool') return [];
+      const toolName = ev.toolName || '';
+      if (ASK_TOOLS.has(toolName)) {
+        const input = ev.input || {};
+        return [{
+          kind: 'ask',
+          toolCallId: ev.toolCallId || null,
+          question: typeof input.question === 'string' ? input.question : '',
+          options: Array.isArray(input.options) ? input.options.slice(0, 12) : [],
+        }];
+      }
+      return [{
+        kind: 'tool_start',
+        toolName,
+        toolCallId: ev.toolCallId || null,
+        label: friendlyToolLabel(toolName),
+        preview: toolInputPreview(ev.input),
+        input: ev.input,
+      }];
+    }
+    case 'error': {
+      const e = ev.error;
+      const message = e && typeof e === 'object' ? (e.message || '') : String(e || '');
+      return [{ kind: 'error', message: redactSecrets(message), recoverable: ev.recoverable === true }];
+    }
+    case 'notice': {
+      return [{
+        kind: 'notice',
+        noticeType: ev.noticeType || null,
+        reason: ev.reason || null,
+        text: redactSecrets(ev.message || ''),
+      }];
+    }
+    case 'done': {
+      return [{ kind: 'done', reason: ev.reason || 'completed', text: typeof ev.text === 'string' ? ev.text : '' }];
+    }
+    // content_update / iteration_start / iteration_end / usage → no UI action
+    default:
+      return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session-id correlation (for --id resume)
+// ---------------------------------------------------------------------------
+
+/**
+ * Cline does NOT emit a resumable session id in its `--json` stream — it only
+ * records sessions in `cline history --json`. We correlate the new session with
+ * a strict BEFORE/AFTER snapshot diff: the caller records the set of session ids
+ * that existed before spawning; this picks the run's session ONLY from records
+ * that are (a) new since then, (b) in the same working directory, and (c) within
+ * the run's time window. It binds ONLY when exactly one candidate remains —
+ * never guessing — so two concurrent runs in the same directory both decline
+ * rather than risk binding the wrong session.
+ *
+ * @param {Array} historyAfter      parsed `cline history --json` taken AFTER the run
+ * @param {object} o
+ * @param {string} o.cwd            the run's working directory (required to match)
+ * @param {Set|Array} [o.beforeIds] session ids that existed BEFORE the run (excluded)
+ * @param {number} [o.sinceMs]      spawn timestamp (ms); only sessions started at/after count
+ * @param {string} [o.promptNeedle] a slice of the prompt; further narrows candidates
+ * @returns {string|null}  the session id when exactly one candidate matches, else null
+ */
+function pickClineSessionId(historyAfter, o) {
+  if (!Array.isArray(historyAfter) || !o || !o.cwd) return null;
+  const before = o.beforeIds instanceof Set
+    ? o.beforeIds
+    : new Set(Array.isArray(o.beforeIds) ? o.beforeIds : []);
+  const since = typeof o.sinceMs === 'number' ? o.sinceMs - 2000 : null; // small clock-skew slack
+  const candidates = historyAfter.filter((s) => {
+    if (!s || s.cwd !== o.cwd || !s.sessionId) return false;
+    if (before.has(s.sessionId)) return false; // only sessions NEW since the before-snapshot
+    if (since != null) {
+      const started = Date.parse(s.startedAt || s.updatedAt || '');
+      if (Number.isFinite(started) && started < since) return false;
+    }
+    if (o.promptNeedle && typeof s.prompt === 'string' && !s.prompt.includes(o.promptNeedle)) return false;
+    return true;
+  });
+  // Strict: bind only on a single unambiguous candidate; otherwise decline.
+  return candidates.length === 1 ? candidates[0].sessionId : null;
+}
+
+module.exports = {
+  MIN_CLINE_VERSION,
+  parseClineVersion,
+  compareVersions,
+  classifyClineVersion,
+  redactSecrets,
+  redactValue,
+  classifyClineError,
+  classifyClineAuth,
+  CLINE_AUTH_ENV_VARS,
+  buildClineArgs,
+  redactArgs,
+  ClineStreamParser,
+  interpretClineEnvelope,
+  friendlyToolLabel,
+  toolInputPreview,
+  pickClineSessionId,
+};

--- a/packages/agent-connector/src/adapters/cline.js
+++ b/packages/agent-connector/src/adapters/cline.js
@@ -670,12 +670,14 @@ class ClineAdapter extends BaseAdapter {
     return new Promise((resolve) => {
       let settled = false;
       let watchdogTimer = null;
+      let fallbackTimer = null;
       let lastDataMs = Date.now();
       let silences = 0;
       let queue = Promise.resolve();
 
       const cleanup = () => {
         if (watchdogTimer) { clearInterval(watchdogTimer); watchdogTimer = null; }
+        if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
         if (proc.stdout) proc.stdout.removeAllListeners();
         if (proc.stderr) proc.stderr.removeAllListeners();
       };
@@ -808,14 +810,26 @@ class ClineAdapter extends BaseAdapter {
         }
       }, WATCHDOG_INTERVAL_MS);
 
-      proc.on('exit', (code, signal) => {
-        // Drain any trailing buffered lines, then settle once the queue flushes.
-        const tail = parser.flush();
-        for (const ev of tail) queue = queue.then(() => handleEvent(ev)).catch(() => {});
+      // Finalize only once BOTH the process has exited AND stdout has ended.
+      // Listening on 'exit' alone is racy: on some platforms (notably macOS) the
+      // final stdout chunk carrying `run_result` is delivered AFTER 'exit'
+      // fires, which would drop the answer. Waiting for stdout 'end' guarantees
+      // every 'data' event was emitted first. A short fallback after 'exit'
+      // covers the rare case where a lingering child keeps the pipe open so
+      // 'end' never arrives (the data is already buffered/delivered by then).
+      let exited = false;
+      let stdoutEnded = false;
+      let exitCode = null;
+      let exitSignal = null;
+
+      const finalize = () => {
+        if (settled) return;
+        if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+        for (const ev of parser.flush()) queue = queue.then(() => handleEvent(ev)).catch(() => {});
         for (const ev of stderrParser.flush()) adoptStderr(ev);
         queue = queue.then(() => {
-          if (code !== 0 && !state.ok && !state.resultError && !state.eventError && !state.stderrError) {
-            const why = signal ? `terminated by signal ${signal}` : `exited with code ${code}`;
+          if (exitCode !== 0 && !state.ok && !state.resultError && !state.eventError && !state.stderrError) {
+            const why = exitSignal ? `terminated by signal ${exitSignal}` : `exited with code ${exitCode}`;
             if (stderrText.trim()) this._log(`cline stderr: ${redactSecrets(stderrText.trim().slice(0, 500))}`);
             if (!this._stoppingChannels.has(channel)) {
               state.resultError = `Cline ${why}.`;
@@ -823,6 +837,20 @@ class ClineAdapter extends BaseAdapter {
           }
           settle();
         }).catch(() => settle());
+      };
+      const maybeFinalize = () => { if (exited && stdoutEnded) finalize(); };
+
+      if (proc.stdout) proc.stdout.on('end', () => { stdoutEnded = true; maybeFinalize(); });
+      else stdoutEnded = true;
+
+      proc.on('exit', (code, signal) => {
+        exited = true;
+        exitCode = code;
+        exitSignal = signal;
+        // If stdout 'end' hasn't fired shortly after exit (a lingering child
+        // holding the pipe), force finalization — buffered data is already in.
+        fallbackTimer = setTimeout(() => { stdoutEnded = true; finalize(); }, 1500);
+        maybeFinalize();
       });
 
       proc.on('error', (err) => {

--- a/packages/agent-connector/src/adapters/cline.js
+++ b/packages/agent-connector/src/adapters/cline.js
@@ -678,8 +678,11 @@ class ClineAdapter extends BaseAdapter {
       const cleanup = () => {
         if (watchdogTimer) { clearInterval(watchdogTimer); watchdogTimer = null; }
         if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
-        if (proc.stdout) proc.stdout.removeAllListeners();
-        if (proc.stderr) proc.stderr.removeAllListeners();
+        // Drop data/end listeners but KEEP an 'error' guard: a SIGKILL'd child's
+        // pipe can still emit 'error' after we settle, and an unhandled stream
+        // 'error' would crash the process.
+        if (proc.stdout) { proc.stdout.removeAllListeners(); proc.stdout.on('error', () => {}); }
+        if (proc.stderr) { proc.stderr.removeAllListeners(); proc.stderr.on('error', () => {}); }
       };
       const settle = () => {
         if (settled) return;
@@ -769,6 +772,14 @@ class ClineAdapter extends BaseAdapter {
           }
         }
       };
+
+      // Swallow stdio stream errors. When we SIGKILL the process (stop /
+      // watchdog), the child's stdout/stderr pipe can emit an 'error'
+      // (EPIPE/EBADF/ECONNRESET) — notably on macOS — and an unhandled stream
+      // 'error' event would throw and crash the daemon/process. We finalize via
+      // exit/end anyway, so these are safe to ignore.
+      if (proc.stdout) proc.stdout.on('error', () => {});
+      if (proc.stderr) proc.stderr.on('error', () => {});
 
       // stdout: the event stream
       proc.stdout.on('data', (chunk) => {

--- a/packages/agent-connector/src/adapters/cline.js
+++ b/packages/agent-connector/src/adapters/cline.js
@@ -1,0 +1,882 @@
+/**
+ * Cline CLI adapter for OpenAgents workspace.
+ *
+ * Bridges the Cline CLI (https://github.com/cline/cline, `npm i -g cline`) to an
+ * OpenAgents workspace:
+ *   - polling loop + per-channel task dispatch (inherited from BaseAdapter)
+ *   - one `cline --json` subprocess per user message (Cline runs the agent loop
+ *     in-process for a one-shot run; killing the process tree stops the task)
+ *   - the NDJSON event stream is parsed (see cline-stream.js) and mapped to the
+ *     standard OpenAgents events (thinking / status / todos / response / error)
+ *   - real session continuity via Cline's `--id` resume, correlated from
+ *     `cline history --json` (Cline does not emit the session id inline)
+ *
+ * Cline-specific behavior lives here and in cline-stream.js; the shared
+ * connectivity, queuing, redaction patterns and process-group teardown follow
+ * the same conventions as the Claude/Gemini adapters.
+ *
+ * Minimum supported CLI is 3.0.0 (HARD gate): a confirmed-older CLI refuses to
+ * start; an undetermined version proceeds leniently.
+ *
+ * Verified against Cline CLI v3.0.26 / v3.0.27.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, execFile, spawn } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');
+const { defaultAgentWorkdir, whichBinary, getEnhancedEnv } = require('../paths');
+const {
+  ClineStreamParser,
+  interpretClineEnvelope,
+  buildClineArgs,
+  redactArgs,
+  redactSecrets,
+  classifyClineError,
+  classifyClineAuth,
+  classifyClineVersion,
+  pickClineSessionId,
+  MIN_CLINE_VERSION,
+} = require('./cline-stream');
+
+const IS_WINDOWS = process.platform === 'win32';
+
+// Idle watchdog: if stdout is silent this long while a run is in flight we
+// nudge the user; after MAX consecutive silences we kill the (possibly hung)
+// process. Cline can hang on connection errors without exiting, so this is the
+// backstop that prevents a thread spinning on "thinking…" forever.
+const WATCHDOG_INTERVAL_MS = 15_000;
+const WATCHDOG_NUDGE_AT = 2;     // ~30s of silence → "still working"
+const WATCHDOG_MAX = 20;         // ~5 min of silence → kill
+
+// The ONE known-benign stderr {type:"error"} diagnostic Cline emits on every
+// run (verified v3.0.27). Matched EXACTLY (whole, trimmed message) so it can
+// never swallow a real error that merely starts with "hook dispatch failed:".
+const BENIGN_STDERR_RE = /^hook dispatch failed: session\.hook requires a valid hook event payload\.?$/i;
+
+// Cline version check cache: keyed by resolved binary path so it is shared
+// across messages (no `cline --version` per status refresh) yet re-detects
+// after the TTL — short enough that an install/upgrade isn't masked for long.
+const VERSION_CACHE_TTL_MS = 5 * 60 * 1000;
+const _clineVersionCache = new Map(); // binPath -> { version, supported, at }
+
+class ClineAdapter extends BaseAdapter {
+  /**
+   * @param {object} opts - BaseAdapter opts plus:
+   * @param {Set} [opts.disabledModules]
+   * @param {string} [opts.workingDir]
+   */
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+    // channel → { sessionId, workingDir }
+    this._channelSessions = {};
+    // channel → child process (the in-flight `cline` run)
+    this._channelProcesses = {};
+    this._stoppingChannels = new Set();
+    this._sessionsFile = path.join(
+      os.homedir(), '.openagents', 'sessions',
+      `${this.workspaceId}_${this.agentName}_cline.json`,
+    );
+    this._loadSessions();
+  }
+
+  // ------------------------------------------------------------------
+  // Session persistence (real Cline session ids, bound to working dir)
+  // ------------------------------------------------------------------
+
+  _loadSessions() {
+    try {
+      if (fs.existsSync(this._sessionsFile)) {
+        const data = JSON.parse(fs.readFileSync(this._sessionsFile, 'utf-8'));
+        if (data && typeof data === 'object') {
+          Object.assign(this._channelSessions, data);
+          this._log(`Loaded ${Object.keys(data).length} Cline session(s)`);
+        }
+      }
+    } catch {
+      this._log('Could not load Cline sessions file, starting fresh');
+    }
+  }
+
+  _saveSessions() {
+    try {
+      fs.mkdirSync(path.dirname(this._sessionsFile), { recursive: true });
+      fs.writeFileSync(this._sessionsFile, JSON.stringify(this._channelSessions));
+    } catch {}
+  }
+
+  /** Return a valid saved session id for this channel, or null. Only resume
+   *  when the saved working dir matches the current one (don't cross projects). */
+  _resumableSession(channel, workingDir) {
+    const entry = this._channelSessions[channel];
+    if (!entry || !entry.sessionId) return null;
+    if (entry.workingDir && workingDir && entry.workingDir !== workingDir) return null;
+    return entry.sessionId;
+  }
+
+  _clearSession(channel) {
+    if (this._channelSessions[channel]) {
+      delete this._channelSessions[channel];
+      this._saveSessions();
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Control actions (stop / restart)
+  // ------------------------------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      const channel = (payload && typeof payload === 'object') ? payload.channel : null;
+      if (channel && this._channelProcesses[channel]) {
+        this._stoppingChannels.add(channel);
+        await this._stopProcess(this._channelProcesses[channel]);
+        delete this._channelProcesses[channel];
+        delete this._channelQueues[channel];
+        try { await this.sendResponse(channel, 'Execution stopped by user.'); } catch {}
+      } else {
+        await this._stopAllProcesses('Execution stopped by user.');
+      }
+      return;
+    }
+    if (action === 'restart') {
+      const channel = (payload && typeof payload === 'object') ? payload.channel : null;
+      if (channel) {
+        if (this._channelProcesses[channel]) {
+          try { await this._stopProcess(this._channelProcesses[channel]); } catch {}
+          delete this._channelProcesses[channel];
+        }
+        this._clearSession(channel);
+        try {
+          await this.client.sendMessage(this.workspaceId, channel, this.token,
+            'Session restarted — next message starts a fresh Cline session.',
+            { senderType: 'agent', senderName: this.agentName, messageType: 'status',
+              metadata: { agent_mode: this._mode }, sessionId: this._sessionId });
+        } catch {}
+      } else {
+        this._channelSessions = {};
+        this._saveSessions();
+        await this._stopAllProcesses('Execution stopped.');
+      }
+      return;
+    }
+    await super._onControlAction(action, payload);
+  }
+
+  /** Daemon shutdown — tear down any in-flight cline runs so threads don't
+   *  hang showing "running". Fire-and-forget; the daemon allows a short grace. */
+  stop() {
+    this._stopAllProcesses(
+      'Task interrupted — daemon restarting. Send another message to continue.',
+    ).catch(() => {});
+    super.stop();
+  }
+
+  async _stopAllProcesses(message = 'Execution stopped.') {
+    const entries = Object.entries(this._channelProcesses);
+    if (!entries.length) return;
+    this._log(`Stopping ${entries.length} running Cline process(es)...`);
+    for (const [channel, proc] of entries) {
+      this._stoppingChannels.add(channel);
+      await this._stopProcess(proc);
+      delete this._channelProcesses[channel];
+      delete this._channelQueues[channel];
+      try { await this.sendResponse(channel, message); } catch {}
+    }
+  }
+
+  /**
+   * Stop a cline process tree gracefully then forcefully. We SIGINT first
+   * (Cline's documented graceful-abort signal) so it can wind down its tool
+   * work, then escalate to SIGTERM/SIGKILL on the whole POSIX process group
+   * (the node wrapper + the bun worker share the group) or via `taskkill /T`
+   * on Windows. The shared `cline --cline-hub-daemon` (ppid=1, its own group)
+   * is intentionally left running — it is per-cwd infrastructure shared across
+   * runs, like a language server; `cline doctor fix` clears stale ones.
+   */
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { proc.kill('SIGINT'); } catch {}
+        const exited = await this._waitExit(proc, 1500);
+        if (!exited) {
+          try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000, windowsHide: true }); } catch {}
+        }
+      } else {
+        try { process.kill(-proc.pid, 'SIGINT'); } catch { try { proc.kill('SIGINT'); } catch {} }
+        let exited = await this._waitExit(proc, 1500);
+        if (!exited) {
+          try { process.kill(-proc.pid, 'SIGTERM'); } catch { try { proc.kill('SIGTERM'); } catch {} }
+          exited = await this._waitExit(proc, 1500);
+        }
+        if (!exited) {
+          try { process.kill(-proc.pid, 'SIGKILL'); } catch { try { proc.kill('SIGKILL'); } catch {} }
+          await this._waitExit(proc, 1000);
+        }
+      }
+    } catch {}
+  }
+
+  _waitExit(proc, ms) {
+    return new Promise((resolve) => {
+      if (proc.exitCode !== null) { resolve(true); return; }
+      const t = setTimeout(() => resolve(false), ms);
+      proc.once('exit', () => { clearTimeout(t); resolve(true); });
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Binary resolution (cross-platform; mirrors the Claude/Gemini adapters)
+  // ------------------------------------------------------------------
+
+  _findNodeBin() {
+    const home = os.homedir();
+    const candidates = IS_WINDOWS
+      ? [path.join(home, '.openagents', 'nodejs', 'node.exe')]
+      : [path.join(home, '.openagents', 'nodejs', 'node'),
+         path.join(home, '.openagents', 'nodejs', 'bin', 'node')];
+    for (const c of candidates) if (fs.existsSync(c)) return c;
+    return 'node';
+  }
+
+  /**
+   * Resolve a shim/symlink to [nodeBin, jsEntry] so we spawn the JS wrapper
+   * directly. On Windows this avoids wrapping a `.cmd` in `cmd.exe /c`, whose
+   * 8191-char command-line cap would truncate a long prompt. Cline's
+   * `bin/cline` IS a Node script (it re-spawns the bundled native binary), so
+   * running it under node is the most robust path on every OS.
+   */
+  _resolveToNodeCmd(binPath) {
+    const nodeBin = this._findNodeBin();
+    if (IS_WINDOWS && binPath.toLowerCase().endsWith('.cmd')) {
+      try {
+        const cmdDir = path.dirname(path.resolve(binPath));
+        const content = fs.readFileSync(binPath, 'utf-8');
+        const jsMatch = content.match(/%dp0%\\([^\s"*?]+\.m?js)/i);
+        if (jsMatch) return [nodeBin, path.resolve(cmdDir, jsMatch[1])];
+        const exeMatch = content.match(/%dp0%\\([^\s"*?]+\.exe)/i);
+        if (exeMatch) return [path.resolve(cmdDir, exeMatch[1])];
+      } catch {}
+    } else {
+      try {
+        let target = binPath;
+        if (fs.lstatSync(binPath).isSymbolicLink()) {
+          target = path.resolve(path.dirname(binPath), fs.readlinkSync(binPath));
+        }
+        if (target.endsWith('.js') || target.endsWith('.mjs')) return [nodeBin, target];
+        // Cline's package bin (`node_modules/cline/bin/cline`) is an
+        // extensionless Node script with a `#!/usr/bin/env node` shebang. Run
+        // it under node explicitly — required on Windows (no shebang support)
+        // and harmless elsewhere.
+        if (this._isNodeShebangScript(target)) return [nodeBin, target];
+      } catch {}
+    }
+    return null;
+  }
+
+  /** True when a file begins with a `#!...node` shebang. */
+  _isNodeShebangScript(filePath) {
+    try {
+      const fd = fs.openSync(filePath, 'r');
+      try {
+        const buf = Buffer.alloc(64);
+        const n = fs.readSync(fd, buf, 0, 64, 0);
+        const head = buf.slice(0, n).toString('utf-8');
+        return head.startsWith('#!') && /\bnode\b/.test(head.split('\n')[0]);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  _findClineBinary() {
+    const home = os.homedir();
+    const ext = IS_WINDOWS ? '.cmd' : '';
+
+    // Tier 0: isolated runtime prefix (~/.openagents/runtimes/cline/)
+    const runtimeCandidate = path.join(home, '.openagents', 'runtimes', 'cline', 'node_modules', '.bin', `cline${ext}`);
+    if (fs.existsSync(runtimeCandidate)) return runtimeCandidate;
+
+    // Tier 0b: legacy portable install
+    const portable = path.join(home, '.openagents', 'nodejs', 'node_modules', '.bin', `cline${ext}`);
+    if (fs.existsSync(portable)) return portable;
+
+    // Tier 0c: the package's OWN bin. npm does not create a node_modules/.bin
+    // shim for Cline (its `bin` is "./bin/cline"), so a local prefix install
+    // leaves no `.bin/cline` — but the package bin is always present and is a
+    // Node script we run via _resolveToNodeCmd. Check the runtime then legacy
+    // prefix.
+    for (const root of [
+      path.join(home, '.openagents', 'runtimes', 'cline', 'node_modules', 'cline'),
+      path.join(home, '.openagents', 'nodejs', 'node_modules', 'cline'),
+    ]) {
+      const pkgBin = path.join(root, 'bin', 'cline');
+      if (fs.existsSync(pkgBin)) return pkgBin;
+    }
+
+    // Tier 1: PATH search with the ENRICHED env (a packaged daemon's PATH is
+    // minimal and would miss nvm/fnm/volta/homebrew/npm-global dirs).
+    try {
+      const env = getEnhancedEnv();
+      if (IS_WINDOWS) {
+        const r = execSync('where cline.cmd 2>nul || where cline.exe 2>nul || where cline 2>nul', {
+          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
+        });
+        const hit = r.split(/\r?\n/)[0].trim();
+        if (hit) return hit;
+      } else {
+        const hit = execSync('which cline', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
+        if (hit) return hit;
+      }
+    } catch {}
+
+    // Tier 2: next to the current Node interpreter (npm global)
+    const nearNode = path.join(path.dirname(process.execPath), `cline${ext}`);
+    if (fs.existsSync(nearNode)) return nearNode;
+
+    // Tier 3: common install locations
+    const candidates = IS_WINDOWS ? [
+      path.join(process.env.APPDATA || '', 'npm', 'cline.cmd'),
+    ] : [
+      path.join(home, '.local', 'bin', 'cline'),
+      path.join(home, '.npm-global', 'bin', 'cline'),
+      '/opt/homebrew/bin/cline',
+      '/usr/local/bin/cline',
+    ];
+    for (const c of candidates) if (fs.existsSync(c)) return c;
+
+    // Tier 4: deep scan of every known bin dir (nvm/fnm/volta/homebrew/…)
+    const viaWhich = whichBinary('cline');
+    if (viaWhich) return viaWhich;
+
+    return null;
+  }
+
+  /** Resolve [cmd, ...args] for spawning, handling node-script wrappers. */
+  _spawnableCmd(binPath, args) {
+    const resolved = this._resolveToNodeCmd(binPath);
+    if (resolved) return [...resolved, ...args];
+    if (IS_WINDOWS && binPath.toLowerCase().endsWith('.cmd')) return ['cmd.exe', '/c', binPath, ...args];
+    return [binPath, ...args];
+  }
+
+  // ------------------------------------------------------------------
+  // Version preflight (cached; HARD minimum 3.0.0)
+  // ------------------------------------------------------------------
+
+  /** Run `cline --version` and return its raw output. Isolated for testing. */
+  _readClineVersionRaw(clineBin) {
+    return execSync(`"${clineBin}" --version`, { encoding: 'utf-8', timeout: 8000, windowsHide: true }).trim();
+  }
+
+  /**
+   * Resolve the installed Cline version and its compatibility, cached per
+   * binary path with a TTL so repeated messages/status refreshes don't re-spawn
+   * `cline --version`, while an upgrade is picked up after the TTL.
+   * @returns {{version: string|null, compatible: boolean|null}}
+   *   compatible true → >= MIN; false → CONFIRMED too old; null → undetermined.
+   */
+  _checkClineVersion(clineBin) {
+    const now = Date.now();
+    const cached = _clineVersionCache.get(clineBin);
+    if (cached && (now - cached.at) < VERSION_CACHE_TTL_MS) {
+      return { version: cached.version, compatible: cached.supported };
+    }
+    let version = null;
+    let supported = null; // undetermined unless we can parse a version
+    try {
+      ({ version, supported } = classifyClineVersion(this._readClineVersionRaw(clineBin)));
+    } catch {
+      // `cline --version` failed → undetermined (NOT treated as compatible).
+      version = null;
+      supported = null;
+    }
+    _clineVersionCache.set(clineBin, { version, supported, at: now });
+    return { version, compatible: supported };
+  }
+
+  /** Clear the shared version cache (test hook; also call after install/upgrade). */
+  static _clearVersionCache() {
+    _clineVersionCache.clear();
+  }
+
+  // ------------------------------------------------------------------
+  // Auth / config introspection (no secret values are read or logged)
+  // ------------------------------------------------------------------
+
+  _readProvidersConfig() {
+    const cfg = path.join(os.homedir(), '.cline', 'data', 'settings', 'providers.json');
+    try {
+      if (!fs.existsSync(cfg)) return null;
+      return JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    } catch {
+      return { __parse_error: true };
+    }
+  }
+
+  /** Classify auth using providers.json + the agent env (heuristic, never an
+   *  absolute verdict). Returns the classifyClineAuth shape; a parse error maps
+   *  to `unknown` (not a hard failure). No secret values are read or returned. */
+  _authState() {
+    const parsed = this._readProvidersConfig();
+    // classifyClineAuth treats the `{__parse_error:true}` sentinel as unknown.
+    return classifyClineAuth(parsed, this.agentEnv || process.env);
+  }
+
+  // ------------------------------------------------------------------
+  // Prompt assembly
+  // ------------------------------------------------------------------
+
+  /** A compact, Cline-appropriate context header. We do NOT inject the full
+   *  workspace system prompt (it advertises MCP tools Cline isn't wired with);
+   *  Cline keeps its own coding system prompt, and `-s` would replace it. */
+  _contextHeader(channel) {
+    const lines = [
+      `[OpenAgents workspace] You are "${this.agentName}", a coding agent in workspace channel "${channel}".`,
+    ];
+    if (this._mode === 'plan') {
+      lines.push('You are in PLAN mode: investigate and propose a plan; do not modify files.');
+    }
+    lines.push('Work in the current working directory. Reply concisely. The user request follows:');
+    return lines.join('\n');
+  }
+
+  /** Short transcript of recent chat used to re-seed context when starting a
+   *  fresh session (resume unavailable). Bounded to keep argv small on Windows. */
+  async _buildChannelRecap(channel, currentMessage) {
+    try {
+      const messages = await this.client.getRecentMessages(this.workspaceId, channel, this.token, 30);
+      if (!messages || messages.length === 0) return null;
+      const lines = [];
+      for (const m of messages) {
+        const mt = m.messageType || 'chat';
+        if (mt === 'status' || mt === 'thinking' || mt === 'loading' || mt === 'todos') continue;
+        const text = (m.content || '').trim();
+        if (!text || text === currentMessage) continue;
+        const who = m.senderType === 'human' ? (m.senderName || 'user') : (m.senderName || 'agent');
+        lines.push(`[${who}] ${text.length > 800 ? text.slice(0, 800) + '…' : text}`);
+      }
+      if (lines.length === 0) return null;
+      return 'Recent conversation in this channel for context:\n\n' + lines.slice(-12).join('\n');
+    } catch {
+      return null;
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Message handling
+  // ------------------------------------------------------------------
+
+  async _handleMessage(msg) {
+    let content = (msg.content || '').trim();
+    const attachments = msg.attachments || [];
+    const attText = formatAttachmentsForPrompt(attachments, 'skills');
+    if (attText) content = content ? content + attText : attText.trim();
+    if (!content) return;
+
+    const channel = msg.sessionId || this.channelName;
+    this._stoppingChannels.delete(channel);
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${channel}: ${redactSecrets(content.slice(0, 80))}...`);
+
+    // Resolve and validate the working directory up front. Never silently fall
+    // back to the launcher/repo dir — return a clear error instead.
+    const workingDir = this.workingDir || defaultAgentWorkdir(this.agentName);
+    if (this.workingDir && !this._dirExists(this.workingDir)) {
+      await this.sendError(channel, `Working directory does not exist: ${this.workingDir}`);
+      return;
+    }
+
+    const clineBin = this._findClineBinary();
+    if (!clineBin) {
+      await this.sendError(channel,
+        'Cline CLI not found. Install it with: npm install -g cline');
+      return;
+    }
+
+    // HARD minimum version gate. A CONFIRMED-older CLI must not start; an
+    // undetermined version (compatible === null) proceeds leniently.
+    const ver = this._checkClineVersion(clineBin);
+    if (ver.compatible === false) {
+      this._log(`Refusing to start: Cline ${ver.version} < minimum ${MIN_CLINE_VERSION}`);
+      await this.sendError(channel,
+        `Cline CLI ${ver.version} is below the minimum supported version ${MIN_CLINE_VERSION}. ` +
+        'Please upgrade with: npm install -g cline@latest');
+      return;
+    }
+
+    // Auto-title + resume-from on first encounter (parity with other adapters).
+    if (!this._titledSessions.has(channel)) {
+      this._titledSessions.add(channel);
+      try {
+        const info = await this.client.getSession(this.workspaceId, channel, this.token);
+        const resumeFrom = info.resumeFrom;
+        if (resumeFrom && !this._channelSessions[channel] && this._channelSessions[resumeFrom]) {
+          this._channelSessions[channel] = { ...this._channelSessions[resumeFrom] };
+          this._saveSessions();
+        }
+        const title = generateSessionTitle(content);
+        if (title && !info.titleManuallySet && SESSION_DEFAULT_RE.test(info.title || '')) {
+          await this.client.updateSession(this.workspaceId, channel, this.token, { title, autoTitle: true });
+        }
+      } catch {}
+    }
+
+    await this.sendStatus(channel, 'thinking...');
+
+    // One retry: if resuming a stale session fails, retry once fresh.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const resumeId = attempt === 0 ? this._resumableSession(channel, workingDir) : null;
+
+      // Build the prompt. Resuming → Cline already has history, send the bare
+      // turn. Fresh → prepend a context header (+ recap when available).
+      let prompt;
+      // For a fresh run, snapshot the existing session ids BEFORE spawning so we
+      // can later identify our run's NEW session unambiguously (concurrency-safe).
+      let beforeIds = null;
+      if (resumeId) {
+        prompt = content;
+      } else {
+        const header = this._contextHeader(channel);
+        const recap = await this._buildChannelRecap(channel, content);
+        prompt = recap
+          ? `${header}\n\n${recap}\n\n---\n\n${content}`
+          : `${header}\n\n${content}`;
+        const before = await this._readHistory(clineBin);
+        beforeIds = new Set(Array.isArray(before) ? before.map((s) => s && s.sessionId).filter(Boolean) : []);
+      }
+
+      const args = buildClineArgs({
+        prompt,
+        cwd: workingDir,
+        sessionId: resumeId || undefined,
+        planMode: this._mode === 'plan',
+        provider: (this.agentEnv.CLINE_PROVIDER || '').trim() || undefined,
+        model: (this.agentEnv.CLINE_MODEL || '').trim() || undefined,
+        apiKey: (this.agentEnv.CLINE_API_KEY || '').trim() || undefined,
+        thinking: (this.agentEnv.CLINE_THINKING || '').trim() || undefined,
+      });
+
+      const spawnStartMs = Date.now();
+      const result = await this._runCline(channel, clineBin, args, workingDir);
+
+      if (result.userStopped) return;
+
+      // Stale-session handling: a resume that died/erred with nothing useful →
+      // clear and retry fresh once.
+      if (resumeId && !result.ok && !result.anyOutput && attempt === 0) {
+        this._log(`Resume of session ${resumeId} failed — clearing and retrying fresh`);
+        this._clearSession(channel);
+        continue;
+      }
+
+      // Persist / refresh the session id for next turn.
+      if (resumeId) {
+        // Resume keeps the same id; ensure the binding is still recorded.
+        this._channelSessions[channel] = { sessionId: resumeId, workingDir };
+        this._saveSessions();
+      } else if (result.ok || result.anyOutput) {
+        await this._captureSessionId(channel, clineBin, workingDir, spawnStartMs, content, beforeIds);
+      }
+
+      // Emit final response or a classified error.
+      if (result.finalText) {
+        try { await this.sendResponse(channel, result.finalText); } catch {}
+      } else if (result.errorMessage) {
+        const { kind, userMessage } = classifyClineError(result.errorMessage);
+        try { await this.sendError(channel, this._withAuthHint(userMessage, kind)); } catch {}
+      } else if (!result.anyOutput) {
+        try { await this.sendResponse(channel, 'No response generated. Please try again.'); } catch {}
+      }
+      return;
+    }
+  }
+
+  _dirExists(p) {
+    try { return fs.statSync(p).isDirectory(); } catch { return false; }
+  }
+
+  /**
+   * Append an actionable hint to an auth/provider/model error, based on the
+   * (heuristic) config state. We do NOT block on config; this only enriches the
+   * message AFTER a real failure. For an undetermined state we say so rather
+   * than asserting the user is unauthenticated.
+   * @param {string} userMessage  the classified user-facing error
+   * @param {string} [kind]       error kind from classifyClineError
+   */
+  _withAuthHint(userMessage, kind) {
+    // Only auth/provider/model failures warrant a config hint.
+    if (kind && !['auth', 'provider', 'model'].includes(kind)) return userMessage;
+    try {
+      const auth = this._authState();
+      if (auth.state === 'no_credentials') {
+        return userMessage + `\n\nProvider "${auth.provider}" is selected but has no stored credential. Set an API key in the launcher, or run \`cline auth\`.`;
+      }
+      if (auth.state === 'unknown') {
+        return userMessage + '\n\nConfig detection could not confirm Cline auth (the run result is authoritative). If this keeps failing, set an API key for this agent in the launcher, or run `cline auth`.';
+      }
+    } catch {}
+    return userMessage;
+  }
+
+  /**
+   * Spawn one `cline --json` run, stream-parse it, and resolve a summary:
+   *   { ok, finalText, errorMessage, anyOutput, userStopped }
+   * `ok` reflects run_result.finishReason === "completed".
+   */
+  _runCline(channel, clineBin, args, workingDir) {
+    const cleanEnv = { ...(this.agentEnv || process.env) };
+    const [cmd, ...spawnArgs] = this._spawnableCmd(clineBin, args);
+
+    this._log(`Spawning cline in ${workingDir}: ${redactArgs([clineBin, ...args]).join(' ')}`);
+
+    const proc = spawn(cmd, spawnArgs, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: cleanEnv,
+      cwd: workingDir,
+      detached: !IS_WINDOWS,
+      windowsHide: true,
+    });
+    this._channelProcesses[channel] = proc;
+
+    const parser = new ClineStreamParser();
+    const state = {
+      finalText: '',            // last assistant text block of the turn
+      pendingText: [],          // text blocks accumulated since the last tool use
+      hadToolSinceText: false,
+      anyOutput: false,
+      ok: false,
+      // Error sources in priority order (resolved into errorMessage at settle):
+      resultError: '',          // run_result/done with a non-completed reason — authoritative
+      eventError: '',           // agent_event {type:error}
+      stderrError: '',          // fatal {type:error} on stderr (benign noise filtered)
+      errorMessage: '',         // resolved, user-facing-bound error text
+      finished: false,
+      userStopped: false,
+    };
+
+    let stderrParser = new ClineStreamParser();
+    let stderrText = '';
+
+    return new Promise((resolve) => {
+      let settled = false;
+      let watchdogTimer = null;
+      let lastDataMs = Date.now();
+      let silences = 0;
+      let queue = Promise.resolve();
+
+      const cleanup = () => {
+        if (watchdogTimer) { clearInterval(watchdogTimer); watchdogTimer = null; }
+        if (proc.stdout) proc.stdout.removeAllListeners();
+        if (proc.stderr) proc.stderr.removeAllListeners();
+      };
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        // Resolve the user-facing error by priority: an authoritative
+        // run_result/done failure beats an agent error event, which beats a
+        // (non-benign) stderr error line.
+        state.errorMessage = state.resultError || state.eventError || state.stderrError || '';
+        // Only promote accumulated text to a final answer on a successful run —
+        // never present partial text as the answer when the run failed.
+        if (!state.finalText && !state.errorMessage && state.pendingText.length) {
+          state.finalText = state.pendingText.join('\n').trim();
+        }
+        if (this._stoppingChannels.has(channel)) state.userStopped = true;
+        delete this._channelProcesses[channel];
+        resolve(state);
+      };
+
+      const handleEvent = async (ev) => {
+        const events = interpretClineEnvelope(ev);
+        for (const e of events) {
+          switch (e.kind) {
+            case 'reasoning':
+              state.anyOutput = true;
+              try { await this.sendThinking(channel, e.text); } catch {}
+              break;
+            case 'text':
+              state.anyOutput = true;
+              if (state.hadToolSinceText) { state.pendingText = []; state.hadToolSinceText = false; }
+              state.pendingText.push(e.text);
+              try { await this.sendThinking(channel, e.text); } catch {}
+              break;
+            case 'tool_start':
+              state.anyOutput = true;
+              state.hadToolSinceText = true;
+              try {
+                await this.sendStatus(channel, e.preview ? `${e.label}: ${e.preview}` : e.label);
+              } catch {}
+              break;
+            case 'tool_end':
+              if (!e.ok && e.error) {
+                try { await this.sendStatus(channel, `${e.toolName} failed: ${e.error}`); } catch {}
+              }
+              break;
+            case 'ask':
+              // Headless runs cannot round-trip an interactive answer; surface
+              // the question (and options) so the user at least sees it.
+              state.anyOutput = true;
+              {
+                const opts = e.options && e.options.length ? `\n\nOptions: ${e.options.join(' · ')}` : '';
+                try { await this.sendResponse(channel, `❓ ${e.question || 'The agent is asking for input.'}${opts}`); } catch {}
+              }
+              break;
+            case 'notice':
+              if (e.text) { try { await this.sendStatus(channel, e.text); } catch {} }
+              break;
+            case 'error':
+              if (e.message && !state.eventError) state.eventError = e.message;
+              break;
+            case 'done':
+              // `done` carries the turn outcome. reason "completed" → text is the
+              // final answer; any other reason (error/aborted/max_iterations/…) →
+              // text is the failure message, never an assistant reply.
+              if (e.reason === 'completed') {
+                if (e.text && !state.finalText) state.finalText = e.text.trim();
+              } else if (e.text && !state.resultError) {
+                state.resultError = e.text.trim();
+              }
+              break;
+            case 'aborted':
+              if (e.text && !state.resultError) state.resultError = e.text.trim();
+              break;
+            case 'result':
+              state.ok = e.ok;
+              // On a completed run, run_result.text is the final answer. On a
+              // failed run it is the ERROR text — authoritative, never a reply.
+              if (e.ok) {
+                if (e.text) { state.finalText = e.text.trim(); state.anyOutput = true; }
+              } else if (e.text) {
+                state.resultError = e.text.trim();
+              }
+              state.finished = true;
+              break;
+            default:
+              break;
+          }
+        }
+      };
+
+      // stdout: the event stream
+      proc.stdout.on('data', (chunk) => {
+        lastDataMs = Date.now();
+        silences = 0;
+        const envs = parser.push(chunk);
+        for (const ev of envs) queue = queue.then(() => handleEvent(ev)).catch(() => {});
+      });
+
+      // stderr: kept SEPARATE. Fatal cline errors arrive here as
+      // {type:"error",message}; everything else is diagnostic noise that must
+      // never be shown as an assistant reply. We only adopt a parsed error
+      // message (lowest priority, used only if no stream error is known), and
+      // filter known-benign diagnostics so they can't mask the real cause.
+      const adoptStderr = (ev) => {
+        if (!ev || ev.type !== 'error' || !ev.message) return;
+        if (BENIGN_STDERR_RE.test(String(ev.message).trim())) return; // exact known noise only
+        state.stderrError = redactSecrets(String(ev.message)); // last non-benign wins
+      };
+      proc.stderr.on('data', (chunk) => {
+        for (const ev of stderrParser.push(chunk)) adoptStderr(ev);
+        stderrText += chunk.toString('utf-8');
+      });
+
+      // Idle watchdog
+      watchdogTimer = setInterval(async () => {
+        if (settled) return;
+        const elapsed = Date.now() - lastDataMs;
+        if (elapsed < WATCHDOG_INTERVAL_MS) { silences = 0; return; }
+        silences++;
+        lastDataMs = Date.now();
+        if (silences === WATCHDOG_NUDGE_AT) {
+          try { await this.sendStatus(channel, 'Still working...'); } catch {}
+        }
+        if (silences >= WATCHDOG_MAX) {
+          this._log(`Watchdog: cline silent ${silences * 15}s on ${channel} — killing`);
+          state.resultError = state.resultError || 'Cline became unresponsive and was stopped.';
+          await this._stopProcess(proc);
+        }
+      }, WATCHDOG_INTERVAL_MS);
+
+      proc.on('exit', (code, signal) => {
+        // Drain any trailing buffered lines, then settle once the queue flushes.
+        const tail = parser.flush();
+        for (const ev of tail) queue = queue.then(() => handleEvent(ev)).catch(() => {});
+        for (const ev of stderrParser.flush()) adoptStderr(ev);
+        queue = queue.then(() => {
+          if (code !== 0 && !state.ok && !state.resultError && !state.eventError && !state.stderrError) {
+            const why = signal ? `terminated by signal ${signal}` : `exited with code ${code}`;
+            if (stderrText.trim()) this._log(`cline stderr: ${redactSecrets(stderrText.trim().slice(0, 500))}`);
+            if (!this._stoppingChannels.has(channel)) {
+              state.resultError = `Cline ${why}.`;
+            }
+          }
+          settle();
+        }).catch(() => settle());
+      });
+
+      proc.on('error', (err) => {
+        state.resultError = state.resultError || `Failed to start Cline: ${redactSecrets(err.message)}`;
+        settle();
+      });
+    });
+  }
+
+  /**
+   * After a fresh run, correlate the new session via `cline history --json`
+   * (Cline does not emit the session id inline). Uses a BEFORE/AFTER snapshot
+   * diff: only sessions that are NEW since `beforeIds`, in this working dir, and
+   * within the run window are considered, and we bind ONLY on a single
+   * unambiguous candidate — never guessing. Best-effort and non-fatal; failure
+   * just means the next turn starts a fresh session. The prompt is never logged.
+   */
+  async _captureSessionId(channel, clineBin, workingDir, spawnStartMs, userContent, beforeIds) {
+    try {
+      const after = await this._readHistory(clineBin);
+      if (!Array.isArray(after)) {
+        this._log(`Session correlation skipped for ${channel}: history unavailable`);
+        return;
+      }
+      const needle = (userContent || '').replace(/\s+/g, ' ').trim().slice(0, 40) || undefined;
+      const opts = { cwd: workingDir, sinceMs: spawnStartMs, beforeIds: beforeIds || new Set(), promptNeedle: needle };
+      const sessionId = pickClineSessionId(after, opts);
+      if (sessionId) {
+        this._channelSessions[channel] = { sessionId, workingDir };
+        this._saveSessions();
+        this._log(`Captured Cline session ${sessionId} for ${channel}`);
+      } else {
+        // Count the ambiguous/zero candidates for diagnostics — no prompt, no values.
+        const before = opts.beforeIds instanceof Set ? opts.beforeIds : new Set(beforeIds || []);
+        const fresh = after.filter((s) => s && s.cwd === workingDir && s.sessionId && !before.has(s.sessionId)).length;
+        this._log(`Session correlation declined for ${channel}: ${fresh} new candidate(s) in workdir — next turn starts fresh`);
+      }
+    } catch (e) {
+      this._log(`Could not capture Cline session id (non-fatal): ${e && e.message ? e.message : e}`);
+    }
+  }
+
+  _readHistory(clineBin) {
+    return new Promise((resolve) => {
+      const [cmd, ...args] = this._spawnableCmd(clineBin, ['history', '--json', '--limit', '30']);
+      execFile(cmd, args, {
+        encoding: 'utf-8', timeout: 10000, windowsHide: true,
+        env: { ...(this.agentEnv || process.env) }, maxBuffer: 8 * 1024 * 1024,
+      }, (err, stdout) => {
+        if (err) { resolve(null); return; }
+        try { resolve(JSON.parse(stdout)); } catch { resolve(null); }
+      });
+    });
+  }
+}
+
+module.exports = ClineAdapter;

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -14,6 +14,7 @@ const CursorAdapter = require('./cursor');
 const HermesAdapter = require('./hermes');
 const GeminiAdapter = require('./gemini');
 const KimiAdapter = require('./kimi');
+const ClineAdapter = require('./cline');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -25,11 +26,12 @@ const ADAPTER_MAP = {
   hermes: HermesAdapter,
   gemini: GeminiAdapter,
   kimi: KimiAdapter,
+  cline: ClineAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, cline)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -52,6 +54,7 @@ module.exports = {
   HermesAdapter,
   GeminiAdapter,
   KimiAdapter,
+  ClineAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -10,6 +10,30 @@ const { EnvManager } = require('./env');
 const STATUS_CACHE_TTL_MS = 10000;
 const statusCache = new Map();
 
+// Cache `--version` output so frequent launcher status refreshes don't re-spawn
+// the CLI on every poll. Keyed by the version command; cleared on install/
+// uninstall so an upgrade is reflected promptly.
+const VERSION_CACHE_TTL_MS = 60000;
+const versionCache = new Map(); // versionCmd -> { version, ts }
+
+/** Parse a dotted version out of arbitrary text; null if none. */
+function _parseDottedVersion(s) {
+  const m = String(s || '').match(/(\d+)\.(\d+)(?:\.(\d+))?(?:[-.][0-9A-Za-z.]+)?/);
+  return m ? m[0] : null;
+}
+
+/** Compare dotted versions a vs b → -1 | 0 | 1. */
+function _cmpVersions(a, b) {
+  const pa = String(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] || 0; const y = pb[i] || 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
 /**
  * Manages installation and uninstallation of agent runtimes.
  *
@@ -193,8 +217,53 @@ class Installer {
     }
 
     const checkCmd = entry && entry.install ? entry.install.check_command : null;
-    const versionCmd = checkCmd || `${entry && entry.install && entry.install.binary || agentType} --version`;
+    // Prefer the resolved absolute binary path (quoted) over the bare name:
+    // it's unambiguous and lets `--version` succeed for binaries resolved via
+    // the package-bin fallback (which are not on PATH).
+    const versionCmd = checkCmd || `"${binary}" --version`;
 
+    let version = this._readVersion(versionCmd);
+
+    const readiness = this._evaluateReadiness(agentType, entry, binary);
+
+    // Optional HARD minimum-version gate (generic; opt-in per agent via
+    // check_ready.min_version or install.min_version). A CONFIRMED-older CLI is
+    // incompatible → not ready. An undetermined version (unparseable) is left
+    // as compatible:null and does NOT block. Agents without min_version are
+    // unaffected (compatible:true).
+    const minVersion = (entry && ((entry.check_ready && entry.check_ready.min_version) || (entry.install && entry.install.min_version))) || null;
+    let compatible = true;
+    if (minVersion) {
+      const parsed = _parseDottedVersion(version);
+      if (parsed) {
+        compatible = _cmpVersions(parsed, minVersion) >= 0;
+      } else {
+        compatible = null; // version present but unparseable → undetermined
+      }
+      if (compatible === false) {
+        const label = (entry && entry.label) || agentType;
+        const upgradeCmd = entry && entry.install ? this._getInstallCommand(entry.install) : null;
+        return {
+          installed: true,
+          binary,
+          version,
+          compatible: false,
+          ready: false,
+          auth_mode: null,
+          execution_mode: 'unavailable',
+          message: `${label} ${version} is older than the supported minimum ${minVersion}.` +
+            (upgradeCmd ? ` Upgrade with: ${upgradeCmd}` : ' Please upgrade.'),
+        };
+      }
+    }
+
+    return { installed: true, binary, version, compatible, ...readiness };
+  }
+
+  /** Read (and briefly cache) a CLI's `--version` output → dotted version string. */
+  _readVersion(versionCmd) {
+    const cached = versionCache.get(versionCmd);
+    if (cached && (Date.now() - cached.ts) < VERSION_CACHE_TTL_MS) return cached.version;
     let version = null;
     try {
       const raw = execSync(versionCmd, {
@@ -203,13 +272,13 @@ class Installer {
         env: getEnhancedEnv(),
         timeout: 10000,
       }).trim();
-      // Extract version number (e.g. "openclaw 2024.1.5" → "2024.1.5")
       const match = raw.match(/(\d+[\d.]+\d+)/);
-      version = match ? match[1] : raw.split('\n')[0];
-    } catch {}
-
-    const readiness = this._evaluateReadiness(agentType, entry, binary);
-    return { installed: true, binary, version, ...readiness };
+      version = match ? match[1] : (raw.split('\n')[0] || null);
+    } catch {
+      version = null;
+    }
+    versionCache.set(versionCmd, { version, ts: Date.now() });
+    return version;
   }
 
   _evaluateReadiness(agentType, entry, binary) {
@@ -723,6 +792,51 @@ class Installer {
       const found = whichBinary(candidate);
       if (found) return found;
     }
+    // Fallback: resolve the installed package's OWN bin from its package.json
+    // when npm did not create a node_modules/.bin/<binary> shim for the
+    // top-level package. This happens for packages whose `bin` path is
+    // declared as "./bin/x" (e.g. Cline): a local `npm install --prefix DIR`
+    // links dependency bins but not the explicitly-installed root package's,
+    // so a PATH lookup finds nothing even though the CLI is present and
+    // runnable. Generic and backward-compatible — only runs after PATH misses.
+    const pkgBin = this._resolvePackageBin(agentType, entry, binary);
+    if (pkgBin) return pkgBin;
+    return null;
+  }
+
+  /**
+   * Resolve the absolute path to a package's own executable from its
+   * package.json `bin` field, searched in the runtime and legacy prefixes.
+   * Returns null when not installed there or the bin file is missing.
+   */
+  _resolvePackageBin(agentType, entry, binary) {
+    // Derive the npm package name the same way getInstallInfo does.
+    const npmPkg = entry && entry.install ? entry.install.npm_package : null;
+    const installCmd = entry && entry.install ? this._getInstallCommand(entry.install) : null;
+    let npmPkgFromCmd = null;
+    if (!npmPkg && installCmd && installCmd.includes('npm install')) {
+      const m = installCmd.match(/npm install\s+(?:-g\s+)?(@?[\w-]+(?:\/[\w-]+)?)(?:@\S*)?$/);
+      if (m) npmPkgFromCmd = m[1];
+    }
+    const pkgName = npmPkg || npmPkgFromCmd || binary;
+    const prefixes = [
+      path.join(getRuntimePrefix(agentType), 'node_modules'),
+      path.join(os.homedir(), '.openagents', 'nodejs', 'node_modules'),
+    ];
+    for (const modules of prefixes) {
+      const pkgDir = path.join(modules, pkgName);
+      const pkgJsonPath = path.join(pkgDir, 'package.json');
+      try {
+        if (!fs.existsSync(pkgJsonPath)) continue;
+        const bin = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')).bin;
+        let rel = null;
+        if (typeof bin === 'string') rel = bin;
+        else if (bin && typeof bin === 'object') rel = bin[binary] || bin[pkgName] || Object.values(bin)[0];
+        if (!rel) continue;
+        const abs = path.join(pkgDir, rel);
+        if (fs.existsSync(abs)) return abs;
+      } catch {}
+    }
     return null;
   }
 
@@ -770,8 +884,10 @@ class Installer {
     // Drop the 30s PATH/whichBinary caches so the very next getInstallInfo
     // sees the freshly-created bin dir (e.g. ~/.cursor/bin) instead of the
     // pre-install snapshot. Without this, install completes but UI keeps
-    // showing "not installed" until the cache expires.
+    // showing "not installed" until the cache expires. Also drop the version
+    // cache so an upgrade's new version is reflected immediately.
     try { clearBinaryLookupCache(); } catch {}
+    try { versionCache.clear(); } catch {}
   }
 
   _markUninstalled(agentType) {
@@ -794,6 +910,7 @@ class Installer {
 
     // Symmetric with _markInstalled: invalidate so detection re-runs cleanly.
     try { clearBinaryLookupCache(); } catch {}
+    try { versionCache.clear(); } catch {}
   }
 
   // -- Shell env + exec --

--- a/packages/agent-connector/test/cline-stream.test.js
+++ b/packages/agent-connector/test/cline-stream.test.js
@@ -1,0 +1,373 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  MIN_CLINE_VERSION,
+  parseClineVersion,
+  compareVersions,
+  classifyClineVersion,
+  redactSecrets,
+  redactValue,
+  classifyClineError,
+  classifyClineAuth,
+  buildClineArgs,
+  redactArgs,
+  ClineStreamParser,
+  interpretClineEnvelope,
+  pickClineSessionId,
+} = require('../src/adapters/cline-stream');
+
+// Helper: drive a parser with a sequence of chunks and collect interpreted events.
+function interpretChunks(chunks) {
+  const p = new ClineStreamParser();
+  const out = [];
+  for (const c of chunks) for (const env of p.push(c)) out.push(...interpretClineEnvelope(env));
+  for (const env of p.flush()) out.push(...interpretClineEnvelope(env));
+  return out;
+}
+
+describe('cline version handling', () => {
+  it('parses a dotted version from --version output', () => {
+    assert.equal(parseClineVersion('3.0.26'), '3.0.26');
+    assert.equal(parseClineVersion('cline version 3.0.26\n'), '3.0.26');
+    assert.equal(parseClineVersion('v2.1.0-nightly'), '2.1.0-nightly');
+    assert.equal(parseClineVersion('garbage'), null);
+  });
+
+  it('compares versions correctly', () => {
+    assert.equal(compareVersions('3.0.26', '3.0.0'), 1);
+    assert.equal(compareVersions('2.9.9', '3.0.0'), -1);
+    assert.equal(compareVersions('3.0.0', '3.0.0'), 0);
+  });
+
+  it('classifies supported / too-old / undetermined', () => {
+    assert.deepEqual(classifyClineVersion('3.0.26'), { version: '3.0.26', supported: true });
+    assert.equal(classifyClineVersion(`${MIN_CLINE_VERSION}`).supported, true);
+    assert.equal(classifyClineVersion('2.0.0').supported, false);   // too old → incompatible
+    assert.deepEqual(classifyClineVersion('not-a-version'), { version: null, supported: null }); // lenient
+  });
+});
+
+describe('secret redaction', () => {
+  it('redacts API keys, bearer tokens and AWS keys from text', () => {
+    const r = redactSecrets('key sk-ant-api03-ABCDEFGHIJKLMNOP and Authorization: Bearer abcdef123456 plus AKIAIOSFODNN7EXAMPLE');
+    assert.ok(!r.includes('sk-ant-api03-ABCDEFGHIJKLMNOP'));
+    assert.ok(!r.includes('abcdef123456'));
+    assert.ok(!r.includes('AKIAIOSFODNN7EXAMPLE'));
+    assert.ok(r.includes('«redacted»'));
+  });
+
+  it('redacts sensitive object keys without mutating the input', () => {
+    const input = { apiKey: 'sk-secret-123456789', model: 'gpt', nested: { token: 'tkn-abcdefghij' } };
+    const out = redactValue(input);
+    assert.equal(out.apiKey, '«redacted»');
+    assert.equal(out.nested.token, '«redacted»');
+    assert.equal(out.model, 'gpt');
+    // original untouched
+    assert.equal(input.apiKey, 'sk-secret-123456789');
+  });
+});
+
+describe('error classification', () => {
+  it('maps the real Unauthorized message to auth', () => {
+    const { kind } = classifyClineError(
+      "Unauthorized: Please make sure you're using the latest version of Cline and re-authenticate your Cline account.");
+    assert.equal(kind, 'auth');
+  });
+  it('classifies rate limit / model / provider / network / timeout / config', () => {
+    assert.equal(classifyClineError('429 Too Many Requests').kind, 'rate_limit');
+    assert.equal(classifyClineError('model claude-x does not exist').kind, 'model');
+    assert.equal(classifyClineError('unknown provider foo').kind, 'provider');
+    assert.equal(classifyClineError('getaddrinfo ENOTFOUND api.example.com').kind, 'network');
+    assert.equal(classifyClineError('run timed out after 60s').kind, 'timeout');
+    assert.equal(classifyClineError('failed to parse providers.json').kind, 'config');
+    assert.equal(classifyClineError('something weird').kind, 'unknown');
+  });
+  it('redacts secrets that appear inside an error message', () => {
+    const { userMessage } = classifyClineError('bad key sk-ant-SECRETKEY1234567 rejected');
+    assert.ok(!userMessage.includes('sk-ant-SECRETKEY1234567'));
+  });
+});
+
+describe('auth classification from providers.json (conservative heuristic)', () => {
+  it('no config file + no env key → unknown (never asserts unauthenticated)', () => {
+    assert.equal(classifyClineAuth(null, {}).state, 'unknown');
+  });
+  it('no config but a native env key → ready', () => {
+    assert.equal(classifyClineAuth(null, { ANTHROPIC_API_KEY: 'sk-ant-xxxxxxxx' }).state, 'ready');
+    assert.equal(classifyClineAuth(null, { CLINE_API_KEY: 'k' }).state, 'ready');
+    assert.equal(classifyClineAuth(null, { OPENROUTER_API_KEY: 'k' }).state, 'ready');
+  });
+  it('empty providers.json (no providers) → unknown (cannot confirm)', () => {
+    assert.equal(classifyClineAuth({ version: 1, providers: {} }, {}).state, 'unknown');
+    assert.equal(classifyClineAuth({}, {}).state, 'unknown');
+  });
+  it('the real unauthenticated cline-account default (no apiKey) → unknown, NOT no_credentials', () => {
+    // The `cline` provider authenticates via account/OAuth — a missing apiKey is
+    // not evidence of "no credentials"; must not be misclassified.
+    const parsed = {
+      version: 1,
+      lastUsedProvider: 'cline',
+      providers: { cline: { settings: { provider: 'cline', model: 'z-ai/glm-5.2' }, tokenSource: 'manual' } },
+    };
+    const r = classifyClineAuth(parsed, {});
+    assert.equal(r.state, 'unknown');
+    assert.equal(r.provider, 'cline');
+  });
+  it('a key-based provider selected with no credential → no_credentials', () => {
+    const parsed = { version: 1, lastUsedProvider: 'anthropic', providers: { anthropic: { settings: { provider: 'anthropic', model: 'claude-sonnet-4-6' } } } };
+    const r = classifyClineAuth(parsed, {});
+    assert.equal(r.state, 'no_credentials');
+    assert.equal(r.provider, 'anthropic');
+  });
+  it('a stored apiKey (nested) → ready, and never echoes the value', () => {
+    const parsed = {
+      version: 1,
+      lastUsedProvider: 'anthropic',
+      providers: { anthropic: { settings: { provider: 'anthropic', apiKey: 'sk-ant-REALKEY123456', model: 'claude-sonnet-4-6' } } },
+    };
+    const r = classifyClineAuth(parsed, {});
+    assert.equal(r.state, 'ready');
+    assert.equal(r.provider, 'anthropic');
+    assert.ok(!JSON.stringify(r).includes('sk-ant-REALKEY123456'));
+  });
+  it('a provider that stores a non-apiKey credential (token) → ready', () => {
+    const parsed = { version: 1, lastUsedProvider: 'acme', providers: { acme: { settings: { provider: 'acme', accessToken: 'tok-abcdef123456' } } } };
+    assert.equal(classifyClineAuth(parsed, {}).state, 'ready');
+  });
+  it('malformed / structure-changed providers.json → unknown (not no_credentials)', () => {
+    assert.equal(classifyClineAuth('not-an-object', {}).state, 'unknown');
+    assert.equal(classifyClineAuth([1, 2, 3], {}).state, 'unknown');
+    assert.equal(classifyClineAuth({ __parse_error: true }, {}).state, 'unknown');
+    assert.equal(classifyClineAuth({ version: 2, accounts: {} }, {}).state, 'unknown'); // shape changed
+  });
+  it('unknown state is never reported as ready', () => {
+    for (const j of [null, {}, { providers: {} }, 'x', { __parse_error: true }]) {
+      assert.notEqual(classifyClineAuth(j, {}).state, 'ready');
+    }
+  });
+});
+
+describe('buildClineArgs', () => {
+  it('always puts --json first and the prompt LAST (positional, never a flag)', () => {
+    const args = buildClineArgs({ prompt: '--help me', cwd: '/tmp/x' });
+    assert.equal(args[0], '--json');
+    assert.equal(args[args.length - 1], '--help me'); // dash-leading prompt is safe as last positional
+    assert.ok(args.includes('-c'));
+    assert.equal(args[args.indexOf('-c') + 1], '/tmp/x');
+  });
+
+  it('defaults to act mode with explicit --auto-approve true', () => {
+    const args = buildClineArgs({ prompt: 'hi' });
+    assert.ok(args.includes('--auto-approve'));
+    assert.equal(args[args.indexOf('--auto-approve') + 1], 'true');
+    assert.ok(!args.includes('-p'));
+  });
+
+  it('uses -p for plan mode (no auto-approve)', () => {
+    const args = buildClineArgs({ prompt: 'hi', planMode: true });
+    assert.ok(args.includes('-p'));
+    assert.ok(!args.includes('--auto-approve'));
+  });
+
+  it('maps resume / provider / model / key / thinking / timeout', () => {
+    const args = buildClineArgs({
+      prompt: 'go', cwd: '/w', sessionId: '123_abc', provider: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6', apiKey: 'sk-secret', thinking: 'high', timeoutSec: 90,
+    });
+    assert.equal(args[args.indexOf('--id') + 1], '123_abc');
+    assert.equal(args[args.indexOf('-P') + 1], 'openrouter');
+    assert.equal(args[args.indexOf('-m') + 1], 'anthropic/claude-sonnet-4.6');
+    assert.equal(args[args.indexOf('-k') + 1], 'sk-secret');
+    assert.equal(args[args.indexOf('--thinking') + 1], 'high');
+    assert.equal(args[args.indexOf('-t') + 1], '90');
+  });
+
+  it('passes special characters in the prompt verbatim (no shell, no escaping)', () => {
+    const weird = 'multi\nline "quoted" $VAR `cmd` 中文 && rm -rf /';
+    const args = buildClineArgs({ prompt: weird });
+    assert.equal(args[args.length - 1], weird);
+  });
+
+  it('throws without a prompt', () => {
+    assert.throws(() => buildClineArgs({ cwd: '/x' }), /prompt/);
+  });
+
+  it('redactArgs hides the -k value and the prompt', () => {
+    const args = buildClineArgs({ prompt: 'secret task text', apiKey: 'sk-ant-KEY123456' });
+    const red = redactArgs(['cline', ...args]);
+    assert.ok(!red.join(' ').includes('sk-ant-KEY123456'));
+    assert.ok(!red.join(' ').includes('secret task text'));
+    assert.ok(red.includes('«prompt»'));
+  });
+});
+
+describe('ClineStreamParser — chunking and framing', () => {
+  const line = (o) => JSON.stringify(o) + '\n';
+
+  it('parses multiple complete lines in one chunk', () => {
+    const p = new ClineStreamParser();
+    const got = p.push(line({ type: 'run_start' }) + line({ type: 'agent_event', event: { type: 'iteration_start', iteration: 1 } }));
+    assert.equal(got.length, 2);
+  });
+
+  it('reassembles a JSON object split across several chunks', () => {
+    const p = new ClineStreamParser();
+    const full = line({ type: 'agent_event', event: { type: 'content_end', contentType: 'text', text: 'hello world' } });
+    const a = full.slice(0, 20);
+    const b = full.slice(20, 45);
+    const c = full.slice(45);
+    assert.equal(p.push(a).length, 0);
+    assert.equal(p.push(b).length, 0);
+    const got = p.push(c);
+    assert.equal(got.length, 1);
+    assert.equal(got[0].event.text, 'hello world');
+  });
+
+  it('handles \\r\\n line endings and a trailing incomplete line (flush)', () => {
+    const p = new ClineStreamParser();
+    const got = p.push('{"type":"run_start"}\r\n{"type":"agent_event","event":{"type":"done","reason":"completed","text":"x"}}');
+    assert.equal(got.length, 1); // only the first (terminated) line
+    const tail = p.flush();
+    assert.equal(tail.length, 1);
+    assert.equal(tail[0].event.type, 'done');
+  });
+
+  it('skips non-JSON garbage lines without throwing', () => {
+    const p = new ClineStreamParser();
+    const got = p.push('not json here\n' + line({ type: 'run_result', finishReason: 'completed', text: 'ok' }));
+    assert.equal(got.length, 1);
+    assert.equal(p.garbage.length, 1);
+  });
+});
+
+describe('interpretClineEnvelope — event mapping', () => {
+  const agent = (event) => ({ type: 'agent_event', event });
+
+  it('maps content_end text → a single text event (deltas ignored, no duplication)', () => {
+    const evs = interpretChunks([
+      JSON.stringify(agent({ type: 'content_start', contentType: 'text', text: 'hel', accumulated: 'hel' })) + '\n',
+      JSON.stringify(agent({ type: 'content_start', contentType: 'text', text: 'lo', accumulated: 'hello' })) + '\n',
+      JSON.stringify(agent({ type: 'content_end', contentType: 'text', text: 'hello' })) + '\n',
+    ]);
+    const texts = evs.filter((e) => e.kind === 'text');
+    assert.equal(texts.length, 1);
+    assert.equal(texts[0].text, 'hello');
+  });
+
+  it('maps reasoning content_end → reasoning', () => {
+    const evs = interpretChunks([JSON.stringify(agent({ type: 'content_end', contentType: 'reasoning', reasoning: 'thinking…' })) + '\n']);
+    assert.deepEqual(evs, [{ kind: 'reasoning', text: 'thinking…' }]);
+  });
+
+  it('maps tool_start with input preview and tool_end with error', () => {
+    const start = interpretClineEnvelope(agent({ type: 'content_start', contentType: 'tool', toolName: 'run_commands', toolCallId: 't1', input: { commands: ['ls -la'] } }));
+    assert.equal(start[0].kind, 'tool_start');
+    assert.equal(start[0].toolName, 'run_commands');
+    assert.ok(start[0].preview.includes('ls -la'));
+    const end = interpretClineEnvelope(agent({ type: 'content_end', contentType: 'tool', toolName: 'run_commands', toolCallId: 't1', error: 'boom', durationMs: 12 }));
+    assert.equal(end[0].kind, 'tool_end');
+    assert.equal(end[0].ok, false);
+    assert.equal(end[0].error, 'boom');
+  });
+
+  it('maps the ask tools to an ask event', () => {
+    const evs = interpretClineEnvelope(agent({ type: 'content_start', contentType: 'tool', toolName: 'ask_followup_question', toolCallId: 'a1', input: { question: 'Which file?', options: ['a', 'b'] } }));
+    assert.equal(evs[0].kind, 'ask');
+    assert.equal(evs[0].question, 'Which file?');
+    assert.deepEqual(evs[0].options, ['a', 'b']);
+  });
+
+  it('maps agent_event error (redacting secrets) and run_result', () => {
+    const err = interpretClineEnvelope(agent({ type: 'error', error: { name: 'Error', message: 'bad key sk-ant-LEAKED1234567', stack: 'x' }, recoverable: false }));
+    assert.equal(err[0].kind, 'error');
+    assert.ok(!err[0].message.includes('sk-ant-LEAKED1234567'));
+    const res = interpretClineEnvelope({ type: 'run_result', finishReason: 'completed', text: 'done', model: { id: 'm' } });
+    assert.deepEqual(res, [{ kind: 'result', finishReason: 'completed', ok: true, text: 'done', model: 'm' }]);
+    const fail = interpretClineEnvelope({ type: 'run_result', finishReason: 'error', text: 'nope' });
+    assert.equal(fail[0].ok, false);
+  });
+
+  it('maps run_aborted and hook agent_start; ignores noise events', () => {
+    assert.equal(interpretClineEnvelope({ type: 'run_aborted', reason: 'sigint', message: 'm' })[0].kind, 'aborted');
+    assert.equal(interpretClineEnvelope({ type: 'hook_event', hookEventName: 'agent_start', taskId: 'c1', agentId: 'a1' })[0].kind, 'session');
+    assert.deepEqual(interpretClineEnvelope({ type: 'hook_event', hookEventName: 'tool_call' }), []);
+    assert.deepEqual(interpretClineEnvelope({ type: 'run_start', providerId: 'cline' }), []);
+    assert.deepEqual(interpretClineEnvelope(agent({ type: 'iteration_end', iteration: 1 })), []);
+    assert.deepEqual(interpretClineEnvelope(agent({ type: 'usage', inputTokens: 1 })), []);
+    assert.deepEqual(interpretClineEnvelope(agent({ type: 'content_update', contentType: 'tool' })), []);
+  });
+
+  it('handles two events packed in one chunk and one event split across chunks', () => {
+    const evs = interpretChunks([
+      '{"type":"agent_event","event":{"type":"content_end","contentType":"text","text":"A"}}\n{"type":"agent_eve',
+      'nt","event":{"type":"content_end","contentType":"text","text":"B"}}\n',
+    ]);
+    const texts = evs.filter((e) => e.kind === 'text').map((e) => e.text);
+    assert.deepEqual(texts, ['A', 'B']);
+  });
+});
+
+describe('pickClineSessionId — resume correlation (strict before/after snapshot)', () => {
+  const T0 = Date.parse('2026-06-17T06:00:00.000Z');
+  const base = (over) => ({ sessionId: 's', cwd: '/proj', startedAt: '2026-06-17T06:00:05.000Z', prompt: '<user_input mode="act">do a thing</user_input>', ...over });
+
+  it('binds the single NEW session in the working dir', () => {
+    const before = new Set(['old1', 'old2']);
+    const after = [base({ sessionId: 'old1' }), base({ sessionId: 'new1' })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before }), 'new1');
+  });
+
+  it('declines when two NEW sessions appear in the same dir (concurrent runs)', () => {
+    const before = new Set(['old1']);
+    const after = [base({ sessionId: 'old1' }), base({ sessionId: 'newA' }), base({ sessionId: 'newB', startedAt: '2026-06-17T06:00:06.000Z' })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before }), null);
+  });
+
+  it('declines on ambiguity even when prompt prefixes are identical', () => {
+    const before = new Set();
+    const same = '<user_input mode="act">fix the bug in</user_input>';
+    const after = [base({ sessionId: 'a', prompt: same }), base({ sessionId: 'b', prompt: same })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before, promptNeedle: 'fix the bug in' }), null);
+  });
+
+  it('a prompt needle can narrow to a unique candidate', () => {
+    const before = new Set();
+    const after = [
+      base({ sessionId: 'a', prompt: '<user_input mode="act">unique-XYZ task</user_input>' }),
+      base({ sessionId: 'b', prompt: '<user_input mode="act">something else</user_input>' }),
+    ];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before, promptNeedle: 'unique-XYZ' }), 'a');
+  });
+
+  it('never re-selects a pre-existing (old) session id', () => {
+    const before = new Set(['pre']);
+    const after = [base({ sessionId: 'pre', startedAt: '2026-06-17T06:00:05.000Z' })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before }), null);
+  });
+
+  it('does not cross working directories', () => {
+    const before = new Set();
+    const after = [base({ sessionId: 'mine' }), base({ sessionId: 'theirs', cwd: '/other-proj' })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before }), 'mine');
+    assert.equal(pickClineSessionId(after, { cwd: '/other-proj', sinceMs: T0, beforeIds: before }), 'theirs');
+  });
+
+  it('ignores records started before the spawn window', () => {
+    const before = new Set();
+    const after = [base({ sessionId: 'old', startedAt: '2026-06-17T05:00:00.000Z' })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: before }), null);
+  });
+
+  it('returns null when there are no new candidates', () => {
+    assert.equal(pickClineSessionId([], { cwd: '/proj', sinceMs: T0, beforeIds: new Set() }), null);
+    assert.equal(pickClineSessionId(null, { cwd: '/proj' }), null);
+  });
+
+  it('accepts beforeIds as an array too', () => {
+    const after = [base({ sessionId: 'old' }), base({ sessionId: 'fresh' })];
+    assert.equal(pickClineSessionId(after, { cwd: '/proj', sinceMs: T0, beforeIds: ['old'] }), 'fresh');
+  });
+});

--- a/packages/agent-connector/test/cline.test.js
+++ b/packages/agent-connector/test/cline.test.js
@@ -1,0 +1,504 @@
+'use strict';
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ClineAdapter = require('../src/adapters/cline');
+const { ADAPTER_MAP, createAdapter } = require('../src/adapters');
+const { buildClineArgs } = require('../src/adapters/cline-stream');
+
+const IS_WINDOWS = process.platform === 'win32';
+
+// ---------------------------------------------------------------------------
+// A mock `cline` binary: a Node script that emits a scripted NDJSON sequence
+// (matching the real v3.0.26 wire format) chosen by FAKE_SCENARIO, so the
+// adapter's spawn → parse → stream path can be exercised without a real CLI,
+// API key, or network. Written once for the suite.
+// ---------------------------------------------------------------------------
+let tmpRoot;
+let fakeBin;
+
+const FAKE_SCRIPT = `#!/usr/bin/env node
+'use strict';
+const args = process.argv.slice(2);
+// Subcommands used by the adapter's helpers:
+if (args[0] === '--version') { process.stdout.write((process.env.FAKE_VERSION || '3.0.26') + '\\n'); process.exit(0); }
+if (args[0] === 'history') { process.stdout.write((process.env.FAKE_HISTORY || '[]') + '\\n'); process.exit(0); }
+const scenario = process.env.FAKE_SCENARIO || 'complete';
+const ts = '2026-06-17T00:00:00.000Z';
+const w = (o) => process.stdout.write(JSON.stringify(Object.assign({ts}, o)) + '\\n');
+const agent = (event) => w({ type: 'agent_event', event });
+
+let stopped = false;
+const onSig = () => { stopped = true; w({ type: 'run_aborted', reason: 'sigterm', message: 'aborted' }); process.exit(130); };
+process.on('SIGINT', onSig);
+process.on('SIGTERM', onSig);
+
+if (scenario === 'complete') {
+  w({ type: 'hook_event', hookEventName: 'agent_start', agentId: 'a1', taskId: 'c1', parentAgentId: null });
+  w({ type: 'run_start', providerId: 'cline', modelId: 'm', catalog: 'live', thinking: 'off', mode: 'act' });
+  agent({ type: 'iteration_start', iteration: 1 });
+  // streamed text deltas + final block
+  agent({ type: 'content_start', contentType: 'text', text: 'Hel', accumulated: 'Hel' });
+  agent({ type: 'content_start', contentType: 'text', text: 'lo', accumulated: 'Hello' });
+  agent({ type: 'content_end', contentType: 'text', text: 'Hello, I will edit a file.' });
+  // a tool call
+  agent({ type: 'content_start', contentType: 'tool', toolName: 'editor', toolCallId: 't1', input: { file_path: 'src/x.js' } });
+  agent({ type: 'content_end', contentType: 'tool', toolName: 'editor', toolCallId: 't1', output: 'ok', durationMs: 5 });
+  agent({ type: 'iteration_end', iteration: 1, hadToolCalls: true, toolCallCount: 1 });
+  // final answer block (after the tool)
+  agent({ type: 'content_end', contentType: 'text', text: 'Done — edited src/x.js.' });
+  agent({ type: 'done', reason: 'completed', text: 'Done — edited src/x.js.', iterations: 1 });
+  w({ type: 'hook_event', hookEventName: 'agent_end', agentId: 'a1', taskId: 'c1', parentAgentId: null });
+  w({ type: 'run_result', finishReason: 'completed', iterations: 1, durationMs: 10, text: 'Done — edited src/x.js.', model: { id: 'm' } });
+  process.exit(0);
+} else if (scenario === 'auth_error') {
+  // Faithful to real Cline v3.0.27: a benign 'hook dispatch failed' diagnostic
+  // on stderr, the failure carried by a done{reason:'error'} (text = message),
+  // a run_result{finishReason:'error'}, and the real error repeated on stderr.
+  w({ type: 'hook_event', hookEventName: 'agent_start', agentId: 'a1', taskId: 'c1', parentAgentId: null });
+  process.stderr.write(JSON.stringify({ ts, type: 'error', message: 'hook dispatch failed: session.hook requires a valid hook event payload' }) + '\\n');
+  agent({ type: 'iteration_start', iteration: 1 });
+  agent({ type: 'done', reason: 'error', text: "Unauthorized: Please re-authenticate your Cline account.", iterations: 1 });
+  w({ type: 'run_result', finishReason: 'error', iterations: 1, durationMs: 3, text: 'Unauthorized: Please re-authenticate your Cline account.', model: { id: 'm' } });
+  process.stderr.write(JSON.stringify({ ts, type: 'error', message: 'Unauthorized: Please re-authenticate your Cline account.' }) + '\\n');
+  process.exit(1);
+} else if (scenario === 'stderr_noise') {
+  // Diagnostic noise on stderr (NOT JSON error) must never become a reply.
+  process.stderr.write('debug: starting up\\n[trace] connecting to hub on 127.0.0.1\\n');
+  agent({ type: 'content_end', contentType: 'text', text: 'The real answer.' });
+  w({ type: 'run_result', finishReason: 'completed', iterations: 1, durationMs: 4, text: 'The real answer.', model: { id: 'm' } });
+  process.exit(0);
+} else if (scenario === 'hang') {
+  w({ type: 'hook_event', hookEventName: 'agent_start', agentId: 'a1', taskId: 'c1', parentAgentId: null });
+  agent({ type: 'iteration_start', iteration: 1 });
+  setInterval(() => {}, 1000); // run forever until signalled
+} else if (scenario === 'net_error') {
+  // A real network failure alongside the benign hook-dispatch noise.
+  process.stderr.write(JSON.stringify({ ts, type: 'error', message: 'hook dispatch failed: session.hook requires a valid hook event payload' }) + '\\n');
+  agent({ type: 'done', reason: 'error', text: 'getaddrinfo ENOTFOUND api.example.com', iterations: 1 });
+  w({ type: 'run_result', finishReason: 'error', iterations: 1, durationMs: 3, text: 'getaddrinfo ENOTFOUND api.example.com', model: { id: 'm' } });
+  process.exit(1);
+} else if (scenario === 'stderr_only_real') {
+  // No run_result/done error — the failure is ONLY on stderr, mixed with the
+  // benign noise. The benign line must be filtered; the real one must survive.
+  process.stderr.write(JSON.stringify({ ts, type: 'error', message: 'hook dispatch failed: session.hook requires a valid hook event payload' }) + '\\n');
+  process.stderr.write(JSON.stringify({ ts, type: 'error', message: 'hook dispatch failed: provider crashed unexpectedly' }) + '\\n');
+  process.exit(1);
+} else {
+  process.exit(0);
+}
+`;
+
+function makeAdapter(extra = {}) {
+  const a = new ClineAdapter({
+    workspaceId: 'ws',
+    channelName: 'thread',
+    token: 'token',
+    agentName: 'cline-bot',
+    agentEnv: extra.agentEnv || {},
+    workingDir: extra.workingDir || tmpRoot,
+  });
+  // Stub all network-touching message helpers to capture calls.
+  a._captured = { thinking: [], status: [], response: [], error: [], todos: [] };
+  a.sendThinking = async (_c, t) => { a._captured.thinking.push(t); };
+  a.sendStatus = async (_c, t) => { a._captured.status.push(t); };
+  a.sendResponse = async (_c, t) => { a._captured.response.push(t); };
+  a.sendError = async (_c, t) => { a._captured.error.push(t); };
+  a.sendTodos = async (_c, t) => { a._captured.todos.push(t); };
+  a._log = () => {};
+  // Stub the workspace client calls _handleMessage makes (all wrapped in
+  // try/catch in the adapter, but give benign returns so the happy path runs).
+  a.client = {
+    getSession: async () => ({ title: 'Session 1', titleManuallySet: false, resumeFrom: null }),
+    updateSession: async () => ({}),
+    getRecentMessages: async () => [],
+  };
+  // Point binary resolution at the mock.
+  a._findClineBinary = () => fakeBin;
+  return a;
+}
+
+before(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cline-test-'));
+  fakeBin = path.join(tmpRoot, IS_WINDOWS ? 'fake-cline.cmd' : 'fake-cline');
+  if (IS_WINDOWS) {
+    // A .cmd that shells to node on the sibling .js (mirrors npm shims).
+    fs.writeFileSync(path.join(tmpRoot, 'fake-cline.js'), FAKE_SCRIPT);
+    fs.writeFileSync(fakeBin, `@echo off\r\nnode "%~dp0fake-cline.js" %*\r\n`);
+  } else {
+    fs.writeFileSync(fakeBin, FAKE_SCRIPT, { mode: 0o755 });
+  }
+});
+
+after(() => {
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe('ClineAdapter — registration', () => {
+  it('is registered under the cline agent type', () => {
+    assert.equal(ADAPTER_MAP.cline, ClineAdapter);
+    const inst = createAdapter('cline', { workspaceId: 'ws', channelName: 't', token: 'tok', agentName: 'c', agentEnv: {} });
+    assert.ok(inst instanceof ClineAdapter);
+  });
+});
+
+describe('ClineAdapter — session persistence & resume binding', () => {
+  it('persists and reloads channel sessions bound to a working dir', () => {
+    const a = makeAdapter();
+    a._channelSessions['thread'] = { sessionId: 's-123', workingDir: '/proj' };
+    a._saveSessions();
+
+    const b = makeAdapter();
+    assert.deepEqual(b._channelSessions['thread'], { sessionId: 's-123', workingDir: '/proj' });
+    // resumes only when the working dir matches (never cross projects)
+    assert.equal(b._resumableSession('thread', '/proj'), 's-123');
+    assert.equal(b._resumableSession('thread', '/other'), null);
+    b._clearSession('thread');
+    assert.equal(b._resumableSession('thread', '/proj'), null);
+  });
+});
+
+describe('ClineAdapter — working directory validation', () => {
+  it('detects missing vs existing directories', () => {
+    const a = makeAdapter();
+    assert.equal(a._dirExists(tmpRoot), true);
+    assert.equal(a._dirExists(path.join(tmpRoot, 'does-not-exist')), false);
+  });
+
+  it('handles paths with spaces and non-ASCII characters', () => {
+    const a = makeAdapter();
+    const weird = path.join(tmpRoot, 'my project 中文 dir');
+    fs.mkdirSync(weird, { recursive: true });
+    assert.equal(a._dirExists(weird), true);
+    // and buildClineArgs carries such a path through -c without escaping
+    const args = buildClineArgs({ prompt: 'hi', cwd: weird });
+    assert.equal(args[args.indexOf('-c') + 1], weird);
+  });
+});
+
+describe('ClineAdapter — _runCline against the mock CLI', () => {
+  it('streams thinking + tool status and returns the final completed text once', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    const args = buildClineArgs({ prompt: 'edit file', cwd: tmpRoot });
+    const result = await a._runCline('thread', fakeBin, args, tmpRoot);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.finalText, 'Done — edited src/x.js.');
+    assert.equal(result.anyOutput, true);
+    assert.equal(result.userStopped, false);
+    // both text blocks streamed as thinking
+    assert.ok(a._captured.thinking.includes('Hello, I will edit a file.'));
+    assert.ok(a._captured.thinking.includes('Done — edited src/x.js.'));
+    // the tool call surfaced as a status with a friendly label + preview
+    assert.ok(a._captured.status.some((s) => /Editing file/.test(s) && /src\/x\.js/.test(s)));
+    // process cleaned up
+    assert.equal(a._channelProcesses['thread'], undefined);
+  });
+
+  it('does not emit a duplicate final result / response', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    const args = buildClineArgs({ prompt: 'edit file', cwd: tmpRoot });
+    const result = await a._runCline('thread', fakeBin, args, tmpRoot);
+    // _runCline returns a single finalText; the final text block appears once
+    // in the thinking stream (not repeated by the run_result echo).
+    const dones = a._captured.thinking.filter((t) => t === 'Done — edited src/x.js.');
+    assert.equal(dones.length, 1);
+    assert.equal(result.finalText, 'Done — edited src/x.js.');
+  });
+
+  it('classifies an auth error and keeps it off the assistant reply', async () => {
+    const { classifyClineError } = require('../src/adapters/cline-stream');
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'auth_error' } });
+    const args = buildClineArgs({ prompt: 'do x', cwd: tmpRoot });
+    const result = await a._runCline('thread', fakeBin, args, tmpRoot);
+    assert.equal(result.ok, false);
+    // the real error wins, not the benign 'hook dispatch failed' stderr noise…
+    assert.ok(/unauthorized|re-authenticate/i.test(result.errorMessage));
+    assert.ok(!/hook dispatch failed/i.test(result.errorMessage));
+    // …and it classifies as auth
+    assert.equal(classifyClineError(result.errorMessage).kind, 'auth');
+    // a done{reason:error} text must NEVER be surfaced as the assistant answer
+    assert.equal(result.finalText, '');
+  });
+
+  it('keeps stderr diagnostics out of the response (stdout/stderr isolation)', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'stderr_noise' } });
+    const args = buildClineArgs({ prompt: 'answer', cwd: tmpRoot });
+    const result = await a._runCline('thread', fakeBin, args, tmpRoot);
+    assert.equal(result.finalText, 'The real answer.');
+    // none of the stderr noise leaked into thinking/response/error
+    const all = [...a._captured.thinking, ...a._captured.response, ...a._captured.error].join('\n');
+    assert.ok(!/connecting to hub|debug: starting up/.test(all));
+  });
+
+  it('stops a running task: process is killed, marked userStopped, nothing left running', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'hang' } });
+    const args = buildClineArgs({ prompt: 'long task', cwd: tmpRoot });
+    const runPromise = a._runCline('thread', fakeBin, args, tmpRoot);
+
+    // wait until the process is registered and has started emitting
+    await waitFor(() => a._channelProcesses['thread'] && a._captured.status.length >= 0, 4000);
+    const proc = a._channelProcesses['thread'];
+    assert.ok(proc, 'process should be registered while running');
+
+    a._stoppingChannels.add('thread');
+    await a._stopProcess(proc);
+    const result = await runPromise;
+
+    assert.equal(result.userStopped, true);
+    assert.equal(a._channelProcesses['thread'], undefined);
+    // the child must really be gone
+    assert.notEqual(proc.exitCode === null && proc.signalCode === null, true);
+  });
+});
+
+describe('ClineAdapter — _handleMessage orchestration', () => {
+  it('runs the task end-to-end and posts the final response', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage({ content: 'edit the file', sessionId: 'thread', senderType: 'human', senderName: 'user' });
+    assert.ok(a._captured.response.includes('Done — edited src/x.js.'));
+    assert.equal(a._captured.error.length, 0);
+    assert.equal(a._channelProcesses['thread'], undefined);
+  });
+
+  it('returns a clear error when the working directory does not exist', async () => {
+    const missing = path.join(tmpRoot, 'no-such-dir');
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' }, workingDir: missing });
+    await a._handleMessage({ content: 'do x', sessionId: 'thread', senderType: 'human' });
+    assert.ok(a._captured.error.some((e) => /working directory does not exist/i.test(e)));
+    assert.equal(a._captured.response.length, 0);
+  });
+
+  it('returns a clear error when the Cline binary is not found', async () => {
+    const a = makeAdapter({ agentEnv: {} });
+    a._findClineBinary = () => null;
+    await a._handleMessage({ content: 'do x', sessionId: 'thread', senderType: 'human' });
+    assert.ok(a._captured.error.some((e) => /cline cli not found/i.test(e)));
+  });
+
+  it('surfaces a classified auth error to the user (not the raw stack)', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'auth_error' } });
+    await a._handleMessage({ content: 'do x', sessionId: 'thread', senderType: 'human' });
+    assert.ok(a._captured.error.some((e) => /not authenticated|re-authenticate|cline auth/i.test(e)));
+    assert.equal(a._captured.response.length, 0);
+  });
+});
+
+describe('ClineAdapter — hard minimum version gate', () => {
+  const FAKEBIN = '/fake/cline/bin';
+
+  it('reports compatible for >= 3.0.0', () => {
+    ClineAdapter._clearVersionCache();
+    const a = makeAdapter();
+    a._readClineVersionRaw = () => '3.0.27';
+    const v = a._checkClineVersion(FAKEBIN);
+    assert.equal(v.version, '3.0.27');
+    assert.equal(v.compatible, true);
+  });
+
+  it('reports incompatible for a CONFIRMED older version', () => {
+    ClineAdapter._clearVersionCache();
+    const a = makeAdapter();
+    a._readClineVersionRaw = () => '2.0.0';
+    assert.equal(a._checkClineVersion(FAKEBIN).compatible, false);
+  });
+
+  it('refuses to start the agent when the version is too old (does not spawn)', async () => {
+    ClineAdapter._clearVersionCache();
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    a._readClineVersionRaw = () => '2.1.0';
+    let spawned = false;
+    const orig = a._runCline.bind(a);
+    a._runCline = (...args) => { spawned = true; return orig(...args); };
+    await a._handleMessage({ content: 'do x', sessionId: 'thread', senderType: 'human' });
+    assert.equal(spawned, false, 'must not spawn an incompatible CLI');
+    assert.ok(a._captured.error.some((e) => /below the minimum|3\.0\.0|upgrade/i.test(e)));
+    assert.equal(a._captured.response.length, 0);
+  });
+
+  it('treats an unparseable version as undetermined (compatible:null, not blocked)', async () => {
+    ClineAdapter._clearVersionCache();
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    a._readClineVersionRaw = () => 'cline build banana';
+    assert.equal(a._checkClineVersion(FAKEBIN).compatible, null);
+    // and it proceeds to run normally
+    let spawned = false;
+    const orig = a._runCline.bind(a);
+    a._runCline = (...args) => { spawned = true; return orig(...args); };
+    await a._handleMessage({ content: 'do x', sessionId: 'thread', senderType: 'human' });
+    assert.equal(spawned, true);
+  });
+
+  it('treats a failed version command as undetermined (compatible:null)', () => {
+    ClineAdapter._clearVersionCache();
+    const a = makeAdapter();
+    a._readClineVersionRaw = () => { throw new Error('ENOENT'); };
+    assert.equal(a._checkClineVersion(FAKEBIN).compatible, null);
+  });
+
+  it('caches the version (one detection within TTL) and re-detects after clear', () => {
+    ClineAdapter._clearVersionCache();
+    const a = makeAdapter();
+    let calls = 0;
+    a._readClineVersionRaw = () => { calls++; return '3.0.27'; };
+    a._checkClineVersion(FAKEBIN);
+    a._checkClineVersion(FAKEBIN);
+    assert.equal(calls, 1, 'second call within TTL must hit the cache');
+    ClineAdapter._clearVersionCache();
+    a._checkClineVersion(FAKEBIN);
+    assert.equal(calls, 2, 'after cache clear it re-detects');
+  });
+});
+
+describe('ClineAdapter — stderr noise filtering (tightened)', () => {
+  it('keeps a real network error while filtering the benign hook noise', async () => {
+    const { classifyClineError } = require('../src/adapters/cline-stream');
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'net_error' } });
+    const args = buildClineArgs({ prompt: 'go', cwd: tmpRoot });
+    const result = await a._runCline('thread', fakeBin, args, tmpRoot);
+    assert.equal(result.ok, false);
+    assert.equal(classifyClineError(result.errorMessage).kind, 'network');
+    assert.ok(!/hook dispatch failed/i.test(result.errorMessage));
+  });
+
+  it('does NOT filter a different "hook dispatch failed: <other>" — that is a real error', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'stderr_only_real' } });
+    const args = buildClineArgs({ prompt: 'go', cwd: tmpRoot });
+    const result = await a._runCline('thread', fakeBin, args, tmpRoot);
+    assert.equal(result.ok, false);
+    // the exact benign line is filtered; the different one survives as the error
+    assert.match(result.errorMessage, /provider crashed unexpectedly/);
+    assert.notEqual(result.errorMessage.trim(), 'hook dispatch failed: session.hook requires a valid hook event payload');
+  });
+});
+
+describe('ClineAdapter — session capture (before/after snapshot, concurrency-safe)', () => {
+  const isoNow = () => new Date(Date.now()).toISOString();
+
+  it('binds the single new session, excluding pre-existing ids', async () => {
+    const a = makeAdapter();
+    a._channelSessions = {}; // isolate from any persisted sessions file
+    a._readHistory = async () => ([
+      { sessionId: 'old', cwd: tmpRoot, startedAt: isoNow() },
+      { sessionId: 'fresh', cwd: tmpRoot, startedAt: isoNow() },
+    ]);
+    await a._captureSessionId('thread', fakeBin, tmpRoot, Date.now() - 1000, 'do a thing', new Set(['old']));
+    assert.deepEqual(a._channelSessions['thread'], { sessionId: 'fresh', workingDir: tmpRoot });
+  });
+
+  it('declines to bind when two new sessions appear in the same working dir', async () => {
+    const a = makeAdapter();
+    a._channelSessions = {};
+    a._readHistory = async () => ([
+      { sessionId: 'a', cwd: tmpRoot, startedAt: isoNow() },
+      { sessionId: 'b', cwd: tmpRoot, startedAt: isoNow() },
+    ]);
+    await a._captureSessionId('thread', fakeBin, tmpRoot, Date.now() - 1000, 'do a thing', new Set());
+    assert.equal(a._channelSessions['thread'], undefined);
+  });
+
+  it('does not fail the turn when history is unavailable', async () => {
+    const a = makeAdapter();
+    a._channelSessions = {};
+    a._readHistory = async () => null;
+    await assert.doesNotReject(a._captureSessionId('thread', fakeBin, tmpRoot, Date.now() - 1000, 'x', new Set()));
+    assert.equal(a._channelSessions['thread'], undefined);
+  });
+});
+
+describe('Installer — package-bin fallback (generic; fixes Cline detection)', () => {
+  // Cline's npm package declares `bin: "./bin/cline"`; a local `npm install
+  // --prefix` does NOT create a node_modules/.bin shim for it, so PATH lookup
+  // misses it. The installer must fall back to the package's own bin so
+  // healthCheck reports installed (and the launcher badge is correct).
+  const { Installer } = require('../src/installer');
+  const { getRuntimePrefix } = require('../src/paths');
+
+  it('resolves a package whose bin has no node_modules/.bin shim', () => {
+    const agentType = 'clinefbtest';
+    const prefix = getRuntimePrefix(agentType);
+    const pkgDir = path.join(prefix, 'node_modules', agentType);
+    const binDir = path.join(pkgDir, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: agentType, bin: { [agentType]: './bin/runme' } }));
+    const binFile = path.join(binDir, 'runme');
+    fs.writeFileSync(binFile, '#!/usr/bin/env node\n', { mode: 0o755 });
+    try {
+      const mockRegistry = {
+        getEntry: () => ({
+          name: agentType,
+          install: { binary: agentType, linux: `npm install -g ${agentType}`, macos: `npm install -g ${agentType}`, windows: `npm install -g ${agentType}` },
+        }),
+      };
+      const inst = new Installer(mockRegistry, fs.mkdtempSync(path.join(os.tmpdir(), 'inst-')));
+      // Not on PATH → must resolve via the package-bin fallback.
+      assert.equal(inst.which(agentType), binFile);
+      assert.equal(inst.getInstallInfo(agentType).installed, true);
+    } finally {
+      fs.rmSync(prefix, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Installer — minimum version gate (generic; opt-in via check_ready.min_version)', () => {
+  const { Installer } = require('../src/installer');
+  const mkInst = (minVersion) => {
+    const inst = new Installer({
+      getResolveRules: () => [],
+      getEntry: () => ({
+        name: 'veragent',
+        label: 'VerAgent',
+        install: { binary: 'veragent', linux: 'npm install -g veragent', macos: 'npm install -g veragent', windows: 'npm install -g veragent' },
+        check_ready: minVersion ? { min_version: minVersion } : {},
+      }),
+    }, fs.mkdtempSync(path.join(os.tmpdir(), 'inst-')));
+    inst._whichBinary = () => '/fake/veragent';
+    return inst;
+  };
+
+  it('a CONFIRMED older version → installed:true, compatible:false, ready:false, upgrade message', () => {
+    const inst = mkInst('3.0.0');
+    inst._readVersion = () => '2.4.1';
+    const h = inst.healthCheck('veragent');
+    assert.equal(h.installed, true);
+    assert.equal(h.compatible, false);
+    assert.equal(h.ready, false);
+    assert.match(h.message, /older than the supported minimum|upgrade/i);
+  });
+
+  it('a new-enough version → compatible:true', () => {
+    const inst = mkInst('3.0.0');
+    inst._readVersion = () => '3.0.27';
+    assert.equal(inst.healthCheck('veragent').compatible, true);
+  });
+
+  it('an unparseable version → compatible:null (undetermined, not force-blocked)', () => {
+    const inst = mkInst('3.0.0');
+    inst._readVersion = () => 'banana';
+    assert.equal(inst.healthCheck('veragent').compatible, null);
+  });
+
+  it('agents WITHOUT min_version are unaffected (compatible:true)', () => {
+    const inst = mkInst(null);
+    inst._readVersion = () => '0.0.1';
+    assert.equal(inst.healthCheck('veragent').compatible, true);
+  });
+});
+
+function waitFor(cond, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      let ok = false;
+      try { ok = cond(); } catch {}
+      if (ok) return resolve();
+      if (Date.now() - start > timeoutMs) return reject(new Error('waitFor timed out'));
+      setTimeout(tick, 25);
+    };
+    tick();
+  });
+}

--- a/packages/agent-connector/test/stop-control.test.js
+++ b/packages/agent-connector/test/stop-control.test.js
@@ -25,14 +25,24 @@ function isPidAlive(pid) {
 function readFirstLine(stream) {
   return new Promise((resolve, reject) => {
     let buffer = '';
-    const timeout = setTimeout(() => reject(new Error('Timed out waiting for child pid')), 3000);
+    let settled = false;
+    const finish = (fn) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      fn();
+    };
+    const timeout = setTimeout(() => finish(() => reject(new Error('Timed out waiting for child pid'))), 3000);
+    // Guard the stream against 'error'. When the child is later SIGKILL'd, its
+    // stdout pipe can emit EPIPE/EBADF/ECONNRESET (notably on macOS); without an
+    // 'error' listener that becomes an unhandled 'error' event that crashes the
+    // whole test worker. The listener persists for the stream's lifetime, so a
+    // post-resolve error during teardown is swallowed instead of throwing.
+    stream.on('error', () => finish(() => reject(new Error('stdout stream error'))));
     stream.on('data', (chunk) => {
       buffer += chunk.toString('utf-8');
       const idx = buffer.indexOf('\n');
-      if (idx >= 0) {
-        clearTimeout(timeout);
-        resolve(buffer.slice(0, idx).trim());
-      }
+      if (idx >= 0) finish(() => resolve(buffer.slice(0, idx).trim()));
     });
   });
 }
@@ -120,6 +130,11 @@ describe('agent stop control', () => {
       detached: process.platform !== 'win32',
       windowsHide: true,
     });
+    // Killing the child can make its stdio/process emit 'error' (EPIPE/EBADF on
+    // macOS). Swallow so it never becomes an unhandled 'error' that crashes the
+    // test worker.
+    proc.on('error', () => {});
+    if (proc.stdout) proc.stdout.on('error', () => {});
 
     try {
       const childPid = Number(await readFirstLine(proc.stdout));
@@ -288,6 +303,11 @@ describe('agent stop control', () => {
       detached: process.platform !== 'win32',
       windowsHide: true,
     });
+    // Killing the child can make its stdio/process emit 'error' (EPIPE/EBADF on
+    // macOS). Swallow so it never becomes an unhandled 'error' that crashes the
+    // test worker.
+    proc.on('error', () => {});
+    if (proc.stdout) proc.stdout.on('error', () => {});
 
     try {
       const childPid = Number(await readFirstLine(proc.stdout));

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -211,6 +211,33 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       placeholder: "gpt-4o, claude-sonnet-4-6, etc.",
     },
   ],
+  // Cline supports many providers (its own account, Anthropic, OpenAI,
+  // OpenRouter, …). The launcher collects an optional per-run API key plus the
+  // provider/model selection (mapped by the adapter to Cline's -k/-P/-m). All
+  // fields are optional: a user can instead run `cline auth` to sign in and the
+  // agent will use Cline's stored credentials.
+  cline: [
+    {
+      name: "CLINE_API_KEY",
+      description:
+        "API key for the selected provider — or leave blank and run `cline auth` to sign in.",
+      required: false,
+      password: true,
+    },
+    {
+      name: "CLINE_PROVIDER",
+      description:
+        "Provider id (cline, anthropic, openai, openrouter, …). Leave blank for Cline's configured default.",
+      required: false,
+      placeholder: "openrouter",
+    },
+    {
+      name: "CLINE_MODEL",
+      description: "Model id for the selected provider.",
+      required: false,
+      placeholder: "anthropic/claude-sonnet-4.6",
+    },
+  ],
 }
 
 /**
@@ -311,7 +338,7 @@ const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
  * an API key, so they're a rougher first-run experience than the key-only
  * agents; keep onboarding to the smoother options.
  */
-const ONBOARDING_HIDDEN = new Set<string>(["cursor", "hermes"])
+const ONBOARDING_HIDDEN = new Set<string>(["cursor", "hermes", "cline"])
 
 /**
  * The agents the launcher/workspace core officially supports today, in the
@@ -332,6 +359,7 @@ const CORE_AGENTS: readonly string[] = [
   "hermes",
   "kimi",
   "gemini",
+  "cline",
 ]
 const CORE_AGENT_ORDER = new Map<string, number>(
   CORE_AGENTS.map((name, i) => [name, i]),
@@ -480,6 +508,73 @@ async function testLLMConnection(
         success: false,
         error:
           "Cursor signs in through its own service — there's no key endpoint to test here. Save the key and launch the agent to verify.",
+      }
+    }
+
+    // ── Cline: routes by the selected provider ──
+    // Cline targets many providers; we test the API-key providers we can reach
+    // (Anthropic, OpenAI, OpenRouter) and give an honest message for the rest
+    // (e.g. Cline's own account, or a custom endpoint configured via `cline auth`).
+    const clineKey = pick("CLINE_API_KEY")
+    if (clineKey && !anthropicKey && !openaiKey && !geminiKey) {
+      const provider = pick("CLINE_PROVIDER").toLowerCase()
+      const clineModel = pick("CLINE_MODEL")
+      if (provider.includes("anthropic")) {
+        const base = "https://api.anthropic.com"
+        const model = clineModel || "claude-3-5-haiku-latest"
+        const { status, text } = await httpRequestJson(
+          `${base}/v1/messages`,
+          "POST",
+          {
+            "x-api-key": clineKey,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+          },
+          JSON.stringify({
+            model,
+            max_tokens: 16,
+            messages: [{ role: "user", content: "Say hi in 5 words." }],
+          }),
+        )
+        if (status >= 400)
+          return { success: false, error: `HTTP ${status}: ${text.slice(0, 200)}` }
+        let reply = ""
+        try {
+          reply = JSON.parse(text)?.content?.[0]?.text || ""
+        } catch {}
+        return { success: true, model, response: reply.slice(0, 80) }
+      }
+      if (provider.includes("openai") || provider.includes("openrouter")) {
+        const base = provider.includes("openrouter")
+          ? "https://openrouter.ai/api/v1"
+          : "https://api.openai.com/v1"
+        const model =
+          clineModel || (provider.includes("openrouter") ? "openai/gpt-4o-mini" : "gpt-4o-mini")
+        const { status, text } = await httpRequestJson(
+          `${base}/chat/completions`,
+          "POST",
+          { Authorization: `Bearer ${clineKey}`, "Content-Type": "application/json" },
+          JSON.stringify({
+            model,
+            max_tokens: 16,
+            messages: [{ role: "user", content: "Say hi in 5 words." }],
+          }),
+        )
+        if (status >= 400)
+          return { success: false, error: `HTTP ${status}: ${text.slice(0, 200)}` }
+        let reply = "",
+          used = model
+        try {
+          const p = JSON.parse(text)
+          reply = p?.choices?.[0]?.message?.content || ""
+          used = p?.model || model
+        } catch {}
+        return { success: true, model: used, response: reply.slice(0, 80) }
+      }
+      return {
+        success: false,
+        error:
+          "Cline targets your selected provider — this provider can't be tested directly here. Save the settings and launch the agent to verify (or run `cline auth`).",
       }
     }
 

--- a/sdk/src/openagents/registry/cline.yaml
+++ b/sdk/src/openagents/registry/cline.yaml
@@ -1,11 +1,14 @@
 name: cline
 label: Cline
-description: Autonomous coding agent (VS Code extension)
+description: Autonomous coding agent CLI by Cline Bot
 homepage: https://github.com/cline/cline
-tags: [coding, vscode, autonomous]
+tags: [coding, cli, autonomous]
 
 install:
-  binary: code
-  macos: "code --install-extension saoudrizwan.claude-dev"
-  linux: "code --install-extension saoudrizwan.claude-dev"
-  windows: "code --install-extension saoudrizwan.claude-dev"
+  binary: cline
+  requires: [nodejs]
+  verify: "cline --version"
+  verify_win: "cline --version"
+  macos: "npm install -g cline"
+  linux: "npm install -g cline"
+  windows: "npm install -g cline"

--- a/workspace/backend/app/routers/network.py
+++ b/workspace/backend/app/routers/network.py
@@ -615,11 +615,13 @@ _AGENT_CATALOG = [
     {
         "name": "cline",
         "label": "Cline",
-        "description": "Autonomous coding agent for VS Code",
+        "description": "Autonomous coding agent CLI by Cline Bot",
         "install_command": "npm install -g cline",
         "homepage": "https://github.com/cline/cline",
-        "tags": ["coding", "vscode", "autonomous"],
-        "builtin": False,
+        "tags": ["coding", "cli", "autonomous"],
+        "builtin": True,
+        "featured": True,
+        "order": 9,
     },
     {
         "name": "copilot",


### PR DESCRIPTION
## Summary

Add Cline CLI support to OpenAgents Workspace, including installation and version checks, configuration detection, NDJSON streaming, session recovery, task interruption, process cleanup, tests, and documentation.

## Testing

* Agent Connector: 270 passed
* Cline tests: 73 passed
* Verified with Cline 3.0.27 on macOS/Linux
* Windows paths are covered by automated tests but not yet manually verified
