### PR TITLE
fix(agn): reject unknown agent type in `create` before creating entry

### DIFF
--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -134,6 +134,18 @@ async function cmdCreate(connector, flags, positional) {
   const type = flags.type || 'openclaw';
   const role = flags.role || 'worker';
 
+  // Validate the runtime type BEFORE creating any local entry. A typo'd or
+  // otherwise unknown type (e.g. "calude") must not leave a broken agent in
+  // config — an uninstalled-but-valid type is fine and handled further down.
+  if (!connector.registry.getEntry(type)) {
+    const known = connector.registry.getCatalogSync().map((e) => e.name).sort();
+    print(`Error: unknown agent type '${type}'.`);
+    print(`Supported types: ${known.join(', ')}`);
+    print('Run `agn search` to browse available agent types.');
+    process.exitCode = 1;
+    return;
+  }
+
   try {
     connector.addAgent({ name, type, role, path: flags.path || process.cwd() });
 

--- a/packages/agent-connector/test/cli.test.js
+++ b/packages/agent-connector/test/cli.test.js
@@ -114,6 +114,23 @@ describe('CLI', () => {
     }
   });
 
+  it('create rejects an unknown agent type without creating an entry', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
+    try {
+      const res = runCapture({}, 'create', 'random-bot', '--type', 'calude', '--config', tmpDir);
+      assert.equal(res.code, 1);
+      assert.ok(res.stdout.includes("unknown agent type 'calude'"));
+      assert.ok(!res.stdout.includes('Created local agent'));
+
+      // The invalid agent must NOT be persisted to config.
+      const listOut = runWithConfig(tmpDir, 'list');
+      assert.ok(listOut.includes('No agents configured'));
+      assert.ok(!listOut.includes('random-bot'));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('env set and get', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-cli-'));
     try {


### PR DESCRIPTION
## Problem

Running `agn create <name> --type <type>` with a typo'd/unknown type created the
local agent entry **first**, then only afterward printed a warning that the
runtime wasn't installed:

```
➜ agn create random-bot --type calude
Created local agent: random-bot (type: calude)     ← broken entry persisted
...
Runtime 'calude' is not installed. Run: agn install calude
```

The entry (`calude`, a typo for `claude`) can never run — there's no such
adapter/runtime — yet it's left behind in `~/.openagents/daemon.yaml`.

## Fix

Validate `--type` against the registry catalog **before** `addAgent`. On an
unknown type: print an error listing the supported types, exit non-zero, and
create nothing. A valid-but-uninstalled type (e.g. `claude` without the CLI)
still creates and prompts to install, exactly as before.

```
➜ agn create random-bot --type calude
Error: unknown agent type 'calude'.
Supported types: aider, amp, claude, cline, codex, copilot, cursor, gemini, goose, hermes, kimi, nanoclaw, openclaw, opencode
Run `agn search` to browse available agent types.
(exit 1, no entry created)
```

## Test

Added `create rejects an unknown agent type without creating an entry` to
`test/cli.test.js` — asserts exit 1, the error message, and that `list` shows
`No agents configured` afterward. Full `cli.test.js` suite passes (18/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)