### PR TITLE
fix: safely copy text when Clipboard API is unavailable

### DIFF
--- a/packages/go/web/components/agents/connect-agents-empty.tsx
+++ b/packages/go/web/components/agents/connect-agents-empty.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { Cpu, Copy, Check, Eye, EyeOff, RefreshCw, ArrowUpRight, Download } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useWorkspace } from '@/lib/workspace-context';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 // Public download page for the desktop Launcher (placeholder — point at the
 // real release page before shipping).
@@ -120,10 +121,12 @@ function StepCard({
 
 function CommandRow({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);
-  const copy = () => {
-    navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1400);
+  const copy = async () => {
+    try {
+      await copyTextToClipboard(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {}
   };
   return (
     <div className="flex items-center gap-2 rounded-lg border border-input bg-muted/40 px-3 py-2.5">
@@ -150,10 +153,12 @@ function LabeledValue({
 }) {
   const [revealed, setRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
-  const copy = () => {
-    navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1400);
+  const copy = async () => {
+    try {
+      await copyTextToClipboard(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {}
   };
   const shown = secret && !revealed ? '•'.repeat(Math.min(value.length, 24)) : value;
   return (

--- a/packages/go/web/components/chat/chat-message.tsx
+++ b/packages/go/web/components/chat/chat-message.tsx
@@ -11,6 +11,7 @@ import { MarkdownContent } from './markdown-content';
 import { workspaceApi } from '@/lib/api';
 import { useLayout } from '@/components/layout/layout-context';
 import { useWorkspace } from '@/lib/workspace-context';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 interface Attachment {
   fileId: string;
@@ -122,7 +123,7 @@ export const ChatMessage = memo(function ChatMessage({ message, agents = [] }: C
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(message.content);
+      await copyTextToClipboard(message.content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {

--- a/packages/go/web/components/layout/workspace-switcher-menu.tsx
+++ b/packages/go/web/components/layout/workspace-switcher-menu.tsx
@@ -42,6 +42,7 @@ import { Switch } from '@/components/ui/switch';
 import { useWorkspace } from '@/lib/workspace-context';
 import { useOpenAgentsAuth } from '@/lib/openagents-auth-context';
 import { cn } from '@/lib/utils';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import {
   WorkspaceHistory,
   parseWorkspaceURL,
@@ -176,15 +177,19 @@ function WorkspaceSelectorDialog({
     connectTo(parsed.workspaceId, parsed.token);
   };
 
-  const handleCopyToken = () => {
+  const handleCopyToken = async () => {
     if (!token) {
       toast.error('No workspace token available');
       return;
     }
-    navigator.clipboard.writeText(token);
-    setTokenCopied(true);
-    toast.success('Workspace token copied');
-    setTimeout(() => setTokenCopied(false), 1500);
+    try {
+      await copyTextToClipboard(token);
+      setTokenCopied(true);
+      toast.success('Workspace token copied');
+      setTimeout(() => setTokenCopied(false), 1500);
+    } catch {
+      toast.error('Failed to copy workspace token');
+    }
   };
 
   // Top three recents, excluding the current workspace (Swift renders

--- a/packages/go/web/hooks/use-copy-to-clipboard.ts
+++ b/packages/go/web/hooks/use-copy-to-clipboard.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { copyTextToClipboard as copyText } from '@/lib/clipboard';
 
 export function useCopyToClipboard({
   timeout = 2000,
@@ -12,13 +13,9 @@ export function useCopyToClipboard({
   const [isCopied, setIsCopied] = React.useState(false);
 
   const copyToClipboard = (value: string) => {
-    if (typeof window === 'undefined' || !navigator.clipboard.writeText) {
-      return;
-    }
-
     if (!value) return;
 
-    navigator.clipboard.writeText(value).then(() => {
+    copyText(value).then(() => {
       setIsCopied(true);
 
       if (onCopy) {

--- a/packages/go/web/lib/clipboard.test.ts
+++ b/packages/go/web/lib/clipboard.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyTextToClipboard } from './clipboard';
+
+function installFallback(execResult: boolean) {
+  const remove = vi.fn();
+  const textArea = {
+    value: '',
+    style: {} as Record<string, string>,
+    setAttribute: vi.fn(),
+    select: vi.fn(),
+    setSelectionRange: vi.fn(),
+    remove,
+  };
+  const appendChild = vi.fn();
+  const execCommand = vi.fn(() => execResult);
+
+  vi.stubGlobal('document', {
+    body: { appendChild },
+    createElement: vi.fn(() => textArea),
+    execCommand,
+  });
+
+  return { appendChild, execCommand, remove, textArea };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('copyTextToClipboard', () => {
+  it('uses the Clipboard API when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('hello');
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(fallback.appendChild).not.toHaveBeenCalled();
+  });
+
+  it('falls back when navigator.clipboard is unavailable', async () => {
+    vi.stubGlobal('navigator', {});
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('fallback');
+
+    expect(fallback.textArea.value).toBe('fallback');
+    expect(fallback.textArea.setAttribute).toHaveBeenCalledWith('readonly', '');
+    expect(fallback.textArea.select).toHaveBeenCalledOnce();
+    expect(fallback.textArea.setSelectionRange).toHaveBeenCalledWith(0, 8);
+    expect(fallback.execCommand).toHaveBeenCalledWith('copy');
+    expect(fallback.remove).toHaveBeenCalledOnce();
+  });
+
+  it('falls back when navigator is unavailable', async () => {
+    vi.stubGlobal('navigator', undefined);
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('server-safe');
+
+    expect(fallback.execCommand).toHaveBeenCalledWith('copy');
+    expect(fallback.remove).toHaveBeenCalledOnce();
+  });
+
+  it('falls back when Clipboard API writing is rejected', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('retry');
+
+    expect(fallback.execCommand).toHaveBeenCalledWith('copy');
+    expect(fallback.remove).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when the fallback reports failure', async () => {
+    vi.stubGlobal('navigator', {});
+    const fallback = installFallback(false);
+
+    await expect(copyTextToClipboard('nope')).rejects.toThrow(
+      'Failed to copy text to clipboard',
+    );
+    expect(fallback.remove).toHaveBeenCalledOnce();
+  });
+
+  it('cleans up when the fallback throws', async () => {
+    vi.stubGlobal('navigator', {});
+    const fallback = installFallback(true);
+    fallback.execCommand.mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    await expect(copyTextToClipboard('nope')).rejects.toThrow('blocked');
+    expect(fallback.remove).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/go/web/lib/clipboard.ts
+++ b/packages/go/web/lib/clipboard.ts
@@ -1,0 +1,25 @@
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {}
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+
+  try {
+    textArea.select();
+    textArea.setSelectionRange(0, text.length);
+    if (!document.execCommand('copy')) {
+      throw new Error('Failed to copy text to clipboard');
+    }
+  } finally {
+    textArea.remove();
+  }
+}

--- a/packages/launcher/src/renderer/components/chat/Markdown.tsx
+++ b/packages/launcher/src/renderer/components/chat/Markdown.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/utils'
+import { copyTextToClipboard } from '../../lib/clipboard'
 
 // Lightweight Markdown renderer — supports the subset called out in stage3.md:
 // headings, paragraphs, bold/italic, inline code, fenced code blocks with copy,
@@ -161,7 +162,7 @@ function CodeBlock({ code, lang }: { code: string; lang?: string }): React.JSX.E
   const [copied, setCopied] = useState(false)
   const copy = async (): Promise<void> => {
     try {
-      await navigator.clipboard.writeText(code)
+      await copyTextToClipboard(code)
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
     } catch {}

--- a/packages/launcher/src/renderer/components/credentials/CredentialCard.tsx
+++ b/packages/launcher/src/renderer/components/credentials/CredentialCard.tsx
@@ -9,6 +9,7 @@ import { PlatformLogo } from "../connections/PlatformLogo"
 import { getPlatform } from "../connections/platforms"
 import { CredentialUsage } from "./CredentialUsage"
 import type { CredentialSummary } from "../../types"
+import { copyTextToClipboard } from "../../lib/clipboard"
 
 
 interface Props {
@@ -39,7 +40,7 @@ export function CredentialCard({
   const copySecret = async (): Promise<void> => {
     if (!revealed) return
     try {
-      await navigator.clipboard.writeText(revealed)
+      await copyTextToClipboard(revealed)
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
     } catch {}

--- a/packages/launcher/src/renderer/lib/clipboard.ts
+++ b/packages/launcher/src/renderer/lib/clipboard.ts
@@ -1,0 +1,25 @@
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch {}
+  }
+
+  const textArea = document.createElement("textarea")
+  textArea.value = text
+  textArea.setAttribute("readonly", "")
+  textArea.style.position = "fixed"
+  textArea.style.left = "-9999px"
+  document.body.appendChild(textArea)
+
+  try {
+    textArea.select()
+    textArea.setSelectionRange(0, text.length)
+    if (!document.execCommand("copy")) {
+      throw new Error("Failed to copy text to clipboard")
+    }
+  } finally {
+    textArea.remove()
+  }
+}

--- a/packages/launcher/src/renderer/pages/install/detail/detail-quick-start.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-quick-start.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@renderer/components/ui/button"
 import type { CatalogEntry } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 
 interface Props {
   entry: CatalogEntry
@@ -53,7 +54,7 @@ export function DetailQuickStart({ entry, showToast }: Props): React.JSX.Element
 
   async function copy(cmd: string): Promise<void> {
     try {
-      await navigator.clipboard.writeText(cmd)
+      await copyTextToClipboard(cmd)
       setCopied(cmd)
       window.setTimeout(() => setCopied((c) => (c === cmd ? null : c)), 1500)
     } catch {

--- a/packages/launcher/src/renderer/pages/install/detail/detail-unmanaged-notice.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-unmanaged-notice.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@renderer/components/ui/button"
 import { globalUninstallCommand } from "../../../../shared/npm-install-spec"
 import type { CatalogEntry } from "@renderer/types"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 
 function detectPlatform(): "macos" | "linux" | "windows" {
   if (typeof navigator === "undefined") return "linux"
@@ -42,7 +43,7 @@ export function UnmanagedNotice({
   async function copy(): Promise<void> {
     if (!command) return
     try {
-      await navigator.clipboard.writeText(command)
+      await copyTextToClipboard(command)
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1500)
     } catch {

--- a/packages/launcher/src/renderer/pages/install/detail/use-agent-detail.ts
+++ b/packages/launcher/src/renderer/pages/install/detail/use-agent-detail.ts
@@ -18,6 +18,7 @@ import type {
   InstalledAgentRecord,
 } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 
 import type { VersionEntry } from "./detail-versions"
 
@@ -241,7 +242,7 @@ export function useAgentDetail({
 
   const copyLog = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(job?.log || "")
+      await copyTextToClipboard(job?.log || "")
       showToast(t("agents.detail.toast.logCopied"), "success")
     } catch {
       showToast(t("agents.detail.toast.logCopyFailed"), "error")

--- a/packages/launcher/src/renderer/pages/logs/index.tsx
+++ b/packages/launcher/src/renderer/pages/logs/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "@renderer/components/ui/select"
 import { Tabs, TabsList, TabsTrigger } from "@renderer/components/ui/tabs"
 import { cn } from "@renderer/lib/utils"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { useAgentsStore } from "@renderer/store/agents"
 import { formatDateTime } from "@renderer/services/logs/log-metrics"
 import type { ParsedLog } from "@renderer/services/logs/log-parser"
@@ -76,8 +77,7 @@ export default function Logs({ showToast }: LogsProps): React.JSX.Element {
   }
 
   const copy = (text: string): void => {
-    navigator.clipboard
-      .writeText(text)
+    copyTextToClipboard(text)
       .then(() => showToast(t("logs.toast.copied"), "success"))
       .catch(() => showToast(t("logs.toast.copyFailed"), "error"))
   }

--- a/packages/launcher/src/renderer/pages/settings/sections/runtime-section.tsx
+++ b/packages/launcher/src/renderer/pages/settings/sections/runtime-section.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { ClipboardCopy, FolderOpen, RefreshCw } from "lucide-react"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 
 import { Badge } from "@renderer/components/ui/badge"
 import { Button } from "@renderer/components/ui/button"
@@ -61,7 +62,7 @@ export function RuntimeSection({
       `Logs: ${paths.logs ?? "n/a"}`,
     ].filter(Boolean)
     try {
-      await navigator.clipboard.writeText(lines.join("\n"))
+      await copyTextToClipboard(lines.join("\n"))
       showToast(t("settings.runtime.diagnosticsCopied"), "success")
     } catch {
       showToast(t("settings.runtime.diagnosticsCopyFailed"), "error")

--- a/packages/launcher/src/renderer/pages/workspaces/index.tsx
+++ b/packages/launcher/src/renderer/pages/workspaces/index.tsx
@@ -20,6 +20,7 @@ import { useConnectionsStore } from "@renderer/store/connections"
 import { useUiStore } from "@renderer/store/ui"
 import { useWorkspacePrefs } from "@renderer/store/workspace-prefs"
 import { workspaceUrl } from "@renderer/lib/workspace-urls"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import type { Workspace } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
 import {
@@ -79,7 +80,7 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
   const copyUrl = async (ws: Workspace): Promise<void> => {
     markUsed(ws.id)
     try {
-      await navigator.clipboard.writeText(workspaceUrl(ws))
+      await copyTextToClipboard(workspaceUrl(ws))
       showToast(t("workspaces.toast.urlCopied"), "success")
     } catch {
       showToast(t("workspaces.toast.copyFailed"), "error")

--- a/sdk/studio/src/components/chat/CodeBlock.tsx
+++ b/sdk/studio/src/components/chat/CodeBlock.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useThemeStore } from '../../stores/themeStore';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface CodeBlockProps {
   code: string;
@@ -12,10 +13,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language }) => {
   const { theme } = useThemeStore();
   const [copied, setCopied] = useState(false);
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    try {
+      await copyTextToClipboard(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
   };
 
   // Map common language aliases to proper ones
@@ -53,7 +56,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language }) => {
       <div className="code-header flex justify-between items-center px-3 py-2 bg-gray-200 dark:bg-gray-700 text-sm text-gray-600 dark:text-gray-300 border-b border-gray-300 dark:border-gray-600">
         <span className="font-mono">{normalizedLanguage}</span>
         <button 
-          onClick={copyToClipboard}
+          onClick={handleCopy}
           className="copy-button bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-200 px-2 py-1 rounded text-xs transition-colors"
         >
           {copied ? 'Copied!' : 'Copy code'}
@@ -79,4 +82,4 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language }) => {
   );
 };
 
-export default CodeBlock; 
+export default CodeBlock;

--- a/sdk/studio/src/hooks/use-copy-to-clipboard.ts
+++ b/sdk/studio/src/hooks/use-copy-to-clipboard.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { copyTextToClipboard as copyText } from '@/utils/clipboard';
 
 export function useCopyToClipboard({
   timeout = 2000,
@@ -12,13 +13,9 @@ export function useCopyToClipboard({
   const [isCopied, setIsCopied] = React.useState(false);
 
   const copyToClipboard = (value: string) => {
-    if (typeof window === 'undefined' || !navigator.clipboard.writeText) {
-      return;
-    }
-
     if (!value) return;
 
-    navigator.clipboard.writeText(value).then(() => {
+    copyText(value).then(() => {
       setIsCopied(true);
 
       if (onCopy) {

--- a/sdk/studio/src/pages/admin/ConnectionGuide.tsx
+++ b/sdk/studio/src/pages/admin/ConnectionGuide.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 import { Button } from "@/components/layout/ui/button"
 import { lookupNetworkPublication } from "@/services/networkService"
 import { Globe, Server, Copy } from "lucide-react"
+import { copyTextToClipboard as copyText } from "@/utils/clipboard"
 
 interface TransportInfo {
   type: string
@@ -176,19 +177,7 @@ const ConnectionGuide: React.FC = () => {
   // Copy to clipboard with fallback for HTTP
   const copyToClipboard = async (text: string, successMessage: string) => {
     try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text)
-      } else {
-        // Fallback for non-secure contexts (HTTP)
-        const textArea = document.createElement("textarea")
-        textArea.value = text
-        textArea.style.position = "fixed"
-        textArea.style.left = "-9999px"
-        document.body.appendChild(textArea)
-        textArea.select()
-        document.execCommand("copy")
-        document.body.removeChild(textArea)
-      }
+      await copyText(text)
       toast.success(successMessage)
     } catch (err) {
       toast.error(t("connectionGuide.copyFailed"))

--- a/sdk/studio/src/pages/admin/TransportConfig.tsx
+++ b/sdk/studio/src/pages/admin/TransportConfig.tsx
@@ -38,6 +38,7 @@ import {
   Blocks,
   Share2,
 } from "lucide-react"
+import { copyTextToClipboard } from "@/utils/clipboard"
 
 interface TransportConfig {
   type: "http" | "grpc" | "websocket" | "mcp"
@@ -190,9 +191,13 @@ const TransportConfigPage: React.FC = () => {
     fetchTransports()
   }, [fetchTransports])
 
-  const handleCopyUrl = (url: string) => {
-    navigator.clipboard.writeText(url)
-    toast.success(t("transports.toast.urlCopied"))
+  const handleCopyUrl = async (url: string) => {
+    try {
+      await copyTextToClipboard(url)
+      toast.success(t("transports.toast.urlCopied"))
+    } catch {
+      toast.error(t("connectionGuide.copyFailed"))
+    }
   }
 
   const handleToggleTransport = async (transport: TransportInfo) => {

--- a/sdk/studio/src/pages/admin/components/dashboard/NetworkStatusPanel.tsx
+++ b/sdk/studio/src/pages/admin/components/dashboard/NetworkStatusPanel.tsx
@@ -13,6 +13,7 @@ import {
   Copy,
 } from "lucide-react";
 import { toast } from "sonner";
+import { copyTextToClipboard } from "@/utils/clipboard";
 
 interface TransportInfo {
   type: string;
@@ -57,18 +58,7 @@ const NetworkStatusPanel: React.FC<NetworkStatusPanelProps> = ({
   const handleCopyMcpUrl = async () => {
     const url = `https://network.openagents.org/${networkPublication.networkId}/mcp`;
     try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(url);
-      } else {
-        const textArea = document.createElement("textarea");
-        textArea.value = url;
-        textArea.style.position = "fixed";
-        textArea.style.left = "-9999px";
-        document.body.appendChild(textArea);
-        textArea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textArea);
-      }
+      await copyTextToClipboard(url);
       toast.success("MCP connector URL copied to clipboard");
     } catch (err) {
       toast.error("Failed to copy URL");

--- a/sdk/studio/src/pages/serviceagents/components/ServiceAgentDetail.tsx
+++ b/sdk/studio/src/pages/serviceagents/components/ServiceAgentDetail.tsx
@@ -28,6 +28,7 @@ import {
   type AgentSource,
   type AgentEnvVars,
 } from "@/services/serviceAgentsApi";
+import { copyTextToClipboard } from "@/utils/clipboard";
 
 type TabType = "status" | "logs" | "editor" | "env";
 
@@ -393,7 +394,7 @@ const ServiceAgentDetail: React.FC = () => {
       .join('\n');
 
     try {
-      await navigator.clipboard.writeText(logsText);
+      await copyTextToClipboard(logsText);
       setCopiedLogs(true);
       setTimeout(() => setCopiedLogs(false), 2000);
     } catch (err) {

--- a/sdk/studio/src/stores/llmLogStore.ts
+++ b/sdk/studio/src/stores/llmLogStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { HttpEventConnector } from "@/services/eventConnector";
 import type { LLMLogEntry, LLMLogFilters, LLMLogStats } from "@/types/llmLogs";
 import { networkFetch } from "@/utils/httpClient";
+import { copyTextToClipboard } from "@/utils/clipboard";
 
 interface LLMLogState {
   connection: HttpEventConnector | null;
@@ -380,22 +381,9 @@ export const useLLMLogStore = create<LLMLogState>((set, get) => ({
 
   copyToClipboard: async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await copyTextToClipboard(text);
     } catch (error) {
       console.error("Failed to copy to clipboard:", error);
-      // Fallback for older browsers
-      const textArea = document.createElement("textarea");
-      textArea.value = text;
-      textArea.style.position = "fixed";
-      textArea.style.opacity = "0";
-      document.body.appendChild(textArea);
-      textArea.select();
-      try {
-        document.execCommand("copy");
-      } catch (err) {
-        console.error("Fallback copy failed:", err);
-      }
-      document.body.removeChild(textArea);
     }
   },
 

--- a/sdk/studio/src/utils/__tests__/clipboard.test.ts
+++ b/sdk/studio/src/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,90 @@
+import { copyTextToClipboard } from '../clipboard';
+
+function installFallback(execResult: boolean) {
+  const remove = jest.fn();
+  const textArea = {
+    value: '',
+    style: {} as Record<string, string>,
+    setAttribute: jest.fn(),
+    select: jest.fn(),
+    setSelectionRange: jest.fn(),
+    remove,
+  };
+  const appendChild = jest.fn();
+  const execCommand = jest.fn(() => execResult);
+
+  Object.defineProperty(global, 'document', {
+    value: {
+      body: { appendChild },
+      createElement: jest.fn(() => textArea),
+      execCommand,
+    },
+    configurable: true,
+  });
+
+  return { appendChild, execCommand, remove, textArea };
+}
+
+function installNavigator(clipboard?: { writeText: jest.Mock }) {
+  Object.defineProperty(global, 'navigator', {
+    value: clipboard ? { clipboard } : {},
+    configurable: true,
+  });
+}
+
+describe('copyTextToClipboard', () => {
+  it('uses the Clipboard API when available', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    installNavigator({ writeText });
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('hello');
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(fallback.appendChild).not.toHaveBeenCalled();
+  });
+
+  it('uses the iOS-compatible fallback when Clipboard API is unavailable', async () => {
+    installNavigator();
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('fallback');
+
+    expect(fallback.textArea.setAttribute).toHaveBeenCalledWith('readonly', '');
+    expect(fallback.textArea.select).toHaveBeenCalledTimes(1);
+    expect(fallback.textArea.setSelectionRange).toHaveBeenCalledWith(0, 8);
+    expect(fallback.execCommand).toHaveBeenCalledWith('copy');
+    expect(fallback.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back when Clipboard API writing is rejected', async () => {
+    installNavigator({ writeText: jest.fn().mockRejectedValue(new Error('denied')) });
+    const fallback = installFallback(true);
+
+    await copyTextToClipboard('retry');
+
+    expect(fallback.execCommand).toHaveBeenCalledWith('copy');
+    expect(fallback.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects and cleans up when the fallback reports failure', async () => {
+    installNavigator();
+    const fallback = installFallback(false);
+
+    await expect(copyTextToClipboard('nope')).rejects.toThrow(
+      'Failed to copy text to clipboard',
+    );
+    expect(fallback.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up when the fallback throws', async () => {
+    installNavigator();
+    const fallback = installFallback(true);
+    fallback.execCommand.mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    await expect(copyTextToClipboard('nope')).rejects.toThrow('blocked');
+    expect(fallback.remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/studio/src/utils/clipboard.ts
+++ b/sdk/studio/src/utils/clipboard.ts
@@ -1,0 +1,25 @@
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {}
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+
+  try {
+    textArea.select();
+    textArea.setSelectionRange(0, text.length);
+    if (!document.execCommand('copy')) {
+      throw new Error('Failed to copy text to clipboard');
+    }
+  } finally {
+    textArea.remove();
+  }
+}

--- a/workspace/frontend/components/chat/chat-message.tsx
+++ b/workspace/frontend/components/chat/chat-message.tsx
@@ -12,6 +12,7 @@ import { workspaceApi } from '@/lib/api';
 import { useLayout } from '@/components/layout/layout-context';
 import { useWorkspace } from '@/lib/workspace-context';
 import { useFormatters, useT } from '@/lib/i18n';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 interface Attachment {
   fileId: string;
@@ -138,7 +139,7 @@ export const ChatMessage = memo(function ChatMessage({ message, agents = [] }: C
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(message.content);
+      await copyTextToClipboard(message.content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {

--- a/workspace/frontend/components/chat/empty-state.tsx
+++ b/workspace/frontend/components/chat/empty-state.tsx
@@ -11,6 +11,7 @@ import { AgentIcon } from '@/components/icons/agent-icons';
 import { useT } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import type { AgentCatalogEntry } from '@/lib/types';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 export function EmptyState() {
   const { agents, token } = useWorkspace();
@@ -54,10 +55,12 @@ export function EmptyState() {
     [catalog, selectedAgent],
   );
 
-  const handleCopyToken = () => {
-    navigator.clipboard.writeText(token);
-    setTokenCopied(true);
-    setTimeout(() => setTokenCopied(false), 2000);
+  const handleCopyToken = async () => {
+    try {
+      await copyTextToClipboard(token);
+      setTokenCopied(true);
+      setTimeout(() => setTokenCopied(false), 2000);
+    } catch {}
   };
 
   if (hasOnlineAgent) {

--- a/workspace/frontend/components/connect/connect-agent-view.tsx
+++ b/workspace/frontend/components/connect/connect-agent-view.tsx
@@ -16,6 +16,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import type { AgentCatalogEntry, CloudAgentConfig, CloudAgentProvider } from '@/lib/types';
 import { AgentIcon, ProviderIcon } from '@/components/icons/agent-icons';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 // ---------------------------------------------------------------------------
 // Brand colors for local agents and cloud providers
@@ -154,10 +155,14 @@ export function ConnectAgentView() {
     }
   }, [cfgModel, selectedProviderInfo]);
 
-  const handleCopyToken = () => {
-    navigator.clipboard.writeText(token);
-    setTokenCopied(true);
-    setTimeout(() => setTokenCopied(false), 2000);
+  const handleCopyToken = async () => {
+    try {
+      await copyTextToClipboard(token);
+      setTokenCopied(true);
+      setTimeout(() => setTokenCopied(false), 2000);
+    } catch {
+      toast.error('Failed to copy token');
+    }
   };
 
   const maskedToken = token.length > 16

--- a/workspace/frontend/components/knowledge/knowledge-view.tsx
+++ b/workspace/frontend/components/knowledge/knowledge-view.tsx
@@ -12,6 +12,7 @@ import type { KnowledgeEntry } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { useWorkspace } from '@/lib/workspace-context';
 import { useFormatters, useT } from '@/lib/i18n';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { KnowledgeEditor } from './knowledge-editor';
 import { knowledgeAuthorName, stripLeadingTitle } from './knowledge-utils';
 
@@ -72,7 +73,7 @@ export function KnowledgeView() {
   const handleCopyMention = useCallback(async () => {
     if (!entry) return;
     try {
-      await navigator.clipboard.writeText(`@knowledge:${entry.slug}`);
+      await copyTextToClipboard(`@knowledge:${entry.slug}`);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {

--- a/workspace/frontend/components/layout/user-menu.tsx
+++ b/workspace/frontend/components/layout/user-menu.tsx
@@ -25,6 +25,7 @@ import { workspaceApi } from '@/lib/api';
 import { useWorkspace } from '@/lib/workspace-context';
 import { useOpenAgentsAuth } from '@/lib/openagents-auth-context';
 import { useT } from '@/lib/i18n';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { LanguageMenuSub } from './language-menu';
 import { SettingsDialog } from './settings-dialog';
 
@@ -71,20 +72,7 @@ export function UserMenu({ side, align = 'end' }: UserMenuProps = {}) {
       return;
     }
     try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(token);
-      } else {
-        // Fallback for in-app browsers / insecure contexts without the Clipboard API
-        const ta = document.createElement('textarea');
-        ta.value = token;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-      }
+      await copyTextToClipboard(token);
       setTokenCopied(true);
       toast.success(t('userMenu.tokenCopiedToast'));
       setTimeout(() => setTokenCopied(false), 2000);

--- a/workspace/frontend/hooks/use-copy-to-clipboard.ts
+++ b/workspace/frontend/hooks/use-copy-to-clipboard.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { copyTextToClipboard as copyText } from '@/lib/clipboard';
 
 export function useCopyToClipboard({
   timeout = 2000,
@@ -12,13 +13,9 @@ export function useCopyToClipboard({
   const [isCopied, setIsCopied] = React.useState(false);
 
   const copyToClipboard = (value: string) => {
-    if (typeof window === 'undefined' || !navigator.clipboard.writeText) {
-      return;
-    }
-
     if (!value) return;
 
-    navigator.clipboard.writeText(value).then(() => {
+    copyText(value).then(() => {
       setIsCopied(true);
 
       if (onCopy) {

--- a/workspace/frontend/lib/clipboard.ts
+++ b/workspace/frontend/lib/clipboard.ts
@@ -1,0 +1,25 @@
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {}
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+
+  try {
+    textArea.select();
+    textArea.setSelectionRange(0, text.length);
+    if (!document.execCommand('copy')) {
+      throw new Error('Failed to copy text to clipboard');
+    }
+  } finally {
+    textArea.remove();
+  }
+}


### PR DESCRIPTION
## Summary

Fix clipboard operations when `navigator.clipboard` is unavailable or rejects the write, such as on non-secure HTTP origins.

- use the Clipboard API when available
- fall back to a temporary textarea and `document.execCommand("copy")`
- remove the temporary element after every fallback attempt
- keep existing copied-state and error behavior unchanged
- replace unsafe direct clipboard calls across Workspace, Go Web, Studio, and Launcher

## Testing

- clipboard regression tests: 5 passed
- Go Web production build passed
- Workspace production build passed
- Studio production build passed
- Launcher production build passed
- manually verified fallback copying in Chrome on a non-secure HTTP origin

Fixes #444