### PR TITLE
fix: redact credentials from agent status messages

### DIFF
--- a/packages/agent-connector/src/adapters/base.js
+++ b/packages/agent-connector/src/adapters/base.js
@@ -18,7 +18,11 @@
 'use strict';
 
 const { WorkspaceClient, SessionRevokedError } = require('../workspace-client');
-const { generateSessionTitle, SESSION_DEFAULT_RE } = require('./utils');
+const {
+  generateSessionTitle,
+  redactSensitiveHeaders,
+  SESSION_DEFAULT_RE,
+} = require('./utils');
 const { defaultAgentWorkdir } = require('../paths');
 
 const DEFAULT_ENDPOINT = 'https://workspace-endpoint.openagents.org';
@@ -697,7 +701,8 @@ class BaseAdapter {
 
   async sendStatus(channel, content, extraMeta) {
     try {
-      await this.client.sendMessage(this.workspaceId, channel, this.token, content, {
+      const safeContent = redactSensitiveHeaders(content);
+      await this.client.sendMessage(this.workspaceId, channel, this.token, safeContent, {
         senderType: 'agent',
         senderName: this.agentName,
         messageType: 'status',

--- a/packages/agent-connector/src/adapters/utils.js
+++ b/packages/agent-connector/src/adapters/utils.js
@@ -100,8 +100,20 @@ function formatAttachmentsForPrompt(attachments, toolMode = 'mcp', isWindows = p
   return lines.join('\n');
 }
 
+/**
+ * Redact credentials from HTTP headers embedded in status text.
+ */
+function redactSensitiveHeaders(text) {
+  if (typeof text !== 'string' || !text) return text;
+  return text.replace(
+    /(\b(?:authorization|(?:[a-z0-9]+-)*(?:token|key))\s*:\s*)(?:(?:bearer|basic|token)\s+)?[^\s"'`]+/gi,
+    '$1[REDACTED]'
+  );
+}
+
 module.exports = {
   SESSION_DEFAULT_RE,
   generateSessionTitle,
   formatAttachmentsForPrompt,
+  redactSensitiveHeaders,
 };

--- a/packages/agent-connector/test/adapter-utils.test.js
+++ b/packages/agent-connector/test/adapter-utils.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const BaseAdapter = require('../src/adapters/base');
+const { redactSensitiveHeaders } = require('../src/adapters/utils');
+
+describe('redactSensitiveHeaders', () => {
+  it('redacts workspace tokens in quoted curl headers', () => {
+    const command = 'curl -H "X-Workspace-Token: workspace-secret" https://example.test';
+    assert.equal(
+      redactSensitiveHeaders(command),
+      'curl -H "X-Workspace-Token: [REDACTED]" https://example.test'
+    );
+  });
+
+  it('redacts authorization schemes and credentials', () => {
+    assert.equal(
+      redactSensitiveHeaders("curl -H 'Authorization: Bearer bearer-secret'"),
+      "curl -H 'Authorization: [REDACTED]'"
+    );
+    assert.equal(
+      redactSensitiveHeaders('Authorization: Basic dXNlcjpwYXNz'),
+      'Authorization: [REDACTED]'
+    );
+  });
+
+  it('redacts generic token and key headers case-insensitively', () => {
+    assert.equal(
+      redactSensitiveHeaders('X-Auth-Token: abc X-API-Key: def'),
+      'X-Auth-Token: [REDACTED] X-API-Key: [REDACTED]'
+    );
+  });
+
+  it('leaves non-sensitive headers unchanged', () => {
+    const command = 'curl -H "Content-Type: application/json" -H "Accept: */*"';
+    assert.equal(redactSensitiveHeaders(command), command);
+  });
+
+  it('passes through empty and non-string values', () => {
+    assert.equal(redactSensitiveHeaders(''), '');
+    assert.equal(redactSensitiveHeaders(null), null);
+  });
+
+  it('redacts status content before sending it to the workspace', async () => {
+    const adapter = new BaseAdapter({
+      workspaceId: 'ws',
+      channelName: 'main',
+      token: 'workspace-token',
+      agentName: 'codex',
+    });
+    let sentContent;
+    adapter.client = {
+      sendMessage: async (_workspaceId, _channel, _token, content) => {
+        sentContent = content;
+      },
+    };
+
+    await adapter.sendStatus(
+      'main',
+      '**Running:** `curl -H "X-Workspace-Token: workspace-secret"`'
+    );
+
+    assert.equal(
+      sentContent,
+      '**Running:** `curl -H "X-Workspace-Token: [REDACTED]"`'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Redact sensitive HTTP header values before agent status messages are sent to a workspace.

- sanitize status content centrally in `BaseAdapter.sendStatus()`
- redact `Authorization`, `*-Token`, and `*-Key` header values
- preserve non-sensitive headers and surrounding command text
- cover direct helper behavior and the shared status-send path

## Testing

- `node --test test/adapter-utils.test.js` — 6 passed
- Node syntax checks passed for the modified source and test files
- full agent-connector suite: 450 passed; unrelated existing Windows/environment-dependent tests failed
- lint could not run because the package's existing lint script references an unavailable `eslint` executable

Fixes #437