### PR TITLE
feat: add Requesty as an OpenAI-compatible LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ agn connect my-aider <workspace-token>              # connect Aider into a works
 
 **Provider, model & key.** `AIDER_PROVIDER` decides which provider environment
 variable your `LLM_API_KEY` is injected into. It accepts `auto` (default),
-`openai`, `anthropic`, `openrouter`, `gemini`, `deepseek`, or
+`openai`, `anthropic`, `openrouter`, `requesty`, `gemini`, `deepseek`, or
 `openai-compatible`:
 
 | `AIDER_PROVIDER` | Key injected as | Notes |
@@ -166,6 +166,7 @@ variable your `LLM_API_KEY` is injected into. It accepts `auto` (default),
 | `anthropic` | `ANTHROPIC_API_KEY` | e.g. `AIDER_MODEL=sonnet` / `opus` / `claude-3-5-sonnet-20241022` |
 | `openai` | `OPENAI_API_KEY` | e.g. `AIDER_MODEL=gpt-4o` |
 | `openrouter` | `OPENROUTER_API_KEY` | e.g. `AIDER_MODEL=openrouter/anthropic/claude-3.5-sonnet` |
+| `requesty` | `REQUESTY_API_KEY` | e.g. `AIDER_MODEL=requesty/openai/gpt-4o` |
 | `gemini` | `GEMINI_API_KEY` | e.g. `AIDER_MODEL=gemini/gemini-1.5-pro` |
 | `deepseek` | `DEEPSEEK_API_KEY` | e.g. `AIDER_MODEL=deepseek/deepseek-chat` |
 | `openai-compatible` | `OPENAI_API_KEY` + `OPENAI_API_BASE` | **requires `LLM_BASE_URL`**; the model is normalized to `openai/<model>` |

--- a/llms.txt
+++ b/llms.txt
@@ -579,6 +579,7 @@ This allows you to configure LLM settings once at the environment level rather t
 | `together` | `TOGETHER_API_KEY` | meta-llama/Llama-2-70b-chat-hf |
 | `perplexity` | `PERPLEXITY_API_KEY` | llama-3.1-sonar-huge-128k-online |
 | `openrouter` | `OPENROUTER_API_KEY` | (any model via OpenRouter) |
+| `requesty` | `REQUESTY_API_KEY` | (any model via Requesty) |
 | `bedrock` | `AWS_ACCESS_KEY_ID` | anthropic.claude-3-5-sonnet |
 | `custom` | `CUSTOM_API_KEY` | (requires DEFAULT_LLM_BASE_URL) |
 

--- a/sdk/src/openagents/config/llm_configs.py
+++ b/sdk/src/openagents/config/llm_configs.py
@@ -27,6 +27,7 @@ class LLMProviderType(str, Enum):
     PERPLEXITY = "perplexity"
     GROQ = "groq"
     OPENROUTER = "openrouter"
+    REQUESTY = "requesty"
     MINIMAX = "minimax"
     LITELLM = "litellm"
     CUSTOM = "custom"  # Custom OpenAI-compatible endpoint
@@ -185,6 +186,13 @@ MODEL_CONFIGS: Dict[str, Dict[str, Any]] = {
         "api_base": "https://openrouter.ai/api/v1",
         "models": [],  # User specifies model name (e.g., "anthropic/claude-3-opus")
         "API_KEY_ENV_VAR": "OPENROUTER_API_KEY",
+    },
+    # Requesty (OpenAI-compatible LLM gateway)
+    "requesty": {
+        "provider": "generic",
+        "api_base": "https://router.requesty.ai/v1",
+        "models": [],  # User specifies model name (e.g., "openai/gpt-4o-mini")
+        "API_KEY_ENV_VAR": "REQUESTY_API_KEY",
     },
     # MiniMax
     "minimax": {
@@ -495,6 +503,7 @@ def create_model_provider(
         "perplexity",
         "groq",
         "openrouter",
+        "requesty",
     ]:
         # Use predefined API base if not provided
         if not api_base and provider in MODEL_CONFIGS:


### PR DESCRIPTION
## What this adds

Adds a `requesty` provider entry mirroring the existing `openrouter` entry:

- OpenAI-compatible base URL: `https://router.requesty.ai/v1`
- API key env var: `REQUESTY_API_KEY`
- `provider/model` naming (e.g. `openai/gpt-4o-mini`), same convention as OpenRouter

### Changes

- `sdk/src/openagents/config/llm_configs.py`
  - `REQUESTY = "requesty"` added to the `LLMProviderType` enum next to `OPENROUTER`
  - A `requesty` entry added to `MODEL_CONFIGS` with `provider: generic`, the base URL, and `API_KEY_ENV_VAR`
  - `"requesty"` added to the generic-provider list so its predefined `api_base` is used
- `README.md` — added `requesty` to the accepted `AIDER_PROVIDER` values and a table row
- `llms.txt` — added a `requesty` provider table row

### Testing

Ran a live chat completion against `https://router.requesty.ai/v1/chat/completions` with model `openai/gpt-4o-mini` and got an HTTP 200 with a valid completion. Also imported the modified module and confirmed `LLMProviderType.REQUESTY` and `MODEL_CONFIGS["requesty"]` resolve as expected.

### Links

- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
