### PR TITLE
fix: remove missing setup.cfg from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Python project files
-COPY pyproject.toml setup.py setup.cfg MANIFEST.in ./
+COPY pyproject.toml setup.py MANIFEST.in ./
 COPY sdk/src/ ./sdk/src/
 
 # Install Python dependencies


### PR DESCRIPTION
## Summary

Remove the nonexistent `setup.cfg` file from the root Dockerfile's project-file `COPY` instruction.

The repository no longer contains `setup.cfg`, so Docker fails before reaching dependency installation:

```text
"/setup.cfg": not found
```

## Testing

- verified every source in the updated `COPY` instruction exists
- `git diff --check` passes

Fixes #353