### PR TITLE
feat(providers): refresh MiniMax models and endpoints

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -580,6 +580,7 @@ This allows you to configure LLM settings once at the environment level rather t
 | `perplexity` | `PERPLEXITY_API_KEY` | llama-3.1-sonar-huge-128k-online |
 | `openrouter` | `OPENROUTER_API_KEY` | (any model via OpenRouter) |
 | `bedrock` | `AWS_ACCESS_KEY_ID` | anthropic.claude-3-5-sonnet |
+| `minimax` | `MINIMAX_API_KEY` | MiniMax-M3, MiniMax-M2.7 |
 | `custom` | `CUSTOM_API_KEY` | (requires DEFAULT_LLM_BASE_URL) |
 
 ### Provider-Specific Configuration
@@ -602,12 +603,39 @@ export AWS_ACCESS_KEY_ID="..."
 export AWS_SECRET_ACCESS_KEY="..."
 export AWS_REGION="us-east-1"
 
+# MiniMax
+export DEFAULT_LLM_PROVIDER="minimax"
+export DEFAULT_LLM_MODEL_NAME="MiniMax-M3"
+export DEFAULT_LLM_API_KEY="your-api-key"
+export DEFAULT_LLM_BASE_URL="https://api.minimax.io/v1"
+
 # Custom OpenAI-compatible (Ollama, vLLM, LM Studio, etc.)
 export DEFAULT_LLM_PROVIDER="custom"
 export DEFAULT_LLM_MODEL_NAME="llama3"
 export DEFAULT_LLM_BASE_URL="http://localhost:11434/v1"
 export DEFAULT_LLM_API_KEY="not-needed"  # Some local servers don't require a key
 ```
+
+### MiniMax Endpoints
+
+The MiniMax provider supports OpenAI- and Anthropic-compatible APIs in both
+regions through the existing `DEFAULT_LLM_BASE_URL` setting:
+
+| Protocol | Global | China |
+|----------|--------|-------|
+| OpenAI-compatible | `https://api.minimax.io/v1` | `https://api.minimaxi.com/v1` |
+| Anthropic-compatible | `https://api.minimax.io/anthropic` | `https://api.minimaxi.com/anthropic` |
+
+Keep `DEFAULT_LLM_PROVIDER="minimax"` for either protocol. The provider selects
+the protocol from the base URL. Anthropic-compatible base URLs end at
+`/anthropic`; do not append `/v1`.
+
+`MiniMax-M3` has a 1,000,000-token total context window, accepts text, image,
+and video input, and supports adaptive or disabled thinking. `MiniMax-M2.7` has
+a 204,800-token total context window, accepts text input, and keeps thinking
+enabled. See the [MiniMax API overview](https://platform.minimax.io/docs/api-reference/api-overview)
+for current model limits and the [pricing guide](https://platform.minimax.io/docs/guides/pricing-paygo)
+for current costs.
 
 ### Specifying Model Directly
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ sdk = [
     "jinja2>=3.1.0",
     "mcp>=1.15.0",
     "openai>=1.98",
+    "anthropic>=0.49.0",
     "litellm>=1.80.0,<1.87",
     "prometheus-client>=0.16.0",
     "structlog>=23.0.0",

--- a/sdk/src/openagents/config/llm_configs.py
+++ b/sdk/src/openagents/config/llm_configs.py
@@ -191,6 +191,7 @@ MODEL_CONFIGS: Dict[str, Dict[str, Any]] = {
         "provider": "minimax",
         "api_base": "https://api.minimax.io/v1",
         "models": [
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
         ],

--- a/sdk/src/openagents/config/llm_configs.py
+++ b/sdk/src/openagents/config/llm_configs.py
@@ -397,6 +397,8 @@ def determine_provider(
             return "qwen"
         elif "x.ai" in api_base:
             return "grok"
+        elif "api.minimax.io" in api_base or "api.minimaxi.com" in api_base:
+            return "minimax"
         elif "anthropic.com" in api_base:
             return "claude"
         elif "googleapis.com" in api_base:
@@ -463,7 +465,9 @@ def create_model_provider(
             model_name=model_name, api_base=api_base, api_key=api_key, **kwargs
         )
     elif provider == "claude" or provider == "anthropic":
-        return AnthropicProvider(model_name=model_name, api_key=api_key, **kwargs)
+        return AnthropicProvider(
+            model_name=model_name, api_base=api_base, api_key=api_key, **kwargs
+        )
     elif provider == "bedrock":
         return BedrockProvider(model_name=model_name, **kwargs)
     elif provider == "gemini":

--- a/sdk/src/openagents/lms/providers.py
+++ b/sdk/src/openagents/lms/providers.py
@@ -141,8 +141,15 @@ class OpenAIProvider(BaseModelProvider):
 class AnthropicProvider(BaseModelProvider):
     """Anthropic Claude provider."""
 
-    def __init__(self, model_name: str, api_key: Optional[str] = None, **kwargs):
+    def __init__(
+        self,
+        model_name: str,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        **kwargs,
+    ):
         self.model_name = model_name
+        self.api_base = api_base.rstrip("/") if api_base else None
 
         try:
             import anthropic
@@ -152,7 +159,12 @@ class AnthropicProvider(BaseModelProvider):
             )
 
         api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-        self.client = anthropic.AsyncAnthropic(api_key=api_key)
+        if self.api_base:
+            self.client = anthropic.AsyncAnthropic(
+                api_key=api_key, base_url=self.api_base
+            )
+        else:
+            self.client = anthropic.AsyncAnthropic(api_key=api_key)
 
     async def chat_completion(
         self,
@@ -587,7 +599,7 @@ class GeminiProvider(BaseModelProvider):
 
 
 class MiniMaxProvider(BaseModelProvider):
-    """MiniMax provider using OpenAI-compatible API."""
+    """MiniMax provider using OpenAI- or Anthropic-compatible APIs."""
 
     def __init__(
         self,
@@ -597,7 +609,24 @@ class MiniMaxProvider(BaseModelProvider):
         **kwargs,
     ):
         self.model_name = model_name
-        self.api_base = api_base or "https://api.minimax.io/v1"
+        self.api_base = (api_base or "https://api.minimax.io/v1").rstrip("/")
+        self.protocol = (
+            "anthropic" if self.api_base.endswith("/anthropic") else "openai"
+        )
+
+        effective_api_key = api_key or os.getenv("MINIMAX_API_KEY")
+        if not effective_api_key:
+            logger.warning("No MINIMAX_API_KEY provided for MiniMax provider")
+
+        self._anthropic_provider = None
+        if self.protocol == "anthropic":
+            self._anthropic_provider = AnthropicProvider(
+                model_name=model_name,
+                api_base=self.api_base,
+                api_key=effective_api_key or "dummy",
+            )
+            self.client = self._anthropic_provider.client
+            return
 
         try:
             from openai import AsyncOpenAI
@@ -606,17 +635,19 @@ class MiniMaxProvider(BaseModelProvider):
                 "openai package is required for MiniMax provider. Install with: pip install openai"
             )
 
-        effective_api_key = api_key or os.getenv("MINIMAX_API_KEY")
-        if not effective_api_key:
-            logger.warning("No MINIMAX_API_KEY provided for MiniMax provider")
-        self.client = AsyncOpenAI(base_url=self.api_base, api_key=effective_api_key or "dummy")
+        self.client = AsyncOpenAI(
+            base_url=self.api_base, api_key=effective_api_key or "dummy"
+        )
 
     async def chat_completion(
         self,
         messages: List[Dict[str, Any]],
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
-        """Generate chat completion using MiniMax OpenAI-compatible API."""
+        """Generate a chat completion using the configured MiniMax protocol."""
+        if self._anthropic_provider:
+            return await self._anthropic_provider.chat_completion(messages, tools)
+
         kwargs = {
             "model": self.model_name,
             "messages": messages,
@@ -655,6 +686,8 @@ class MiniMaxProvider(BaseModelProvider):
 
     def format_tools(self, tools: List[Any]) -> List[Dict[str, Any]]:
         """Format tools for MiniMax function calling."""
+        if self._anthropic_provider:
+            return self._anthropic_provider.format_tools(tools)
         return [tool.to_openai_function() for tool in tools]
 
 

--- a/sdk/src/openagents/models/agent_config.py
+++ b/sdk/src/openagents/models/agent_config.py
@@ -176,6 +176,11 @@ class AgentConfig(BaseModel):
                 return "qwen"
             elif "x.ai" in self.api_base:
                 return "grok"
+            elif (
+                "api.minimax.io" in self.api_base
+                or "api.minimaxi.com" in self.api_base
+            ):
+                return "minimax"
             elif "anthropic.com" in self.api_base:
                 return "claude"
             elif "googleapis.com" in self.api_base:
@@ -203,6 +208,8 @@ class AgentConfig(BaseModel):
             return "together"
         elif "sonar" in model_lower:
             return "perplexity"
+        elif "minimax" in model_lower:
+            return "minimax"
         elif "anthropic." in self.model_name:
             return "bedrock"
 

--- a/tests/lms/test_minimax_provider.py
+++ b/tests/lms/test_minimax_provider.py
@@ -170,9 +170,10 @@ class TestMiniMaxConfig:
     def test_minimax_has_correct_models(self):
         """Test that minimax config has the correct models."""
         models = MODEL_CONFIGS["minimax"]["models"]
+        assert "MiniMax-M3" in models
         assert "MiniMax-M2.7" in models
         assert "MiniMax-M2.7-highspeed" in models
-        assert len(models) == 2
+        assert len(models) == 3
 
     def test_minimax_has_correct_api_base(self):
         """Test that minimax config has the correct API base URL."""

--- a/tests/lms/test_minimax_provider.py
+++ b/tests/lms/test_minimax_provider.py
@@ -1,17 +1,30 @@
 """Unit tests for the MiniMax provider."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from openagents.lms.providers import MiniMaxProvider
+import pytest
+
 from openagents.config.llm_configs import (
     MODEL_CONFIGS,
     LLMProviderType,
+    create_model_provider,
     determine_provider,
     get_supported_models,
     get_provider_type,
     is_supported_provider,
 )
+from openagents.lms.providers import AnthropicProvider, MiniMaxProvider
+from openagents.models.agent_config import AgentConfig
+
+
+MINIMAX_OPENAI_BASE_URLS = [
+    "https://api.minimax.io/v1",
+    "https://api.minimaxi.com/v1",
+]
+MINIMAX_ANTHROPIC_BASE_URLS = [
+    "https://api.minimax.io/anthropic",
+    "https://api.minimaxi.com/anthropic",
+]
 
 
 class TestMiniMaxProvider:
@@ -35,6 +48,46 @@ class TestMiniMaxProvider:
             model_name="MiniMax-M2.7", api_key="test-key", api_base=custom_url
         )
         assert provider.api_base == custom_url
+
+    @pytest.mark.parametrize("api_base", MINIMAX_OPENAI_BASE_URLS)
+    def test_uses_openai_compatible_endpoints(self, api_base):
+        """Test that both OpenAI-compatible regional endpoints are usable."""
+        with patch("openai.AsyncOpenAI") as mock_client:
+            provider = MiniMaxProvider(
+                model_name="MiniMax-M3", api_key="test-key", api_base=api_base
+            )
+
+        assert provider.protocol == "openai"
+        mock_client.assert_called_once_with(base_url=api_base, api_key="test-key")
+
+    @pytest.mark.parametrize("api_base", MINIMAX_ANTHROPIC_BASE_URLS)
+    def test_uses_anthropic_compatible_endpoints(self, api_base):
+        """Test that both Anthropic-compatible regional endpoints are usable."""
+        with patch("openagents.lms.providers.AnthropicProvider") as provider_class:
+            provider = MiniMaxProvider(
+                model_name="MiniMax-M3", api_key="test-key", api_base=api_base
+            )
+
+        assert provider.protocol == "anthropic"
+        provider_class.assert_called_once_with(
+            model_name="MiniMax-M3", api_base=api_base, api_key="test-key"
+        )
+        assert provider.client is provider_class.return_value.client
+
+    def test_anthropic_provider_passes_custom_base_url_to_sdk(self):
+        """Test that AnthropicProvider preserves a custom API base URL."""
+        anthropic_module = MagicMock()
+        api_base = "https://api.minimax.io/anthropic"
+
+        with patch.dict("sys.modules", {"anthropic": anthropic_module}):
+            provider = AnthropicProvider(
+                model_name="MiniMax-M3", api_key="test-key", api_base=api_base
+            )
+
+        assert provider.api_base == api_base
+        anthropic_module.AsyncAnthropic.assert_called_once_with(
+            api_key="test-key", base_url=api_base
+        )
 
     def test_uses_env_api_key(self, monkeypatch):
         """Test that MiniMaxProvider reads API key from MINIMAX_API_KEY env var."""
@@ -85,7 +138,7 @@ class TestMiniMaxProvider:
             return_value=mock_response,
         ) as mock_create:
             messages = [{"role": "user", "content": "Hi"}]
-            result = await provider.chat_completion(messages)
+            await provider.chat_completion(messages)
 
             call_kwargs = mock_create.call_args[1]
             assert call_kwargs["temperature"] == 1.0
@@ -159,6 +212,25 @@ class TestMiniMaxProvider:
             assert "tools" in call_kwargs
             assert call_kwargs["tool_choice"] == "auto"
 
+    @pytest.mark.asyncio
+    async def test_chat_completion_delegates_anthropic_protocol(self):
+        """Test that Anthropic-compatible requests use AnthropicProvider."""
+        messages = [{"role": "user", "content": "Hello"}]
+        expected = {"content": "Hi", "tool_calls": []}
+
+        with patch("openagents.lms.providers.AnthropicProvider") as provider_class:
+            delegate = provider_class.return_value
+            delegate.chat_completion = AsyncMock(return_value=expected)
+            provider = MiniMaxProvider(
+                model_name="MiniMax-M3",
+                api_key="test-key",
+                api_base="https://api.minimax.io/anthropic",
+            )
+            result = await provider.chat_completion(messages)
+
+        assert result == expected
+        delegate.chat_completion.assert_awaited_once_with(messages, None)
+
 
 class TestMiniMaxConfig:
     """Tests for MiniMax configuration entries."""
@@ -170,8 +242,7 @@ class TestMiniMaxConfig:
     def test_minimax_has_correct_models(self):
         """Test that minimax config has the correct models."""
         models = MODEL_CONFIGS["minimax"]["models"]
-        assert "MiniMax-M3" in models
-        assert "MiniMax-M2.7" in models
+        assert models[:2] == ["MiniMax-M3", "MiniMax-M2.7"]
         assert "MiniMax-M2.7-highspeed" in models
         assert len(models) == 3
 
@@ -200,6 +271,7 @@ class TestMiniMaxConfig:
     def test_get_supported_models(self):
         """Test get_supported_models for minimax."""
         models = get_supported_models("minimax")
+        assert "MiniMax-M3" in models
         assert "MiniMax-M2.7" in models
         assert "MiniMax-M2.7-highspeed" in models
 
@@ -216,6 +288,11 @@ class TestDetermineProvider:
         provider = determine_provider(None, "MiniMax-M2.7", None)
         assert provider == "minimax"
 
+    def test_detects_minimax_m3(self):
+        """Test that MiniMax-M3 is auto-detected as minimax provider."""
+        provider = determine_provider(None, "MiniMax-M3", None)
+        assert provider == "minimax"
+
     def test_detects_minimax_m2_7_highspeed(self):
         """Test that MiniMax-M2.7-highspeed is auto-detected as minimax provider."""
         provider = determine_provider(None, "MiniMax-M2.7-highspeed", None)
@@ -225,3 +302,45 @@ class TestDetermineProvider:
         """Test that explicit 'minimax' provider is respected."""
         provider = determine_provider("minimax", "MiniMax-M2.7", None)
         assert provider == "minimax"
+
+    @pytest.mark.parametrize(
+        "api_base", MINIMAX_OPENAI_BASE_URLS + MINIMAX_ANTHROPIC_BASE_URLS
+    )
+    def test_detects_minimax_endpoints(self, api_base):
+        """Test that all MiniMax endpoints are auto-detected."""
+        provider = determine_provider(None, "custom-model", api_base)
+        assert provider == "minimax"
+
+    def test_agent_config_detects_minimax_m3(self):
+        """Test that AgentConfig detects MiniMax-M3 consistently."""
+        config = AgentConfig(instruction="Be helpful.", model_name="MiniMax-M3")
+        assert config.determine_provider() == "minimax"
+
+    @pytest.mark.parametrize(
+        "api_base", MINIMAX_OPENAI_BASE_URLS + MINIMAX_ANTHROPIC_BASE_URLS
+    )
+    def test_agent_config_detects_minimax_endpoints(self, api_base):
+        """Test that AgentConfig detects all MiniMax endpoint variants."""
+        config = AgentConfig(
+            instruction="Be helpful.", model_name="custom-model", api_base=api_base
+        )
+        assert config.determine_provider() == "minimax"
+
+
+class TestMiniMaxFactory:
+    """Tests for MiniMax provider construction."""
+
+    @pytest.mark.parametrize("api_base", MINIMAX_ANTHROPIC_BASE_URLS)
+    def test_factory_preserves_anthropic_base_url(self, api_base):
+        """Test that the provider factory preserves Anthropic base URLs."""
+        with patch("openagents.lms.MiniMaxProvider") as provider_class:
+            create_model_provider(
+                provider="minimax",
+                model_name="MiniMax-M3",
+                api_base=api_base,
+                api_key="test-key",
+            )
+
+        provider_class.assert_called_once_with(
+            model_name="MiniMax-M3", api_base=api_base, api_key="test-key"
+        )


### PR DESCRIPTION
## Summary

Refresh the MiniMax provider with `MiniMax-M3` and complete its regional OpenAI- and Anthropic-compatible endpoint support.

## Changes

- Add `MiniMax-M3` ahead of `MiniMax-M2.7` in the provider model list.
- Route `/anthropic` base URLs through the existing Anthropic provider while preserving the single `api_base` configuration surface.
- Auto-detect MiniMax model names and global or China endpoint variants consistently.
- Add the Anthropic SDK to the `sdk` extra and document both protocols, regions, context limits, modalities, and thinking support.
- Cover model registration, endpoint selection, factory propagation, provider delegation, and agent configuration in tests.

## Testing

- `pytest tests/lms -q` - 81 passed
- `ruff check --select E4,E7,E9,F --ignore E402 sdk/src/openagents/config/llm_configs.py sdk/src/openagents/lms/providers.py sdk/src/openagents/models/agent_config.py tests/lms/test_minimax_provider.py` - passed
- Captured SDK requests confirm `/v1/chat/completions` for OpenAI-compatible bases and `/anthropic/v1/messages` for Anthropic-compatible bases in both regions.
