### PR TITLE
add GitHub Copilot CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ agn connect my-agent <workspace-token>    # connect agent into workspace
 | **Hermes Agent** | ✅ Supported | Nous Hermes CLI with tools, profiles, and memory |
 | **Cursor** | ✅ Supported | AI code editor |
 | **OpenCode** | ✅ Supported | Open-source terminal agent |
-| Aider, Goose, Gemini CLI, Copilot, Amp | 🔜 Coming soon | |
+| **GitHub Copilot CLI** | ✅ Supported | GitHub's official `copilot` CLI ([guide](docs/agents/github-copilot-cli.md)) |
+| Aider, Goose, Gemini CLI, Amp | 🔜 Coming soon | |
 
 ---
 

--- a/docs/agents/github-copilot-cli.md
+++ b/docs/agents/github-copilot-cli.md
@@ -1,0 +1,311 @@
+# GitHub Copilot CLI
+
+OpenAgents supports GitHub's **official Copilot CLI** — the standalone
+executable `copilot`, distributed as the npm package
+[`@github/copilot`](https://www.npmjs.com/package/@github/copilot).
+
+> **This is not the retired `gh copilot` extension.** The old
+> `gh extension install github/gh-copilot` flow (binary `gh`, subcommand
+> `gh copilot`) is deprecated. OpenAgents detects and launches the `copilot`
+> executable only and never invokes `gh`.
+
+- **Internal agent id:** `copilot`
+- **User-facing name:** GitHub Copilot CLI
+- **Adapter:** `packages/agent-connector/src/adapters/copilot.js`
+- **Stream parser:** `packages/agent-connector/src/adapters/copilot-stream-parser.js`
+
+---
+
+## Installation
+
+Install from any official source — OpenAgents auto-detects the `copilot`
+executable regardless of how it got there:
+
+| Method | Command | Notes |
+|--------|---------|-------|
+| npm (default) | `npm install -g @github/copilot` | Requires Node.js. This is what the launcher's installer runs. |
+| Homebrew | `brew install copilot` *(if/when published)* | No Node.js requirement. |
+| WinGet | `winget install GitHub.Copilot` *(if/when published)* | No Node.js requirement; resolves via `%LOCALAPPDATA%\Microsoft\WinGet\Links`. |
+| Standalone binary | per GitHub's instructions | No Node.js requirement. |
+
+The **npm** path requires Node.js. Homebrew / WinGet / standalone-binary
+installs do **not** require Node.js, and OpenAgents does not force a Node.js
+requirement on those — only the npm install command is Node-gated.
+
+### Detection details
+
+- OpenAgents looks for `copilot` (`copilot.cmd` / `copilot.exe` on Windows)
+  across: the isolated runtime prefix (`~/.openagents/runtimes/copilot`), the
+  enriched `PATH`, the npm global prefix, and common install locations
+  (Homebrew, `~/.local/bin`, WinGet Links).
+- An install **marker** is written only after a successful install and never
+  overrides real binary detection.
+- A binary on `PATH` always wins over a stale marker.
+
+---
+
+## Minimum supported version
+
+**`1.0.0`** — declared in `registry.json` (`install.min_version`), mirrored in
+the adapter (`CopilotAdapter.MIN_VERSION`) and asserted equal by a test.
+
+**Basis.** The adapter requires `--output-format=json` (JSONL) — which per
+GitHub's investigation was introduced in `0.0.422` — plus non-interactive `-p`
+with `--no-ask-user`, granular `--allow-tool`/`--add-dir`, `--resume`/`--name`
+session control, and `--secret-env-vars`/`--no-remote`. Per the spec
+("采用所有必需能力中的最高版本"), the floor is the **GA 1.0 line**, which is the
+first release series where the full set is present and stable and the documented
+CLI Reference applies. The integration was **verified end-to-end against
+`1.0.63`** (the current `latest`; published range is `0.0.326` … `1.0.63`).
+
+> The gate is generic — any registry entry may declare `install.min_version`
+> (see `packages/agent-connector/src/installer.js`). If GitHub's changelog later
+> pins an exact earlier 0.0.x build that has *all* required flags, lower this one
+> field (and the adapter constant) accordingly.
+
+Two enforcement points share the same floor:
+- **`installer.healthCheck('copilot')`** for the launcher UI (table below).
+- **`CopilotAdapter._checkVersionGate()`** runs `copilot --version` before
+  spawning a turn and refuses (with an upgrade message) when below the floor, so
+  an old CLI never gets a turn that would fail with `unknown option`.
+
+Health-check behaviour (`installer.healthCheck('copilot')`):
+
+| Detected version | `installed` | `compatible` | `ready` | Behaviour |
+|------------------|-------------|--------------|---------|-----------|
+| ≥ `min_version`  | `true` | `true` | per auth | Normal. |
+| < `min_version`  | `true` | `false` | `false` | **Launch blocked**, upgrade prompt. Never shown as "not installed". |
+| unparseable      | `true` | `null` (unknown) | per auth | Not blocked, not falsely "compatible". |
+| not found        | `false` | `null` | `false` | Offer install. |
+
+Version results are cached briefly and the cache is cleared on
+install/uninstall.
+
+---
+
+## Authentication
+
+The Copilot CLI authenticates against **GitHub**, not an OpenAgents-collected
+API key. Verified token precedence (from `copilot login --help` /
+`copilot help environment`, v1.0.63):
+
+1. `COPILOT_GITHUB_TOKEN`
+2. `GH_TOKEN`
+3. `GITHUB_TOKEN`
+
+If none is set, the CLI uses a token from a prior `copilot` `/login` (stored in
+the **system credential store**, else plaintext under `~/.copilot/`), or a
+`gh auth` session. **Supported token types:** fine-grained v2 PATs
+(`github_pat_…`) with the **"Copilot Requests"** permission, OAuth tokens from
+the Copilot CLI app, and OAuth tokens from `gh`. **Classic `ghp_` PATs are NOT
+supported.** GitHub Enterprise (data residency): `GH_HOST` / `COPILOT_GH_HOST`
+or `copilot login --host`. BYOK custom providers: `COPILOT_PROVIDER_*`.
+
+You can either:
+
+- **Sign in interactively:** run `copilot` once and use `/login` (browser device
+  flow), **or**
+- **Provide a token:** set `COPILOT_GITHUB_TOKEN` (the launcher offers an
+  optional, password-masked field for this).
+
+### How OpenAgents reports auth state (`auth_status`)
+
+There is **no side-effect-free, non-interactive "am I authed?" command**
+(verified: an unauthenticated `-p … --output-format json` run prints the auth
+error to **stderr**, leaves stdout empty, and exits 1). So OpenAgents reports a
+four-state `auth_status` rather than a binary verdict:
+
+| `auth_status` | Meaning |
+|---------------|---------|
+| `ready` | A token env var is present (positive signal). |
+| `unknown` | No token env var detected — but you may already be signed in via `copilot` /login, the keychain, or `gh`. **Not** a claim of "no credentials**; does **not** block a launch attempt. |
+| `no_credentials` | (Other agents) creds definitively absent. |
+| — incompatible — | Version below the floor (separate `compatible:false`). |
+
+Copilot is marked `unverifiable` in the registry, so absence of a token yields
+`unknown`, never a false "not signed in". The **final authority is the CLI's own
+run result** — auth/authorization failures are classified from live stderr (see
+[Common errors](#common-errors)).
+
+OpenAgents **never** reads, prints, or forwards your token: it does not run
+commands that echo a token, never logs env-var values, never reads the system
+keychain contents, and never sends any token to the workspace frontend.
+
+---
+
+## Using it in a Workspace
+
+1. **Install** GitHub Copilot CLI from the launcher (or `npm install -g @github/copilot`).
+2. **Sign in** (run `copilot`, or set `COPILOT_GITHUB_TOKEN`).
+3. **Create** a "GitHub Copilot CLI" agent and pick a **project working
+   directory**. The directory must exist — the agent will not silently fall
+   back to another folder.
+4. **Send a task** in the workspace. You'll receive real-time:
+   - assistant text, thinking/status narration,
+   - tool calls, shell commands (with exit codes), file edits,
+   - and a single final answer per turn.
+5. **Stop** a running task from the workspace at any time.
+
+### Plan vs. Act mode
+
+| OpenAgents mode | Copilot CLI behaviour |
+|-----------------|-----------------------|
+| **plan** | Launched with `--plan` — analysis/planning only; **no write tools granted**. |
+| **act** (execute) | Read/write/shell granted (least-privilege), **scoped to the working directory** via `--add-dir`. |
+
+### Permissions actually granted
+
+- Filesystem access is **scoped to the working directory** (`--add-dir <wd>`).
+  We do **not** pass `--allow-all-paths`.
+- Interactive prompts are disabled (`--no-ask-user`) because the workspace
+  cannot answer them. If the CLI still asks, the turn fails with a clear
+  message instead of hanging.
+- In act mode a minimal tool set is pre-authorized: `--allow-tool=shell` and
+  `--allow-tool=write` (tool IDs **verified** against `copilot help permissions`,
+  v1.0.63). We do **not** default to `--allow-all` / `--yolo`, nor grant
+  network/URL access (`--allow-url`/`--allow-all-urls`).
+- `--secret-env-vars=<names>` is passed (only when a secret var is actually set)
+  so the CLI strips/redacts those env **values** from shell/MCP environments and
+  its own output — in addition to OpenAgents' own redaction. Only variable
+  **NAMES** are passed; **token values never enter argv**.
+- Optional-value flags use the `=` form (`--allow-tool=…`, `--resume=…`,
+  `--secret-env-vars=…`) as required by the CLI's argument parser.
+
+> Tool IDs are centralized in `ACT_ALLOW_TOOLS` in the adapter. `write` = file
+> create/modify; `shell` = all shell commands (Copilot also supports finer
+> matchers like `shell(git:*)`).
+
+---
+
+## Sessions
+
+Verified session semantics (`copilot --help`, v1.0.63):
+- `-r, --resume[=value]` resumes by **session ID, task ID, ID prefix (7+ hex),
+  or name** (name match is exact, case-insensitive).
+- `-n, --name <name>` sets a name for a **new** session; `--session-id <uuid>`
+  resumes by ID or fixes a new session's UUID.
+- Session/state files live under `~/.copilot` (override: `COPILOT_HOME`).
+
+How OpenAgents uses this:
+- It persists the **real Copilot session id** emitted in the JSONL `session`
+  event (per channel, under `~/.openagents/sessions/`) and resumes via
+  `--resume=<id>`. It never impersonates a session with the OpenAgents agent id.
+- The first turn seeds a **stable, working-directory-bound `--name`** (a hash of
+  working dir + workspace + channel), so a session for one project is never
+  resumed against another, and concurrent agents in the same dir don't cross
+  sessions.
+- A resume against a vanished session — verified real error
+  `Error: No session, task, or name matched '…'` (stderr, exit 1, empty stdout) —
+  is detected and transparently retried as a **fresh** session.
+
+> **Verification status.** Session *flags* are verified against the real CLI.
+> Whether a non-interactive `-p` run **emits a `session` id on stdout** could
+> **not** be confirmed (no Copilot subscription in CI — auth blocks before any
+> model output). If, in practice, no session id is returned, resume-by-name
+> still works via the seeded `--name`; if neither proves reliable, the adapter
+> degrades to **one-session-per-task** and never fakes a resumed conversation.
+
+---
+
+## Interrupting & cleanup
+
+Stopping a task sends an escalating interrupt — `SIGINT` → `SIGTERM` →
+`SIGKILL` — to the **whole process group** (Unix) or via `taskkill /T`
+(Windows), so any shell/MCP children Copilot spawned are cleaned up too. After a
+stop the thread settles to Idle/Stopped and no further messages are pushed.
+
+---
+
+## Security & privacy
+
+### What OpenAgents does
+- Tokens (`COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, OAuth/fine-grained
+  PATs), `Authorization`/`x-api-key` headers, and secret env **values** are
+  **redacted** from all OpenAgents logs and diagnostics. Tool args and error
+  text are redacted too.
+- The **full prompt is never logged** (the spawn log shows `<prompt>`); raw JSONL
+  is not dumped — unknown events log only a short redacted diagnostic.
+- The prompt is a **discrete `-p` argv element, never concatenated into a shell
+  string** — no command/argument injection.
+
+### Copilot data flows you should know about
+These are **Copilot CLI** behaviours, not OpenAgents'. We distinguish them
+precisely rather than claiming "nothing is ever uploaded":
+
+| Mechanism | Default | What OpenAgents does |
+|-----------|---------|----------------------|
+| `--share-gist` (upload session to a secret gist) | opt-in only | **Never passed.** |
+| `--share[=path]` (write a session markdown file) | opt-in only | **Never passed.** |
+| **Remote control** (`--remote`: drive the session from GitHub web/mobile) | CLI default unspecified | We pass **`--no-remote`** to disable it for workspace runs. |
+| **Session history** stored locally under `~/.copilot` (`COPILOT_HOME`) | on | Not modified — uses your existing Copilot config. |
+| **Agentic memory** (`memory`, cross-session fact recall) | on (per CLI) | Not modified — uses your existing Copilot config. |
+| Telemetry / OpenTelemetry | per your Copilot config | Not enabled or configured by us. |
+
+OpenAgents does **not** modify your global Copilot configuration. Where the CLI
+supports a disable flag we use it for the run (`--no-remote`); session/memory
+storage remains governed by **your** Copilot setup.
+
+### Caveats
+- A prompt passed as a process argument **may be visible to the OS process list
+  / diagnostic tools** while the task runs.
+- Copilot's local session history (under `~/.copilot`) **may contain prompts,
+  replies, tool output, and file changes** — it is local but not OpenAgents-
+  managed; clear it via Copilot if needed.
+
+---
+
+## Platform support
+
+| Platform | Status |
+|----------|--------|
+| Linux | **Real CLI `1.0.63` verified**: install, `--version`, `--help`, `help environment/permissions`, `login --help`, and unauthenticated / invalid-token / stale-resume runs (stderr + exit codes). Adapter unit-tested with a mock CLI. A **successful task** (real subscription) was not run — see below. |
+| macOS | Implemented (process-group interrupt, Homebrew detection). Real-CLI run **not** verified in this environment. |
+| Windows | Implemented (`copilot.cmd`/`.exe`, npm-shim → node resolution, `taskkill /T`). Real-CLI run **not** verified in this environment. |
+
+> Captured real-CLI output (de-identified) lives in
+> `packages/agent-connector/test/fixtures/copilot-cli-real-samples.md`.
+
+---
+
+## Common errors
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| "GitHub Copilot CLI not found" | `copilot` not installed / not on PATH | Install via npm/Homebrew/WinGet. |
+| "…is too old — upgrade…" | Below `min_version` | Upgrade the CLI. |
+| "Not signed in to GitHub Copilot…" | No credentials (real: `No authentication information found`) | Run `copilot` `/login`, `gh auth login`, or set `COPILOT_GITHUB_TOKEN`. |
+| "token is invalid, expired, or revoked (401)…" | Token rejected (real: `could not be validated … 401 … Bad credentials`) | Use a fine-grained token with "Copilot Requests" (classic `ghp_` not supported) or `/login`. |
+| "Access denied (403)… SAML/SSO…" | SSO not authorized / insufficient scope | Authorize the org's SSO for your token. |
+| "blocked by an organization/enterprise policy" | Org disabled Copilot CLI | Contact your GitHub org admin. |
+| "No active GitHub Copilot subscription/seat" | No Copilot entitlement | Obtain a Copilot subscription/seat. |
+| "GitHub host configuration error…" | Bad `GH_HOST`/`COPILOT_GH_HOST` | Fix the GHE data-residency hostname. |
+| "Custom model provider (BYOK) is misconfigured…" | Bad `COPILOT_PROVIDER_*` | Fix provider base URL / key / type. |
+| "model is unavailable" | `COPILOT_MODEL` not allowed | Clear `COPILOT_MODEL` or pick a supported model. |
+| "requested interactive input…" | CLI hit an `ask_user` prompt | Re-run with a more specific task. |
+| "Working directory does not exist" | Bad project path | Pick an existing directory. |
+
+---
+
+## Known limitations / follow-ups
+
+- **Verified against real CLI `1.0.63`:** the full **flag set** the adapter uses
+  (`-p`, `--output-format json`, `--stream`, `--model`, `--add-dir`,
+  `--no-ask-user`, `--plan`, `--allow-tool=shell|write`, `--resume=`, `--name`,
+  `--secret-env-vars=`, `--no-remote`), the **tool IDs** `shell`/`write`, the
+  **token env vars**, and **error/stderr/exit-code behaviour** for
+  unauth/invalid-token/stale-resume.
+- **NOT verified:** the **success-path JSONL event schema** (text/tool/file/done
+  event names on stdout). No Copilot subscription was available in CI, and
+  auth fails before any model output, so no successful-task JSONL could be
+  captured. The parser's success-event mapping (`EVENT_KIND_BY_TYPE`) is
+  therefore best-effort, intentionally narrow, and isolated to one table;
+  unknown events degrade to a redacted diagnostic and never crash a task or fake
+  a completion. **Confirm against a real authenticated run before relying on
+  rich tool/file event rendering.**
+- Whether a non-interactive run **emits a session id on stdout** is unverified;
+  resume-by-name and a one-session-per-task fallback cover this honestly.
+- No Python SDK adapter ships (the Python daemon was removed; the Node.js
+  agent-connector is the runtime). The Python registry entry is catalog-only.
+- The launcher surfaces a token field rather than a dedicated "Login" button for
+  Copilot, because there is no verified non-interactive status command to drive
+  a hosted-login probe (auth errors only surface at run time, on stderr).

--- a/packages/agent-connector/CLAUDE.md
+++ b/packages/agent-connector/CLAUDE.md
@@ -29,6 +29,8 @@ src/
     cursor.js         CursorAdapter — extends LlmDirectAdapter for Cursor CLI
     hermes.js         HermesAdapter — Nous Research Hermes bridge
     gemini.js         GeminiAdapter — Google Gemini CLI bridge
+    copilot.js        CopilotAdapter — official GitHub Copilot CLI (`copilot`) bridge, JSONL stream
+    copilot-stream-parser.js  Pure JSONL framing + event classification for Copilot CLI
     llm-direct.js     LlmDirectAdapter — base for adapters that call LLM APIs directly (SSE streaming)
     index.js          Adapter registry mapping type names to classes
     utils.js          Shared adapter utilities

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -178,20 +178,59 @@
   {
     "name": "copilot",
     "label": "GitHub Copilot CLI",
-    "description": "GitHub Copilot coding agent for the terminal",
-    "homepage": "https://github.com/features/copilot",
+    "description": "GitHub's official Copilot coding agent for the terminal (the `copilot` CLI, not the retired `gh copilot` extension)",
+    "homepage": "https://github.com/github/copilot-cli",
     "tags": [
       "coding",
       "github",
       "cli"
     ],
+    "order": 9,
+    "support": { "install": true, "workspace": true, "collaboration": false },
+    "builtin": true,
     "install": {
-      "binary": "gh",
-      "verify": "gh copilot --version >/dev/null 2>&1",
-      "verify_win": "gh copilot --version >nul 2>nul",
-      "macos": "gh extension install github/gh-copilot",
-      "linux": "gh extension install github/gh-copilot",
-      "windows": "gh extension install github/gh-copilot"
+      "binary": "copilot",
+      "npm_package": "@github/copilot",
+      "requires": [
+        "nodejs"
+      ],
+      "min_version": "1.0.0",
+      "verify": "copilot --version >/dev/null 2>&1",
+      "verify_win": "copilot --version >nul 2>nul",
+      "macos": "npm install -g @github/copilot",
+      "linux": "npm install -g @github/copilot",
+      "windows": "npm install -g @github/copilot"
+    },
+    "adapter": {
+      "module": "openagents.adapters.copilot",
+      "class": "CopilotAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "COPILOT_GITHUB_TOKEN",
+        "description": "GitHub token with Copilot access (optional — you can also sign in by running `copilot`, or rely on GH_TOKEN / GITHUB_TOKEN / gh auth)",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "COPILOT_MODEL",
+        "description": "Model to use (optional; leave blank for the account default)",
+        "required": false
+      }
+    ],
+    "check_ready": {
+      "env_vars": [
+        "COPILOT_GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN"
+      ],
+      "saved_env_key": "COPILOT_GITHUB_TOKEN",
+      "login_command": "copilot",
+      "unverifiable": true,
+      "not_ready_message": "Sign-in not confirmed. A token env var (COPILOT_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN) is one option; you may already be signed in via `copilot` /login or `gh auth`. Auth is confirmed when you run a task."
     }
   },
   {

--- a/packages/agent-connector/src/adapters/copilot-stream-parser.js
+++ b/packages/agent-connector/src/adapters/copilot-stream-parser.js
@@ -1,0 +1,380 @@
+/**
+ * GitHub Copilot CLI — JSONL stream parser (pure, no I/O).
+ *
+ * This module turns the raw byte stream produced by
+ *   `copilot -p "<prompt>" --output-format=json`
+ * into a sequence of *normalized* events the CopilotAdapter can map onto
+ * OpenAgents workspace messages. It is deliberately split into two layers:
+ *
+ *   1. FRAMING (schema-agnostic) — `frameChunk()` / `CopilotStreamParser`
+ *      Reassembles complete text lines from arbitrary chunk boundaries. This
+ *      is the part that is fully specified regardless of the CLI version:
+ *      one JSON object per line (JSONL), lines may be split across chunks,
+ *      a single chunk may carry many lines, line endings may be `\n` or
+ *      `\r\n`, blank lines and non-JSON noise must be tolerated. This layer
+ *      is exhaustively unit-tested and does not depend on any field names.
+ *
+ *   2. CLASSIFICATION (schema-aware) — `classifyEvent()`
+ *      Maps one parsed JSON object onto a normalized event `{ kind, ... }`.
+ *      The concrete field/type names live in ONE table (`EVENT_KIND_BY_TYPE`
+ *      + the field extractors) so that, once the JSONL schema of the locally
+ *      installed `@github/copilot` build is captured, only this table needs
+ *      to change — the adapter and the framing layer stay untouched.
+ *
+ * ── Schema status ────────────────────────────────────────────────────────
+ * The GitHub Copilot CLI (`@github/copilot`, executable `copilot`) ships its
+ * structured output as JSONL via `--output-format=json`. The exact `type`
+ * strings and payload shapes evolve between releases and MUST be confirmed
+ * against the actually-installed build (see docs/agents/github-copilot-cli.md
+ * and the delivery report). Until then the mapping below recognizes the
+ * documented/observed families and ALWAYS degrades unknown objects to a
+ * redacted `unknown` event instead of throwing — so a schema drift downgrades
+ * fidelity, never crashes a task. Never infer an event's meaning from a field
+ * name alone; verify against real output or the official source.
+ *
+ * Normalized event kinds (the adapter's stable contract):
+ *   { kind: 'session',     sessionId }                  real CLI session id/name
+ *   { kind: 'text_delta',  text }                       streaming assistant text
+ *   { kind: 'text',        text }                       final/complete assistant text
+ *   { kind: 'reasoning',   text }                       thinking / status narration
+ *   { kind: 'tool_start',  tool, input }               a tool/command is starting
+ *   { kind: 'tool_result', tool, result, isError }     a tool/command finished
+ *   { kind: 'file_change', path, action }              a file was read/written
+ *   { kind: 'shell',       command, exitCode, output } a shell command ran
+ *   { kind: 'permission',  detail, granted }           a permission decision
+ *   { kind: 'ask_user',    question }                   CLI wants interactive input
+ *   { kind: 'usage',       model, usage }              model / token accounting
+ *   { kind: 'done',        status }                     turn completed (terminal)
+ *   { kind: 'error',       message, code }              failure (terminal)
+ *   { kind: 'unknown',     raw }                        unrecognized (redacted)
+ */
+
+'use strict';
+
+// ────────────────────────────────────────────────────────────────────────
+// Redaction (shared by the adapter for logs + unknown-event diagnostics)
+// ────────────────────────────────────────────────────────────────────────
+
+// GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ (classic + fine-grained github_pat_),
+// plus generic bearer/secret shapes. Kept conservative to avoid mangling code.
+const TOKEN_PATTERNS = [
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  /\b(?:sk|pk|rk)-[A-Za-z0-9_-]{16,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._-]{16,}\b/gi,
+  /\b[A-Fa-f0-9]{40,}\b/g, // long hex blobs (OAuth/refresh tokens)
+];
+
+// Env-style assignments of well-known secret-bearing variables — redact the
+// value, keep the key so logs still say *which* var was involved.
+const SECRET_ENV_KEYS = [
+  'COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN', 'GH_COPILOT_TOKEN',
+  'GITHUB_COPILOT_TOKEN', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY',
+  'AZURE_API_KEY', 'GOOGLE_API_KEY', 'OA_WORKSPACE_TOKEN',
+];
+const SECRET_ENV_RE = new RegExp(
+  `\\b(${SECRET_ENV_KEYS.join('|')})(\\s*[=:]\\s*)("?)([^\\s"']+)`,
+  'gi',
+);
+const AUTH_HEADER_RE = /\b(authorization|x-api-key|x-github-token)(\s*:\s*)(\S+)/gi;
+
+/**
+ * Redact secrets from an arbitrary string for safe logging / diagnostics.
+ * Never throws; non-strings are coerced. Pure.
+ */
+function redactSensitive(value) {
+  let s;
+  if (typeof value === 'string') s = value;
+  else { try { s = JSON.stringify(value); } catch { s = String(value); } }
+  if (!s) return s;
+  s = s.replace(SECRET_ENV_RE, (_m, k, sep, q) => `${k}${sep}${q}***`);
+  s = s.replace(AUTH_HEADER_RE, (_m, k, sep) => `${k}${sep}***`);
+  for (const re of TOKEN_PATTERNS) s = s.replace(re, '***');
+  return s;
+}
+
+/**
+ * Produce a short, redacted, single-line diagnostic for an unknown event so a
+ * schema drift is observable in logs without dumping a full transcript or any
+ * secret. Pure.
+ */
+function diagnosticForUnknown(obj, maxLen = 300) {
+  let s;
+  try { s = JSON.stringify(obj); } catch { s = String(obj); }
+  s = redactSensitive(s).replace(/\s+/g, ' ').trim();
+  return s.length > maxLen ? s.slice(0, maxLen) + '…' : s;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Framing (schema-agnostic) — pure
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Append `chunk` to `buffer` and split off every complete line.
+ * Returns `{ lines, rest }` where `lines` are complete lines (no trailing
+ * newline, `\r` stripped) and `rest` is the leftover partial line to carry
+ * into the next call. Handles `\n` and `\r\n`. Pure — no state retained.
+ *
+ * @param {string} buffer  carry-over from the previous call
+ * @param {string|Buffer} chunk  new bytes
+ * @returns {{ lines: string[], rest: string }}
+ */
+function frameChunk(buffer, chunk) {
+  const text = (buffer || '') + (chunk == null ? '' : chunk.toString('utf-8'));
+  const parts = text.split('\n');
+  const rest = parts.pop(); // last element is the incomplete tail (maybe '')
+  const lines = parts.map((l) => (l.endsWith('\r') ? l.slice(0, -1) : l));
+  return { lines, rest };
+}
+
+/**
+ * Parse one JSONL line into an object, or null when the line is blank or not
+ * valid JSON (CLIs occasionally interleave human-readable banners/noise). A
+ * single corrupt line must never abort the surrounding task. Pure.
+ *
+ * @param {string} line
+ * @returns {object|null}
+ */
+function parseLine(line) {
+  if (line == null) return null;
+  const trimmed = String(line).trim();
+  if (!trimmed) return null;
+  if (trimmed[0] !== '{' && trimmed[0] !== '[') return null; // fast reject noise
+  try {
+    const v = JSON.parse(trimmed);
+    return (v && typeof v === 'object') ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Classification (schema-aware) — pure. SINGLE source of field/type mapping.
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps a Copilot CLI event `type` (lowercased) to a normalized kind.
+ *
+ * ── Verification status (IMPORTANT) ──────────────────────────────────────
+ * VERIFIED against real CLI v1.0.63: `--output-format json` is "JSONL, one JSON
+ * object per line"; auth/session/network failures print to STDERR with EMPTY
+ * stdout (no JSONL error event) — so those are NOT parsed here, the adapter
+ * classifies them from stderr. The success-path stdout event names below
+ * (text/tool/file/done/etc.) could NOT be captured (no Copilot subscription in
+ * CI), so they are BEST-EFFORT, intentionally focused rather than broad, and
+ * must be confirmed against a real authenticated run. The deliberately small
+ * alias set avoids misclassifying unrelated objects; anything unrecognized
+ * degrades to a redacted `unknown` event (never a crash, never a false `done`).
+ * When real samples are available, extend THIS table only.
+ */
+const EVENT_KIND_BY_TYPE = {
+  // session lifecycle / identity (kind only mapped when an id is also present)
+  session: 'session', 'session.created': 'session', 'session.started': 'session',
+  session_started: 'session', thread: 'session', 'thread.started': 'session',
+  // streaming assistant text (qualified names only — no bare 'delta'/'token')
+  'text.delta': 'text_delta', text_delta: 'text_delta',
+  'message.delta': 'text_delta', 'assistant.delta': 'text_delta',
+  content_block_delta: 'text_delta',
+  // final assistant text (qualified/explicit names only — no bare 'message')
+  text: 'text', 'message.completed': 'text', 'assistant.message': 'text',
+  assistant: 'text', completion: 'text', agent_message: 'text',
+  // reasoning / status narration
+  reasoning: 'reasoning', thinking: 'reasoning', thought: 'reasoning',
+  status: 'reasoning', progress: 'reasoning',
+  // tool calls
+  tool_call: 'tool_start', 'tool.call': 'tool_start', tool_use: 'tool_start',
+  'tool.started': 'tool_start', tool_start: 'tool_start', function_call: 'tool_start',
+  tool_result: 'tool_result', 'tool.result': 'tool_result',
+  'tool.completed': 'tool_result', tool_output: 'tool_result',
+  function_result: 'tool_result',
+  // file + shell specializations (may also arrive as generic tool events)
+  file_change: 'file_change', file_edit: 'file_change', 'file.changed': 'file_change',
+  file_write: 'file_change', file_read: 'file_change',
+  shell: 'shell', command_execution: 'shell', 'shell.exec': 'shell',
+  // permissions + interactive prompts
+  permission: 'permission', 'permission.request': 'permission',
+  permission_request: 'permission', permission_denied: 'permission',
+  approval: 'permission',
+  ask_user: 'ask_user', 'user.prompt': 'ask_user', input_request: 'ask_user',
+  // accounting (explicit only — bare 'model'/'tokens' are too generic)
+  usage: 'usage',
+  // terminal (no bare 'end'/'result' — 'result' collides with tool results)
+  done: 'done', completed: 'done', 'turn.completed': 'done', finish: 'done',
+  error: 'error', failure: 'error', 'turn.failed': 'error', failed: 'error',
+  fatal: 'error', aborted: 'error',
+};
+
+function _firstString(obj, keys) {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string' && v.length) return v;
+  }
+  return undefined;
+}
+
+function _coerceText(v) {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object') {
+    if (typeof v.text === 'string') return v.text;
+    if (Array.isArray(v.content)) {
+      return v.content
+        .map((b) => (typeof b === 'string' ? b : (b && typeof b.text === 'string' ? b.text : '')))
+        .join('');
+    }
+    if (typeof v.content === 'string') return v.content;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a parsed JSON object into a normalized event. Never throws; an
+ * unrecognized shape becomes `{ kind: 'unknown', raw }` with a redacted
+ * diagnostic. Pure — the single place that knows Copilot field names.
+ *
+ * @param {object} obj
+ * @returns {{kind: string} & object}
+ */
+function classifyEvent(obj) {
+  if (!obj || typeof obj !== 'object') {
+    return { kind: 'unknown', raw: diagnosticForUnknown(obj) };
+  }
+
+  const rawType = _firstString(obj, ['type', 'event', 'event_type', 'kind', 'name']);
+  let kind = rawType ? EVENT_KIND_BY_TYPE[rawType.toLowerCase()] : undefined;
+
+  // Nested item types: some CLIs wrap the real type in `item.type`
+  // (e.g. { type: 'item.completed', item: { type: 'command_execution' } }).
+  const item = (obj.item && typeof obj.item === 'object') ? obj.item : null;
+  if (item) {
+    const itemType = _firstString(item, ['type', 'kind']);
+    const itemKind = itemType ? EVENT_KIND_BY_TYPE[itemType.toLowerCase()] : undefined;
+    if (itemKind) kind = itemKind;
+  }
+  const src = item || obj;
+
+  switch (kind) {
+    case 'session': {
+      const sessionId = _firstString(src, [
+        'session_id', 'sessionId', 'session', 'thread_id', 'threadId', 'id', 'name',
+      ]);
+      if (!sessionId) break; // not actually a session event → fall to unknown
+      return { kind: 'session', sessionId };
+    }
+    case 'text_delta': {
+      const text = _coerceText(src.delta) ?? _coerceText(src.text) ?? _coerceText(src.content) ?? _coerceText(src);
+      return { kind: 'text_delta', text: text || '' };
+    }
+    case 'text': {
+      const text = _coerceText(src.text) ?? _coerceText(src.message) ?? _coerceText(src.content) ?? _coerceText(src);
+      return { kind: 'text', text: text || '' };
+    }
+    case 'reasoning': {
+      const text = _coerceText(src.text) ?? _coerceText(src.reasoning) ?? _coerceText(src.message)
+        ?? _coerceText(src.content) ?? _firstString(src, ['status', 'label', 'title']) ?? '';
+      return { kind: 'reasoning', text };
+    }
+    case 'tool_start': {
+      const tool = _firstString(src, ['tool', 'tool_name', 'name', 'function']) || 'tool';
+      const input = src.input ?? src.arguments ?? src.args ?? src.parameters ?? src.params;
+      return { kind: 'tool_start', tool, input };
+    }
+    case 'tool_result': {
+      const tool = _firstString(src, ['tool', 'tool_name', 'name', 'function']) || 'tool';
+      const result = src.result ?? src.output ?? src.content ?? src.stdout;
+      const isError = !!(src.is_error ?? src.isError ?? src.error ?? (src.exit_code != null && src.exit_code !== 0));
+      return { kind: 'tool_result', tool, result, isError };
+    }
+    case 'file_change': {
+      const filePath = _firstString(src, ['path', 'file', 'file_path', 'filename', 'filePath']);
+      const action = _firstString(src, ['action', 'operation', 'change', 'mode'])
+        || (rawType && /read/i.test(rawType) ? 'read' : 'edit');
+      return { kind: 'file_change', path: filePath || '', action };
+    }
+    case 'shell': {
+      const command = _firstString(src, ['command', 'cmd', 'shell', 'script']) || '';
+      const exitCode = src.exit_code ?? src.exitCode ?? src.code ?? null;
+      const output = _coerceText(src.output) ?? _coerceText(src.stdout) ?? '';
+      return { kind: 'shell', command, exitCode, output };
+    }
+    case 'permission': {
+      const detail = _firstString(src, ['detail', 'message', 'tool', 'resource', 'reason'])
+        || diagnosticForUnknown(src, 120);
+      const granted = !!(src.granted ?? src.allowed ?? src.approved);
+      return { kind: 'permission', detail, granted };
+    }
+    case 'ask_user': {
+      const question = _firstString(src, ['question', 'prompt', 'message', 'text']) || '';
+      return { kind: 'ask_user', question };
+    }
+    case 'usage': {
+      const model = _firstString(src, ['model', 'model_id', 'modelName']);
+      const usage = src.usage ?? src.tokens ?? src.cost ?? null;
+      return { kind: 'usage', model, usage };
+    }
+    case 'done': {
+      const status = _firstString(src, ['status', 'reason', 'result']) || 'completed';
+      return { kind: 'done', status };
+    }
+    case 'error': {
+      const err = (src.error && typeof src.error === 'object') ? src.error : src;
+      const message = _firstString(err, ['message', 'error', 'detail', 'reason'])
+        || (typeof src.error === 'string' ? src.error : '')
+        || 'Copilot CLI reported an error';
+      const code = _firstString(err, ['code', 'type', 'status']) || null;
+      return { kind: 'error', message: redactSensitive(message), code };
+    }
+    default:
+      break;
+  }
+  return { kind: 'unknown', raw: diagnosticForUnknown(obj) };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Stateful incremental parser — thin wrapper over the pure functions
+// ────────────────────────────────────────────────────────────────────────
+
+class CopilotStreamParser {
+  constructor() {
+    this._buffer = '';
+  }
+
+  /**
+   * Feed a stdout chunk; returns the normalized events newly completed by it.
+   * Partial trailing data is retained until the next push()/flush().
+   * @param {string|Buffer} chunk
+   * @returns {Array<object>}
+   */
+  push(chunk) {
+    const { lines, rest } = frameChunk(this._buffer, chunk);
+    this._buffer = rest;
+    const events = [];
+    for (const line of lines) {
+      const obj = parseLine(line);
+      if (obj === null) continue; // blank or non-JSON noise — skip, never throw
+      events.push(classifyEvent(obj));
+    }
+    return events;
+  }
+
+  /**
+   * Flush any buffered trailing line (e.g. last line without a newline at
+   * process exit). Returns the normalized events it yields. Idempotent.
+   * @returns {Array<object>}
+   */
+  flush() {
+    const tail = this._buffer;
+    this._buffer = '';
+    const obj = parseLine(tail);
+    return obj === null ? [] : [classifyEvent(obj)];
+  }
+}
+
+module.exports = {
+  CopilotStreamParser,
+  frameChunk,
+  parseLine,
+  classifyEvent,
+  redactSensitive,
+  diagnosticForUnknown,
+  EVENT_KIND_BY_TYPE,
+};

--- a/packages/agent-connector/src/adapters/copilot.js
+++ b/packages/agent-connector/src/adapters/copilot.js
@@ -1,0 +1,796 @@
+/**
+ * GitHub Copilot CLI adapter for OpenAgents workspace.
+ *
+ * Bridges the OFFICIAL GitHub Copilot CLI — executable `copilot`, npm package
+ * `@github/copilot` — to an OpenAgents workspace. This is NOT the retired
+ * `gh copilot` GitHub CLI extension; this adapter never invokes `gh`.
+ *
+ * Per incoming workspace message it spawns one `copilot -p <prompt>
+ * --output-format=json` subprocess (cwd = the agent's working directory),
+ * parses the JSONL event stream via the standalone pure parser
+ * (./copilot-stream-parser), maps events onto workspace messages, persists the
+ * real Copilot session id per channel for resume, and can interrupt + clean up
+ * the whole process tree on demand.
+ *
+ * Design notes specific to Copilot CLI (do not copy Cline/Codex semantics
+ * blindly):
+ *   • Auth is GitHub-based (env tokens / gh / keychain OAuth) — never read or
+ *     log tokens; the launcher/installer reports auth state, the CLI's own run
+ *     result is the final authority.
+ *   • Permissions are explicit and least-privilege: scoped to the working dir
+ *     via --add-dir, interactive prompts disabled (--no-ask-user) since the
+ *     workspace cannot answer them. We never default to --allow-all / --yolo /
+ *     --allow-all-paths / --allow-url.
+ *   • plan mode → analysis only (--plan, no write tools); act mode → controlled
+ *     read/write/shell within the working dir.
+ *
+ * ── Verification status ────────────────────────────────────────────────────
+ * The concrete CLI flags and JSONL `type` strings used here follow the
+ * documented `@github/copilot` interface and are CENTRALIZED (flags in
+ * `_buildArgs`, the JSONL schema in copilot-stream-parser). They must be
+ * confirmed against the locally installed build; see
+ * docs/agents/github-copilot-cli.md. Unknown events degrade gracefully rather
+ * than crashing a task.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, execFileSync, spawn } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
+const { whichBinary, getEnhancedEnv, defaultAgentWorkdir } = require('../paths');
+const { compareVersions } = require('../installer');
+const { CopilotStreamParser, redactSensitive } = require('./copilot-stream-parser');
+
+const IS_WINDOWS = process.platform === 'win32';
+
+// Minimum Copilot CLI version the adapter can drive. Kept in sync with
+// registry.json `install.min_version`. Basis: the GA 1.0 line is the first to
+// stably provide everything the adapter relies on — `--output-format=json`
+// (JSONL; introduced ~0.0.422), non-interactive `-p` with `--no-ask-user`,
+// granular `--allow-tool`/`--add-dir`, `--resume`/`--name` session control, and
+// `--secret-env-vars`/`--no-remote`. Verified end-to-end against 1.0.63.
+const MIN_VERSION = '1.0.0';
+
+// Token-bearing env var NAMES Copilot reads (verified precedence via
+// `copilot help environment`): COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN.
+// Plus OpenAgents' own workspace token. We pass the NAMES (never values) to
+// `--secret-env-vars` so the CLI strips/redacts them, and use the list to scrub
+// our own diagnostics. We never log their VALUES.
+const SECRET_ENV_VARS = [
+  'COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN', 'OA_WORKSPACE_TOKEN',
+];
+
+// Tool identifiers granted in act mode (least-privilege). VERIFIED against
+// `copilot help permissions` (v1.0.63): `shell` (all shell commands) and `write`
+// (file create/modify). Paths are scoped via --add-dir; we deliberately do NOT
+// enable network/URL or all-paths access by default.
+const ACT_ALLOW_TOOLS = ['shell', 'write'];
+
+// How long to wait for a turn before giving up (no output / hung CLI).
+const TURN_TIMEOUT_MS = 10 * 60 * 1000;
+
+class CopilotAdapter extends BaseAdapter {
+  /**
+   * @param {object} opts - BaseAdapter opts plus:
+   * @param {Set} [opts.disabledModules]
+   */
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+
+    const env = this.agentEnv || process.env;
+    // Official model env var (verified via `copilot help environment`).
+    this._model = env.COPILOT_MODEL || '';
+    this._versionGate = null; // cached { version, compatible } from --version
+
+    // Per-channel real Copilot session reference (id or stable name) + live procs
+    this._channelSessions = {};
+    this._channelProcesses = {};
+    this._stoppingChannels = new Set();
+    this._sessionsFile = path.join(
+      os.homedir(), '.openagents', 'sessions',
+      `${this.workspaceId}_${this.agentName}_copilot.json`,
+    );
+    this._loadSessions();
+
+    this._copilotBin = this._findCopilotBinary();
+    if (this._copilotBin) {
+      this._log(`Copilot CLI: ${this._copilotBin}`);
+    } else {
+      this._log('Warning: copilot CLI not found (install: npm install -g @github/copilot)');
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Session persistence (per-channel Copilot session reference)
+  // ------------------------------------------------------------------
+
+  _loadSessions() {
+    try {
+      if (fs.existsSync(this._sessionsFile)) {
+        const data = JSON.parse(fs.readFileSync(this._sessionsFile, 'utf-8'));
+        if (data && typeof data === 'object') {
+          Object.assign(this._channelSessions, data);
+          this._log(`Loaded ${Object.keys(data).length} session(s)`);
+        }
+      }
+    } catch {
+      this._log('Could not load sessions file, starting fresh');
+    }
+  }
+
+  _saveSessions() {
+    try {
+      fs.mkdirSync(path.dirname(this._sessionsFile), { recursive: true });
+      fs.writeFileSync(this._sessionsFile, JSON.stringify(this._channelSessions));
+    } catch {}
+  }
+
+  /**
+   * A stable, working-dir-bound session name for a channel. Binding the working
+   * directory into the name prevents a session created for one project from
+   * being resumed against another (the spec's "Session 与 working directory
+   * 绑定" / no cross-project resume requirement).
+   */
+  _stableSessionName(channel) {
+    const wd = this.workingDir || defaultAgentWorkdir(this.agentName);
+    const hash = require('crypto').createHash('sha1')
+      .update(`${wd} ${this.workspaceId} ${channel}`).digest('hex').slice(0, 12);
+    return `openagents-${hash}`;
+  }
+
+  // ------------------------------------------------------------------
+  // Binary discovery (multi-tier; never resolves the retired `gh` extension)
+  // ------------------------------------------------------------------
+
+  _findCopilotBinary() {
+    const home = os.homedir();
+    // Windows: npm shim is copilot.cmd; a winget/standalone install is copilot.exe.
+    const exts = IS_WINDOWS ? ['.cmd', '.exe', ''] : [''];
+    const named = (dir) => {
+      for (const e of exts) {
+        const c = path.join(dir, `copilot${e}`);
+        try { if (fs.existsSync(c)) return c; } catch {}
+      }
+      return null;
+    };
+
+    // Tier 0: isolated runtime prefix (~/.openagents/runtimes/copilot/.bin)
+    let hit = named(path.join(home, '.openagents', 'runtimes', 'copilot', 'node_modules', '.bin'));
+    if (hit) return hit;
+    // Tier 0b: legacy portable npm prefix
+    hit = named(path.join(home, '.openagents', 'nodejs', 'node_modules', '.bin'));
+    if (hit) return hit;
+
+    // Tier 1: PATH search using the enriched env (matches launcher/daemon PATH).
+    try {
+      const env = getEnhancedEnv();
+      if (IS_WINDOWS) {
+        const r = execSync('where copilot.cmd 2>nul || where copilot.exe 2>nul || where copilot 2>nul', {
+          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
+        });
+        const first = r.split(/\r?\n/)[0].trim();
+        if (first) return first;
+      } else {
+        const r = execSync('which copilot', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
+        if (r) return r;
+      }
+    } catch {}
+
+    // Tier 2: next to the current Node interpreter (npm global)
+    hit = named(path.dirname(process.execPath));
+    if (hit) return hit;
+
+    // Tier 3: npm global prefix
+    try {
+      const npmPrefix = execSync('npm config get prefix', {
+        encoding: 'utf-8', timeout: 5000, windowsHide: true,
+      }).trim();
+      if (npmPrefix) {
+        hit = named(npmPrefix) || named(path.join(npmPrefix, 'bin'));
+        if (hit) return hit;
+      }
+    } catch {}
+
+    // Tier 4: common locations (Homebrew, user bins, winget links)
+    const candidates = IS_WINDOWS
+      ? [path.join(process.env.APPDATA || '', 'npm'),
+         path.join(process.env.LOCALAPPDATA || '', 'Microsoft', 'WinGet', 'Links')]
+      : ['/opt/homebrew/bin', '/usr/local/bin',
+         path.join(home, '.local', 'bin'), path.join(home, '.npm-global', 'bin')];
+    for (const dir of candidates) {
+      hit = named(dir);
+      if (hit) return hit;
+    }
+
+    // Tier 5: deep cross-platform PATH scan (nvm/fnm/volta/etc.)
+    return whichBinary('copilot');
+  }
+
+  /**
+   * Resolve [file, prefixArgs] for spawning. On Windows an npm `.cmd` shim is
+   * resolved to `[node, entry.js]` so we can spawn shell:false and keep every
+   * argv element (notably the prompt) literal — no cmd.exe re-parsing, so no
+   * quoting/injection hazard from special characters in the prompt. A native
+   * `.exe` (winget/standalone) is spawned directly. On Unix the binary is spawned
+   * directly. Returns null if resolution is impossible.
+   */
+  _resolveExec(bin, isWindows = IS_WINDOWS) {
+    const lower = bin.toLowerCase();
+
+    // A direct JS entry must run via `node` on EVERY platform. Windows cannot
+    // spawn a `.js` (no shebang support, not a PE → `spawn UNKNOWN`); on Unix a
+    // shebang would work, but routing through node is equivalent and keeps
+    // behaviour identical cross-platform. This also covers test mocks and any
+    // install whose bin resolves straight to a JS file.
+    if (lower.endsWith('.js') || lower.endsWith('.cjs') || lower.endsWith('.mjs')) {
+      return [this._findNodeBin(), bin];
+    }
+
+    if (!isWindows) return [bin];
+
+    // Native executable — spawn directly (shell:false keeps argv literal).
+    if (lower.endsWith('.exe')) return [bin];
+
+    // npm/batch shim: resolve to its real target so we spawn shell:false and
+    // every argv element (notably the prompt) stays literal — no cmd.exe
+    // re-parsing, hence no quoting/injection hazard.
+    if (lower.endsWith('.cmd') || lower.endsWith('.bat')) {
+      try {
+        const content = fs.readFileSync(bin, 'utf-8');
+        const m = content.match(/%dp0%\\([^\s"*?]+\.[cm]?js)/i);
+        if (m) {
+          return [this._findNodeBin(), path.resolve(path.dirname(bin), m[1])];
+        }
+        const exe = content.match(/%dp0%\\([^\s"*?]+\.exe)/i);
+        if (exe) return [path.resolve(path.dirname(bin), exe[1])];
+      } catch {}
+      // Last resort: let cmd.exe run the shim. Args still travel as a literal
+      // argv array via spawn (shell:false), not a concatenated string.
+      return ['cmd.exe', '/c', bin];
+    }
+
+    // No extension (e.g. a Unix-style shim copied to Windows) — spawn directly.
+    return [bin];
+  }
+
+  _findNodeBin() {
+    const home = os.homedir();
+    const candidates = IS_WINDOWS
+      ? [path.join(home, '.openagents', 'nodejs', 'node.exe')]
+      : [path.join(home, '.openagents', 'nodejs', 'bin', 'node'),
+         path.join(home, '.openagents', 'nodejs', 'node')];
+    for (const c of candidates) { try { if (fs.existsSync(c)) return c; } catch {} }
+    return process.execPath || 'node';
+  }
+
+  // ------------------------------------------------------------------
+  // Command construction (argv array — never a shell string)
+  // ------------------------------------------------------------------
+
+  /**
+   * Build the argument vector (excluding the executable). The prompt is always a
+   * single discrete argv element. Permissions are least-privilege and scoped to
+   * the working directory.
+   */
+  _buildArgs(prompt, channel, { skipResume = false } = {}) {
+    const wd = this.workingDir || defaultAgentWorkdir(this.agentName);
+    // Required-value flags take the space form; optional-value/variadic flags
+    // (--resume, --secret-env-vars, --allow-tool — declared `[=value]` /
+    // `[=value...]` in `copilot --help` v1.0.63) MUST use the `=` form so the
+    // next token isn't mistaken for a positional argument.
+    const args = ['-p', prompt, '--output-format', 'json', '--stream', 'on'];
+
+    if (this._model) args.push('--model', this._model);
+
+    // Scope filesystem access to the working dir only (no --allow-all-paths).
+    args.push('--add-dir', wd);
+
+    // Privacy: do not let the session be remote-controlled from GitHub web/mobile
+    // (verified flag `--no-remote`). We never pass --share / --share-gist.
+    args.push('--no-remote');
+
+    // The workspace cannot service interactive prompts, so disable them and
+    // pre-authorize a least-privilege tool set instead of --allow-all/--yolo.
+    // Tool IDs `shell` and `write` are verified against `copilot help permissions`.
+    args.push('--no-ask-user');
+    if (this._mode === 'plan') {
+      // Analysis/planning only — do not grant write capability.
+      args.push('--plan');
+    } else {
+      for (const t of ACT_ALLOW_TOOLS) args.push(`--allow-tool=${t}`);
+    }
+
+    // Defense-in-depth: tell Copilot which env-var NAMES to redact from its own
+    // output (NEVER the values). Only list vars actually present in the child
+    // env so we don't emit a meaningless argument.
+    const env = this.agentEnv || process.env;
+    const presentSecrets = SECRET_ENV_VARS.filter((k) => env[k]);
+    if (presentSecrets.length) args.push(`--secret-env-vars=${presentSecrets.join(',')}`);
+
+    // Resume the channel's prior session when we have a reference, else seed a
+    // stable, working-dir-bound name we can resume by (verified: --resume matches
+    // session id / task id / id-prefix / name, exact case-insensitive).
+    const ref = this._channelSessions[channel];
+    if (ref && !skipResume) {
+      args.push(`--resume=${ref}`);
+    } else if (!ref) {
+      args.push('--name', this._stableSessionName(channel));
+    }
+    return args;
+  }
+
+  _buildSystemContext(channelName) {
+    return buildOpenclawSystemPrompt({
+      agentName: this.agentName,
+      workspaceId: this.workspaceId,
+      channelName,
+      endpoint: this.endpoint,
+      token: this.token,
+      mode: this._mode,
+      disabledModules: this.disabledModules,
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Control actions (stop / interrupt)
+  // ------------------------------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      const channel = (payload && typeof payload === 'object') ? payload.channel : null;
+      if (channel && this._channelProcesses[channel]) {
+        this._stoppingChannels.add(channel);
+        await this._stopProcess(this._channelProcesses[channel]);
+        delete this._channelProcesses[channel];
+        delete this._channelQueues[channel];
+        try { await this.sendStatus(channel, 'Execution stopped by user'); } catch {}
+      } else {
+        for (const [ch, proc] of Object.entries(this._channelProcesses)) {
+          this._stoppingChannels.add(ch);
+          await this._stopProcess(proc);
+          delete this._channelProcesses[ch];
+          try { await this.sendStatus(ch, 'Execution stopped by user'); } catch {}
+        }
+      }
+      return;
+    }
+    await super._onControlAction(action, payload);
+  }
+
+  /**
+   * Daemon shutdown: tear down any in-flight Copilot subprocess so the thread
+   * doesn't get stuck showing "running".
+   */
+  stop() {
+    for (const proc of Object.values(this._channelProcesses)) {
+      this._stopProcess(proc).catch(() => {});
+    }
+    super.stop();
+  }
+
+  /**
+   * Graceful → forceful interrupt of a Copilot subprocess and its whole process
+   * tree (Copilot may spawn shell/MCP children). SIGINT first so the CLI can
+   * cancel managed work, then SIGTERM/SIGKILL on the process group (Unix) or
+   * taskkill /T (Windows).
+   */
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { proc.kill('SIGINT'); } catch {}
+        const exited = await this._waitExit(proc, 1500);
+        if (!exited) {
+          try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000, windowsHide: true }); } catch {}
+        }
+      } else {
+        try { process.kill(-proc.pid, 'SIGINT'); } catch { try { proc.kill('SIGINT'); } catch {} }
+        let exited = await this._waitExit(proc, 1500);
+        if (!exited) {
+          try { process.kill(-proc.pid, 'SIGTERM'); } catch { try { proc.kill('SIGTERM'); } catch {} }
+          exited = await this._waitExit(proc, 2000);
+        }
+        if (!exited) {
+          try { process.kill(-proc.pid, 'SIGKILL'); } catch { try { proc.kill('SIGKILL'); } catch {} }
+          await this._waitExit(proc, 1000);
+        }
+      }
+    } catch {}
+  }
+
+  _waitExit(proc, ms) {
+    return new Promise((resolve) => {
+      if (proc.exitCode !== null) return resolve(true);
+      const t = setTimeout(() => resolve(false), ms);
+      proc.once('exit', () => { clearTimeout(t); resolve(true); });
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Message handler
+  // ------------------------------------------------------------------
+
+  async _handleMessage(msg) {
+    const content = (msg.content || '').trim();
+    if (!content) return;
+
+    const channel = msg.sessionId || this.channelName;
+    this._stoppingChannels.delete(channel);
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${channel}: ${redactSensitive(content).slice(0, 80)}...`);
+
+    if (!this._copilotBin) {
+      await this.sendError(channel,
+        'GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot');
+      return;
+    }
+
+    // Hard version gate BEFORE spawning a turn: an older CLI lacks the flags /
+    // JSONL output this adapter requires, so refuse rather than emit a confusing
+    // "unknown option" failure on every run.
+    const gate = this._checkVersionGate();
+    if (gate.compatible === false) {
+      await this.sendError(channel,
+        `GitHub Copilot CLI ${gate.version} is too old — this integration requires ${MIN_VERSION} or newer. Upgrade with: copilot update (or npm install -g @github/copilot).`);
+      return;
+    }
+
+    // Working directory must exist — never silently fall back to the repo cwd.
+    const wd = this.workingDir;
+    if (wd && !this._dirExists(wd)) {
+      await this.sendError(channel, `Working directory does not exist: ${wd}`);
+      return;
+    }
+
+    await this._autoTitleChannel(channel, content);
+    await this.sendStatus(channel, 'thinking...');
+
+    const fullPrompt = `${this._buildSystemContext(channel)}\n\n---\n\nUser message:\n${content}`;
+
+    // Up to 2 attempts: resume first, then a fresh session if resume was stale.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const skipResume = attempt > 0;
+      const args = this._buildArgs(fullPrompt, channel, { skipResume });
+      this._logSpawn(channel, args, skipResume);
+
+      let result;
+      try {
+        result = await this._runTurn(channel, args);
+      } catch (e) {
+        await this.sendError(channel, `Error: ${redactSensitive(e.message)}`);
+        return;
+      }
+
+      if (this._stoppingChannels.has(channel)) return; // user interrupted
+
+      // Stale resume → retry once without it.
+      if (result.staleSession && attempt === 0 && this._channelSessions[channel]) {
+        this._log(`Stale session for ${channel}; retrying with a fresh session`);
+        delete this._channelSessions[channel];
+        this._saveSessions();
+        continue;
+      }
+
+      if (result.errorMessage) {
+        await this.sendError(channel, result.errorMessage);
+        return;
+      }
+      const text = (result.finalText || '').trim();
+      if (text) {
+        await this.sendResponse(channel, text);
+      } else if (result.timedOut) {
+        await this.sendError(channel, 'Copilot CLI timed out before producing a response.');
+      } else {
+        await this.sendResponse(channel, 'No response generated. Please try again.');
+      }
+      return;
+    }
+  }
+
+  _dirExists(p) {
+    try { return fs.statSync(p).isDirectory(); } catch { return false; }
+  }
+
+  /**
+   * Pre-launch version gate. Runs `copilot --version` once (cached), parses the
+   * version, and compares against MIN_VERSION. Returns
+   * { version, compatible: true|false|null }:
+   *   • compatible:false → below MIN_VERSION, callers must not spawn.
+   *   • compatible:null  → version unparseable/undetectable ("unknown"); we do
+   *     NOT block (let the run proceed; runtime errors will surface real issues).
+   * Mirrors the installer's generic gate semantics but lives in the adapter so a
+   * too-old CLI never gets a turn spawned against it.
+   */
+  _checkVersionGate() {
+    if (this._versionGate) return this._versionGate;
+    let version = null;
+    try {
+      // Args as an array (no shell) so paths with spaces/backslashes are safe on
+      // every platform. _resolveExec already normalizes a Windows .cmd shim.
+      const [file, ...prefix] = this._resolveExec(this._copilotBin);
+      const raw = execFileSync(file, [...prefix, '--version'], {
+        encoding: 'utf-8', timeout: 8000, windowsHide: true, env: getEnhancedEnv(),
+      }).trim();
+      const m = raw.match(/(\d+\.\d+\.\d+)/);
+      version = m ? m[1] : null;
+    } catch {}
+    let compatible;
+    if (!version) compatible = null;
+    else compatible = compareVersions(version, MIN_VERSION) >= 0;
+    this._versionGate = { version, compatible };
+    return this._versionGate;
+  }
+
+  _logSpawn(channel, args, skipResume) {
+    // Log a redacted, prompt-free shape of the command. The prompt is replaced
+    // with a placeholder; tokens never appear in argv but redact defensively.
+    const shown = [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '-p') { shown.push('-p', '<prompt>'); i++; continue; }
+      shown.push(args[i]);
+    }
+    this._log(`Spawning copilot ${redactSensitive(shown.join(' '))}${skipResume ? ' (no-resume retry)' : ''}`);
+  }
+
+  /**
+   * Run one Copilot turn: spawn the subprocess, stream-parse stdout, map events
+   * onto workspace messages, capture the session id, and resolve a summary of
+   * the turn. Never rejects on CLI failure — failures come back as
+   * `errorMessage` / `staleSession` / `timedOut` so the caller can react.
+   */
+  _runTurn(channel, args) {
+    const [file, ...prefix] = this._resolveExec(this._copilotBin);
+    const env = getEnhancedEnv({ ...(this.agentEnv || process.env) });
+    const cwd = this.workingDir || defaultAgentWorkdir(this.agentName);
+
+    return new Promise((resolve) => {
+      let proc;
+      try {
+        proc = spawn(file, [...prefix, ...args], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env,
+          cwd,
+          detached: !IS_WINDOWS,
+          windowsHide: true,
+        });
+      } catch (e) {
+        return resolve({ errorMessage: `Failed to launch Copilot CLI: ${redactSensitive(e.message)}` });
+      }
+      this._channelProcesses[channel] = proc;
+
+      const parser = new CopilotStreamParser();
+      // Final-answer accumulation. `finalParts` holds authoritative `text`
+      // events; `deltaBuf` holds streamed `text_delta` text for the current
+      // contiguous block. A final `text` event SUPERSEDES the deltas of its
+      // block (deltas are the streamed pieces of the same message) so the answer
+      // is never duplicated. A tool/file/shell event between text starts a new
+      // block (only the last contiguous block becomes the answer; earlier text
+      // was shown live as thinking).
+      const finalParts = [];
+      let deltaBuf = '';
+      const accumulatedText = () => (finalParts.length ? finalParts.join('\n') : deltaBuf).trim();
+      let sawToolSinceText = false;
+      let errorEvent = null;
+      let stderrBuf = '';
+      let pending = Promise.resolve();
+      let settled = false;
+
+      const timeout = setTimeout(() => {
+        this._stopProcess(proc).catch(() => {});
+        finish({ timedOut: true, finalText: accumulatedText() });
+      }, TURN_TIMEOUT_MS);
+
+      const finish = (summary) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        delete this._channelProcesses[channel];
+        resolve(summary);
+      };
+
+      const handle = async (ev) => {
+        switch (ev.kind) {
+          case 'session':
+            if (ev.sessionId) {
+              this._channelSessions[channel] = ev.sessionId;
+              this._saveSessions();
+            }
+            break;
+          case 'text_delta':
+            // Streamed interim text is shown live as `thinking`; the final
+            // `text` event (if any) is the authoritative answer.
+            if (sawToolSinceText) { finalParts.length = 0; deltaBuf = ''; sawToolSinceText = false; }
+            if (ev.text) { deltaBuf += ev.text; try { await this.sendThinking(channel, ev.text); } catch {} }
+            break;
+          case 'text':
+            // A complete message supersedes the deltas streamed for this block.
+            if (sawToolSinceText) { finalParts.length = 0; sawToolSinceText = false; }
+            deltaBuf = '';
+            if (ev.text) finalParts.push(ev.text);
+            break;
+          case 'reasoning':
+            if (ev.text) { try { await this.sendThinking(channel, ev.text); } catch {} }
+            break;
+          case 'tool_start':
+            sawToolSinceText = true;
+            try { await this.sendStatus(channel, this._describeTool(ev)); } catch {}
+            break;
+          case 'shell':
+            sawToolSinceText = true;
+            try {
+              const ec = (ev.exitCode != null) ? ` (exit ${ev.exitCode})` : '';
+              await this.sendStatus(channel, `**Running:** \`${redactSensitive(String(ev.command)).slice(0, 200)}\`${ec}`);
+            } catch {}
+            break;
+          case 'file_change':
+            sawToolSinceText = true;
+            try { await this.sendStatus(channel, `**${ev.action === 'read' ? 'Reading' : 'Editing'}:** \`${ev.path}\``); } catch {}
+            break;
+          case 'tool_result':
+            // Tool output is operational detail, not an assistant reply — keep it
+            // out of the chat body; just log a redacted note.
+            this._log(`tool_result ${ev.tool}${ev.isError ? ' (error)' : ''}`);
+            break;
+          case 'permission':
+            try { await this.sendStatus(channel, `Permission ${ev.granted ? 'granted' : 'denied'}: ${redactSensitive(ev.detail).slice(0, 160)}`); } catch {}
+            break;
+          case 'ask_user':
+            // We launched with --no-ask-user; if a prompt still surfaces, the
+            // workspace can't answer it. Record it so the turn fails clearly.
+            errorEvent = errorEvent || { message: 'Copilot requested interactive input, which the workspace cannot provide. Re-run with a more specific task.' };
+            break;
+          case 'usage':
+            this._log(`usage model=${ev.model || '?'}`);
+            break;
+          case 'error':
+            errorEvent = errorEvent || { message: ev.message, code: ev.code };
+            break;
+          case 'done':
+            break;
+          case 'unknown':
+            // Preserve a redacted diagnostic; never crash the task.
+            this._log(`unknown event: ${ev.raw}`);
+            break;
+          default:
+            break;
+        }
+      };
+
+      proc.stdout.on('data', (chunk) => {
+        for (const ev of parser.push(chunk)) {
+          pending = pending.then(() => handle(ev)).catch(() => {});
+        }
+      });
+      if (proc.stderr) {
+        proc.stderr.on('data', (c) => { stderrBuf += c.toString('utf-8'); });
+      }
+
+      proc.on('error', (err) => {
+        finish({ errorMessage: `Copilot CLI failed to start: ${redactSensitive(err.message)}` });
+      });
+
+      proc.on('exit', async (code) => {
+        try { for (const ev of parser.flush()) await handle(ev); } catch {}
+        try { await pending; } catch {}
+
+        if (this._stoppingChannels.has(channel)) {
+          return finish({ interrupted: true, finalText: accumulatedText() });
+        }
+
+        const finalText = accumulatedText();
+        const classified = this._classifyOutcome(code, errorEvent, stderrBuf);
+        if (classified) {
+          // A resume against a vanished session: surface as stale so the caller
+          // retries fresh instead of erroring the user.
+          if (classified.staleSession) return finish({ staleSession: true });
+          // If the CLI still produced a usable answer, prefer it over a soft error.
+          if (finalText && !classified.hard) return finish({ finalText });
+          return finish({ errorMessage: classified.message });
+        }
+        finish({ finalText });
+      });
+    });
+  }
+
+  _describeTool(ev) {
+    let preview = '';
+    const inp = ev.input;
+    if (inp && typeof inp === 'object') {
+      preview = inp.command || inp.path || inp.file || inp.file_path || inp.pattern
+        || inp.query || inp.url || (typeof inp.content === 'string' ? inp.content.slice(0, 80) : '')
+        || JSON.stringify(inp).slice(0, 120);
+    } else if (inp != null) {
+      preview = String(inp).slice(0, 120);
+    }
+    return `${ev.tool} › ${redactSensitive(String(preview))}`;
+  }
+
+  // ------------------------------------------------------------------
+  // Error classification (based on event, exit code, and stderr)
+  // ------------------------------------------------------------------
+
+  /**
+   * Turn a turn's terminal signals into a concise, actionable user message and
+   * a stale-session hint. Returns null when the turn succeeded. Detailed,
+   * redacted text only goes to the dev log.
+   *
+   * String patterns are anchored on REAL Copilot CLI v1.0.63 stderr (see
+   * test/fixtures/copilot-cli-real-samples.md) — note auth/session/network
+   * failures in non-interactive mode print to stderr with EMPTY stdout (no JSONL
+   * error event), so classification is driven by stderr + exit code. Broader
+   * synonyms are kept as forward-compatible fallbacks.
+   */
+  _classifyOutcome(exitCode, errorEvent, stderr) {
+    const blob = redactSensitive(`${errorEvent ? (errorEvent.message || '') + ' ' + (errorEvent.code || '') : ''} ${stderr || ''}`).trim();
+    const ok = (exitCode === 0 || exitCode == null) && !errorEvent;
+    if (ok) return null;
+
+    if (blob) this._log(`Copilot failure (exit=${exitCode}): ${blob.slice(0, 400)}`);
+
+    const has = (re) => re.test(blob);
+
+    // Session resume miss → retry fresh (not a user-facing error).
+    // Real: "Error: No session, task, or name matched 'NAME'."
+    if (has(/no session,? .*matched|session\s+(not\s+found|expired|unknown|invalid)|no such session/i)) {
+      return { staleSession: true };
+    }
+    // Token present but REJECTED — must be checked BEFORE the no-credentials rule
+    // because the real CLI appends the SAME "To authenticate … gh auth login"
+    // help block to both messages; only the leading line distinguishes them.
+    // Real: "Authentication token found but could not be validated. Failed to
+    // fetch PAT user login (401): ... Bad credentials".
+    if (has(/could not be validated|bad credentials|authentication token found but|token.*(expired|revoked|invalid)|invalid.*token|\b401\b|unauthorized/i)) {
+      return { hard: true, message: 'GitHub Copilot token is invalid, expired, or revoked (401). Re-authenticate with a fine-grained token that has the "Copilot Requests" permission, or run `copilot` and use /login. (Classic ghp_ tokens are not supported.)' };
+    }
+    // No credentials at all. Real distinguishing line: "No authentication
+    // information found." (Do NOT key on the shared "gh auth login" tail.)
+    if (has(/no authentication information|not (logged|signed) in|no (credentials|token)\b|login required/i)) {
+      return { hard: true, message: 'Not signed in to GitHub Copilot. Set COPILOT_GITHUB_TOKEN (or GH_TOKEN/GITHUB_TOKEN), run `gh auth login`, or run `copilot` and use /login.' };
+    }
+    if (has(/\b403\b|forbidden|sso|saml|single sign-on|not authorized for/i)) {
+      return { hard: true, message: 'Access denied (403). This is usually SAML/SSO not authorized for your token, or insufficient token scope for Copilot CLI.' };
+    }
+    if (has(/organization|enterprise|policy|disabled by|not allowed by|blocked by/i)) {
+      return { hard: true, message: 'GitHub Copilot CLI is blocked by an organization/enterprise policy for this account.' };
+    }
+    if (has(/subscription|not entitled|no copilot|copilot.*(unavailable|inactive)|no seat|seat/i)) {
+      return { hard: true, message: 'No active GitHub Copilot subscription/seat for this account.' };
+    }
+    // GitHub Enterprise host misconfiguration (GH_HOST / COPILOT_GH_HOST / --host).
+    if (has(/gh_host|copilot_gh_host|enterprise.*host|host.*not.*found|unknown host|could not resolve host|invalid host/i)) {
+      return { hard: true, message: 'GitHub host configuration error. Check GH_HOST / COPILOT_GH_HOST (GitHub Enterprise data-residency hostname).' };
+    }
+    // BYOK custom provider misconfiguration (COPILOT_PROVIDER_*).
+    if (has(/copilot_provider|provider.*(base.?url|api.?key|not configured|invalid)|byok/i)) {
+      return { hard: true, message: 'Custom model provider (BYOK) is misconfigured. Check COPILOT_PROVIDER_BASE_URL / COPILOT_PROVIDER_API_KEY / COPILOT_PROVIDER_TYPE.' };
+    }
+    if (has(/model.*(not found|unavailable|unsupported)|unknown model|invalid model/i)) {
+      return { hard: true, message: 'The requested model is unavailable for this account. Clear COPILOT_MODEL or pick a supported model.' };
+    }
+    if (has(/rate limit|429|too many requests|quota|credit/i)) {
+      return { hard: true, message: 'Rate limited or out of Copilot credits. Please wait and try again.' };
+    }
+    if (has(/check your network|network|ENOTFOUND|ECONNREFUSED|ETIMEDOUT|getaddrinfo|socket hang up|503|502|service unavailable/i)) {
+      return { hard: true, message: 'Network or GitHub service error reaching Copilot. Check connectivity and try again.' };
+    }
+    if (has(/permission|not authorized|denied|not allowed to (write|read|run)/i)) {
+      return { hard: true, message: 'Copilot was denied a required permission (path/tool). The task may need access outside the working directory.' };
+    }
+    if (errorEvent && errorEvent.message) {
+      return { hard: true, message: `Copilot error: ${redactSensitive(errorEvent.message).slice(0, 300)}` };
+    }
+    if (exitCode && exitCode !== 0) {
+      return { hard: false, message: `Copilot CLI exited with code ${exitCode}.` };
+    }
+    return null;
+  }
+}
+
+module.exports = CopilotAdapter;
+module.exports.MIN_VERSION = MIN_VERSION;

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -14,6 +14,7 @@ const CursorAdapter = require('./cursor');
 const HermesAdapter = require('./hermes');
 const GeminiAdapter = require('./gemini');
 const KimiAdapter = require('./kimi');
+const CopilotAdapter = require('./copilot');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -25,11 +26,12 @@ const ADAPTER_MAP = {
   hermes: HermesAdapter,
   gemini: GeminiAdapter,
   kimi: KimiAdapter,
+  copilot: CopilotAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, copilot)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -52,6 +54,7 @@ module.exports = {
   HermesAdapter,
   GeminiAdapter,
   KimiAdapter,
+  CopilotAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -10,6 +10,39 @@ const { EnvManager } = require('./env');
 const STATUS_CACHE_TTL_MS = 10000;
 const statusCache = new Map();
 
+// Version detection is comparatively expensive (spawns `<bin> --version`), so
+// results are cached briefly and invalidated on install/uninstall.
+const VERSION_CACHE_TTL_MS = 60000;
+const versionCache = new Map();
+
+/**
+ * Compare two dotted version strings numerically, ignoring any pre-release /
+ * build suffix (e.g. "1.2.3-beta.1" → 1.2.3). Returns -1, 0, or 1.
+ * Returns null when either side has no extractable numeric version.
+ */
+function compareVersions(a, b) {
+  const norm = (v) => {
+    const m = String(v == null ? '' : v).match(/\d+(?:\.\d+)*/);
+    return m ? m[0].split('.').map((n) => parseInt(n, 10)) : null;
+  };
+  const pa = norm(a);
+  const pb = norm(b);
+  if (!pa || !pb) return null;
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+  return 0;
+}
+
+/** Drop the version cache (called on install/uninstall). */
+function clearVersionCache() {
+  versionCache.clear();
+}
+
 /**
  * Manages installation and uninstallation of agent runtimes.
  *
@@ -164,8 +197,11 @@ class Installer {
           installed: false,
           binary: null,
           version: null,
+          compatible: null,
+          min_version: null,
           ready: false,
           auth_mode: null,
+          auth_status: null,
           execution_mode: 'unavailable',
           message: 'Not installed',
         };
@@ -175,6 +211,8 @@ class Installer {
         installed: true,
         binary: null,
         version: null,
+        compatible: true,
+        min_version: null,
         ...this._evaluateReadiness(agentType, entry, null),
       };
     }
@@ -185,8 +223,11 @@ class Installer {
         installed: false,
         binary: null,
         version: null,
+        compatible: null,
+        min_version: null,
         ready: false,
         auth_mode: null,
+        auth_status: null,
         execution_mode: 'unavailable',
         message: 'Not installed',
       };
@@ -194,6 +235,39 @@ class Installer {
 
     const checkCmd = entry && entry.install ? entry.install.check_command : null;
     const versionCmd = checkCmd || `${entry && entry.install && entry.install.binary || agentType} --version`;
+
+    const version = this._detectVersion(binary, versionCmd);
+    const readiness = this._evaluateReadiness(agentType, entry, binary);
+
+    // Generic minimum-version gate (no per-agent special-casing). An entry opts
+    // in by declaring `install.min_version`. Below the floor we keep
+    // installed=true but force compatible=false + ready=false so the launcher
+    // blocks the run and prompts an upgrade (never shows "not installed"). When
+    // the version can't be parsed we report compatible=null ("unknown") rather
+    // than falsely passing the gate, and do NOT hard-block readiness.
+    const gate = this._evaluateCompatibility(entry, version);
+    if (gate.compatible === false) {
+      readiness.ready = false;
+      readiness.message = gate.message;
+    }
+
+    return {
+      installed: true,
+      binary,
+      version,
+      compatible: gate.compatible,
+      min_version: gate.minVersion,
+      ...readiness,
+    };
+  }
+
+  /**
+   * Detect a binary's version string, cached briefly. Returns null on failure.
+   */
+  _detectVersion(binary, versionCmd) {
+    const key = `${binary}\0${versionCmd}`;
+    const cached = versionCache.get(key);
+    if (cached && (Date.now() - cached.ts) < VERSION_CACHE_TTL_MS) return cached.version;
 
     let version = null;
     try {
@@ -205,11 +279,36 @@ class Installer {
       }).trim();
       // Extract version number (e.g. "openclaw 2024.1.5" → "2024.1.5")
       const match = raw.match(/(\d+[\d.]+\d+)/);
-      version = match ? match[1] : raw.split('\n')[0];
+      version = match ? match[1] : (raw.split('\n')[0] || null);
     } catch {}
 
-    const readiness = this._evaluateReadiness(agentType, entry, binary);
-    return { installed: true, binary, version, ...readiness };
+    versionCache.set(key, { version, ts: Date.now() });
+    return version;
+  }
+
+  /**
+   * Evaluate `install.min_version` against a detected version. Generic for any
+   * agent. Returns { compatible: true|false|null, minVersion, message }.
+   *   • no min_version declared → compatible:true (gate disabled)
+   *   • version unparseable      → compatible:null  ("unknown", don't false-pass)
+   *   • version < min_version    → compatible:false (block + upgrade hint)
+   *   • version >= min_version   → compatible:true
+   */
+  _evaluateCompatibility(entry, version) {
+    const minVersion = (entry && entry.install && entry.install.min_version) || null;
+    if (!minVersion) return { compatible: true, minVersion: null, message: null };
+    const cmp = compareVersions(version, minVersion);
+    if (cmp === null) {
+      return { compatible: null, minVersion, message: `Version unknown (requires >= ${minVersion})` };
+    }
+    if (cmp < 0) {
+      return {
+        compatible: false,
+        minVersion,
+        message: `${(entry.label || entry.name || 'This agent')} ${version} is too old — upgrade to ${minVersion} or newer.`,
+      };
+    }
+    return { compatible: true, minVersion, message: null };
   }
 
   _evaluateReadiness(agentType, entry, binary) {
@@ -218,6 +317,7 @@ class Installer {
       return {
         ready: true,
         auth_mode: null,
+        auth_status: 'ready',
         execution_mode: 'unavailable',
         message: 'Ready',
       };
@@ -240,6 +340,7 @@ class Installer {
       return {
         ready: true,
         auth_mode: 'api_key',
+        auth_status: 'ready',
         execution_mode: 'direct',
         message: 'Ready',
       };
@@ -249,6 +350,7 @@ class Installer {
       return {
         ready: true,
         auth_mode: 'cli_login',
+        auth_status: 'ready',
         execution_mode: 'subprocess',
         message: 'Ready',
       };
@@ -261,6 +363,7 @@ class Installer {
       return {
         ready: true,
         auth_mode: 'api_key',
+        auth_status: 'ready',
         execution_mode: 'direct',
         message: 'Ready',
       };
@@ -270,14 +373,21 @@ class Installer {
       return {
         ready: true,
         auth_mode: 'cli_login',
+        auth_status: 'ready',
         execution_mode: 'subprocess',
         message: 'Ready',
       };
     }
 
+    // No positive signal. For agents whose auth cannot be reliably probed
+    // without running them (generic `check_ready.unverifiable`), this is
+    // 'unknown' — they may already be signed in via a CLI login / keychain /
+    // gh — NOT a definitive 'no_credentials'. The launcher can show "unknown"
+    // and still allow a launch attempt; the real run is the final authority.
     return {
       ready: false,
       auth_mode: null,
+      auth_status: checkReady.unverifiable ? 'unknown' : 'no_credentials',
       execution_mode: 'unavailable',
       message: checkReady.not_ready_message || 'Not configured',
     };
@@ -772,6 +882,7 @@ class Installer {
     // pre-install snapshot. Without this, install completes but UI keeps
     // showing "not installed" until the cache expires.
     try { clearBinaryLookupCache(); } catch {}
+    try { clearVersionCache(); } catch {}
   }
 
   _markUninstalled(agentType) {
@@ -794,6 +905,7 @@ class Installer {
 
     // Symmetric with _markInstalled: invalidate so detection re-runs cleanly.
     try { clearBinaryLookupCache(); } catch {}
+    try { clearVersionCache(); } catch {}
   }
 
   // -- Shell env + exec --
@@ -1207,4 +1319,4 @@ class Installer {
   }
 }
 
-module.exports = { Installer };
+module.exports = { Installer, compareVersions, clearVersionCache };

--- a/packages/agent-connector/test/copilot-stream-parser.test.js
+++ b/packages/agent-connector/test/copilot-stream-parser.test.js
@@ -1,0 +1,254 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  CopilotStreamParser,
+  frameChunk,
+  parseLine,
+  classifyEvent,
+  redactSensitive,
+  diagnosticForUnknown,
+} = require('../src/adapters/copilot-stream-parser');
+
+// Collect all events produced by feeding `chunks` then flushing.
+function run(chunks) {
+  const p = new CopilotStreamParser();
+  const out = [];
+  for (const c of chunks) out.push(...p.push(c));
+  out.push(...p.flush());
+  return out;
+}
+
+describe('copilot framing (schema-agnostic)', () => {
+  it('frames a single complete line', () => {
+    const { lines, rest } = frameChunk('', '{"a":1}\n');
+    assert.deepEqual(lines, ['{"a":1}']);
+    assert.equal(rest, '');
+  });
+
+  it('carries a partial line across chunks (JSON split mid-object)', () => {
+    const p = new CopilotStreamParser();
+    assert.deepEqual(p.push('{"type":"text","te'), []);
+    const ev = p.push('xt":"hi"}\n');
+    assert.equal(ev.length, 1);
+    assert.equal(ev[0].kind, 'text');
+    assert.equal(ev[0].text, 'hi');
+  });
+
+  it('splits multiple JSON objects in one chunk', () => {
+    const evs = run(['{"type":"reasoning","text":"a"}\n{"type":"text","text":"b"}\n']);
+    assert.equal(evs.length, 2);
+    assert.equal(evs[0].kind, 'reasoning');
+    assert.equal(evs[1].kind, 'text');
+  });
+
+  it('handles CRLF line endings', () => {
+    const evs = run(['{"type":"text","text":"x"}\r\n{"type":"done"}\r\n']);
+    assert.deepEqual(evs.map((e) => e.kind), ['text', 'done']);
+    assert.equal(evs[0].text, 'x');
+  });
+
+  it('skips blank lines and whitespace-only lines', () => {
+    const evs = run(['\n   \n{"type":"text","text":"y"}\n\n']);
+    assert.equal(evs.length, 1);
+    assert.equal(evs[0].text, 'y');
+  });
+
+  it('skips non-JSON noise/banner lines without throwing', () => {
+    const evs = run(['Copilot CLI v1.2.3\nLogging in...\n{"type":"text","text":"z"}\n']);
+    assert.equal(evs.length, 1);
+    assert.equal(evs[0].text, 'z');
+  });
+
+  it('does not drop the whole task on one corrupt JSON line', () => {
+    const evs = run(['{"type":"text","text":"a"}\n{ broken json \n{"type":"text","text":"b"}\n']);
+    assert.deepEqual(evs.map((e) => e.text), ['a', 'b']);
+  });
+
+  it('flushes a trailing line with no terminating newline (process exit)', () => {
+    const p = new CopilotStreamParser();
+    assert.deepEqual(p.push('{"type":"done"}'), []); // no newline yet
+    const tail = p.flush();
+    assert.equal(tail.length, 1);
+    assert.equal(tail[0].kind, 'done');
+  });
+
+  it('flush is idempotent and empty when nothing buffered', () => {
+    const p = new CopilotStreamParser();
+    assert.deepEqual(p.flush(), []);
+    assert.deepEqual(p.flush(), []);
+  });
+
+  it('accepts Buffer chunks', () => {
+    const evs = run([Buffer.from('{"type":"text","text":"buf"}\n', 'utf-8')]);
+    assert.equal(evs[0].text, 'buf');
+  });
+
+  it('parseLine returns null for blank / noise / array-less primitives', () => {
+    assert.equal(parseLine(''), null);
+    assert.equal(parseLine('   '), null);
+    assert.equal(parseLine('hello'), null);
+    assert.equal(parseLine('42'), null);
+    assert.equal(parseLine('null'), null);
+    assert.deepEqual(parseLine('{"a":1}'), { a: 1 });
+  });
+});
+
+describe('copilot classification (schema mapping)', () => {
+  it('maps a session id from several aliases', () => {
+    assert.equal(classifyEvent({ type: 'session', session_id: 'abc' }).sessionId, 'abc');
+    assert.equal(classifyEvent({ type: 'thread.started', thread_id: 't1' }).sessionId, 't1');
+    assert.equal(classifyEvent({ type: 'session.created', id: 's9' }).sessionId, 's9');
+  });
+
+  it('session event without any id degrades to unknown (no guessing)', () => {
+    assert.equal(classifyEvent({ type: 'session' }).kind, 'unknown');
+  });
+
+  it('streaming text vs final text are distinct kinds', () => {
+    assert.equal(classifyEvent({ type: 'text.delta', delta: 'he' }).kind, 'text_delta');
+    assert.equal(classifyEvent({ type: 'text.delta', delta: 'he' }).text, 'he');
+    assert.equal(classifyEvent({ type: 'message.completed', text: 'done' }).kind, 'text');
+  });
+
+  it('extracts text from nested content blocks', () => {
+    const ev = classifyEvent({ type: 'assistant', message: { content: [{ text: 'a' }, { text: 'b' }] } });
+    assert.equal(ev.kind, 'text');
+    assert.equal(ev.text, 'ab');
+  });
+
+  it('reasoning is its own kind (never treated as final text)', () => {
+    const ev = classifyEvent({ type: 'thinking', text: 'pondering' });
+    assert.equal(ev.kind, 'reasoning');
+    assert.equal(ev.text, 'pondering');
+  });
+
+  it('classifies tool start with input under multiple field names', () => {
+    const a = classifyEvent({ type: 'tool_call', name: 'grep', arguments: { pattern: 'x' } });
+    assert.equal(a.kind, 'tool_start');
+    assert.equal(a.tool, 'grep');
+    assert.deepEqual(a.input, { pattern: 'x' });
+    const b = classifyEvent({ type: 'function_call', function: 'edit', params: { p: 1 } });
+    assert.equal(b.tool, 'edit');
+  });
+
+  it('classifies tool result and flags errors (incl. nonzero exit code)', () => {
+    assert.equal(classifyEvent({ type: 'tool_result', output: 'ok' }).isError, false);
+    assert.equal(classifyEvent({ type: 'tool_result', is_error: true }).isError, true);
+    assert.equal(classifyEvent({ type: 'tool_result', exit_code: 2 }).isError, true);
+  });
+
+  it('classifies file change with path and action', () => {
+    const ev = classifyEvent({ type: 'file_change', path: 'a/b.ts', action: 'write' });
+    assert.equal(ev.kind, 'file_change');
+    assert.equal(ev.path, 'a/b.ts');
+    assert.equal(ev.action, 'write');
+    assert.equal(classifyEvent({ type: 'file_read', file: 'x.md' }).action, 'read');
+  });
+
+  it('classifies shell execution with exit code', () => {
+    const ev = classifyEvent({ type: 'command_execution', command: 'ls -la', exit_code: 0, output: 'files' });
+    assert.equal(ev.kind, 'shell');
+    assert.equal(ev.command, 'ls -la');
+    assert.equal(ev.exitCode, 0);
+  });
+
+  it('handles the nested item.* wrapping shape', () => {
+    const ev = classifyEvent({ type: 'item.completed', item: { type: 'command_execution', command: 'pwd', exit_code: 0 } });
+    assert.equal(ev.kind, 'shell');
+    assert.equal(ev.command, 'pwd');
+  });
+
+  it('classifies permission and ask_user', () => {
+    assert.equal(classifyEvent({ type: 'permission_denied', tool: 'write' }).kind, 'permission');
+    assert.equal(classifyEvent({ type: 'permission', granted: true }).granted, true);
+    assert.equal(classifyEvent({ type: 'ask_user', question: 'Proceed?' }).question, 'Proceed?');
+  });
+
+  it('classifies usage with model + token info', () => {
+    const ev = classifyEvent({ type: 'usage', model: 'gpt-x', usage: { input: 10, output: 5 } });
+    assert.equal(ev.kind, 'usage');
+    assert.equal(ev.model, 'gpt-x');
+    assert.deepEqual(ev.usage, { input: 10, output: 5 });
+  });
+
+  it('classifies terminal done and error', () => {
+    assert.equal(classifyEvent({ type: 'turn.completed' }).kind, 'done');
+    const err = classifyEvent({ type: 'error', error: { message: 'boom', code: 'E1' } });
+    assert.equal(err.kind, 'error');
+    assert.equal(err.message, 'boom');
+    assert.equal(err.code, 'E1');
+  });
+
+  it('unrecognized type degrades to unknown with a redacted diagnostic', () => {
+    const ev = classifyEvent({ type: 'totally_new_event_v9', detail: 'whatever' });
+    assert.equal(ev.kind, 'unknown');
+    assert.equal(typeof ev.raw, 'string');
+    assert.ok(ev.raw.includes('totally_new_event_v9'));
+  });
+});
+
+describe('copilot redaction', () => {
+  it('redacts GitHub tokens (classic + fine-grained)', () => {
+    assert.ok(!redactSensitive('token ghp_' + 'A'.repeat(36)).includes('ghp_'));
+    assert.ok(!redactSensitive('github_pat_' + 'B'.repeat(30)).includes('github_pat_'));
+  });
+
+  it('redacts secret env assignments but keeps the key name', () => {
+    const out = redactSensitive('COPILOT_GITHUB_TOKEN=ghs_' + 'C'.repeat(36));
+    assert.ok(out.includes('COPILOT_GITHUB_TOKEN'));
+    assert.ok(!out.includes('ghs_'));
+    assert.ok(out.includes('***'));
+  });
+
+  it('redacts Authorization / x-api-key headers', () => {
+    const out = redactSensitive('Authorization: Bearer ' + 'd'.repeat(40));
+    assert.ok(out.toLowerCase().includes('authorization'));
+    assert.ok(!out.includes('d'.repeat(40)));
+  });
+
+  it('redacts inside error events flowing through classifyEvent', () => {
+    const ev = classifyEvent({ type: 'error', message: 'auth failed token=ghp_' + 'E'.repeat(36) });
+    assert.ok(!ev.message.includes('ghp_'));
+  });
+
+  it('diagnosticForUnknown truncates and redacts', () => {
+    const big = { type: 'x', blob: 'gho_' + 'F'.repeat(50), pad: 'y'.repeat(500) };
+    const d = diagnosticForUnknown(big);
+    assert.ok(d.length <= 301);
+    assert.ok(!d.includes('gho_'));
+  });
+
+  it('never throws on circular / weird input', () => {
+    const circ = {}; circ.self = circ;
+    assert.doesNotThrow(() => redactSensitive(circ));
+    assert.doesNotThrow(() => classifyEvent(circ));
+    assert.doesNotThrow(() => classifyEvent(null));
+    assert.doesNotThrow(() => classifyEvent(42));
+  });
+});
+
+describe('copilot end-to-end stream (no duplicate final text)', () => {
+  it('a realistic turn yields session, deltas, final, done', () => {
+    const evs = run([
+      '{"type":"session","session_id":"sess-1"}\n',
+      '{"type":"text.delta","delta":"Hel"}\n{"type":"text.delta","delta":"lo"}\n',
+      '{"type":"tool_call","name":"shell","arguments":{"command":"ls"}}\n',
+      '{"type":"tool_result","output":"a.txt","exit_code":0}\n',
+      '{"type":"message.completed","text":"Hello, done."}\n',
+      '{"type":"usage","model":"m","usage":{"input":1}}\n',
+      '{"type":"done","status":"completed"}',
+    ]);
+    const kinds = evs.map((e) => e.kind);
+    assert.deepEqual(kinds, [
+      'session', 'text_delta', 'text_delta', 'tool_start', 'tool_result', 'text', 'usage', 'done',
+    ]);
+    assert.equal(evs[0].sessionId, 'sess-1');
+    // Exactly one terminal 'done' and one final 'text' — adapter relies on this
+    // to avoid double-posting completion / final answer.
+    assert.equal(kinds.filter((k) => k === 'done').length, 1);
+    assert.equal(kinds.filter((k) => k === 'text').length, 1);
+  });
+});

--- a/packages/agent-connector/test/copilot.test.js
+++ b/packages/agent-connector/test/copilot.test.js
@@ -1,0 +1,406 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CopilotAdapter = require('../src/adapters/copilot');
+
+const MOCK = path.join(__dirname, 'fixtures', 'mock-copilot.js');
+try { fs.chmodSync(MOCK, 0o755); } catch {}
+
+let tmp;
+
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cop-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+/**
+ * Build a CopilotAdapter wired to the mock CLI with all network sends captured.
+ */
+function makeAdapter({ scenario = 'success', mode = 'execute', workingDir, model, argsFile, env = {} } = {}) {
+  const a = new CopilotAdapter({
+    workspaceId: 'ws1',
+    channelName: 'general',
+    token: 'tok',
+    agentName: 'cop',
+    agentType: 'copilot',
+    workingDir: workingDir === undefined ? tmp : workingDir,
+    agentEnv: {
+      ...process.env,
+      MOCK_COPILOT_SCENARIO: scenario,
+      ...(argsFile ? { MOCK_COPILOT_ECHO_ARGS_FILE: argsFile } : {}),
+      ...(model ? { COPILOT_MODEL: model } : {}),
+      ...env,
+    },
+  });
+  // Point at the mock CLI and isolate session storage.
+  a._copilotBin = MOCK;
+  a._model = model || '';
+  a._sessionsFile = path.join(tmp, 'sessions.json');
+  a._channelSessions = {};
+  a._mode = mode;
+  // The mock prints version 1.0.63 → passes the gate. Pre-seed the cache so the
+  // common path doesn't spawn an extra `--version` probe per test.
+  a._versionGate = { version: '1.0.63', compatible: true };
+  // Capture all outbound messages; avoid real workspace HTTP.
+  a.sent = [];
+  a.client = { sendMessage: async () => ({}) };
+  a._autoTitleChannel = async () => {};
+  a.sendStatus = async (ch, content, meta) => { a.sent.push({ type: 'status', ch, content, meta }); };
+  a.sendThinking = async (ch, content) => { a.sent.push({ type: 'thinking', ch, content }); };
+  a.sendResponse = async (ch, content) => { a.sent.push({ type: 'response', ch, content }); };
+  a.sendError = async (ch, content) => { a.sent.push({ type: 'error', ch, content }); };
+  // Capture logs to assert redaction.
+  a.logs = [];
+  a._log = (m) => { a.logs.push(m); };
+  return a;
+}
+
+const msg = (content, channel = 'general') => ({ content, sessionId: channel, senderName: 'user', senderType: 'human' });
+
+describe('CopilotAdapter — happy path & event mapping', () => {
+  it('posts a single final response and maps tool/shell/file events to status', async () => {
+    const a = makeAdapter({ scenario: 'success' });
+    await a._handleMessage(msg('list files'));
+
+    const responses = a.sent.filter((s) => s.type === 'response');
+    assert.equal(responses.length, 1, 'exactly one final response (no delta/final duplication)');
+    // The final `message.completed` text supersedes the streamed deltas — the
+    // answer must be EXACTLY the final text, not "All\ndone.\nAll done. …".
+    assert.equal(responses[0].content, 'All done. Created src/x.js.');
+
+    const statuses = a.sent.filter((s) => s.type === 'status').map((s) => s.content).join('\n');
+    assert.match(statuses, /ls -la/);                 // tool_start (shell tool)
+    assert.match(statuses, /Running:.*npm test.*exit 0/); // dedicated shell event
+    assert.match(statuses, /Editing:.*src\/x\.js/);
+
+    // reasoning went to thinking, not the final answer
+    assert.ok(a.sent.some((s) => s.type === 'thinking' && /Looking at the project/.test(s.content)));
+  });
+
+  it('captures and persists the real Copilot session id, then resumes with it', async () => {
+    const argsFile = path.join(tmp, 'args1.json');
+    const a = makeAdapter({ scenario: 'success', argsFile });
+    await a._handleMessage(msg('hi'));
+
+    // Session saved to disk under the real id from the JSONL.
+    assert.equal(a._channelSessions.general, 'mock-sess-123');
+    const saved = JSON.parse(fs.readFileSync(a._sessionsFile, 'utf-8'));
+    assert.equal(saved.general, 'mock-sess-123');
+
+    // Next turn resumes by that id (not the OpenAgents agent id).
+    const argsFile2 = path.join(tmp, 'args2.json');
+    a.agentEnv.MOCK_COPILOT_ECHO_ARGS_FILE = argsFile2;
+    await a._handleMessage(msg('again'));
+    const args2 = JSON.parse(fs.readFileSync(argsFile2, 'utf-8'));
+    // Optional-value flag MUST be the `=` form (verified against real CLI).
+    assert.ok(args2.includes('--resume=mock-sess-123'), 'resumes with the captured session id via =form');
+    assert.ok(!args2.includes('--resume'), 'never the space form for an optional-value flag');
+  });
+
+  it('first turn seeds a stable, working-dir-bound session name (not the agent id)', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'error_auth', argsFile }); // no session captured on failure
+    await a._handleMessage(msg('hi'));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    const ni = args.indexOf('--name');
+    assert.ok(ni >= 0, 'first turn passes --name');
+    assert.match(args[ni + 1], /^openagents-[0-9a-f]{12}$/);
+    assert.notEqual(args[ni + 1], 'cop', 'must not impersonate the agent id as session');
+  });
+});
+
+describe('CopilotAdapter — prompt & permission safety', () => {
+  it('passes a unicode/multiline/special-char prompt as a discrete -p argv element', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'success', argsFile });
+    const tricky = '请修复这个 bug\n```js\nconst x = `${a}`;\n```\n"quotes" $VAR `back` & | ; rm -rf /';
+    await a._handleMessage(msg(tricky));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    const pi = args.indexOf('-p');
+    assert.ok(pi >= 0, '-p present');
+    // The exact prompt content (incl. the system-context prefix) sits in ONE argv
+    // element — never split or shell-interpreted.
+    assert.ok(args[pi + 1].includes(tricky), 'full prompt is a single argv element');
+    // No shell metacharacters leaked into separate argv slots.
+    assert.ok(!args.includes('rm'), 'prompt text not split into argv tokens');
+  });
+
+  it('act mode grants least-privilege tools (=form) scoped to the working dir; never all-access; disables remote', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'success', mode: 'execute', argsFile });
+    await a._handleMessage(msg('do it'));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    assert.ok(args.includes('--no-ask-user'));
+    assert.ok(args.includes('--no-remote'), 'remote control disabled for privacy');
+    assert.ok(args.includes('--output-format') && args[args.indexOf('--output-format') + 1] === 'json');
+    assert.ok(args.includes('--add-dir') && args[args.indexOf('--add-dir') + 1] === tmp);
+    // Verified tool IDs, =form (real CLI optional-value flag).
+    assert.ok(args.includes('--allow-tool=shell'), 'grants shell');
+    assert.ok(args.includes('--allow-tool=write'), 'grants write');
+    for (const banned of ['--allow-all', '--yolo', '--allow-all-paths', '--allow-all-urls', '--allow-url', '--share', '--share-gist', '--remote']) {
+      assert.ok(!args.includes(banned), `must not use ${banned} by default`);
+    }
+  });
+
+  it('plan mode uses --plan and grants no write tools', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'success', mode: 'plan', argsFile });
+    await a._handleMessage(msg('plan it'));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    assert.ok(args.includes('--plan'));
+    assert.ok(!args.some((x) => x.startsWith('--allow-tool')), 'plan mode does not pre-authorize write/shell tools');
+  });
+
+  it('--secret-env-vars passes only variable NAMES (=form), never token values, only when present', async () => {
+    // With a token in the env, the flag lists its NAME, not its value.
+    const argsFile = path.join(tmp, 'args.json');
+    const secret = 'github_pat_' + 'Z'.repeat(30);
+    const a = makeAdapter({ scenario: 'success', argsFile, env: { COPILOT_GITHUB_TOKEN: secret } });
+    await a._handleMessage(msg('hi'));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    const sev = args.find((x) => x.startsWith('--secret-env-vars='));
+    assert.ok(sev, '--secret-env-vars present when a secret var is set');
+    assert.ok(sev.includes('COPILOT_GITHUB_TOKEN'), 'lists the variable NAME');
+    // The actual token value must NEVER appear in argv.
+    assert.ok(!args.some((x) => x.includes(secret)), 'token value never in argv');
+  });
+
+  it('--secret-env-vars is omitted when no secret env var is present', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    // Strip any inherited token vars for this case.
+    const a = makeAdapter({
+      scenario: 'success', argsFile,
+      env: { COPILOT_GITHUB_TOKEN: '', GH_TOKEN: '', GITHUB_TOKEN: '', OA_WORKSPACE_TOKEN: '' },
+    });
+    await a._handleMessage(msg('hi'));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    assert.ok(!args.some((x) => x.startsWith('--secret-env-vars')), 'no meaningless secret-env-vars arg');
+  });
+
+  it('passes a configured model through --model', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'success', model: 'gpt-x', argsFile });
+    await a._handleMessage(msg('hi'));
+    const args = JSON.parse(fs.readFileSync(argsFile, 'utf-8'));
+    assert.ok(args.includes('--model') && args[args.indexOf('--model') + 1] === 'gpt-x');
+  });
+
+  it('does not log the full prompt or any token (redaction)', async () => {
+    const a = makeAdapter({ scenario: 'success' });
+    await a._handleMessage(msg('secret task github_pat_' + 'A'.repeat(30)));
+    const allLogs = a.logs.join('\n');
+    assert.ok(!allLogs.includes('github_pat_' + 'A'.repeat(30)), 'token never logged');
+    assert.ok(allLogs.includes('<prompt>'), 'spawn log uses a prompt placeholder');
+  });
+});
+
+describe('CopilotAdapter — _resolveExec cross-platform launch (Windows-safe)', () => {
+  const nodeLike = (p) => /node(\.exe)?$/i.test(p) || p === process.execPath;
+
+  it('routes a .js binary through node on BOTH platforms (Windows cannot spawn .js directly)', () => {
+    const a = makeAdapter();
+    for (const isWin of [false, true]) {
+      const r = a._resolveExec(MOCK, isWin);
+      assert.equal(r.length, 2, `[node, js] on ${isWin ? 'win' : 'unix'}`);
+      assert.ok(nodeLike(r[0]), 'first element is node');
+      assert.equal(r[1], MOCK, 'second element is the JS entry');
+    }
+  });
+
+  it('REGRESSION: a .js on Windows must NOT resolve to the bare path (the spawn UNKNOWN cause)', () => {
+    const a = makeAdapter();
+    const r = a._resolveExec(MOCK, /* isWindows */ true);
+    assert.notDeepEqual(r, [MOCK], 'bare .js would throw spawn UNKNOWN on Windows');
+    assert.ok(nodeLike(r[0]));
+  });
+
+  it('resolves a real-style Windows copilot.cmd npm shim to [node, <entry>.js] (prompt-safe, no cmd.exe)', () => {
+    const a = makeAdapter();
+    const cmdPath = path.join(tmp, 'copilot.cmd');
+    // Mirrors an npm-generated .cmd shim for @github/copilot (bin → npm-loader.js).
+    fs.writeFileSync(cmdPath,
+      '@ECHO off\r\nSETLOCAL\r\nSET dp0=%~dp0\r\n' +
+      '"%dp0%\\node_modules\\@github\\copilot\\npm-loader.js" %*\r\n');
+    const r = a._resolveExec(cmdPath, /* isWindows */ true);
+    assert.ok(nodeLike(r[0]), 'spawned via node, not the .cmd or cmd.exe');
+    assert.notEqual(r[0].toLowerCase(), 'cmd.exe', 'must not fall back to cmd.exe string handling');
+    assert.ok(r[1].endsWith('npm-loader.js'), 'resolved to the shim target JS');
+    assert.ok(!r.includes(cmdPath), 'the .cmd is never spawned directly');
+  });
+
+  it('resolves a .cmd that forwards to an .exe → [exe]', () => {
+    const a = makeAdapter();
+    const cmdPath = path.join(tmp, 'copilot.cmd');
+    fs.writeFileSync(cmdPath, 'SET dp0=%~dp0\r\n"%dp0%\\copilot-win.exe" %*\r\n');
+    const r = a._resolveExec(cmdPath, true);
+    assert.equal(r.length, 1);
+    assert.ok(r[0].endsWith('copilot-win.exe'));
+  });
+
+  it('spawns a native .exe directly on Windows', () => {
+    const a = makeAdapter();
+    const r = a._resolveExec('C:\\tools\\copilot.exe', true);
+    assert.deepEqual(r, ['C:\\tools\\copilot.exe']);
+  });
+
+  it('unparseable .cmd falls back to cmd.exe /c (last resort) without string concatenation', () => {
+    const a = makeAdapter();
+    const cmdPath = path.join(tmp, 'weird.cmd');
+    fs.writeFileSync(cmdPath, '@echo nothing useful here\r\n');
+    const r = a._resolveExec(cmdPath, true);
+    assert.deepEqual(r, ['cmd.exe', '/c', cmdPath], 'args still pass as a literal argv array, not a concatenated string');
+  });
+});
+
+describe('CopilotAdapter — registry/adapter consistency', () => {
+  it('adapter MIN_VERSION matches registry.json copilot install.min_version', () => {
+    const registry = require('../registry.json');
+    const copilot = registry.find((e) => e.name === 'copilot');
+    assert.ok(copilot, 'copilot entry exists in registry.json');
+    assert.equal(copilot.install.min_version, CopilotAdapter.MIN_VERSION,
+      'registry min_version must equal adapter MIN_VERSION');
+    assert.equal(copilot.install.binary, 'copilot', 'detects the official binary, not gh');
+    assert.equal(copilot.install.npm_package, '@github/copilot');
+  });
+});
+
+describe('CopilotAdapter — version gate (pre-launch)', () => {
+  it('refuses to spawn when the CLI is below the minimum version', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'success', argsFile });
+    a._versionGate = { version: '0.0.500', compatible: false }; // simulate too-old
+    await a._handleMessage(msg('hi'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.match(err.content, /too old|requires 1\.0\.0|upgrade/i);
+    assert.ok(!fs.existsSync(argsFile), 'no turn was spawned (no args written)');
+  });
+
+  it('proceeds when the version is unknown (compatible=null), never falsely blocking', async () => {
+    const argsFile = path.join(tmp, 'args.json');
+    const a = makeAdapter({ scenario: 'success', argsFile });
+    a._versionGate = { version: null, compatible: null };
+    await a._handleMessage(msg('hi'));
+    assert.ok(a.sent.some((s) => s.type === 'response'), 'unknown version still runs');
+  });
+
+  it('_checkVersionGate detects/compares the real CLI version output', () => {
+    const orig = process.env.MOCK_COPILOT_VERSION;
+    try {
+      const a = makeAdapter({ scenario: 'success' });
+      a._versionGate = null; process.env.MOCK_COPILOT_VERSION = '1.2.0';
+      assert.equal(a._checkVersionGate().compatible, true);
+
+      const b = makeAdapter({ scenario: 'success' });
+      b._versionGate = null; process.env.MOCK_COPILOT_VERSION = '0.0.421';
+      assert.equal(b._checkVersionGate().compatible, false);
+
+      const c = makeAdapter({ scenario: 'success' });
+      c._versionGate = null; process.env.MOCK_COPILOT_VERSION = 'nightly';
+      assert.equal(c._checkVersionGate().compatible, null, 'unparseable → unknown, not false-pass');
+    } finally {
+      if (orig === undefined) delete process.env.MOCK_COPILOT_VERSION;
+      else process.env.MOCK_COPILOT_VERSION = orig;
+    }
+  });
+});
+
+describe('CopilotAdapter — errors & resilience', () => {
+  it('classifies an auth failure into an actionable message', async () => {
+    const a = makeAdapter({ scenario: 'error_auth' });
+    await a._handleMessage(msg('hi'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.ok(err, 'an error was surfaced');
+    assert.match(err.content, /sign|token|Copilot/i);
+  });
+
+  it('classifies an invalid/unvalidatable token (401 / Bad credentials)', async () => {
+    const a = makeAdapter({ scenario: 'error_token' });
+    await a._handleMessage(msg('hi'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.match(err.content, /invalid|expired|revoked|401/i);
+    // The fixed guidance mentions classic-token caveat from the real CLI.
+    assert.match(err.content, /Copilot Requests|ghp_|fine-grained/i);
+  });
+
+  it('classifies an organization-policy block', async () => {
+    const a = makeAdapter({ scenario: 'error_org' });
+    await a._handleMessage(msg('hi'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.match(err.content, /organization|enterprise|policy/i);
+  });
+
+  it('retries with a fresh session when a resume is stale', async () => {
+    const a = makeAdapter({ scenario: 'stale_session' });
+    a._channelSessions.general = 'old-session'; // force a --resume on attempt 0
+    a._saveSessions();
+    await a._handleMessage(msg('hi'));
+    const responses = a.sent.filter((s) => s.type === 'response');
+    assert.equal(responses.length, 1);
+    assert.match(responses[0].content, /Fresh session answer/);
+    assert.equal(a._channelSessions.general, 'mock-sess-fresh');
+  });
+
+  it('treats an ask_user prompt as a clear failure (workspace cannot answer)', async () => {
+    const a = makeAdapter({ scenario: 'ask_user' });
+    await a._handleMessage(msg('ambiguous'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.match(err.content, /interactive input|specific/i);
+  });
+
+  it('surfaces an abnormal crash exit without hanging', async () => {
+    const a = makeAdapter({ scenario: 'crash' });
+    await a._handleMessage(msg('hi'));
+    assert.ok(a.sent.some((s) => s.type === 'error'));
+    assert.equal(Object.keys(a._channelProcesses).length, 0, 'process map cleaned up');
+  });
+
+  it('errors when the working directory does not exist (no silent cwd fallback)', async () => {
+    const a = makeAdapter({ scenario: 'success', workingDir: path.join(tmp, 'does-not-exist') });
+    await a._handleMessage(msg('hi'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.match(err.content, /Working directory does not exist/);
+    assert.equal(a.sent.filter((s) => s.type === 'response').length, 0);
+  });
+
+  it('errors when the binary is missing', async () => {
+    const a = makeAdapter({ scenario: 'success' });
+    a._copilotBin = null;
+    await a._handleMessage(msg('hi'));
+    const err = a.sent.find((s) => s.type === 'error');
+    assert.match(err.content, /not found|install/i);
+  });
+});
+
+describe('CopilotAdapter — interrupt & process-tree cleanup', () => {
+  it('stops an in-flight turn, cleans up the process, and settles the UI', async () => {
+    const a = makeAdapter({ scenario: 'timeout_silent' });
+    const turn = a._handleMessage(msg('long task'));
+
+    // Wait until the subprocess is registered.
+    const start = Date.now();
+    while (!a._channelProcesses.general && Date.now() - start < 5000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    assert.ok(a._channelProcesses.general, 'process registered');
+
+    await a._onControlAction('stop', { channel: 'general' });
+    await turn;
+
+    assert.equal(a._channelProcesses.general, undefined, 'process map cleared after stop');
+    assert.ok(a.sent.some((s) => s.type === 'status' && /stopped by user/i.test(s.content)));
+    // No response/error posted after an explicit user stop.
+    assert.ok(!a.sent.some((s) => s.type === 'response'));
+  });
+});
+
+describe('CopilotAdapter — session/working-dir binding', () => {
+  it('binds the session name to the working directory (no cross-project resume)', () => {
+    const a1 = makeAdapter({ scenario: 'success', workingDir: path.join(tmp, 'projA') });
+    const a2 = makeAdapter({ scenario: 'success', workingDir: path.join(tmp, 'projB') });
+    assert.notEqual(a1._stableSessionName('general'), a2._stableSessionName('general'),
+      'different working dirs must yield different session names');
+  });
+});

--- a/packages/agent-connector/test/fixtures/copilot-cli-real-samples.md
+++ b/packages/agent-connector/test/fixtures/copilot-cli-real-samples.md
@@ -1,0 +1,103 @@
+# Real GitHub Copilot CLI output samples (provenance)
+
+Captured from the **official** CLI to ground the adapter/parser. No tokens,
+usernames, repo paths, prompts, or session contents are included.
+
+- **Package:** `@github/copilot`
+- **Version:** `1.0.63` (`copilot --version` → `GitHub Copilot CLI 1.0.63.`)
+- **npm dist-tags:** `latest=1.0.63`, `prerelease=1.0.64-0`; version range `0.0.326` … `1.0.63` (728 published)
+- **Platform captured on:** Linux x64
+- **Auth state:** UNAUTHENTICATED (no Copilot subscription/token available in CI)
+- **Capture commands:** `copilot --help`, `copilot --version`, `copilot help environment|permissions`,
+  `copilot login --help`, and `copilot -p "say hi" --output-format json --stream on …`
+
+> ⚠️ Because no authenticated session was available, the **success-path JSONL
+> schema (text/tool/file/done events on stdout) is NOT verified**. Only the
+> framing contract, error behaviour, flag set, tool IDs, and session/auth flags
+> below are verified against the real CLI.
+
+## Verified: `--output-format json`
+From `copilot --help`:
+> `--output-format <format>  Output format: 'text' (default) or 'json' (JSONL, one JSON object per line)`
+
+## Verified: errors go to STDERR with EMPTY STDOUT and exit code 1
+
+### No credentials (`-p … --output-format json`, no token)
+- exit code: `1`
+- stdout: empty (0 bytes — **no JSONL error event**)
+- stderr:
+```
+Error: No authentication information found.
+
+Copilot can be authenticated with GitHub using an OAuth Token or a Fine-Grained Personal Access Token.
+
+To authenticate, you can use any of the following methods:
+  • Start 'copilot' and run the '/login' command
+  • Set the COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN environment variable
+  • Run 'gh auth login' to authenticate with the GitHub CLI
+```
+
+### Invalid/unvalidatable token (`COPILOT_GITHUB_TOKEN=github_pat_FAKE…`)
+- exit code: `1`
+- stdout: empty (0 bytes)
+- stderr:
+```
+Error: Authentication token found but could not be validated.
+
+  Failed to fetch PAT user login (401): GitHub returned: Bad credentials
+
+Your token may still be valid. Check your network connection and try again.
+```
+
+### Resume against a non-existent session (`--resume=<unknown>`)
+- exit code: `1`
+- stdout: empty (0 bytes)
+- stderr:
+```
+Error: No session, task, or name matched 'nope'.
+
+To resume by session or task ID:  copilot --resume=<id>
+To resume by name:                copilot --resume=<name>
+To name a new session:            copilot --name=<name>
+To pick from existing sessions:   copilot --resume
+To start a new session with ID:   copilot --session-id=<valid-uuid>
+```
+
+### Unknown flag
+- stderr: `error: unknown option '--totally-bogus-flag'`
+
+## Verified: token env vars & login
+From `copilot login --help` / `copilot help environment`:
+- Precedence: `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`.
+- Tokens stored in the system credential store, else plaintext under `~/.copilot/`.
+- Supported: fine-grained v2 PATs (`github_pat_…`, "Copilot Requests" permission), OAuth from the Copilot CLI app, OAuth from `gh`. **Classic `ghp_` PATs are NOT supported.**
+- `GH_HOST` / `COPILOT_GH_HOST` / `copilot login --host` for GitHub Enterprise Cloud (data residency).
+- BYOK: `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE`, `COPILOT_PROVIDER_API_KEY`, … ; `COPILOT_OFFLINE`.
+- `COPILOT_MODEL` sets the model (overridable by `--model`).
+
+## Verified: permission flags & tool IDs
+From `copilot help permissions`:
+- `--allow-tool` / `--deny-tool` / `--allow-all-tools`; denial precedence over allow.
+- Pattern form `kind(argument)`:
+  - `shell(command:*?)` — `shell` alone allows all shell commands; `shell(git:*)` matches prefixes.
+  - `write` — "tools that create and modify files, except shell tool invocations".
+  - `<mcp-server>(tool?)`, `url(domain?)`.
+- `--add-dir <directory>` (repeatable) scopes file access; `--allow-all-paths` disables path checks (we never use it).
+- `--no-ask-user` disables the `ask_user` tool (autonomous).
+- `--plan` starts plan mode.
+
+## Verified: session & privacy flags
+From `copilot --help`:
+- `-r, --resume[=value]` — resume by session ID, task ID, ID prefix (7+ hex), or **name** (exact, case-insensitive).
+- `-n, --name <name>` — set a name for the NEW session.
+- `--session-id <id>` — resume by ID, or set the UUID for a new session.
+- `--continue` — resume the most recent session.
+- `--remote` / `--no-remote` — enable/disable remote control of the session from GitHub web & mobile.
+- `--share[=path]` (markdown file) and `--share-gist` (secret gist) — opt-in only; nothing shared unless passed.
+- `COPILOT_HOME` overrides session/state dir (default `~/.copilot`).
+
+## Verified: optional-value flags accept `=` form (used by the adapter)
+`--resume=…`, `--secret-env-vars=A,B`, `--allow-tool=shell` all parse and reach the
+auth/session stage (vs `error: unknown option`). `--secret-env-vars` help:
+> Environment variable **names** whose values are stripped from shell and MCP
+> server environments and redacted from output (e.g., `--secret-env-vars=MY_KEY,OTHER_KEY`).

--- a/packages/agent-connector/test/fixtures/mock-copilot.js
+++ b/packages/agent-connector/test/fixtures/mock-copilot.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Mock GitHub Copilot CLI for adapter tests — no real `copilot`, GitHub account,
+ * or Copilot subscription required.
+ *
+ * Behaviour is anchored on REAL CLI v1.0.63 output
+ * (see test/fixtures/copilot-cli-real-samples.md):
+ *   - `--version` prints "GitHub Copilot CLI <v>." form.
+ *   - Auth/session/network failures print to STDERR, leave STDOUT EMPTY, exit 1
+ *     (there is NO JSONL error event on stdout in those cases).
+ *
+ * The SUCCESS-path JSONL (text/tool/file/done) is BEST-EFFORT and explicitly
+ * UNVERIFIED (no subscription was available to capture it); it exists only to
+ * exercise the adapter's event mapping, and does not assert the real schema.
+ *
+ * Env-driven:
+ *   MOCK_COPILOT_SCENARIO = success | error_auth | error_token | error_org |
+ *                           stale_session | timeout_silent | ask_user | crash
+ *   MOCK_COPILOT_VERSION  = printed for `--version` (default 1.0.63)
+ *   MOCK_COPILOT_ECHO_ARGS_FILE = if set, write argv (JSON) here for assertions
+ */
+'use strict';
+
+const fs = require('fs');
+
+const argv = process.argv.slice(2);
+
+if (argv.includes('--version') || argv.includes('-v')) {
+  process.stdout.write(`GitHub Copilot CLI ${process.env.MOCK_COPILOT_VERSION || '1.0.63'}.\n`);
+  process.exit(0);
+}
+
+if (process.env.MOCK_COPILOT_ECHO_ARGS_FILE) {
+  try { fs.writeFileSync(process.env.MOCK_COPILOT_ECHO_ARGS_FILE, JSON.stringify(argv)); } catch {}
+}
+
+const scenario = process.env.MOCK_COPILOT_SCENARIO || 'success';
+const emit = (obj) => process.stdout.write(JSON.stringify(obj) + '\n');
+// Real CLI uses `--resume=<value>` (optional-value flag), so detect both forms.
+const resuming = argv.some((a) => a === '--resume' || a.startsWith('--resume='));
+
+function failStderr(text, code = 1) {
+  process.stderr.write(text.endsWith('\n') ? text : text + '\n');
+  process.exit(code);
+}
+
+function run() {
+  switch (scenario) {
+    case 'success':
+      // BEST-EFFORT / UNVERIFIED success-path JSONL (see header).
+      emit({ type: 'session', session_id: 'mock-sess-123' });
+      emit({ type: 'reasoning', text: 'Looking at the project…' });
+      emit({ type: 'tool_call', name: 'shell', arguments: { command: 'ls -la' } });
+      emit({ type: 'tool_result', output: 'a.txt\nb.txt', exit_code: 0 });
+      emit({ type: 'command_execution', command: 'npm test', exit_code: 0, output: 'ok' });
+      emit({ type: 'file_change', path: 'src/x.js', action: 'write' });
+      emit({ type: 'text.delta', delta: 'All ' });
+      emit({ type: 'text.delta', delta: 'done.' });
+      emit({ type: 'message.completed', text: 'All done. Created src/x.js.' });
+      emit({ type: 'usage', model: 'mock-model', usage: { input: 5, output: 3 } });
+      emit({ type: 'done', status: 'completed' });
+      process.exit(0);
+      break;
+    case 'error_auth':
+      // Verified real stderr (no credentials), empty stdout, exit 1.
+      failStderr(
+        'Error: No authentication information found.\n\n' +
+        'Copilot can be authenticated with GitHub using an OAuth Token or a Fine-Grained Personal Access Token.\n\n' +
+        'To authenticate, you can use any of the following methods:\n' +
+        "  • Start 'copilot' and run the '/login' command\n" +
+        '  • Set the COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN environment variable\n' +
+        "  • Run 'gh auth login' to authenticate with the GitHub CLI\n");
+      break;
+    case 'error_token':
+      // Verified real stderr (token present but rejected), empty stdout, exit 1.
+      // NOTE: the real CLI appends the SAME "To authenticate … gh auth login"
+      // help block as the no-credentials error — included here so the classifier
+      // ordering (token-invalid must win over no-credentials) is actually tested.
+      failStderr(
+        'Error: Authentication token found but could not be validated.\n\n' +
+        '  Failed to fetch PAT user login (401): GitHub returned: Bad credentials\n\n' +
+        'Your token may still be valid. Check your network connection and try again.\n\n' +
+        'To authenticate, you can use any of the following methods:\n' +
+        "  • Start 'copilot' and run the '/login' command\n" +
+        '  • Set the COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN environment variable\n' +
+        "  • Run 'gh auth login' to authenticate with the GitHub CLI\n");
+      break;
+    case 'error_org':
+      failStderr('Error: Copilot CLI is disabled by your organization policy.\n');
+      break;
+    case 'stale_session':
+      if (resuming) {
+        // Verified real stderr for a resume miss, empty stdout, exit 1.
+        failStderr("Error: No session, task, or name matched 'mock-sess'.\n");
+      } else {
+        emit({ type: 'session', session_id: 'mock-sess-fresh' });
+        emit({ type: 'message.completed', text: 'Fresh session answer.' });
+        emit({ type: 'done' });
+        process.exit(0);
+      }
+      break;
+    case 'ask_user':
+      emit({ type: 'ask_user', question: 'Which file should I edit?' });
+      process.exit(0);
+      break;
+    case 'timeout_silent':
+      setInterval(() => {}, 1000); // hang until killed
+      break;
+    case 'crash':
+      failStderr('Segmentation fault', 139);
+      break;
+    default:
+      process.exit(0);
+  }
+}
+
+run();

--- a/packages/agent-connector/test/installer.test.js
+++ b/packages/agent-connector/test/installer.test.js
@@ -5,12 +5,40 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { Installer } = require('../src/installer');
+const { Installer, compareVersions, clearVersionCache } = require('../src/installer');
 
 let tmpDir;
 
 const mockRegistry = {
   getEntry: (name) => {
+    if (name === 'gated') {
+      return {
+        name: 'gated',
+        label: 'Gated CLI',
+        install: {
+          binary: 'gated-bin',
+          min_version: '1.2.0',
+          macos: 'npm install -g gated',
+          linux: 'npm install -g gated',
+        },
+      };
+    }
+    if (name === 'unverif') {
+      // Mirrors the Copilot pattern: token env vars + login command, but auth
+      // cannot be reliably probed offline (unverifiable).
+      return {
+        name: 'unverif',
+        label: 'Unverifiable Auth CLI',
+        install: { binary: 'unverif-bin', macos: 'npm install -g unverif', linux: 'npm install -g unverif' },
+        check_ready: {
+          env_vars: ['SOME_TOKEN'],
+          saved_env_key: 'SOME_TOKEN',
+          login_command: 'unverif login',
+          unverifiable: true,
+          not_ready_message: 'Sign-in not confirmed.',
+        },
+      };
+    }
     if (name === 'testpkg') {
       return {
         name: 'testpkg',
@@ -450,5 +478,109 @@ describe('Installer', () => {
       health.message,
       'Not configured. Set OPENAI_API_KEY + OPENAI_BASE_URL, or run: codex login'
     );
+  });
+});
+
+describe('Installer auth_status (generic unverifiable flag)', () => {
+  it('reports auth_status=ready when a token env var is present', () => {
+    process.env.SOME_TOKEN = 'x';
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'unverif-bin';
+    inst._detectVersion = () => '1.0.0';
+    const h = inst.healthCheck('unverif');
+    assert.equal(h.ready, true);
+    assert.equal(h.auth_status, 'ready');
+    delete process.env.SOME_TOKEN;
+  });
+
+  it('reports auth_status=unknown (not no_credentials) when unverifiable and no signal', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'unverif-bin';
+    inst._detectVersion = () => '1.0.0';
+    const h = inst.healthCheck('unverif');
+    assert.equal(h.ready, false);
+    assert.equal(h.auth_status, 'unknown', 'absence of a token must not be claimed as no_credentials');
+  });
+
+  it('reports auth_status=no_credentials for a normal (verifiable) agent with no creds', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'codex';
+    inst._checkStatusCommand = () => false;
+    const h = inst.healthCheck('codex');
+    assert.equal(h.ready, false);
+    assert.equal(h.auth_status, 'no_credentials');
+  });
+});
+
+describe('compareVersions (generic helper)', () => {
+  it('orders versions numerically, not lexically', () => {
+    assert.equal(compareVersions('1.2.0', '1.10.0'), -1);
+    assert.equal(compareVersions('2.0.0', '1.9.9'), 1);
+    assert.equal(compareVersions('1.2.0', '1.2.0'), 0);
+  });
+  it('ignores pre-release / build suffixes and extra segments', () => {
+    assert.equal(compareVersions('1.2.0-beta.3', '1.2.0'), 0);
+    assert.equal(compareVersions('0.0.331', '0.0.330'), 1);
+    assert.equal(compareVersions('1.2', '1.2.0'), 0);
+  });
+  it('returns null when a version is unparseable', () => {
+    assert.equal(compareVersions('unknown', '1.0.0'), null);
+    assert.equal(compareVersions(null, '1.0.0'), null);
+    assert.equal(compareVersions('1.0.0', ''), null);
+  });
+});
+
+describe('Installer min-version gate (generic, no per-agent special-casing)', () => {
+  beforeEach(() => clearVersionCache());
+
+  it('passes the gate and stays ready when version >= min_version', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'gated-bin';
+    inst._detectVersion = () => '1.5.0';
+    const h = inst.healthCheck('gated');
+    assert.equal(h.installed, true);
+    assert.equal(h.compatible, true);
+    assert.equal(h.min_version, '1.2.0');
+  });
+
+  it('blocks (installed=true, compatible=false, ready=false) when below min_version', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'gated-bin';
+    inst._detectVersion = () => '1.0.0';
+    const h = inst.healthCheck('gated');
+    assert.equal(h.installed, true, 'must NOT report not-installed for an old version');
+    assert.equal(h.compatible, false);
+    assert.equal(h.ready, false);
+    assert.match(h.message, /too old|upgrade/i);
+  });
+
+  it('reports compatible=null (unknown) — not a false pass — when version cannot be parsed', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'gated-bin';
+    inst._detectVersion = () => null;
+    const h = inst.healthCheck('gated');
+    assert.equal(h.installed, true);
+    assert.equal(h.compatible, null);
+  });
+
+  it('leaves the gate open (compatible=true) for entries without min_version', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => 'codex';
+    inst._checkStatusCommand = () => true;
+    const h = inst.healthCheck('codex');
+    assert.equal(h.compatible, true);
+    assert.equal(h.min_version, null);
+  });
+
+  it('caches a detected version and serves the same result within the TTL', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    // Use a real, fast version command so the cache path is genuinely exercised.
+    const v1 = inst._detectVersion('node', `"${process.execPath}" --version`);
+    assert.match(String(v1), /\d+\.\d+/);
+    const v2 = inst._detectVersion('node', `"${process.execPath}" --version`);
+    assert.equal(v2, v1, 'cached value returned on the second call');
+    clearVersionCache();
+    const v3 = inst._detectVersion('node', `"${process.execPath}" --version`);
+    assert.equal(v3, v1, 're-detection after cache clear yields the same version');
   });
 });

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -311,7 +311,7 @@ const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
  * an API key, so they're a rougher first-run experience than the key-only
  * agents; keep onboarding to the smoother options.
  */
-const ONBOARDING_HIDDEN = new Set<string>(["cursor", "hermes"])
+const ONBOARDING_HIDDEN = new Set<string>(["cursor", "hermes", "copilot"])
 
 /**
  * The agents the launcher/workspace core officially supports today, in the
@@ -332,6 +332,7 @@ const CORE_AGENTS: readonly string[] = [
   "hermes",
   "kimi",
   "gemini",
+  "copilot",
 ]
 const CORE_AGENT_ORDER = new Map<string, number>(
   CORE_AGENTS.map((name, i) => [name, i]),

--- a/sdk/src/openagents/registry/copilot.yaml
+++ b/sdk/src/openagents/registry/copilot.yaml
@@ -1,11 +1,23 @@
 name: copilot
 label: GitHub Copilot CLI
-description: GitHub Copilot coding agent for the terminal
-homepage: https://github.com/features/copilot
+description: GitHub's official Copilot coding agent for the terminal (the `copilot` CLI, not the retired `gh copilot` extension)
+homepage: https://github.com/github/copilot-cli
 tags: [coding, github, cli]
 
+# Official GitHub Copilot CLI — executable `copilot`, npm package `@github/copilot`.
+# This is NOT the deprecated `gh copilot` GitHub CLI extension; detection and
+# launch never touch `gh`.
+#
+# The executable adapter, readiness rules, min_version gate and support flags
+# live in the hand-maintained packages/agent-connector/registry.json (the JS
+# agent-connector is the runtime). This YAML stays catalog-only — like the other
+# non-builtin entries (aider/amp/cline/goose) — because the Python daemon was
+# removed; a Python adapter can be added later if that runtime is revived.
 install:
-  binary: gh
-  macos: "gh extension install github/gh-copilot"
-  linux: "gh extension install github/gh-copilot"
-  windows: "gh extension install github/gh-copilot"
+  binary: copilot
+  npm_package: "@github/copilot"
+  requires: [nodejs]
+  min_version: "1.0.0"
+  macos: "npm install -g @github/copilot"
+  linux: "npm install -g @github/copilot"
+  windows: "npm install -g @github/copilot"

--- a/workspace/backend/app/routers/network.py
+++ b/workspace/backend/app/routers/network.py
@@ -624,9 +624,9 @@ _AGENT_CATALOG = [
     {
         "name": "copilot",
         "label": "GitHub Copilot CLI",
-        "description": "GitHub Copilot coding agent for the terminal",
+        "description": "GitHub's official Copilot coding agent for the terminal (the `copilot` CLI, not the retired `gh copilot` extension)",
         "install_command": "npm install -g @github/copilot",
-        "homepage": "https://github.com/features/copilot",
+        "homepage": "https://github.com/github/copilot-cli",
         "tags": ["coding", "github", "cli"],
         "builtin": False,
     },


### PR DESCRIPTION
Add end-to-end GitHub Copilot CLI support for Workspace, including installation and version checks, authentication handling, secure task execution, JSONL streaming, session recovery, interruption, tests, and documentation.
