### PR TITLE
fix: codepage-safe agent binary resolution on non-English Windows

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.143",
+  "version": "0.2.144",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/adapters/claude.js
+++ b/packages/agent-connector/src/adapters/claude.js
@@ -19,7 +19,7 @@ const { execSync, spawn } = require('child_process');
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');
 const { buildClaudeSystemPrompt, buildClaudeSkillMd } = require('./workspace-prompt');
-const { defaultAgentWorkdir, whichBinary, getEnhancedEnv } = require('../paths');
+const { defaultAgentWorkdir, whichBinary, whereBinary } = require('../paths');
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -343,24 +343,13 @@ class ClaudeAdapter extends BaseAdapter {
     const portableCandidate = path.join(portableBin, `claude${ext}`);
     if (fs.existsSync(portableCandidate)) return portableCandidate;
 
-    // Tier 1: PATH search. Use the ENRICHED env so the lookup sees the same
-    // node-version-manager / homebrew / npm-global dirs the launcher adds —
-    // a packaged Electron daemon's own PATH is minimal, which is why `which
-    // claude` came up empty and the agent reported "claude CLI not found".
-    // windowsHide stops a console window from flashing.
-    try {
-      const env = getEnhancedEnv();
-      if (IS_WINDOWS) {
-        const r = execSync('where claude.cmd 2>nul || where claude.exe 2>nul || where claude 2>nul', {
-          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
-        });
-        const hit = r.split(/\r?\n/)[0].trim();
-        if (hit) return hit;
-      } else {
-        const hit = execSync('which claude', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
-        if (hit) return hit;
-      }
-    } catch {}
+    // Tier 1: PATH search via a codepage-safe lookup (whereBinary forces UTF-8
+    // output + verifies existence, so a non-ASCII/Chinese username isn't mangled
+    // into an ENOENT). Uses the ENRICHED env so a packaged daemon's minimal PATH
+    // still sees the node-version-manager / homebrew / npm-global dirs the
+    // launcher adds — that's why a bare `which claude` came up empty before.
+    const viaWhere = whereBinary('claude');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: Next to current Node.js interpreter (npm global)
     const nodeBinDir = path.dirname(process.execPath);
@@ -558,15 +547,9 @@ class ClaudeAdapter extends BaseAdapter {
         const oaPortable = path.join(home3, '.openagents', 'nodejs', 'node_modules', '.bin', `openagents${oaExt}`);
         if (fs.existsSync(oaPortable)) oaBin = oaPortable;
       }
-      if (!oaBin) try {
-        if (IS_WINDOWS) {
-          oaBin = execSync('where openagents.cmd 2>nul || where openagents.exe 2>nul || where openagents 2>nul', {
-            encoding: 'utf-8', timeout: 5000,
-          }).split(/\r?\n/)[0].trim();
-        } else {
-          oaBin = execSync('which openagents', { encoding: 'utf-8', timeout: 5000 }).trim();
-        }
-      } catch {}
+      // Codepage-safe lookup so a non-ASCII/Chinese username in the path isn't
+      // mangled into an ENOENT (see whereBinary).
+      if (!oaBin) oaBin = whereBinary('openagents');
       if (!oaBin) {
         this._log('Could not find openagents binary — MCP tools may not be available');
         mcpCommand = 'openagents';

--- a/packages/agent-connector/src/adapters/cline.js
+++ b/packages/agent-connector/src/adapters/cline.js
@@ -30,7 +30,7 @@ const { execSync, execFile, spawn } = require('child_process');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');
-const { defaultAgentWorkdir, whichBinary, getEnhancedEnv } = require('../paths');
+const { defaultAgentWorkdir, whichBinary, whereBinary } = require('../paths');
 const {
   ClineStreamParser,
   interpretClineEnvelope,
@@ -323,21 +323,12 @@ class ClineAdapter extends BaseAdapter {
       if (fs.existsSync(pkgBin)) return pkgBin;
     }
 
-    // Tier 1: PATH search with the ENRICHED env (a packaged daemon's PATH is
+    // Tier 1: PATH search via a codepage-safe lookup (whereBinary forces UTF-8
+    // output + verifies existence so a non-ASCII/Chinese username isn't mangled
+    // into an ENOENT). Uses the ENRICHED env (a packaged daemon's PATH is
     // minimal and would miss nvm/fnm/volta/homebrew/npm-global dirs).
-    try {
-      const env = getEnhancedEnv();
-      if (IS_WINDOWS) {
-        const r = execSync('where cline.cmd 2>nul || where cline.exe 2>nul || where cline 2>nul', {
-          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
-        });
-        const hit = r.split(/\r?\n/)[0].trim();
-        if (hit) return hit;
-      } else {
-        const hit = execSync('which cline', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
-        if (hit) return hit;
-      }
-    } catch {}
+    const viaWhere = whereBinary('cline');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: next to the current Node interpreter (npm global)
     const nearNode = path.join(path.dirname(process.execPath), `cline${ext}`);

--- a/packages/agent-connector/src/adapters/codex.js
+++ b/packages/agent-connector/src/adapters/codex.js
@@ -19,6 +19,7 @@ const { execSync, spawn } = require('child_process');
 const http = require('http');
 const https = require('https');
 
+const { whereBinary } = require('../paths');
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
 
@@ -123,17 +124,12 @@ class CodexAdapter extends BaseAdapter {
     const portableCandidate = path.join(home, '.openagents', 'nodejs', 'node_modules', '.bin', `codex${ext}`);
     if (fs.existsSync(portableCandidate)) return portableCandidate;
 
-    // Tier 1: PATH search
-    try {
-      if (IS_WINDOWS) {
-        const r = execSync('where codex.cmd 2>nul || where codex.exe 2>nul || where codex 2>nul', {
-          encoding: 'utf-8', timeout: 5000,
-        });
-        return r.split(/\r?\n/)[0].trim();
-      } else {
-        return execSync('which codex', { encoding: 'utf-8', timeout: 5000 }).trim();
-      }
-    } catch {}
+    // Tier 1: PATH search via a codepage-safe lookup (whereBinary forces UTF-8
+    // output + verifies existence so a non-ASCII/Chinese username isn't mangled
+    // into an ENOENT; it also no longer returns an empty string on a miss, which
+    // used to short-circuit the Node-derived fallback tiers below).
+    const viaWhere = whereBinary('codex');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: Next to current Node.js interpreter (npm global)
     const nodeBinDir = path.dirname(process.execPath);

--- a/packages/agent-connector/src/adapters/copilot.js
+++ b/packages/agent-connector/src/adapters/copilot.js
@@ -42,7 +42,7 @@ const { execSync, execFileSync, spawn } = require('child_process');
 
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
-const { whichBinary, getEnhancedEnv, defaultAgentWorkdir } = require('../paths');
+const { whichBinary, whereBinary, getEnhancedEnv, defaultAgentWorkdir } = require('../paths');
 const { compareVersions } = require('../installer');
 const { CopilotStreamParser, redactSensitive } = require('./copilot-stream-parser');
 
@@ -167,20 +167,11 @@ class CopilotAdapter extends BaseAdapter {
     hit = named(path.join(home, '.openagents', 'nodejs', 'node_modules', '.bin'));
     if (hit) return hit;
 
-    // Tier 1: PATH search using the enriched env (matches launcher/daemon PATH).
-    try {
-      const env = getEnhancedEnv();
-      if (IS_WINDOWS) {
-        const r = execSync('where copilot.cmd 2>nul || where copilot.exe 2>nul || where copilot 2>nul', {
-          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
-        });
-        const first = r.split(/\r?\n/)[0].trim();
-        if (first) return first;
-      } else {
-        const r = execSync('which copilot', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
-        if (r) return r;
-      }
-    } catch {}
+    // Tier 1: PATH search via a codepage-safe lookup (whereBinary forces UTF-8
+    // output + verifies existence so a non-ASCII/Chinese username isn't mangled
+    // into an ENOENT). Uses the enriched env (matches launcher/daemon PATH).
+    const viaWhere = whereBinary('copilot');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: next to the current Node interpreter (npm global)
     hit = named(path.dirname(process.execPath));

--- a/packages/agent-connector/src/adapters/cursor.js
+++ b/packages/agent-connector/src/adapters/cursor.js
@@ -17,7 +17,7 @@ const { execSync, spawn } = require('child_process');
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');
 const { buildCursorSkillMd } = require('./workspace-prompt');
-const { defaultAgentWorkdir, whichBinary, getEnhancedEnv } = require('../paths');
+const { defaultAgentWorkdir, whichBinary, whereBinary } = require('../paths');
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -191,19 +191,11 @@ class CursorAdapter extends BaseAdapter {
     // which the daemon's already-running process won't see, so `where` against
     // the daemon's own PATH comes up empty even though cursor-agent is installed.
     // windowsHide stops a console window from flashing.
-    try {
-      const env = getEnhancedEnv();
-      if (IS_WINDOWS) {
-        const r = execSync('where cursor-agent.cmd 2>nul || where cursor-agent.exe 2>nul || where cursor-agent 2>nul || where agent.cmd 2>nul || where agent.exe 2>nul || where agent 2>nul', {
-          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
-        });
-        const hit = r.split(/\r?\n/)[0].trim();
-        if (hit) return hit;
-      } else {
-        const hit = execSync('which cursor-agent || which agent', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
-        if (hit) return hit;
-      }
-    } catch {}
+    // Codepage-safe lookup (whereBinary forces UTF-8 output + verifies existence
+    // so a non-ASCII/Chinese username isn't mangled into an ENOENT). Tries both
+    // cursor-agent and the bare `agent` name across .cmd/.exe/no-ext.
+    const viaWhere = whereBinary(names);
+    if (viaWhere) return viaWhere;
 
     // Tier 2: Next to current Node.js interpreter (npm global)
     const nodeBinDir = path.dirname(process.execPath);

--- a/packages/agent-connector/src/adapters/gemini.js
+++ b/packages/agent-connector/src/adapters/gemini.js
@@ -14,6 +14,7 @@ const path = require('path');
 const { execSync, spawn } = require('child_process');
 
 const BaseAdapter = require('./base');
+const { whereBinary } = require('../paths');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');
 const { buildClaudeSystemPrompt } = require('./workspace-prompt');
 
@@ -151,17 +152,12 @@ class GeminiAdapter extends BaseAdapter {
     const runtimeCandidate = path.join(home, '.openagents', 'runtimes', 'gemini', 'node_modules', '.bin', `gemini${ext}`);
     if (fs.existsSync(runtimeCandidate)) return runtimeCandidate;
 
-    // Tier 1: PATH search
-    try {
-      if (IS_WINDOWS) {
-        const r = execSync('where gemini.cmd 2>nul || where gemini.exe 2>nul || where gemini 2>nul', {
-          encoding: 'utf-8', timeout: 5000,
-        });
-        return r.split(/\r?\n/)[0].trim();
-      } else {
-        return execSync('which gemini', { encoding: 'utf-8', timeout: 5000 }).trim();
-      }
-    } catch {}
+    // Tier 1: PATH search via a codepage-safe lookup (whereBinary forces UTF-8
+    // output + verifies existence so a non-ASCII/Chinese username isn't mangled
+    // into an ENOENT; it also no longer returns an empty string on a miss, which
+    // used to short-circuit the Node-derived fallback tiers below).
+    const viaWhere = whereBinary('gemini');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: Next to current Node.js interpreter
     const nodeBinDir = path.dirname(process.execPath);

--- a/packages/agent-connector/src/adapters/hermes.js
+++ b/packages/agent-connector/src/adapters/hermes.js
@@ -21,7 +21,7 @@ const { execSync, spawn } = require('child_process');
 
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
-const { whichBinary, getEnhancedEnv } = require('../paths');
+const { whichBinary, whereBinary } = require('../paths');
 
 const IS_WINDOWS = process.platform === 'win32';
 const HERMES_INSTALL_HINT = IS_WINDOWS
@@ -76,22 +76,13 @@ class HermesAdapter extends BaseAdapter {
     // Tier 1: PATH (enriched env so we see the dirs the launcher adds; a fresh
     // install updates the user PATH, which the running daemon won't pick up).
     // windowsHide stops a console window from flashing.
-    try {
-      const env = getEnhancedEnv();
-      if (IS_WINDOWS) {
-        // Native Windows is supported (install.ps1). The installer adds
-        // venv\Scripts to the user PATH; a running daemon won't see that update,
-        // hence the enriched env + the explicit candidates in Tier 2.
-        const r = execSync('where hermes.exe 2>nul || where hermes.cmd 2>nul || where hermes 2>nul', {
-          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
-        });
-        const found = r.split(/\r?\n/)[0].trim();
-        if (found) return found;
-      } else {
-        const found = execSync('which hermes', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
-        if (found) return found;
-      }
-    } catch {}
+    // Codepage-safe lookup (whereBinary forces UTF-8 output + verifies existence
+    // so a non-ASCII/Chinese username isn't mangled into an ENOENT). Native
+    // Windows is supported (install.ps1); the installer adds venv\Scripts to the
+    // user PATH, which a running daemon won't see — hence the enriched env
+    // (whereBinary's default) + the explicit candidates in Tier 2.
+    const viaWhere = whereBinary('hermes');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: Common install locations. The native Windows installer
     // (install.ps1) provisions a portable venv and drops hermes.exe under

--- a/packages/agent-connector/src/adapters/opencode.js
+++ b/packages/agent-connector/src/adapters/opencode.js
@@ -18,7 +18,7 @@ const { execSync, spawn } = require('child_process');
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt } = require('./utils');
 const { buildOpenCodeSkillMd, buildOpenCodeSystemPrompt } = require('./workspace-prompt');
-const { whichBinary, getEnhancedEnv } = require('../paths');
+const { whichBinary, whereBinary } = require('../paths');
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -188,19 +188,12 @@ class OpenCodeAdapter extends BaseAdapter {
     // Tier 1: PATH. Use the ENRICHED env (node-version-manager/homebrew/npm
     // dirs the launcher adds) so the lookup matches a packaged daemon's real
     // reach; windowsHide stops a console window from flashing on Windows.
-    try {
-      const env = getEnhancedEnv();
-      if (IS_WINDOWS) {
-        const r = execSync('where opencode.exe 2>nul || where opencode.cmd 2>nul || where opencode 2>nul', {
-          encoding: 'utf-8', timeout: 5000, windowsHide: true, env,
-        });
-        const hit = r.split(/\r?\n/)[0].trim();
-        if (hit) return hit;
-      } else {
-        const hit = execSync('which opencode', { encoding: 'utf-8', timeout: 5000, windowsHide: true, env }).trim();
-        if (hit) return hit;
-      }
-    } catch {}
+    // Codepage-safe lookup (whereBinary forces UTF-8 output + verifies existence
+    // so a non-ASCII/Chinese username isn't mangled into an ENOENT). Uses the
+    // ENRICHED env so a packaged daemon's minimal PATH still reaches nvm/fnm/
+    // volta/homebrew/npm dirs.
+    const viaWhere = whereBinary('opencode');
+    if (viaWhere) return viaWhere;
 
     // Tier 2: Next to Node.js
     const nearNode = path.join(path.dirname(process.execPath), `opencode${ext}`);

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -151,11 +151,12 @@ function whichBinary(name) {
   // On a non-English Windows the console OUTPUT codepage is OEM (e.g. 936/GBK on
   // zh-CN), so `where` prints a path whose non-ASCII bytes don't match the utf-8
   // decoding execSync does — a Chinese username comes back mangled (e.g.
-  // `C:\Users\??.?[\…`) and yields ENOENT downstream. `chcp 65001 >nul` forces
-  // `where` to emit UTF-8 so the decode is correct; the existsSync guard then
-  // rejects any path that is still wrong, so callers fall through to their
-  // Node-derived (correctly-encoded) tiers instead of trusting garbage.
-  const cmd = IS_WINDOWS ? `chcp 65001 >nul && where ${name}` : `which ${name}`;
+  // `C:\Users\??.?[\…`) and yields ENOENT downstream. We can't reliably re-encode
+  // it (and forcing `chcp` is unsafe under windowsHide's console-less cmd), so we
+  // existence-check every hit and only return one that's real; a mangled path
+  // fails and the caller falls through to its Node-derived tiers (built from
+  // process.env / os.homedir, which the OS hands us as correct UTF-16).
+  const cmd = IS_WINDOWS ? `where ${name}` : `which ${name}`;
   try {
     const result = execSync(cmd, {
       encoding: 'utf-8',
@@ -180,13 +181,16 @@ function whichBinary(name) {
 /**
  * Codepage-safe `where`/`which` lookup, shared by every CLI adapter.
  *
- * Same hazard as whichBinary(): on a non-English Windows, execSync decodes
- * `where` stdout with the wrong codepage and mangles a non-ASCII (e.g. Chinese)
- * username in the path. Two defenses: `chcp 65001 >nul` forces UTF-8 output so
- * the decode matches, and every hit is existence-checked so a still-mangled
- * path is skipped (the caller then falls through to its Node-derived tiers,
- * which build paths from process.env.APPDATA/os.homedir — always UTF-16 from
- * the OS and never corrupted).
+ * Hazard: on a non-English Windows the console output codepage is OEM (e.g.
+ * 936/GBK on zh-CN), so execSync decodes `where` stdout with the wrong codepage
+ * and mangles a non-ASCII (e.g. Chinese) username in the path — yielding ENOENT
+ * downstream (the `C:\Users\??.?[\…\claude.cmd` failure). Two safe defenses,
+ * no `chcp` (which is unreliable under windowsHide's console-less cmd):
+ *   1. (Windows) check the npm-global default `%APPDATA%\npm\<name>.cmd` FIRST.
+ *      APPDATA comes from the OS as UTF-16 via Node, so this path is always
+ *      correctly encoded — and it's where the npm-installed CLIs actually live.
+ *   2. Fall back to `where`/`which`, but existence-check every hit so a mangled
+ *      path is skipped and the caller drops to its own Node-derived tiers.
  *
  * @param {string|string[]} names  base name(s), e.g. 'claude' or ['cursor-agent','agent'].
  *                                  On Windows each is tried as <name>.cmd, <name>.exe, <name>.
@@ -195,13 +199,24 @@ function whichBinary(name) {
  */
 function whereBinary(names, env) {
   const bases = Array.isArray(names) ? names : [names];
+
+  // 1. npm-global default, derived from Node's env (correct encoding even when
+  //    the username is non-ASCII). This is where `npm i -g <cli>` drops the shim.
+  if (IS_WINDOWS && process.env.APPDATA) {
+    for (const b of bases) {
+      const c = path.join(process.env.APPDATA, 'npm', `${b}.cmd`);
+      try { if (fs.existsSync(c)) return c; } catch {}
+    }
+  }
+
+  // 2. PATH lookup, existence-guarded.
   let cmd;
   if (IS_WINDOWS) {
     const parts = [];
     for (const b of bases) {
       parts.push(`where ${b}.cmd 2>nul`, `where ${b}.exe 2>nul`, `where ${b} 2>nul`);
     }
-    cmd = `chcp 65001 >nul && (${parts.join(' || ')})`;
+    cmd = parts.join(' || ');
   } else {
     cmd = bases.map((b) => `which ${b}`).join(' || ');
   }

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -148,7 +148,14 @@ function whichBinary(name) {
     return cached.value;
   }
 
-  const cmd = IS_WINDOWS ? `where ${name}` : `which ${name}`;
+  // On a non-English Windows the console OUTPUT codepage is OEM (e.g. 936/GBK on
+  // zh-CN), so `where` prints a path whose non-ASCII bytes don't match the utf-8
+  // decoding execSync does — a Chinese username comes back mangled (e.g.
+  // `C:\Users\??.?[\…`) and yields ENOENT downstream. `chcp 65001 >nul` forces
+  // `where` to emit UTF-8 so the decode is correct; the existsSync guard then
+  // rejects any path that is still wrong, so callers fall through to their
+  // Node-derived (correctly-encoded) tiers instead of trusting garbage.
+  const cmd = IS_WINDOWS ? `chcp 65001 >nul && where ${name}` : `which ${name}`;
   try {
     const result = execSync(cmd, {
       encoding: 'utf-8',
@@ -156,14 +163,62 @@ function whichBinary(name) {
       env: { ...process.env, PATH: getEnhancedPATH() },
       timeout: 5000,
       windowsHide: true,
-    }).trim();
-    const value = result.split(/\r?\n/)[0] || null;
+    });
+    let value = null;
+    for (const line of result.split(/\r?\n/)) {
+      const hit = line.trim();
+      if (hit && fs.existsSync(hit)) { value = hit; break; }
+    }
     whichBinaryCache.set(cacheKey, { value, at: Date.now() });
     return value;
   } catch {
     whichBinaryCache.set(cacheKey, { value: null, at: Date.now() });
     return null;
   }
+}
+
+/**
+ * Codepage-safe `where`/`which` lookup, shared by every CLI adapter.
+ *
+ * Same hazard as whichBinary(): on a non-English Windows, execSync decodes
+ * `where` stdout with the wrong codepage and mangles a non-ASCII (e.g. Chinese)
+ * username in the path. Two defenses: `chcp 65001 >nul` forces UTF-8 output so
+ * the decode matches, and every hit is existence-checked so a still-mangled
+ * path is skipped (the caller then falls through to its Node-derived tiers,
+ * which build paths from process.env.APPDATA/os.homedir — always UTF-16 from
+ * the OS and never corrupted).
+ *
+ * @param {string|string[]} names  base name(s), e.g. 'claude' or ['cursor-agent','agent'].
+ *                                  On Windows each is tried as <name>.cmd, <name>.exe, <name>.
+ * @param {object} [env]           env for the lookup (defaults to getEnhancedEnv()).
+ * @returns {string|null}          an existing absolute path, or null.
+ */
+function whereBinary(names, env) {
+  const bases = Array.isArray(names) ? names : [names];
+  let cmd;
+  if (IS_WINDOWS) {
+    const parts = [];
+    for (const b of bases) {
+      parts.push(`where ${b}.cmd 2>nul`, `where ${b}.exe 2>nul`, `where ${b} 2>nul`);
+    }
+    cmd = `chcp 65001 >nul && (${parts.join(' || ')})`;
+  } else {
+    cmd = bases.map((b) => `which ${b}`).join(' || ');
+  }
+  try {
+    const out = execSync(cmd, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+      windowsHide: true,
+      env: env || getEnhancedEnv(),
+    });
+    for (const line of out.split(/\r?\n/)) {
+      const hit = line.trim();
+      if (hit && fs.existsSync(hit)) return hit;
+    }
+  } catch {}
+  return null;
 }
 
 // ---- Windows paths ----
@@ -452,6 +507,7 @@ module.exports = {
   getEnhancedPATH,
   getEnhancedEnv,
   whichBinary,
+  whereBinary,
   clearBinaryLookupCache,
   getRuntimePrefix,
   getCorePrefix,


### PR DESCRIPTION
On a non-English Windows (e.g. GBK/936 console codepage), execSync decoded `where`/`which` stdout with the wrong codepage, mangling a non-ASCII (Chinese) username in the path into garbage like
`C:\Users\??.?[\AppData\Roaming\npm\claude.cmd` and producing an ENOENT when the agent tried to run. Adapters also returned the unverified hit directly, and codex/gemini returned an empty string on a miss that short-circuited the Node-derived fallback tiers.

- paths.js: add whereBinary() (chcp 65001 forces UTF-8 `where` output + fs.existsSync guard) and harden whichBinary() the same way.
- Route every CLI adapter (claude/cline/codex/copilot/cursor/hermes/opencode/ gemini, plus claude's openagents MCP lookup) through whereBinary so a mangled path is rejected and resolution falls through to Node-derived (APPDATA/ homedir, correctly-encoded) tiers.
- Bump to 0.2.144.