### PR TITLE
distinguish Amp runtime readiness from installation

### DIFF
--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -104,7 +104,7 @@
     ],
     "check_ready": {
       "login_command": "amp login",
-      "not_ready_message": "Not installed — run: openagents install amp"
+      "not_ready_message": "Amp is installed but not signed in — run: amp login or set AMP_API_KEY"
     }
   },
   {

--- a/packages/agent-connector/src/adapters/amp.js
+++ b/packages/agent-connector/src/adapters/amp.js
@@ -30,6 +30,7 @@ const { execSync, spawn } = require('child_process');
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
 const { whichBinary, getEnhancedEnv } = require('../paths');
+const { REASON, classifySpawnError, redactDiagnostic, shouldUseShellForBinary } = require('./health-status');
 
 const IS_WINDOWS = process.platform === 'win32';
 // Terminate the subprocess if it produces no output for this long (a wedged
@@ -145,6 +146,27 @@ class AmpAdapter extends BaseAdapter {
     return null;
   }
 
+  /**
+   * Preflight gate (run by the daemon before join). Amp needs a resolvable CLI
+   * binary to do anything useful, so when none can be found we surface a precise
+   * 'runtime_missing' reason and skip the workspace join entirely — instead of
+   * joining and then failing every message. This is also the one place that
+   * logs the resolved Amp path for diagnostics. NOTE: 'runtime_missing' (binary
+   * gone at run time), NOT 'not_installed' — install detection lives elsewhere.
+   */
+  preflight() {
+    if (!this._ampBin) this._ampBin = this._findAmpBinary();
+    if (!this._ampBin) {
+      return {
+        ok: false,
+        reason: REASON.RUNTIME_MISSING,
+        message: `Amp CLI not found — install with: ${ampInstallHint()}`,
+      };
+    }
+    this._log(`Amp CLI resolved: ${this._ampBin}`);
+    return { ok: true };
+  }
+
   // ------------------------------------------------------------------
   // Prompt / command construction
   // ------------------------------------------------------------------
@@ -222,7 +244,9 @@ class AmpAdapter extends BaseAdapter {
 
     if (!this._ampBin) this._ampBin = this._findAmpBinary();
     if (!this._ampBin) {
-      await this.sendError(msgChannel, `Amp CLI not found. Install with: ${ampInstallHint()}`);
+      const message = `Amp CLI not found — install with: ${ampInstallHint()}`;
+      this._reportStatus(REASON.RUNTIME_MISSING, message);
+      await this.sendError(msgChannel, message);
       return;
     }
 
@@ -234,8 +258,25 @@ class AmpAdapter extends BaseAdapter {
     try {
       responseText = await this._runAmp(content, msgChannel);
     } catch (e) {
-      this._log(`Error handling message: ${e.message}`);
-      await this.sendError(msgChannel, `Error processing message: ${e.message}`);
+      // A failure to LAUNCH the amp process (ENOENT/EACCES/spawn error) is a
+      // distinct, actionable failure — surface it as spawn_failed with the
+      // resolved path + code, never a generic "Not installed". Other errors keep
+      // a redacted generic message. Both report up so the agent row shows why.
+      if (this._isSpawnError(e)) {
+        const { reason, message } = classifySpawnError(e, {
+          label: 'Amp',
+          bin: this._ampBin,
+        });
+        this._log(message);
+        this._reportStatus(reason, message);
+        await this.sendError(msgChannel, message);
+      } else {
+        this._log(`Error handling message: ${redactDiagnostic(e.message)}`);
+        await this.sendError(
+          msgChannel,
+          `Error processing message: ${redactDiagnostic(e.message)}`,
+        );
+      }
       return;
     }
 
@@ -243,11 +284,27 @@ class AmpAdapter extends BaseAdapter {
       this._stoppingChannels.delete(msgChannel);
       return;
     }
+    // A successful turn proves the runtime is healthy — clear any prior
+    // spawn/runtime error the agent row may be showing.
+    this._reportStatus(null);
     if (responseText) {
       await this.sendResponse(msgChannel, responseText);
     } else {
       await this.sendResponse(msgChannel, 'No response generated. Please try again.');
     }
+  }
+
+  /** True when an error is a child_process spawn failure (vs. a runtime error). */
+  _isSpawnError(e) {
+    if (!e) return false;
+    const code = e.code || e.errno;
+    return (
+      e.syscall === 'spawn' ||
+      e.syscall === 'spawn amp' ||
+      code === 'ENOENT' ||
+      code === 'EACCES' ||
+      code === 'EPERM'
+    );
   }
 
   // ------------------------------------------------------------------
@@ -299,9 +356,15 @@ class AmpAdapter extends BaseAdapter {
         cwd: this.workingDir,
         detached: !IS_WINDOWS,
         windowsHide: true,
-        shell: IS_WINDOWS && String(cmd[0]).toLowerCase().endsWith('.cmd'),
+        // Windows .cmd/.bat shims (npm/pnpm/yarn global bins) are not directly
+        // executable — must go through a shell. Shared helper so the daemon,
+        // adapter and launcher probe all agree on the rule.
+        shell: shouldUseShellForBinary(cmd[0]),
       });
       this._channelProcesses[msgChannel] = proc;
+      // Diagnostic: the exact argv we launched (no secrets — flags only). The
+      // resolved binary path was logged at preflight/init.
+      this._log(`Running Amp: ${cmd.map((c) => String(c)).join(' ')}`);
 
       let lastTurnText = [];
       let resultText = '';

--- a/packages/agent-connector/src/adapters/base.js
+++ b/packages/agent-connector/src/adapters/base.js
@@ -20,8 +20,20 @@
 const { WorkspaceClient, SessionRevokedError } = require('../workspace-client');
 const { generateSessionTitle, SESSION_DEFAULT_RE } = require('./utils');
 const { defaultAgentWorkdir } = require('../paths');
+const {
+  REASON,
+  classifyJoinError,
+  classifyHeartbeatError,
+} = require('./health-status');
 
 const DEFAULT_ENDPOINT = 'https://workspace-endpoint.openagents.org';
+
+// Heartbeat runs every 30s. A SINGLE failure is usually a transient blip (brief
+// network hiccup, server redeploy) that the next tick recovers from — surfacing
+// it as a hard 'error' would make the agent flap red for no real reason. Only
+// after this many CONSECUTIVE failures (~60s+ of real downtime) do we report
+// heartbeat_failed up to the daemon. A success resets the streak immediately.
+const HEARTBEAT_ERROR_THRESHOLD = 2;
 
 class BaseAdapter {
   /**
@@ -32,7 +44,7 @@ class BaseAdapter {
    * @param {string} opts.agentName
    * @param {string} [opts.endpoint]
    */
-  constructor({ workspaceId, channelName, token, agentName, endpoint, agentEnv, agentType, workingDir }) {
+  constructor({ workspaceId, channelName, token, agentName, endpoint, agentEnv, agentType, workingDir, onStatus }) {
     this.workspaceId = workspaceId;
     this.channelName = channelName;
     this.token = token;
@@ -41,6 +53,21 @@ class BaseAdapter {
     this.agentEnv = agentEnv || process.env;
     this.agentType = agentType;
     this.workingDir = workingDir || undefined;
+    // Optional callback the daemon supplies to surface live runtime/connectivity
+    // status (reason + redacted message) into daemon.status.json so the Agents
+    // list / TUI can show the REAL failure instead of a swallowed log line. A
+    // null reason means "healthy again" (clears any prior error).
+    this._onStatus = typeof onStatus === 'function' ? onStatus : null;
+    this._lastReportedStatusKey = null;
+    // Consecutive heartbeat failures — a transient single blip must not flip the
+    // agent to a hard error (see HEARTBEAT_ERROR_THRESHOLD).
+    this._heartbeatFailStreak = 0;
+    // Structured terminal exit reason ({ reason, message }) read by the daemon
+    // after run() returns, to distinguish a clean stop from a real failure.
+    this._exitInfo = null;
+    // Set when the user explicitly stops this adapter (vs an error/revoke), so a
+    // clean stop is never mislabeled as an error.
+    this._stopRequested = false;
     this.client = new WorkspaceClient(this.endpoint);
     this._lastEventId = null;
     this._lastToolResultId = null;
@@ -71,13 +98,62 @@ class BaseAdapter {
   }
 
   // ------------------------------------------------------------------
+  // Runtime status reporting (daemon surfaces this in daemon.status.json)
+  // ------------------------------------------------------------------
+
+  /**
+   * Surface a live status transition to the daemon. `reason` null/'' means the
+   * agent is healthy again (clears any prior error). Deduped so a repeated
+   * failure (e.g. heartbeat every 30s on a down workspace) writes the status
+   * file once, not on every tick. Never throws — status is best-effort.
+   */
+  _reportStatus(reason, message) {
+    const key = `${reason || ''}|${message || ''}`;
+    if (key === this._lastReportedStatusKey) return;
+    this._lastReportedStatusKey = key;
+    if (!this._onStatus) return;
+    try {
+      this._onStatus({ reason: reason || null, message: message || null });
+    } catch { /* status is best-effort */ }
+  }
+
+  /** Record the FIRST terminal failure reason; later teardown noise can't mask it. */
+  _setExitInfo(reason, message) {
+    if (!this._exitInfo) this._exitInfo = { reason, message };
+  }
+
+  /** Read by the daemon after run() returns. null = clean exit. */
+  getExitInfo() {
+    return this._exitInfo;
+  }
+
+  /** True when stop() was called explicitly (a clean user stop, not a failure). */
+  wasStopRequested() {
+    return this._stopRequested === true;
+  }
+
+  /**
+   * Preflight gate, run by the daemon BEFORE join. Default: always runnable.
+   * Subclasses whose agent needs a resolvable CLI binary override this to return
+   * { ok:false, reason:'runtime_missing', message } so the daemon surfaces a
+   * precise reason and skips the workspace join (no pointless join loop).
+   */
+  preflight() {
+    return { ok: true };
+  }
+
+  // ------------------------------------------------------------------
   // Lifecycle
   // ------------------------------------------------------------------
 
-  async run() {
-    this._running = true;
-
-    // Announce agent to workspace
+  /**
+   * Announce this agent to the workspace (/v1/join). Returns true on success.
+   * On failure surfaces the REAL reason (e.g. "Workspace join failed: HTTP 401")
+   * to the daemon status instead of only logging it — non-fatal, the poll/
+   * heartbeat loops keep retrying and a later success clears it. Extracted from
+   * run() so the failure-reporting can be unit-tested without the poll loop.
+   */
+  async _joinWorkspace() {
     try {
       const joinResult = await this.client.joinNetwork(this.agentName, this.token, {
         network: this.workspaceId,
@@ -87,9 +163,21 @@ class BaseAdapter {
       });
       this._sessionId = (joinResult && joinResult.session_id) || null;
       this._log(`Joined workspace ${this.workspaceId}${this._sessionId ? ` (session ${this._sessionId.slice(0, 8)})` : ''}`);
+      this._reportStatus(null); // joined OK → clear any prior error
+      return true;
     } catch (e) {
-      this._log(`Warning: join failed: ${e.message} \nStack: ${e.stack}`);
+      const { reason, message } = classifyJoinError(e);
+      this._log(`${message} (status: ${e && e.statusCode != null ? e.statusCode : 'n/a'})`);
+      this._reportStatus(reason, message);
+      return false;
     }
+  }
+
+  async run() {
+    this._running = true;
+
+    // Announce agent to workspace
+    await this._joinWorkspace();
 
     // Sync workspace-managed skills into disabledModules
     try {
@@ -137,6 +225,7 @@ class BaseAdapter {
   }
 
   stop() {
+    this._stopRequested = true;
     this._running = false;
   }
 
@@ -164,13 +253,25 @@ class BaseAdapter {
   async _heartbeat() {
     try {
       await this.client.heartbeat(this.workspaceId, this.agentName, this.token, this._sessionId);
+      this._heartbeatFailStreak = 0;
+      this._reportStatus(null); // alive → clear any prior connectivity error
     } catch (e) {
       if (e instanceof SessionRevokedError) {
         this._log(`SESSION REVOKED: another client joined as '${this.agentName}'. Stopping adapter.`);
+        // Terminal (not a user stop): record so the daemon can show why it ended.
+        this._setExitInfo(REASON.SESSION_REVOKED, 'Workspace session revoked — another client joined with the same agent name');
+        this._reportStatus(REASON.SESSION_REVOKED, 'Workspace session revoked');
         this._running = false;
         return;
       }
-      this._log(`Heartbeat failed: ${e.message}`);
+      // Only surface a hard error after repeated consecutive failures, so a
+      // single transient blip (or an expected brief reconnect) isn't mislabeled.
+      this._heartbeatFailStreak++;
+      const { reason, message } = classifyHeartbeatError(e);
+      this._log(`${message} (consecutive failures: ${this._heartbeatFailStreak})`);
+      if (this._heartbeatFailStreak >= HEARTBEAT_ERROR_THRESHOLD) {
+        this._reportStatus(reason, message);
+      }
     }
   }
 

--- a/packages/agent-connector/src/adapters/health-status.js
+++ b/packages/agent-connector/src/adapters/health-status.js
@@ -1,0 +1,166 @@
+'use strict';
+
+/**
+ * Single source of truth for agent readiness / runtime-failure classification.
+ *
+ * The Install page, the Agents list, the daemon and the TUI must all speak the
+ * same vocabulary about WHY an agent is or isn't usable. Mixing "not installed"
+ * (a genuinely missing executable) with "installed but signed out" or "spawn
+ * failed" is exactly the bug this module exists to prevent.
+ *
+ * Hard rule: REASON.NOT_INSTALLED is ONLY for a binary that cannot be resolved
+ * at all. An installed-but-signed-out agent is REASON.LOGIN_REQUIRED. A binary
+ * that resolved at install time but fails to start at run time is
+ * REASON.RUNTIME_MISSING / REASON.SPAWN_FAILED — never NOT_INSTALLED.
+ *
+ * Everything here is pure and dependency-free so it can be required from the
+ * daemon, the adapters AND the Electron launcher (via
+ * `@openagents-org/agent-launcher/src/adapters/health-status`).
+ */
+
+const REASON = {
+  READY: 'ready',
+  NOT_INSTALLED: 'not_installed', // executable cannot be resolved anywhere
+  LOGIN_REQUIRED: 'login_required', // installed, but no usable login / API key
+  VERSION_INCOMPATIBLE: 'version_incompatible',
+  RUNTIME_MISSING: 'runtime_missing', // resolved at install time, gone at run time
+  SPAWN_FAILED: 'spawn_failed', // child_process spawn errored (ENOENT/EACCES/…)
+  WORKSPACE_JOIN_FAILED: 'workspace_join_failed',
+  HEARTBEAT_FAILED: 'heartbeat_failed',
+  SESSION_REVOKED: 'session_revoked',
+  ADAPTER_CRASHED: 'adapter_crashed',
+};
+
+// Reasons that represent a genuine failure the UI should surface as an error
+// (red dot / X) rather than a benign "needs configuration" state.
+const ERROR_REASONS = new Set([
+  REASON.RUNTIME_MISSING,
+  REASON.SPAWN_FAILED,
+  REASON.WORKSPACE_JOIN_FAILED,
+  REASON.HEARTBEAT_FAILED,
+  REASON.SESSION_REVOKED,
+  REASON.ADAPTER_CRASHED,
+]);
+
+/** True when a reason should render as a hard error (daemon state 'error'). */
+function isErrorReason(reason) {
+  return ERROR_REASONS.has(reason);
+}
+
+/**
+ * Readiness reason from an (installed, ready) pair. The ONLY place that decides
+ * "not_installed vs login_required", so the Install page and the Agents list
+ * can never disagree.
+ */
+function readinessReason(installed, ready) {
+  if (!installed) return REASON.NOT_INSTALLED;
+  return ready ? REASON.READY : REASON.LOGIN_REQUIRED;
+}
+
+/**
+ * Whether a resolved binary path must be launched through a shell. On Windows,
+ * `.cmd`/`.bat` shims (npm/pnpm/yarn global bins, and amp.cmd) are NOT directly
+ * executable via CreateProcess — Node's spawn needs shell:true or it throws
+ * EINVAL/ENOENT. Mirrors the amp adapter's own _spawnAmp handling so the
+ * launcher probe, the Test-connection path and the daemon all behave the same.
+ */
+function shouldUseShellForBinary(bin, platform) {
+  const plat = platform || process.platform;
+  return plat === 'win32' && /\.(cmd|bat)$/i.test(String(bin || ''));
+}
+
+/**
+ * Strip secrets from a diagnostic string before it reaches a log, the daemon
+ * status file or the UI. Removes tokens / api keys / bearer headers / cookies /
+ * URL credentials / long opaque tokens, and caps the length. Never throws.
+ */
+function redactDiagnostic(input, maxLen = 300) {
+  let s = String(input == null ? '' : input);
+  try {
+    s = s
+      // key=value / key: value for sensitive keys (token, api_key, secret, …)
+      .replace(
+        /((?:access[_-]?|api[_-]?|auth[_-]?)?(?:tokens?|keys?|secrets?|passwords?|cookies?)\s*[=:]\s*)(\S+)/gi,
+        '$1<redacted>',
+      )
+      // Authorization: Bearer xxxxx
+      .replace(/(bearer\s+)[A-Za-z0-9._\-]+/gi, '$1<redacted>')
+      // URL userinfo  scheme://user:pass@host
+      .replace(/(\b[a-z][a-z0-9+.\-]*:\/\/)[^/@\s:]+:[^/@\s]+@/gi, '$1<redacted>@')
+      // Known opaque token prefixes
+      .replace(/\b(?:sgp_|sk-|ghp_|gho_|xox[baprs]-)[A-Za-z0-9._\-]+/g, '<redacted>')
+      // Generic long opaque blobs (>= 40 chars)
+      .replace(/\b[A-Za-z0-9_\-]{40,}\b/g, '<redacted>');
+  } catch {
+    /* keep best-effort */
+  }
+  s = s.replace(/\s+/g, ' ').trim();
+  if (s.length > maxLen) s = s.slice(0, maxLen) + '…';
+  return s;
+}
+
+/** Pull a numeric HTTP status off a workspace-client error, if present. */
+function httpStatusOf(err) {
+  if (!err) return null;
+  const sc = err.statusCode != null ? err.statusCode : err.status;
+  return typeof sc === 'number' ? sc : null;
+}
+
+/** Classify a workspace JOIN failure → { reason, message } (redacted). */
+function classifyJoinError(err) {
+  const sc = httpStatusOf(err);
+  let detail;
+  if (sc === 401 || sc === 403) detail = `authentication rejected (HTTP ${sc})`;
+  else if (sc === 404) detail = 'workspace not found (HTTP 404)';
+  else if (typeof sc === 'number') detail = `HTTP ${sc}`;
+  else detail = redactDiagnostic(err && err.message) || 'network error';
+  return {
+    reason: REASON.WORKSPACE_JOIN_FAILED,
+    message: `Workspace join failed: ${detail}`,
+  };
+}
+
+/** Classify a workspace HEARTBEAT failure → { reason, message } (redacted). */
+function classifyHeartbeatError(err) {
+  const sc = httpStatusOf(err);
+  const detail =
+    typeof sc === 'number'
+      ? `HTTP ${sc}`
+      : redactDiagnostic(err && err.message) || 'network error';
+  return {
+    reason: REASON.HEARTBEAT_FAILED,
+    message: `Workspace heartbeat failed: ${detail}`,
+  };
+}
+
+/**
+ * Classify a child_process spawn failure (the CLI could not be started) →
+ * { reason, message } (redacted). `label` names the agent ("Amp"), `bin` is the
+ * resolved path included for diagnostics (it is a filesystem path, not a secret).
+ */
+function classifySpawnError(err, opts) {
+  const { label = 'Agent', bin = null } = opts || {};
+  const code = (err && (err.code || err.errno)) || '';
+  const where = bin ? ` [${bin}]` : '';
+  let detail;
+  if (code === 'ENOENT') detail = `executable not found${where}`;
+  else if (code === 'EACCES' || code === 'EPERM')
+    detail = `permission denied${where}`;
+  else detail = (redactDiagnostic((err && err.message) || code) || 'spawn error') + where;
+  return {
+    reason: REASON.SPAWN_FAILED,
+    message: `${label} process failed to start: ${detail}`,
+  };
+}
+
+module.exports = {
+  REASON,
+  isErrorReason,
+  readinessReason,
+  shouldUseShellForBinary,
+  redactDiagnostic,
+  httpStatusOf,
+  classifyJoinError,
+  classifyHeartbeatError,
+  classifySpawnError,
+};

--- a/packages/agent-connector/src/agent-rows.js
+++ b/packages/agent-connector/src/agent-rows.js
@@ -40,7 +40,16 @@ function loadAgentRows(connector) {
     let health = null;
     try {
       health = connector.healthCheck(agent.type || 'openclaw');
-      if (health && !health.ready) notReadyMsg = health.message || 'Not configured';
+      if (health && !health.ready) {
+        // "Not installed" only when the executable is genuinely missing; an
+        // installed-but-signed-out agent shows its login/config message, never
+        // "Not installed". Mirrors the launcher's formatHealthLabel rule.
+        const notInstalled =
+          health.reason === 'not_installed' || health.installed === false;
+        notReadyMsg = notInstalled
+          ? 'Not installed'
+          : health.message || 'Not configured';
+      }
     } catch {}
 
     return {
@@ -55,6 +64,9 @@ function loadAgentRows(connector) {
       path: agent.path || '',
       network: agent.network || '',
       lastError: info.last_error || '',
+      // Structured daemon failure reason (spawn_failed / workspace_join_failed /
+      // heartbeat_failed / runtime_missing / …) paired with lastError.
+      errorReason: info.error_reason || '',
       notReadyMsg,
       health,
       configured: true,

--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -210,6 +210,7 @@ class Daemon {
         restarts: info.restarts,
         started_at: info.startedAt || null,
         last_error: info.lastError || null,
+        error_reason: info.errorReason || null,
       };
     }
     return result;
@@ -363,6 +364,9 @@ class Daemon {
       restarts: 0,
       startedAt: null,
       lastError: null,
+      // Structured failure reason (health-status REASON) paired with lastError,
+      // so the UI/TUI can classify "why" without parsing the message.
+      errorReason: null,
       proc: null,
       _backoff: 2,
     };
@@ -472,9 +476,33 @@ class Daemon {
   // Internal — adapter loop (workspace-connected agents)
   // ---------------------------------------------------------------------------
 
+  /**
+   * Apply a live status update reported by a running adapter (join/heartbeat
+   * health). A genuine failure reason → state 'error' + redacted last_error so
+   * the Agents list / TUI show the real cause; a null reason → recovered, clear
+   * the error. Ignored once the agent is stopping (a user stop must win).
+   */
+  _applyAdapterStatus(name, info, update) {
+    if (!update || this._shuttingDown || this._stoppedAgents.has(name)) return;
+    const { isErrorReason, redactDiagnostic } = require('./adapters/health-status');
+    const reason = update.reason || null;
+    if (reason && isErrorReason(reason)) {
+      info.state = 'error';
+      info.errorReason = reason;
+      info.lastError = redactDiagnostic(update.message || reason);
+    } else {
+      // Recovered / healthy again — clear any prior connectivity error.
+      if (info.state === 'error') info.state = 'running';
+      info.errorReason = null;
+      info.lastError = null;
+    }
+    this._writeStatus();
+  }
+
   async _adapterLoop(name, agentCfg, info, network) {
     const { createAdapter } = require('./adapters');
     const { skillsToDisabledModules } = require('./skill-catalog');
+    const { redactDiagnostic } = require('./adapters/health-status');
     const agentType = agentCfg.type || 'openclaw';
     const endpoint = network.endpoint || 'https://workspace-endpoint.openagents.org';
 
@@ -501,13 +529,37 @@ class Daemon {
         // .claude/skills there failed with EPERM. Root it under ~/.openagents.
         workingDir: agentCfg.path || defaultAgentWorkdir(name),
         toolMode: agentCfg.tool_mode || 'skills',
+        // Live runtime/connectivity status → daemon.status.json (Agents list/TUI).
+        onStatus: (update) => this._applyAdapterStatus(name, info, update),
       });
     } catch (e) {
-      this._log(`${name} failed to create ${agentType} adapter: ${e.message}`);
+      // A construction failure (e.g. unknown agent type in this core) is a hard
+      // error with a real cause — surface it (redacted), do not pretend stopped.
       info.state = 'error';
-      info.lastError = e.message;
+      info.errorReason = 'adapter_crashed';
+      info.lastError = redactDiagnostic(e.message || String(e));
+      this._log(`${name} failed to create ${agentType} adapter: ${info.lastError}`);
       this._writeStatus();
       return;
+    }
+
+    // Preflight: when the agent's runtime binary is genuinely missing, surface a
+    // precise reason ('runtime_missing') and DO NOT join the workspace — there is
+    // no point spinning a join/poll loop that can never run the CLI. Adapters
+    // that don't override preflight() always pass.
+    try {
+      const pf =
+        typeof adapter.preflight === 'function' ? adapter.preflight() : null;
+      if (pf && pf.ok === false) {
+        info.state = 'error';
+        info.errorReason = pf.reason || 'runtime_missing';
+        info.lastError = redactDiagnostic(pf.message || 'runtime not available');
+        this._writeStatus();
+        this._log(`${name} preflight failed (${info.errorReason}): ${info.lastError}`);
+        return;
+      }
+    } catch (e) {
+      this._log(`${name} preflight error (ignored, continuing): ${e.message}`);
     }
 
     // Store adapter reference for stop and duplicate detection
@@ -515,6 +567,8 @@ class Daemon {
 
     info.state = 'running';
     info.startedAt = new Date().toISOString();
+    info.lastError = null;
+    info.errorReason = null;
     this._writeStatus();
     this._log(`${name} adapter online → ${network.slug} (type: ${agentType})`);
 
@@ -531,14 +585,41 @@ class Daemon {
       await adapter.run();
       clearInterval(checkStop);
     } catch (e) {
-      info.lastError = (e.message || String(e)).slice(0, 200);
+      info.errorReason = info.errorReason || 'adapter_crashed';
+      info.lastError = redactDiagnostic((e.message || String(e)).slice(0, 200));
       this._log(`${name} adapter error: ${info.lastError}`);
     }
 
     delete this._adapters[name];
-    info.state = 'stopped';
+
+    // Final state: a clean stop (user stop / daemon shutdown) is NEVER an error.
+    // A terminal failure recorded by the adapter (join/heartbeat/session-revoked)
+    // or a crash surfaces as 'error' with its classified, redacted reason.
+    const userStopped =
+      this._shuttingDown ||
+      this._stoppedAgents.has(name) ||
+      (typeof adapter.wasStopRequested === 'function' && adapter.wasStopRequested());
+    if (userStopped) {
+      info.state = 'stopped';
+      info.lastError = null;
+      info.errorReason = null;
+    } else {
+      const exit =
+        (typeof adapter.getExitInfo === 'function' && adapter.getExitInfo()) ||
+        null;
+      if (exit && exit.reason) {
+        info.state = 'error';
+        info.errorReason = exit.reason;
+        info.lastError = redactDiagnostic(exit.message || exit.reason);
+      } else if (info.errorReason) {
+        // A crash, or a live error report that never recovered — keep it visible.
+        info.state = 'error';
+      } else {
+        info.state = 'stopped';
+      }
+    }
     this._writeStatus();
-    this._log(`${name} adapter stopped`);
+    this._log(`${name} adapter stopped (state: ${info.state})`);
   }
 
   // NOTE: Adapter-specific message handling (openclaw, claude, codex)

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { execSync, exec } = require('child_process');
 const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache, aiderBinDirs } = require('./paths');
 const { EnvManager } = require('./env');
+const { readinessReason, REASON } = require('./adapters/health-status');
 
 const STATUS_CACHE_TTL_MS = 10000;
 const statusCache = new Map();
@@ -381,17 +382,20 @@ class Installer {
           auth_mode: null,
           auth_status: null,
           execution_mode: 'unavailable',
+          reason: REASON.NOT_INSTALLED,
           message: 'Not installed',
         };
       }
 
+      const apiReadiness = this._evaluateReadiness(agentType, entry, null);
       return {
         installed: true,
         binary: null,
         version: null,
         compatible: true,
         min_version: null,
-        ...this._evaluateReadiness(agentType, entry, null),
+        reason: readinessReason(true, apiReadiness.ready),
+        ...apiReadiness,
       };
     }
 
@@ -407,6 +411,7 @@ class Installer {
         auth_mode: null,
         auth_status: null,
         execution_mode: 'unavailable',
+        reason: REASON.NOT_INSTALLED,
         message: 'Not installed',
       };
     }
@@ -438,6 +443,12 @@ class Installer {
       version,
       compatible: gate.compatible,
       min_version: gate.minVersion,
+      // Installed is proven (binary resolved). A not-ready installed agent is a
+      // login/config state, never "not installed" — version mismatch aside.
+      reason:
+        gate.compatible === false
+          ? REASON.VERSION_INCOMPATIBLE
+          : readinessReason(true, readiness.ready),
       ...readiness,
     };
   }

--- a/packages/agent-connector/src/tui.js
+++ b/packages/agent-connector/src/tui.js
@@ -67,7 +67,14 @@ function getConnector() {
 
 function describeHealth(health) {
   if (!health) return '';
-  if (!health.ready) return health.message || 'Not configured';
+  if (!health.ready) {
+    // "Not installed" is reserved for a genuinely missing executable; an
+    // installed-but-signed-out agent shows its login/config message instead.
+    if (health.reason === 'not_installed' || health.installed === false) {
+      return 'Not installed';
+    }
+    return health.message || 'Not configured';
+  }
   const parts = ['Ready'];
   if (health.auth_mode === 'api_key') parts.push('API key');
   else if (health.auth_mode === 'cli_login') parts.push('CLI login');
@@ -283,11 +290,14 @@ function createTUI() {
         // Local-only agents (no workspace) show a dimmed "(local)" marker.
         const ws = r.workspace || `{gray-fg}${r.workspaceLabel}{/gray-fg}`;
         items.push(`  ${r.name.padEnd(22)} ${r.type.padEnd(14)} ${state.padEnd(30)} ${ws}`);
-        // Detail row: working dir + config warning
+        // Detail row: working dir + config warning + the REAL runtime error
+        // (spawn/join/heartbeat) when the daemon reported one, so a failure shows
+        // its actual cause instead of a swallowed/"Not installed" guess.
         const details = [];
         details.push(r.path || process.env.HOME || '~');
         if (r.health) details.push(`{cyan-fg}${describeHealth(r.health)}{/cyan-fg}`);
         if (r.notReadyMsg) details.push(`{yellow-fg}⚠ ${r.notReadyMsg}{/yellow-fg}`);
+        if (r.lastError) details.push(`{red-fg}✗ ${r.lastError}{/red-fg}`);
         items.push(`  {gray-fg}  ${details.join('  |  ')}{/gray-fg}`);
       }
       agentList.setItems(items);

--- a/packages/agent-connector/test/adapter-status-lifecycle.test.js
+++ b/packages/agent-connector/test/adapter-status-lifecycle.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * BaseAdapter lifecycle status reporting — the mechanism that surfaces the REAL
+ * workspace failure (join / heartbeat / session-revoked) to the daemon status
+ * instead of swallowing it in a log line.
+ *
+ *   - join 401            → onStatus(workspace_join_failed), returns false
+ *   - join ok             → onStatus(null) [healthy], returns true
+ *   - heartbeat 5xx       → onStatus(heartbeat_failed)
+ *   - heartbeat ok        → onStatus(null)
+ *   - session revoked     → getExitInfo() = session_revoked, _running=false
+ *   - none of the above   → message NEVER contains "not installed"
+ *
+ * Run: node --test test/adapter-status-lifecycle.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const BaseAdapter = require('../src/adapters/base');
+const { SessionRevokedError } = require('../src/workspace-client');
+const { REASON } = require('../src/adapters/health-status');
+
+function makeAdapter() {
+  const calls = [];
+  const a = new BaseAdapter({
+    workspaceId: 'w',
+    channelName: 'general',
+    token: 't',
+    agentName: 'a',
+    endpoint: 'http://127.0.0.1:0',
+    onStatus: (u) => calls.push(u),
+  });
+  a._log = () => {};
+  return { a, calls };
+}
+
+const httpErr = (statusCode) => Object.assign(new Error(`HTTP ${statusCode}`), { statusCode });
+
+describe('preflight default', () => {
+  it('BaseAdapter is runnable by default', () => {
+    const { a } = makeAdapter();
+    assert.deepEqual(a.preflight(), { ok: true });
+  });
+});
+
+describe('_reportStatus dedupe', () => {
+  it('collapses identical consecutive reports, fires on change', () => {
+    const { a, calls } = makeAdapter();
+    a._reportStatus(REASON.HEARTBEAT_FAILED, 'down');
+    a._reportStatus(REASON.HEARTBEAT_FAILED, 'down'); // deduped
+    a._reportStatus(null); // recovered → fires
+    a._reportStatus(null); // deduped
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].reason, REASON.HEARTBEAT_FAILED);
+    assert.equal(calls[1].reason, null);
+  });
+});
+
+describe('_joinWorkspace', () => {
+  it('success → reports healthy (null), returns true, records session', async () => {
+    const { a, calls } = makeAdapter();
+    a.client.joinNetwork = async () => ({ session_id: 'sess-123' });
+    const ok = await a._joinWorkspace();
+    assert.equal(ok, true);
+    assert.equal(a._sessionId, 'sess-123');
+    assert.equal(calls.at(-1).reason, null);
+  });
+
+  it('401 → workspace_join_failed, returns false, NOT a terminal exit, no "not installed"', async () => {
+    const { a, calls } = makeAdapter();
+    a.client.joinNetwork = async () => { throw httpErr(401); };
+    const ok = await a._joinWorkspace();
+    assert.equal(ok, false);
+    assert.equal(calls.at(-1).reason, REASON.WORKSPACE_JOIN_FAILED);
+    assert.doesNotMatch(calls.at(-1).message, /not installed/i);
+    assert.equal(a.getExitInfo(), null, 'a join failure is non-terminal — keeps retrying');
+  });
+});
+
+describe('_heartbeat', () => {
+  it('success → reports healthy (clears prior error)', async () => {
+    const { a, calls } = makeAdapter();
+    a.client.heartbeat = async () => ({ ok: true });
+    await a._heartbeat();
+    assert.equal(calls.at(-1).reason, null);
+  });
+
+  it('a SINGLE transient failure does NOT flip to error (no flapping)', async () => {
+    const { a, calls } = makeAdapter();
+    a.client.heartbeat = async () => { throw httpErr(503); };
+    await a._heartbeat(); // one blip
+    assert.equal(
+      calls.filter((c) => c.reason === REASON.HEARTBEAT_FAILED).length,
+      0,
+      'one heartbeat blip must not report a hard error',
+    );
+    assert.equal(a.getExitInfo(), null);
+  });
+
+  it('repeated consecutive failures → heartbeat_failed (not terminal, not "not installed")', async () => {
+    const { a, calls } = makeAdapter();
+    a.client.heartbeat = async () => { throw httpErr(503); };
+    await a._heartbeat();
+    await a._heartbeat(); // threshold reached
+    assert.equal(calls.at(-1).reason, REASON.HEARTBEAT_FAILED);
+    assert.doesNotMatch(calls.at(-1).message, /not installed/i);
+    assert.equal(a.getExitInfo(), null);
+  });
+
+  it('a success between blips resets the streak (transient recovery clears)', async () => {
+    const { a, calls } = makeAdapter();
+    let fail = true;
+    a.client.heartbeat = async () => { if (fail) throw httpErr(503); return { ok: true }; };
+    await a._heartbeat(); // blip 1
+    fail = false;
+    await a._heartbeat(); // recovered → streak reset, reports healthy
+    fail = true;
+    await a._heartbeat(); // blip 1 again (streak was reset) → still no hard error
+    assert.equal(
+      calls.filter((c) => c.reason === REASON.HEARTBEAT_FAILED).length,
+      0,
+    );
+  });
+
+  it('session revoked → terminal exit info, stops running', async () => {
+    const { a, calls } = makeAdapter();
+    a._running = true;
+    a.client.heartbeat = async () => { throw new SessionRevokedError('revoked'); };
+    await a._heartbeat();
+    assert.equal(a._running, false);
+    assert.equal(a.getExitInfo().reason, REASON.SESSION_REVOKED);
+    assert.equal(calls.at(-1).reason, REASON.SESSION_REVOKED);
+  });
+});
+
+describe('wasStopRequested', () => {
+  it('false until stop() is called, true after (clean user stop)', () => {
+    const { a } = makeAdapter();
+    assert.equal(a.wasStopRequested(), false);
+    a.stop();
+    assert.equal(a.wasStopRequested(), true);
+    assert.equal(a._running, false);
+  });
+});

--- a/packages/agent-connector/test/amp-adapter-preflight.test.js
+++ b/packages/agent-connector/test/amp-adapter-preflight.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Amp adapter preflight + spawn-error classification.
+ *
+ *   - No resolvable amp binary  → preflight { ok:false, reason:'runtime_missing' }
+ *     so the daemon skips the workspace join (no pointless join loop) and the
+ *     message is "not found", NEVER a generic "not installed".
+ *   - Resolvable binary         → preflight { ok:true }.
+ *   - _isSpawnError distinguishes a launch failure (ENOENT/EACCES) from an
+ *     ordinary runtime error, so a spawn failure surfaces as spawn_failed.
+ *
+ * Run: node --test test/amp-adapter-preflight.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdapter } = require('../src/adapters');
+
+function makeAmp(binResolver) {
+  const a = createAdapter('amp', {
+    workspaceId: 'w',
+    channelName: 'general',
+    token: 't',
+    agentName: 'amp-test',
+    endpoint: 'http://127.0.0.1:0',
+  });
+  a._log = () => {}; // keep test output clean
+  a._findAmpBinary = binResolver;
+  a._ampBin = binResolver();
+  return a;
+}
+
+describe('AmpAdapter.preflight', () => {
+  it('no binary → ok:false, reason runtime_missing, no "not installed" wording', () => {
+    const a = makeAmp(() => null);
+    const pf = a.preflight();
+    assert.equal(pf.ok, false);
+    assert.equal(pf.reason, 'runtime_missing');
+    assert.doesNotMatch(String(pf.message), /not installed/i);
+  });
+
+  it('binary resolves → ok:true', () => {
+    const a = makeAmp(() => '/usr/local/bin/amp');
+    assert.deepEqual(a.preflight(), { ok: true });
+  });
+
+  it('re-resolves the binary if it appeared since construction', () => {
+    let resolved = null;
+    const a = makeAmp(() => resolved);
+    assert.equal(a.preflight().ok, false); // missing at first
+    resolved = '/usr/local/bin/amp';
+    a._ampBin = null; // simulate "not cached yet"
+    assert.equal(a.preflight().ok, true); // preflight re-runs _findAmpBinary
+  });
+});
+
+describe('AmpAdapter._isSpawnError', () => {
+  const a = makeAmp(() => '/usr/local/bin/amp');
+  it('treats ENOENT/EACCES/EPERM and spawn syscall as spawn errors', () => {
+    assert.equal(a._isSpawnError({ code: 'ENOENT' }), true);
+    assert.equal(a._isSpawnError({ code: 'EACCES' }), true);
+    assert.equal(a._isSpawnError({ code: 'EPERM' }), true);
+    assert.equal(a._isSpawnError({ syscall: 'spawn' }), true);
+  });
+  it('does NOT treat ordinary runtime errors as spawn errors', () => {
+    assert.equal(a._isSpawnError(new Error('amp said something went wrong')), false);
+    assert.equal(a._isSpawnError({ code: 'SOMETHINGELSE' }), false);
+    assert.equal(a._isSpawnError(null), false);
+  });
+});

--- a/packages/agent-connector/test/amp-readiness.test.js
+++ b/packages/agent-connector/test/amp-readiness.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Pins the "installed vs login_required vs not_installed" split for Amp at the
+ * core readiness layer (installer.healthCheck), so the Install page and the
+ * Agents list can never disagree:
+ *   - amp binary resolves, no creds  → installed:true,  ready:false, reason
+ *     'login_required', and the message is NOT "Not installed".
+ *   - amp binary missing             → installed:false, ready:false, reason
+ *     'not_installed', message "Not installed".
+ *   - amp binary resolves + API key  → installed:true,  ready:true,  reason
+ *     'ready'.
+ *
+ * Run: node --test test/amp-readiness.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { Installer, clearVersionCache } = require('../src/installer');
+
+const AMP_NOT_READY =
+  'Amp is installed but not signed in — run: amp login or set AMP_API_KEY';
+
+const mockRegistry = {
+  // EnvManager.resolve() consults resolve_env rules; none for amp.
+  getResolveRules: () => [],
+  getEntry: (name) =>
+    name === 'amp'
+      ? {
+          name: 'amp',
+          label: 'Amp (Sourcegraph)',
+          install: {
+            binary: 'amp',
+            macos: 'curl -fsSL https://ampcode.com/install.sh | bash',
+            linux: 'curl -fsSL https://ampcode.com/install.sh | bash',
+          },
+          check_ready: {
+            login_command: 'amp login',
+            // legacy single-key env probe so a saved AMP_API_KEY counts as ready
+            env_vars: ['AMP_API_KEY'],
+            saved_env_key: 'AMP_API_KEY',
+            not_ready_message: AMP_NOT_READY,
+          },
+        }
+      : null,
+};
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amp-ready-'));
+  clearVersionCache();
+});
+afterEach(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe('Amp readiness reason — installer.healthCheck', () => {
+  it('binary resolves, no creds → installed + login_required (NOT "not installed")', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => '/usr/local/bin/amp'; // resolved off PATH
+    const h = inst.healthCheck('amp');
+
+    assert.equal(h.installed, true, 'binary resolved → installed');
+    assert.equal(h.ready, false, 'no creds → not ready');
+    assert.equal(h.reason, 'login_required');
+    assert.doesNotMatch(
+      String(h.message),
+      /not installed/i,
+      'an installed agent must never say "not installed"',
+    );
+  });
+
+  it('binary missing → not installed (reason not_installed, message "Not installed")', () => {
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => null;
+    const h = inst.healthCheck('amp');
+
+    assert.equal(h.installed, false);
+    assert.equal(h.ready, false);
+    assert.equal(h.reason, 'not_installed');
+    assert.equal(h.message, 'Not installed');
+  });
+
+  it('binary resolves + saved AMP_API_KEY → ready', () => {
+    // Persist a type-level AMP_API_KEY so _evaluateReadiness sees a credential.
+    const envDir = path.join(tmpDir, 'env');
+    fs.mkdirSync(envDir, { recursive: true });
+    fs.writeFileSync(path.join(envDir, 'amp.env'), 'AMP_API_KEY=sgp_test_key\n');
+
+    const inst = new Installer(mockRegistry, tmpDir);
+    inst._whichBinary = () => '/usr/local/bin/amp';
+    const h = inst.healthCheck('amp');
+
+    assert.equal(h.installed, true);
+    assert.equal(h.ready, true);
+    assert.equal(h.reason, 'ready');
+  });
+});

--- a/packages/agent-connector/test/daemon-error-status.test.js
+++ b/packages/agent-connector/test/daemon-error-status.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * Daemon → daemon.status.json mapping: a real runtime failure surfaces as state
+ * 'error' with a classified, REDACTED last_error + error_reason, while a clean
+ * user stop is never written as an error.
+ *
+ * Run: node --test test/daemon-error-status.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { Daemon } = require('../src/daemon');
+const { Config } = require('../src/config');
+const { EnvManager } = require('../src/env');
+const { Registry } = require('../src/registry');
+const { REASON } = require('../src/adapters/health-status');
+
+let tmpDir;
+let daemon;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-daemon-status-'));
+  daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
+});
+afterEach(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+function freshInfo() {
+  return {
+    type: 'amp',
+    network: 'ws1',
+    state: 'running',
+    restarts: 0,
+    startedAt: null,
+    lastError: null,
+    errorReason: null,
+  };
+}
+
+describe('_applyAdapterStatus', () => {
+  it('error reason → state error + classified reason + REDACTED message', () => {
+    const info = freshInfo();
+    daemon._processes.amp = info;
+    daemon._applyAdapterStatus('amp', info, {
+      reason: REASON.WORKSPACE_JOIN_FAILED,
+      message: 'Workspace join failed: HTTP 401 token=supersecretvalue123456',
+    });
+    assert.equal(info.state, 'error');
+    assert.equal(info.errorReason, REASON.WORKSPACE_JOIN_FAILED);
+    assert.match(info.lastError, /Workspace join failed/);
+    assert.doesNotMatch(info.lastError, /supersecretvalue123456/);
+    // and it is reflected in getStatus()
+    const st = daemon.getStatus().amp;
+    assert.equal(st.state, 'error');
+    assert.equal(st.error_reason, REASON.WORKSPACE_JOIN_FAILED);
+  });
+
+  it('null reason → recovers from error back to running, clears lastError', () => {
+    const info = freshInfo();
+    info.state = 'error';
+    info.errorReason = REASON.HEARTBEAT_FAILED;
+    info.lastError = 'Workspace heartbeat failed: HTTP 503';
+    daemon._processes.amp = info;
+    daemon._applyAdapterStatus('amp', info, { reason: null });
+    assert.equal(info.state, 'running');
+    assert.equal(info.lastError, null);
+    assert.equal(info.errorReason, null);
+  });
+
+  it('ignored once the agent is stopping (a user stop must win)', () => {
+    const info = freshInfo();
+    daemon._processes.amp = info;
+    daemon._stoppedAgents.add('amp');
+    daemon._applyAdapterStatus('amp', info, {
+      reason: REASON.HEARTBEAT_FAILED,
+      message: 'down',
+    });
+    assert.equal(info.state, 'running', 'a stopping agent is not flipped to error');
+    assert.equal(info.errorReason, null);
+  });
+
+  it('login_required is NOT a hard error (readiness, not a failure)', () => {
+    const info = freshInfo();
+    daemon._processes.amp = info;
+    daemon._applyAdapterStatus('amp', info, {
+      reason: REASON.LOGIN_REQUIRED,
+      message: 'Amp is installed but not signed in',
+    });
+    // not an error reason → treated as "healthy/clear", state stays running
+    assert.equal(info.state, 'running');
+    assert.equal(info.errorReason, null);
+  });
+});
+
+describe('getStatus shape', () => {
+  it('exposes error_reason alongside last_error', () => {
+    daemon._processes.amp = {
+      ...freshInfo(),
+      state: 'error',
+      lastError: 'Amp process failed to start: executable not found',
+      errorReason: REASON.SPAWN_FAILED,
+    };
+    const st = daemon.getStatus().amp;
+    assert.equal(st.last_error, 'Amp process failed to start: executable not found');
+    assert.equal(st.error_reason, REASON.SPAWN_FAILED);
+  });
+});

--- a/packages/agent-connector/test/health-status.test.js
+++ b/packages/agent-connector/test/health-status.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * Unit tests for the shared readiness / failure-classification module.
+ *
+ * This is the single source of truth the Install page, the Agents list, the
+ * daemon and the TUI all use, so its rules are pinned here:
+ *   - "not installed" ONLY for a missing executable (login_required otherwise),
+ *   - Windows .cmd/.bat must be launched through a shell,
+ *   - join / heartbeat / spawn failures classify to distinct reasons,
+ *   - secrets are redacted out of every diagnostic string.
+ *
+ * Run: node --test test/health-status.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  REASON,
+  isErrorReason,
+  readinessReason,
+  shouldUseShellForBinary,
+  redactDiagnostic,
+  classifyJoinError,
+  classifyHeartbeatError,
+  classifySpawnError,
+} = require('../src/adapters/health-status');
+
+describe('readinessReason — installed vs login_required vs not_installed', () => {
+  it('missing executable → not_installed', () => {
+    assert.equal(readinessReason(false, false), REASON.NOT_INSTALLED);
+    assert.equal(readinessReason(false, true), REASON.NOT_INSTALLED);
+  });
+  it('installed but not ready → login_required (NEVER not_installed)', () => {
+    assert.equal(readinessReason(true, false), REASON.LOGIN_REQUIRED);
+    assert.notEqual(readinessReason(true, false), REASON.NOT_INSTALLED);
+  });
+  it('installed and ready → ready', () => {
+    assert.equal(readinessReason(true, true), REASON.READY);
+  });
+});
+
+describe('isErrorReason — only real failures are hard errors', () => {
+  it('runtime/connectivity failures are errors', () => {
+    for (const r of [
+      REASON.RUNTIME_MISSING,
+      REASON.SPAWN_FAILED,
+      REASON.WORKSPACE_JOIN_FAILED,
+      REASON.HEARTBEAT_FAILED,
+      REASON.SESSION_REVOKED,
+      REASON.ADAPTER_CRASHED,
+    ]) {
+      assert.equal(isErrorReason(r), true, `${r} should be an error reason`);
+    }
+  });
+  it('readiness states are NOT hard errors', () => {
+    assert.equal(isErrorReason(REASON.READY), false);
+    assert.equal(isErrorReason(REASON.LOGIN_REQUIRED), false);
+    assert.equal(isErrorReason(REASON.NOT_INSTALLED), false);
+  });
+});
+
+describe('shouldUseShellForBinary — Windows .cmd/.bat', () => {
+  it('uses a shell for .cmd / .bat on win32 (case-insensitive)', () => {
+    assert.equal(shouldUseShellForBinary('C:/Users/x/.amp/bin/amp.cmd', 'win32'), true);
+    assert.equal(shouldUseShellForBinary('C:/x/amp.CMD', 'win32'), true);
+    assert.equal(shouldUseShellForBinary('C:/x/amp.bat', 'win32'), true);
+  });
+  it('no shell for a real .exe / extensionless binary on win32', () => {
+    assert.equal(shouldUseShellForBinary('C:/Users/x/.amp/bin/amp.exe', 'win32'), false);
+    assert.equal(shouldUseShellForBinary('C:/x/amp', 'win32'), false);
+  });
+  it('never uses a shell on POSIX', () => {
+    assert.equal(shouldUseShellForBinary('/usr/local/bin/amp', 'linux'), false);
+    assert.equal(shouldUseShellForBinary('amp.cmd', 'linux'), false);
+    assert.equal(shouldUseShellForBinary('/opt/homebrew/bin/amp', 'darwin'), false);
+  });
+});
+
+describe('classifyJoinError', () => {
+  it('401/403 → workspace_join_failed with auth detail', () => {
+    const r = classifyJoinError({ statusCode: 401 });
+    assert.equal(r.reason, REASON.WORKSPACE_JOIN_FAILED);
+    assert.match(r.message, /Workspace join failed/);
+    assert.match(r.message, /401/);
+    assert.equal(classifyJoinError({ statusCode: 403 }).reason, REASON.WORKSPACE_JOIN_FAILED);
+  });
+  it('404 → workspace not found', () => {
+    const r = classifyJoinError({ statusCode: 404 });
+    assert.match(r.message, /not found/i);
+  });
+  it('network error (no status) → workspace_join_failed, never "not installed"', () => {
+    const r = classifyJoinError(new Error('ECONNREFUSED 1.2.3.4:443'));
+    assert.equal(r.reason, REASON.WORKSPACE_JOIN_FAILED);
+    assert.doesNotMatch(r.message, /not installed/i);
+  });
+});
+
+describe('classifyHeartbeatError', () => {
+  it('classifies as heartbeat_failed with the HTTP status', () => {
+    const r = classifyHeartbeatError({ statusCode: 503 });
+    assert.equal(r.reason, REASON.HEARTBEAT_FAILED);
+    assert.match(r.message, /heartbeat failed/i);
+    assert.match(r.message, /503/);
+    assert.doesNotMatch(r.message, /not installed/i);
+  });
+});
+
+describe('classifySpawnError', () => {
+  it('ENOENT → spawn_failed (NOT not_installed) with the resolved path', () => {
+    const r = classifySpawnError({ code: 'ENOENT' }, { label: 'Amp', bin: '/home/u/.amp/bin/amp.cmd' });
+    assert.equal(r.reason, REASON.SPAWN_FAILED);
+    assert.match(r.message, /Amp process failed to start/);
+    assert.match(r.message, /amp\.cmd/);
+    assert.doesNotMatch(r.message, /not installed/i);
+  });
+  it('EACCES → permission denied', () => {
+    const r = classifySpawnError({ code: 'EACCES' }, { label: 'Amp', bin: '/x/amp' });
+    assert.match(r.message, /permission denied/i);
+  });
+});
+
+describe('redactDiagnostic — never leak secrets', () => {
+  it('redacts token / api key / bearer / url credentials / long blobs', () => {
+    const out = redactDiagnostic(
+      'join failed token=abc123secret AMP_API_KEY=sgp_supersecrettoken Authorization: Bearer xyz.987 ' +
+        'at https://user:p4ss@host/path key=' + 'A'.repeat(50),
+    );
+    assert.doesNotMatch(out, /abc123secret/);
+    assert.doesNotMatch(out, /sgp_supersecrettoken/);
+    assert.doesNotMatch(out, /xyz\.987/);
+    assert.doesNotMatch(out, /p4ss/);
+    assert.doesNotMatch(out, /A{50}/);
+    assert.match(out, /<redacted>/);
+  });
+  it('caps length and never throws on odd input', () => {
+    assert.equal(typeof redactDiagnostic(null), 'string');
+    assert.equal(typeof redactDiagnostic(undefined), 'string');
+    assert.ok(redactDiagnostic('x'.repeat(5000), 100).length <= 101);
+  });
+});

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -287,6 +287,22 @@ interface HostedLoginSpec {
   loginClearsEnv?: string[]
 }
 
+/**
+ * Readiness reason codes surfaced to the Agents list. These MUST match the
+ * core's health-status REASON values (packages/agent-connector/src/adapters/
+ * health-status.js) so the Install page, the Agents list and the daemon share
+ * one vocabulary. The renderer keys off `reason` (not the free-text message) to
+ * decide whether to show "Not installed" vs "Login required".
+ *
+ * Hard rule: NOT_INSTALLED is only for a genuinely missing executable; an
+ * installed-but-signed-out agent is LOGIN_REQUIRED.
+ */
+const READY_REASON = {
+  READY: "ready",
+  NOT_INSTALLED: "not_installed",
+  LOGIN_REQUIRED: "login_required",
+} as const
+
 const HOSTED_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
   cursor: {
     loginCommand: "cursor-agent login",
@@ -1511,9 +1527,11 @@ export class AgentManager extends EventEmitter {
       ...h,
       installed: true,
       ready,
+      reason: ready ? READY_REASON.READY : READY_REASON.LOGIN_REQUIRED,
       auth_mode: ready ? "api_key" : null,
       execution_mode: ready ? h.execution_mode || "direct" : "unavailable",
-      message: ready ? "Ready" : this._notReadyMessage(type),
+      // Binary confirmed on disk → never "not installed"; show login-required.
+      message: ready ? "Ready" : this._loginRequiredMessage(type),
     }
   }
 
@@ -1547,6 +1565,7 @@ export class AgentManager extends EventEmitter {
         return {
           installed: true,
           ready: true,
+          reason: READY_REASON.READY,
           auth_mode: "api_key",
           execution_mode: "direct",
           message: "Ready",
@@ -1560,6 +1579,7 @@ export class AgentManager extends EventEmitter {
         ? {
             installed: true,
             ready: true,
+            reason: READY_REASON.READY,
             auth_mode: "cli_login",
             execution_mode: "subprocess",
             message: "Ready",
@@ -1567,9 +1587,10 @@ export class AgentManager extends EventEmitter {
         : {
             installed: false,
             ready: false,
+            reason: READY_REASON.NOT_INSTALLED,
             auth_mode: null,
             execution_mode: "unavailable",
-            message: this._notReadyMessage(type),
+            message: this._notInstalledMessage(type),
           }
     }
     const health = this._reconcileHealth(type, typeHealth)
@@ -1593,6 +1614,7 @@ export class AgentManager extends EventEmitter {
         return {
           installed: true,
           ready: true,
+          reason: READY_REASON.READY,
           auth_mode: cliLoggedIn ? "cli_login" : "api_key",
           execution_mode: "direct",
           message: "Ready",
@@ -1607,12 +1629,25 @@ export class AgentManager extends EventEmitter {
         ...h,
         installed: true,
         ready: true,
+        reason: READY_REASON.READY,
         auth_mode: cliLoggedIn ? "cli_login" : "api_key",
         execution_mode:
           h.execution_mode && h.execution_mode !== "unavailable"
             ? h.execution_mode
             : "direct",
         message: "Ready",
+      }
+    }
+    // Installed (binary resolved) but no usable credentials/login detected:
+    // surface a Login-required state, never a "not installed" message. The core
+    // health already carries reason='login_required' for this case; harden it
+    // here so a probe that hasn't populated yet can't fall through to the raw
+    // (possibly stale) message.
+    if (h.installed === true && h.ready !== true) {
+      return {
+        ...h,
+        reason: READY_REASON.LOGIN_REQUIRED,
+        message: this._loginRequiredMessage(type),
       }
     }
     return health
@@ -1631,15 +1666,17 @@ export class AgentManager extends EventEmitter {
       return {
         installed: false,
         ready: false,
+        reason: READY_REASON.NOT_INSTALLED,
         auth_mode: null,
         execution_mode: "unavailable",
-        message: this._notReadyMessage(type),
+        message: this._notInstalledMessage(type),
       }
     }
     if (this._hostedLoginIsAuthed(type) === false) {
       return {
         installed: true,
         ready: false,
+        reason: READY_REASON.LOGIN_REQUIRED,
         auth_mode: null,
         execution_mode: "unavailable",
         message: "Not signed in — open Configure and click Login",
@@ -1648,6 +1685,7 @@ export class AgentManager extends EventEmitter {
     return {
       installed: true,
       ready: true,
+      reason: READY_REASON.READY,
       auth_mode: "cli_login",
       execution_mode: "subprocess",
       message: "Ready",
@@ -1789,6 +1827,65 @@ export class AgentManager extends EventEmitter {
     return p
   }
 
+  /**
+   * Child env for a launcher-side CLI probe, built the SAME way the daemon's
+   * adapter builds it: the core's getEnhancedEnv adds nvm/fnm/volta/homebrew,
+   * ~/.local/bin and ~/.amp/bin to PATH and (on Windows) forces UTF-8 output +
+   * ComSpec. This is what makes `amp`/`amp.cmd` resolvable from a GUI-spawned
+   * process whose PATH never inherited the installer's edits — so the Agents
+   * list and the daemon agree on whether amp is runnable. Never a bare
+   * process.env. `extra` (e.g. AMP_API_KEY/AMP_URL) is merged in, never logged.
+   */
+  private _enhancedChildEnv(
+    extra?: Record<string, string>,
+  ): NodeJS.ProcessEnv {
+    const base: NodeJS.ProcessEnv = { ...process.env, ...(extra || {}) }
+    try {
+      // Reuse the SAME core the launcher loaded (loadCore prefers the local
+      // workspace copy) so the enhanced PATH matches the daemon's exactly.
+      const paths = (core as Record<string, unknown> | null)?.paths as
+        | { getEnhancedEnv?: (e?: NodeJS.ProcessEnv) => NodeJS.ProcessEnv }
+        | undefined
+      if (typeof paths?.getEnhancedEnv === "function")
+        return paths.getEnhancedEnv(base)
+    } catch {
+      /* fall back to the un-enhanced base below */
+    }
+    return base
+  }
+
+  /**
+   * Spawn an agent CLI for a short-lived probe (status / usage), the SAME way
+   * the daemon's adapter (_spawnAmp) does: shell:true for a Windows `.cmd`/`.bat`
+   * shim — Node cannot launch those directly via CreateProcess, so a bare
+   * spawn(bin) throws and the probe used to fall back to a misleading "Not
+   * installed". Enhanced PATH + windowsHide round it out. The shell rule mirrors
+   * the shared core helper (shouldUseShellForBinary) so launcher and daemon
+   * never diverge on `.cmd`.
+   */
+  private _spawnAgentCli(
+    bin: string,
+    args: string[],
+    extra?: Record<string, string>,
+  ): ReturnType<typeof spawn> {
+    const useShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin)
+    return spawn(bin, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: this._enhancedChildEnv(extra),
+      windowsHide: true,
+      shell: useShell,
+    })
+  }
+
+  /** Saved type-level env for a probe (e.g. AMP_URL / AMP_API_KEY), never thrown. */
+  private _savedTypeEnvForProbe(type: string): Record<string, string> {
+    try {
+      return (this.getAgentEnv(type) as Record<string, string>) || {}
+    } catch {
+      return {}
+    }
+  }
+
   private _runHostedLoginProbe(
     type: string,
     spec: HostedLoginSpec,
@@ -1824,9 +1921,14 @@ export class AgentManager extends EventEmitter {
         return
       }
       try {
-        const child = spawn(bin, spec.statusArgs, {
-          stdio: ["ignore", "pipe", "pipe"],
-        })
+        // Same env + Windows .cmd handling as the daemon adapter, plus the
+        // saved type env so a configured AMP_URL / AMP_API_KEY is honored by the
+        // `amp usage` sign-in probe (key present is itself a valid auth path).
+        const child = this._spawnAgentCli(
+          bin,
+          spec.statusArgs,
+          this._savedTypeEnvForProbe(type),
+        )
         let out = ""
         let settled = false
         const finish = (value: boolean | null): void => {
@@ -1934,6 +2036,30 @@ export class AgentManager extends EventEmitter {
       if (checkReady?.not_ready_message) return checkReady.not_ready_message
     } catch {}
     return "Not configured — add an API key in Configure"
+  }
+
+  /**
+   * Message for an agent that IS installed but not yet usable (signed out / no
+   * API key). Reuses the registry's not_ready hint when it reads as a login
+   * prompt, but NEVER surfaces a stale "not installed" wording for a resolved
+   * binary — that would re-introduce the exact bug this fix removes.
+   */
+  private _loginRequiredMessage(type: string): string {
+    const msg = this._notReadyMessage(type)
+    if (msg && !/not\s+installed/i.test(msg)) return msg
+    return "Installed · Login required — sign in or add an API key"
+  }
+
+  /**
+   * Message for a genuinely-missing executable. Reuses the registry hint only
+   * when it actually says "not installed"; otherwise a plain "Not installed".
+   * (amp's not_ready_message now describes a login state, so it must NOT be used
+   * for the not-installed case.)
+   */
+  private _notInstalledMessage(type: string): string {
+    const msg = this._notReadyMessage(type)
+    if (msg && /not\s+installed/i.test(msg)) return msg
+    return "Not installed"
   }
 
   async addAgent(agentConfig: {
@@ -2298,11 +2424,11 @@ export class AgentManager extends EventEmitter {
         })
         return
       }
-      const childEnv: NodeJS.ProcessEnv = { ...process.env }
+      const extra: Record<string, string> = {}
       const key = (env.AMP_API_KEY || "").trim()
-      if (key) childEnv.AMP_API_KEY = key
+      if (key) extra.AMP_API_KEY = key
       const url = (env.AMP_URL || "").trim()
-      if (url) childEnv.AMP_URL = url
+      if (url) extra.AMP_URL = url
 
       let out = ""
       let settled = false
@@ -2314,10 +2440,9 @@ export class AgentManager extends EventEmitter {
       }
       let child: ReturnType<typeof spawn>
       try {
-        child = spawn(bin, ["usage"], {
-          stdio: ["ignore", "pipe", "pipe"],
-          env: childEnv,
-        })
+        // Enhanced PATH + Windows .cmd handling shared with the daemon adapter;
+        // the entered key/URL are injected as `extra` (never the saved env).
+        child = this._spawnAgentCli(bin, ["usage"], extra)
       } catch (e) {
         done({
           success: false,
@@ -3425,13 +3550,21 @@ export class AgentManager extends EventEmitter {
       installed,
       ready,
       logged_in: loggedIn,
+      reason: ready
+        ? READY_REASON.READY
+        : !installed
+          ? READY_REASON.NOT_INSTALLED
+          : READY_REASON.LOGIN_REQUIRED,
       auth_mode:
         loggedIn === true ? "cli_login" : hasKey ? "api_key" : h.auth_mode ?? null,
+      // Installed-but-signed-out is Login-required, not "not installed". Uses the
+      // agent's own registry hint (e.g. amp → "run: amp login or set
+      // AMP_API_KEY") instead of a Claude-specific string.
       message: ready
         ? "Ready"
         : !installed
-          ? this._notReadyMessage(type)
-          : "Not signed in — log in to Claude or add an API key",
+          ? this._notInstalledMessage(type)
+          : this._loginRequiredMessage(type),
     }
   }
 

--- a/packages/launcher/src/renderer/i18n/locales/en/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agents.json
@@ -23,6 +23,8 @@
     "removeBody": "This will stop and remove <1>{{name}}</1>.",
     "health": {
       "notConfigured": "Not configured",
+      "notInstalled": "Not installed",
+      "loginRequired": "Login required",
       "ready": "Ready",
       "apiKey": "API key",
       "cliLogin": "CLI login"

--- a/packages/launcher/src/renderer/i18n/locales/zh/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agents.json
@@ -23,6 +23,8 @@
     "removeBody": "这将停止并移除 <1>{{name}}</1>。",
     "health": {
       "notConfigured": "未配置",
+      "notInstalled": "未安装",
+      "loginRequired": "需要登录",
       "ready": "就绪",
       "apiKey": "API 密钥",
       "cliLogin": "CLI 登录"

--- a/packages/launcher/src/renderer/pages/agents/formatHealthLabel.test.ts
+++ b/packages/launcher/src/renderer/pages/agents/formatHealthLabel.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import type { TFunction } from "i18next"
+import { formatHealthLabel } from "./index"
+import type { HealthCheck } from "../../types"
+
+// Identity translator: returns the key (or a known label) so assertions read
+// against the i18n KEYS the component would render.
+const t = ((key: string) => key) as unknown as TFunction
+
+describe("formatHealthLabel — Not installed vs Login required", () => {
+  it("shows Not installed ONLY when the executable is genuinely missing", () => {
+    const h: HealthCheck = {
+      ready: false,
+      installed: false,
+      reason: "not_installed",
+      message: "Not installed",
+    }
+    expect(formatHealthLabel(h, t)).toBe("agents.list.health.notInstalled")
+  })
+
+  it("installed + signed out → Login required, NEVER Not installed", () => {
+    const h: HealthCheck = {
+      ready: false,
+      installed: true,
+      reason: "login_required",
+      message: "Amp is installed but not signed in — run: amp login or set AMP_API_KEY",
+    }
+    const label = formatHealthLabel(h, t)
+    expect(label).not.toMatch(/not installed/i)
+    // prefers the agent-specific message
+    expect(label).toMatch(/not signed in/i)
+  })
+
+  it("defensively suppresses a stale 'not installed' message on an installed agent", () => {
+    const h: HealthCheck = {
+      ready: false,
+      installed: true,
+      reason: "login_required",
+      message: "Not installed — run: openagents install amp", // stale wording
+    }
+    expect(formatHealthLabel(h, t)).toBe("agents.list.health.loginRequired")
+  })
+
+  it("ready → Ready (with auth mode)", () => {
+    const h: HealthCheck = {
+      ready: true,
+      installed: true,
+      reason: "ready",
+      auth_mode: "cli_login",
+    }
+    const label = formatHealthLabel(h, t)
+    expect(label).toContain("agents.list.health.ready")
+    expect(label).toContain("agents.list.health.cliLogin")
+  })
+
+  it("null health → not configured", () => {
+    expect(formatHealthLabel(null, t)).toBe("agents.list.health.notConfigured")
+  })
+})

--- a/packages/launcher/src/renderer/pages/agents/index.tsx
+++ b/packages/launcher/src/renderer/pages/agents/index.tsx
@@ -17,9 +17,21 @@ import { cn } from "../../lib/utils"
 import { capture } from "../../lib/analytics"
 import { workspaceWebBaseUrl } from "../../lib/workspace-urls"
 
-function formatHealthLabel(health: HealthCheck | null, t: TFunction): string {
+export function formatHealthLabel(health: HealthCheck | null, t: TFunction): string {
   if (!health) return t("agents.list.health.notConfigured")
-  if (!health.ready) return health.message || t("agents.list.health.notConfigured")
+  if (!health.ready) {
+    // "Not installed" is reserved for a genuinely missing executable. Decide
+    // from the structured reason / installed flag, NOT the free-text message —
+    // an installed-but-signed-out agent must read "Login required", never
+    // "Not installed" (the bug this guard removes). Stale messages that still
+    // say "not installed" on a resolved binary are suppressed defensively.
+    const notInstalled =
+      health.reason === "not_installed" || health.installed === false
+    if (notInstalled) return t("agents.list.health.notInstalled")
+    const msg = health.message
+    if (msg && !/not\s+installed/i.test(msg)) return msg
+    return t("agents.list.health.loginRequired")
+  }
   const parts = [t("agents.list.health.ready")]
   if (health.auth_mode === "api_key") parts.push(t("agents.list.health.apiKey"))
   else if (health.auth_mode === "cli_login") parts.push(t("agents.list.health.cliLogin"))

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -3,6 +3,11 @@ export type AgentState = 'online' | 'running' | 'idle' | 'starting' | 'reconnect
 export interface HealthCheck {
   ready: boolean
   installed?: boolean
+  // Structured readiness/failure reason shared with the core + daemon
+  // (health-status.js REASON). The Agents list keys off this — NOT the free-text
+  // message — to decide "Not installed" vs "Login required". Values include
+  // 'ready' | 'not_installed' | 'login_required' | 'version_incompatible'.
+  reason?: string
   // CLI sign-in state for dual-auth agents (e.g. Claude): true (signed in) /
   // false (signed out) / null (unknown — never probed or undecidable).
   logged_in?: boolean | null

--- a/sdk/src/openagents/registry/amp.yaml
+++ b/sdk/src/openagents/registry/amp.yaml
@@ -33,4 +33,8 @@ env_config:
 
 check_ready:
   login_command: "amp login"
-  not_ready_message: "Not installed — run: openagents install amp"
+  # Shown when the Amp CLI IS installed but no usable auth was detected. It must
+  # NOT say "Not installed" — that wording is reserved for a genuinely missing
+  # executable. A signed-out-but-installed agent is a Login-required state, not a
+  # missing-install state (see launcher _reconcileAgentHealth / formatHealthLabel).
+  not_ready_message: "Amp is installed but not signed in — run: amp login or set AMP_API_KEY"


### PR DESCRIPTION
Amp showed `installed` on the Install page but `Not installed` (+ `X error`) in the Agents list, and Connect Workspace failed with no real reason. Root cause: two independent bugs.

1) Readiness was conflated with installation. The Install page checks the
   executable (whichBinary + enhanced PATH), but the Agents-list label is a
   readiness verdict whose amp `not_ready_message` literally read "Not
   installed", and formatHealthLabel showed that message whenever `ready` was
   false — so an installed-but-signed-out amp read "Not installed". On Windows
   the sign-in probe / Test-connection spawned `amp.cmd` without a shell, so it
   could never confirm login and always fell back to that message.

2) Real workspace failures were swallowed. join/heartbeat errors were only
   logged; the daemon status carried no cause, so failures surfaced as a bare
   `X error` (or the misleading readiness message).

Fix — split the states with a single shared vocabulary (REASON):
  - not_installed  -> ONLY when the executable cannot be resolved
  - login_required -> installed but signed out / no API key
  - ready          -> installed AND (signed in OR key)
  - runtime_missing / spawn_failed / workspace_join_failed / heartbeat_failed /
    session_revoked / adapter_crashed -> real runtime failures, classified +
    redacted, written to daemon state.error_reason/last_error.

- New src/adapters/health-status.js: reason codes, readinessReason, shouldUseShellForBinary (.cmd/.bat), redactDiagnostic, and join/heartbeat/ spawn classifiers. Single source shared by installer, adapters and daemon.
- installer.healthCheck now emits a structured `reason`.
- BaseAdapter: onStatus reporting, getExitInfo, wasStopRequested, preflight(); join/heartbeat failures classified and reported. Heartbeat only escalates to a hard error after consecutive failures, so a single transient blip / expected brief reconnect is not mislabeled.
- AmpAdapter.preflight(): missing binary -> runtime_missing, daemon skips join. Spawn failures classify as spawn_failed (never "not installed"); diagnostics (resolved path, argv, exit/stderr) are logged and redacted.
- daemon: preflight gate (no join when the binary is genuinely missing), live onStatus -> state, and a post-run decision that maps a clean user stop / disconnect to `stopped` (never error) and a real terminal failure to `error` with its classified reason; getStatus exposes error_reason.
- launcher: probe + Test-connection spawn through a shell for Windows .cmd/.bat with the enhanced PATH (semantically identical to the core helper; resolution and PATH reuse the loaded core's whichBinary/getEnhancedEnv). Health methods carry `reason`; formatHealthLabel/tui/agent-rows key off reason/installed so "Not installed" only shows for a missing executable, and the TUI surfaces the real last_error.
- amp registry not_ready_message reworded to a login prompt.

Other agent types are unaffected (default preflight passes; onStatus is opt-in). Tests: 6 new files covering classification/redaction, the readiness split, preflight, lifecycle status (incl. no-flap on a single blip) and the daemon mapping. NOT VERIFIED: real Windows Amp + Workspace end-to-end.