### PR TITLE
add mini-swe-agent workspace adapter

### DIFF
--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -835,5 +835,75 @@
       "login_command": "hermes setup",
       "not_ready_message": "Hermes not configured — run: hermes setup"
     }
+  },
+  {
+    "name": "mini-swe-agent",
+    "label": "mini-SWE-agent",
+    "description": "A minimal shell-based coding agent for fixing issues and modifying code in a workspace.",
+    "homepage": "https://mini-swe-agent.com",
+    "tags": [
+      "coding",
+      "cli",
+      "shell",
+      "autonomous"
+    ],
+    "builtin": true,
+    "support": {
+      "install": true,
+      "workspace": true,
+      "collaboration": true
+    },
+    "install": {
+      "binary": "mini",
+      "verify": "mini --help",
+      "verify_win": "mini --help",
+      "macos": "pip install mini-swe-agent",
+      "linux": "pip install mini-swe-agent",
+      "windows": "pip install mini-swe-agent"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "MSWEA_MODEL_NAME",
+        "description": "Model to use (routed through LiteLLM), e.g. anthropic/claude-sonnet-4-5 or gpt-4o. Optional when a model is already configured via a config file or `mini-extra config setup`. Passed as --model.",
+        "required": false,
+        "placeholder": "anthropic/claude-sonnet-4-5"
+      },
+      {
+        "name": "MSWEA_MINI_CONFIG_PATH",
+        "description": "Path to a FULL mini config file (YAML). Optional. This REPLACES mini's built-in default config (agent prompt templates, step/environment settings) — it does not merge — so provide a complete file (a good starting point is the output of `mini-extra config setup`). Leave blank to use mini's default config.",
+        "required": false,
+        "placeholder": "/path/to/mini.yaml"
+      },
+      {
+        "name": "MSWEA_COST_LIMIT",
+        "description": "Optional per-run cost limit in USD, passed as --cost-limit. Leave blank for mini's default.",
+        "required": false,
+        "placeholder": "3.0"
+      },
+      {
+        "name": "ANTHROPIC_API_KEY",
+        "description": "Anthropic API key — used when the model is an Anthropic model. Leave blank if using another provider or a key already in your environment.",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "OPENAI_API_KEY",
+        "description": "OpenAI API key — used when the model is an OpenAI model. Leave blank if using another provider or a key already in your environment.",
+        "required": false,
+        "password": true
+      }
+    ],
+    "check_ready": {
+      "env_vars": [
+        "MSWEA_MODEL_NAME",
+        "MSWEA_MINI_CONFIG_PATH",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY"
+      ],
+      "not_ready_message": "mini-SWE-agent CLI detected. Configure a model through environment variables (MSWEA_MODEL_NAME + a provider key), a full config file (MSWEA_MINI_CONFIG_PATH), or the Model field before running a task."
+    }
   }
 ]

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -890,10 +890,34 @@
         "password": true
       },
       {
+        "name": "ANTHROPIC_BASE_URL",
+        "description": "Custom endpoint for native `anthropic/…` models (an enterprise gateway or Anthropic-protocol relay). Leave blank for hosted Anthropic. Note: most third-party relays are OpenAI-compatible — for those use an `openai/…` model + OPENAI_BASE_URL instead.",
+        "required": false,
+        "placeholder": "https://your-anthropic-gateway.example"
+      },
+      {
         "name": "OPENAI_API_KEY",
         "description": "OpenAI API key — used when the model is an OpenAI model. Leave blank if using another provider or a key already in your environment.",
         "required": false,
         "password": true
+      },
+      {
+        "name": "OPENAI_BASE_URL",
+        "description": "Custom endpoint for OpenAI-compatible models (a relay/proxy or self-hosted gateway) — applies only to `openai/…` models. Leave blank for hosted OpenAI, or for native providers like `deepseek/…` / `anthropic/…`.",
+        "required": false,
+        "placeholder": "https://your-relay.example/v1"
+      },
+      {
+        "name": "DEEPSEEK_API_KEY",
+        "description": "DeepSeek API key — used when the model is a `deepseek/…` model (e.g. deepseek/deepseek-chat or deepseek/deepseek-reasoner). Connects directly to api.deepseek.com; no base URL needed.",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "DEEPSEEK_API_BASE",
+        "description": "Custom endpoint for native `deepseek/…` models. Leave blank to use DeepSeek's default (api.deepseek.com).",
+        "required": false,
+        "placeholder": "https://api.deepseek.com"
       }
     ],
     "check_ready": {
@@ -901,7 +925,8 @@
         "MSWEA_MODEL_NAME",
         "MSWEA_MINI_CONFIG_PATH",
         "ANTHROPIC_API_KEY",
-        "OPENAI_API_KEY"
+        "OPENAI_API_KEY",
+        "DEEPSEEK_API_KEY"
       ],
       "not_ready_message": "mini-SWE-agent CLI detected. Configure a model through environment variables (MSWEA_MODEL_NAME + a provider key), a full config file (MSWEA_MINI_CONFIG_PATH), or the Model field before running a task."
     }

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -19,6 +19,7 @@ const GooseAdapter = require('./goose');
 const CopilotAdapter = require('./copilot');
 const ClineAdapter = require('./cline');
 const AmpAdapter = require('./amp');
+const MiniSweAgentAdapter = require('./mini');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -35,11 +36,12 @@ const ADAPTER_MAP = {
   copilot: CopilotAdapter,
   cline: ClineAdapter,
   amp: AmpAdapter,
+  'mini-swe-agent': MiniSweAgentAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, aider, goose, copilot, cline, amp)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, aider, goose, copilot, cline, amp, mini-swe-agent)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -67,6 +69,7 @@ module.exports = {
   CopilotAdapter,
   ClineAdapter,
   AmpAdapter,
+  MiniSweAgentAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/adapters/mini.js
+++ b/packages/agent-connector/src/adapters/mini.js
@@ -1,0 +1,572 @@
+/**
+ * mini-SWE-agent adapter for OpenAgents workspace.
+ *
+ * Bridges the mini-swe-agent CLI (https://mini-swe-agent.com) to an OpenAgents
+ * workspace as a plain shell-based coding agent. Each workspace message spawns
+ * ONE non-interactive `mini` run in the task's workspace directory and exits:
+ *
+ *   mini [--model <model>] --yolo --exit-immediately \
+ *        [--cost-limit <n>] --output <trajectory> --task <prompt>
+ *
+ * Design notes (verified against the mini CLI docs):
+ *  - `mini` defaults to *confirm* mode (interactive) and, when the agent wants
+ *    to finish, PROMPTS for the next step instead of exiting. `--yolo` runs LM
+ *    commands without confirmation and `--exit-immediately` makes it exit on
+ *    finish — BOTH are required for a headless one-shot run, or the daemon would
+ *    hang waiting on stdin. stdin is also given /dev/null (stdio 'ignore') so a
+ *    stray prompt (e.g. the first-run setup wizard) can never wedge the process.
+ *  - mini is a Python process with no JSON event protocol: stdout is drained as
+ *    a best-effort progress log (ANSI-stripped, relayed as `thinking`, capped)
+ *    and the cleaned transcript tail is sent once as the final answer. The exit
+ *    code decides success (non-zero is never reported as success). PYTHONUNBUFFERED
+ *    is set so stdout streams instead of being fully buffered; NO_COLOR keeps
+ *    rich/ANSI escapes out of the relayed log.
+ *  - Each run gets its own --output trajectory file under ~/.openagents/sessions
+ *    (never in the project), removed afterwards, so concurrent channel runs never
+ *    clash on a shared trajectory.
+ *  - Stateless per task: mini keeps no memory across workspace messages (there is
+ *    no fabricated persistent session). The agent is auto-authorized to run shell
+ *    commands via --yolo — consistent with how Goose (GOOSE_MODE=auto) and Copilot
+ *    (--no-ask-user) already auto-execute; there is no shared per-command approval
+ *    gate to hook into.
+ *  - Config: mini's config is set via the MSWEA_MINI_CONFIG_PATH env var (which
+ *    mini reads as its default config file), forwarded through the agent env. We
+ *    intentionally do NOT pass --config: a single --config / MSWEA_MINI_CONFIG_PATH
+ *    REPLACES mini's built-in mini.yaml (agent prompt templates, step/env config)
+ *    rather than merging (verified in mini's run/mini.py), so the launcher field
+ *    is documented as a FULL config file, not a partial override.
+ *  - Multi-provider auth is left to mini/LiteLLM: the user supplies the model
+ *    (MSWEA_MODEL_NAME or the Model field) and provider keys (ANTHROPIC_API_KEY /
+ *    OPENAI_API_KEY / …) through the agent environment, which flows through
+ *    unchanged. Keys never reach the command line or the logs.
+ *
+ * Reuses all shared connectivity / dispatch / state machinery in BaseAdapter;
+ * only the mini-specific subprocess invocation and parsing live here. Node-only
+ * adapter (like Cline / Copilot) — there is no Python mirror.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { whichBinary, getEnhancedEnv, aiderBinDirs } = require('../paths');
+const {
+  REASON,
+  classifySpawnError,
+  redactDiagnostic,
+  shouldUseShellForBinary,
+} = require('./health-status');
+
+const IS_WINDOWS = process.platform === 'win32';
+// Terminate if mini produces no output for this long (a wedged turn). Resets on
+// any stdout activity, so a slow-but-progressing task is never killed.
+const IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+// Cap how many stdout lines are relayed as `thinking` progress, so a task that
+// prints large command output (diffs, test logs) can't flood the channel. The
+// full transcript is still collected for the final answer.
+const MAX_STREAM_UPDATES = 60;
+// Cap the size of the final transcript we post back. mini's own closing summary
+// is at the END of stdout, so we keep the tail when truncating.
+const FINAL_RESPONSE_MAX = 12000;
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const BLANKS_RE = /\n{3,}/g;
+
+// Error signatures → an actionable message. mini routes model calls through
+// LiteLLM, so the failure surface mirrors Aider's; a couple of mini-specific
+// cases (cost limit, no model configured) are added.
+const ERROR_SIGNATURES = [
+  [['authenticationerror', 'invalid api key', 'incorrect api key', 'no api key',
+    'missing these environment variables', 'api key not found', '401',
+    'unauthorized', 'permission denied to access model'],
+    'Authentication failed — configure a model API key (e.g. ANTHROPIC_API_KEY or '
+    + 'OPENAI_API_KEY) for the selected model in the agent environment.'],
+  [['notfounderror', 'model_not_found', 'does not exist', 'unknown model',
+    'could not find model', 'you do not have access to model'],
+    'Model not found or not accessible — check MSWEA_MODEL_NAME / the Model field '
+    + 'and that your key has access.'],
+  [['you must provide a model', 'no model', 'set up a model', 'model is required',
+    'run `mini-extra config setup`', 'run mini-extra config setup'],
+    'No model configured — set MSWEA_MODEL_NAME (or the Model field / a --config '
+    + 'file), or run `mini-extra config setup`.'],
+  [['cost limit', 'costlimit', 'exceeded the cost', 'limitreached', 'limit reached'],
+    'Stopped: the configured cost limit (MSWEA_COST_LIMIT) was reached before the '
+    + 'task finished.'],
+  [['rate limit', 'ratelimiterror', '429', 'quota', 'insufficient_quota'],
+    'Rate-limited or out of quota at the model provider — try again later.'],
+  [['connectionerror', 'timeout', 'could not connect', 'getaddrinfo',
+    'temporary failure in name resolution', 'network is unreachable',
+    'failed to establish a new connection'],
+    'Network error reaching the model provider — check connectivity and the base URL.'],
+];
+
+function miniInstallHint() {
+  return 'pip install mini-swe-agent';
+}
+
+function cleanOutput(text) {
+  return String(text || '').replace(ANSI_RE, '').replace(BLANKS_RE, '\n\n').trim();
+}
+
+function classifyError(stderr, stdout) {
+  const blob = `${stderr}\n${stdout}`.toLowerCase();
+  for (const [needles, message] of ERROR_SIGNATURES) {
+    if (needles.some((n) => blob.includes(n))) return message;
+  }
+  return null;
+}
+
+/**
+ * Wrap a workspace message as a self-contained coding task. mini works on the
+ * files directly via shell (it does NOT use the OpenAgents MCP tools), so the
+ * prompt is a plain instruction — no workspace/MCP context, and deliberately no
+ * SWE-bench / patch / benchmark wording.
+ */
+function buildTaskPrompt(userMessage) {
+  return [
+    'You are working in the current workspace directory.',
+    '',
+    'User request:',
+    userMessage,
+    '',
+    'Work directly on the files in the current workspace.',
+    'Inspect the codebase before editing.',
+    'Run relevant tests or checks where practical.',
+    'Do not merely describe a solution: make the changes in the workspace.',
+    'When finished, summarize:',
+    '- what you changed',
+    '- which checks/tests you ran',
+    '- any remaining limitations',
+  ].join('\n');
+}
+
+class MiniSweAgentAdapter extends BaseAdapter {
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+
+    // channel -> running child process (for stop / cleanup)
+    this._channelProcesses = {};
+    // channels the user explicitly stopped (suppress "no response" noise)
+    this._stoppingChannels = new Set();
+    this._trajCounter = 0;
+
+    // Per-run trajectory files live here, never in the project directory.
+    this._sessionsDir = path.join(
+      os.homedir(), '.openagents', 'sessions', 'mini-swe-agent',
+      `${this.workspaceId}_${this.agentName}`,
+    );
+
+    this._miniBin = this._findMiniBinary();
+    if (this._miniBin) {
+      this._log(`Using mini-SWE-agent CLI: ${this._miniBin}`);
+    } else {
+      this._log(`Warning: mini-SWE-agent CLI not found — install with: ${miniInstallHint()}`);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Binary resolution
+  // ------------------------------------------------------------------
+
+  _findMiniBinary() {
+    // Shared cross-platform resolver runs `which`/`where` against an ENHANCED
+    // PATH (nvm/fnm/volta/homebrew + pip/pipx/uv user-install dirs) — covers the
+    // GUI/daemon "installed but not on PATH" case for a `pip install`.
+    const resolved = whichBinary('mini');
+    if (resolved) return this._resolveExePreference(resolved, IS_WINDOWS);
+
+    // Explicit fallback over the pip/pipx/uv user-install bin dirs plus the uv
+    // tool venv for mini-swe-agent.
+    const names = IS_WINDOWS ? ['mini.exe', 'mini.cmd', 'mini'] : ['mini'];
+    const dirs = [...aiderBinDirs()];
+    const home = os.homedir();
+    if (IS_WINDOWS) {
+      const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+      const uvTools = process.env.UV_TOOL_DIR || path.join(appData, 'uv', 'tools');
+      dirs.push(path.join(uvTools, 'mini-swe-agent', 'Scripts'));
+    } else {
+      const uvTools = process.env.UV_TOOL_DIR
+        || path.join(home, '.local', 'share', 'uv', 'tools');
+      dirs.push(path.join(uvTools, 'mini-swe-agent', 'bin'));
+    }
+    for (const dir of dirs) {
+      for (const name of names) {
+        const c = path.join(dir, name);
+        if (fs.existsSync(c)) return c;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * On Windows, prefer a directly-executable `mini.exe` over a `mini.cmd`/`.bat`
+   * shim that would otherwise have to be launched through a shell. pip/pipx/uv
+   * install a console-script `.exe` wrapper, so this normally resolves to the
+   * exe; if the resolver landed on a .cmd/.bat and a sibling .exe exists, use the
+   * .exe. No-op off Windows. (A .cmd shim still runs correctly via
+   * shouldUseShellForBinary — this just avoids the shell hop.)
+   */
+  _resolveExePreference(binPath, isWindows) {
+    if (!isWindows || !/\.(cmd|bat)$/i.test(String(binPath))) return binPath;
+    const exe = path.join(path.dirname(binPath), 'mini.exe');
+    return fs.existsSync(exe) ? exe : binPath;
+  }
+
+  /**
+   * Preflight gate (run by the daemon before join). mini needs a resolvable CLI
+   * to do anything useful; when none is found we surface 'runtime_missing' and
+   * skip the join. We deliberately do NOT block on a missing model here — mini
+   * can read a model from a global config we can't see, and a stray prompt is
+   * already made safe by the /dev/null stdin. A genuinely unconfigured model
+   * surfaces as a crisp error on the first run instead.
+   */
+  preflight() {
+    if (!this._miniBin) this._miniBin = this._findMiniBinary();
+    if (!this._miniBin) {
+      return {
+        ok: false,
+        reason: REASON.RUNTIME_MISSING,
+        message: `mini-SWE-agent CLI not found — install with: ${miniInstallHint()}`,
+      };
+    }
+    this._log(`mini-SWE-agent CLI resolved: ${this._miniBin}`);
+    return { ok: true };
+  }
+
+  // ------------------------------------------------------------------
+  // Config + command construction
+  // ------------------------------------------------------------------
+
+  _model() {
+    return String(
+      this.agentEnv.MSWEA_MODEL_NAME || this.agentEnv.MSWEA_MODEL
+      || this.agentEnv.LLM_MODEL || '',
+    ).trim();
+  }
+
+  _costLimit() {
+    const raw = String(this.agentEnv.MSWEA_COST_LIMIT || '').trim();
+    if (!raw) return null;
+    return /^\d+(\.\d+)?$/.test(raw) ? raw : null;
+  }
+
+  /**
+   * Build the mini argv. Order is stable: [--model], --yolo, --exit-immediately,
+   * [--cost-limit], [--output], --task <prompt>. The task is always the LAST
+   * argument and is passed as a single argv element (never string-concatenated),
+   * so quotes / spaces / newlines / shell metacharacters in the prompt are
+   * carried verbatim with no shell involvement. Config is NOT a flag here — it
+   * flows via the MSWEA_MINI_CONFIG_PATH env var (see the file header).
+   */
+  _buildMiniArgs({ model, costLimit, trajectoryPath, task }) {
+    const args = [];
+    if (model) args.push('--model', model);
+    args.push('--yolo', '--exit-immediately');
+    if (costLimit) args.push('--cost-limit', String(costLimit));
+    if (trajectoryPath) args.push('--output', trajectoryPath);
+    args.push('--task', task);
+    return args;
+  }
+
+  _buildSubprocessEnv() {
+    const base = getEnhancedEnv(this.agentEnv);
+    if (base.NO_COLOR === undefined) base.NO_COLOR = '1';
+    // mini is a Python process — force line-buffered stdout so progress streams
+    // instead of arriving all at once at exit.
+    base.PYTHONUNBUFFERED = '1';
+    // Skip mini's interactive first-run setup wizard. mini runs it whenever
+    // MSWEA_CONFIGURED is unset (see run/utilities/config.configure_if_first_time),
+    // which — under our /dev/null stdin — aborts with a useless "Aborted." even
+    // when the user HAS configured a model + key via the agent environment. In a
+    // daemon the wizard is never appropriate; the model/keys come from the env.
+    if (base.MSWEA_CONFIGURED === undefined) base.MSWEA_CONFIGURED = 'true';
+    return base;
+  }
+
+  // ------------------------------------------------------------------
+  // Control actions (stop)
+  // ------------------------------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      for (const [channel, proc] of Object.entries(this._channelProcesses)) {
+        this._stoppingChannels.add(channel);
+        await this._stopProcess(proc);
+        delete this._channelProcesses[channel];
+        try { await this.sendStatus(channel, 'Execution stopped by user'); } catch {}
+      }
+      return;
+    }
+    await super._onControlAction(action, payload);
+  }
+
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000 }); } catch {}
+        return;
+      }
+      // POSIX: kill the whole process group (proc was detached) so the shell
+      // commands mini spawned under --yolo are reaped too — not left orphaned.
+      try { process.kill(-proc.pid, 'SIGTERM'); } catch { proc.kill('SIGTERM'); }
+      await new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          try { process.kill(-proc.pid, 'SIGKILL'); } catch { proc.kill('SIGKILL'); }
+          resolve();
+        }, 5000);
+        proc.on('exit', () => { clearTimeout(timeout); resolve(); });
+      });
+    } catch {}
+  }
+
+  /** True when an error is a child_process spawn failure (vs. a runtime error). */
+  _isSpawnError(e) {
+    if (!e) return false;
+    const code = e.code || e.errno;
+    return (
+      e.syscall === 'spawn'
+      || String(e.syscall || '').startsWith('spawn ')
+      || code === 'ENOENT'
+      || code === 'EACCES'
+      || code === 'EPERM'
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Message handler
+  // ------------------------------------------------------------------
+
+  async _handleMessage(msg) {
+    const content = (msg.content || '').trim();
+    if (!content) return;
+
+    const msgChannel = msg.sessionId || this.channelName;
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${msgChannel}: ${content.length} chars`);
+
+    if (!this._miniBin) this._miniBin = this._findMiniBinary();
+    if (!this._miniBin) {
+      const message = `mini-SWE-agent CLI not found — install with: ${miniInstallHint()}`;
+      this._reportStatus(REASON.RUNTIME_MISSING, message);
+      await this.sendError(msgChannel, message);
+      return;
+    }
+
+    await this._autoTitleChannel(msgChannel, content);
+    this._stoppingChannels.delete(msgChannel);
+    await this.sendStatus(msgChannel, 'mini-SWE-agent is working...');
+
+    let result;
+    try {
+      result = await this._runMini(content, msgChannel);
+    } catch (e) {
+      // A failure to LAUNCH the process (ENOENT/EACCES) is a distinct, actionable
+      // failure — surface it as spawn_failed with the resolved path + code.
+      if (this._isSpawnError(e)) {
+        const { reason, message } = classifySpawnError(e, {
+          label: 'mini-SWE-agent',
+          bin: this._miniBin,
+        });
+        this._log(message);
+        this._reportStatus(reason, message);
+        await this.sendError(msgChannel, message);
+      } else {
+        this._log(`Error handling message: ${redactDiagnostic(e.message)}`);
+        await this.sendError(
+          msgChannel,
+          `Error processing message: ${redactDiagnostic(e.message)}`,
+        );
+      }
+      return;
+    }
+
+    if (this._stoppingChannels.has(msgChannel)) {
+      this._stoppingChannels.delete(msgChannel);
+      return;
+    }
+    const { text, error } = result;
+    if (error) {
+      await this.sendError(msgChannel, error);
+      return;
+    }
+    // A successful run proves the runtime is healthy — clear any prior error.
+    this._reportStatus(null);
+    if (text) {
+      await this.sendResponse(msgChannel, text);
+    } else {
+      await this.sendResponse(
+        msgChannel,
+        'mini-SWE-agent finished with no textual output (any file changes were applied '
+        + 'to the workspace directory).',
+      );
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Subprocess execution
+  // ------------------------------------------------------------------
+
+  async _runMini(content, msgChannel) {
+    fs.mkdirSync(this._sessionsDir, { recursive: true });
+    this._trajCounter += 1;
+    // Per-run trajectory file — isolates concurrent channel runs from a shared
+    // default trajectory. Removed after the run (we rely on stdout, not the
+    // trajectory, for the result).
+    const trajectoryPath = path.join(
+      this._sessionsDir, `traj-${process.pid}-${this._trajCounter}.json`,
+    );
+    const cmd = [
+      this._miniBin,
+      ...this._buildMiniArgs({
+        model: this._model(),
+        costLimit: this._costLimit(),
+        trajectoryPath,
+        task: buildTaskPrompt(content),
+      }),
+    ];
+    let result;
+    try {
+      result = await this._spawnMini(cmd, msgChannel);
+    } catch (e) {
+      // Keep the trajectory on a launch failure — it is most useful exactly when
+      // something went wrong.
+      this._log(`mini-SWE-agent trajectory kept for debugging: ${trajectoryPath}`);
+      throw e;
+    }
+    // Retain the trajectory on failure / timeout / cancel (when it matters for
+    // debugging); only clean it up on a clean success. Timeout and cancel both
+    // surface here as result.error and/or a stopping channel.
+    const kept = !!result.error || this._stoppingChannels.has(msgChannel);
+    if (kept) {
+      this._log(`mini-SWE-agent trajectory kept for debugging: ${trajectoryPath}`);
+    } else {
+      try { fs.rmSync(trajectoryPath, { force: true }); } catch {}
+    }
+    return result;
+  }
+
+  _spawnMini(cmd, msgChannel) {
+    return new Promise((resolve, reject) => {
+      const env = this._buildSubprocessEnv();
+
+      const proc = spawn(cmd[0], cmd.slice(1), {
+        // stdin is /dev/null: mini never has a terminal to prompt against, so a
+        // stray confirm / first-run wizard hits EOF and exits instead of hanging.
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env,
+        cwd: this.workingDir,
+        detached: !IS_WINDOWS,
+        windowsHide: true,
+        // Args are always an array (no shell string); the shared helper only
+        // opts into a shell for Windows .cmd/.bat shims so the daemon, adapter
+        // and launcher probe all agree on the rule.
+        shell: shouldUseShellForBinary(cmd[0]),
+      });
+      this._channelProcesses[msgChannel] = proc;
+      // Log the flags only — never the task text or any secret. The task is the
+      // last argv element; everything before it is safe to log.
+      this._log(`Running mini-SWE-agent: ${cmd.slice(0, cmd.indexOf('--task') + 1).map(String).join(' ')} <task>`);
+
+      // Guard the child's stdio streams against a benign post-SIGKILL 'error'
+      // (EPIPE/ECONNRESET) that would otherwise crash the process.
+      if (proc.stdout) proc.stdout.on('error', () => {});
+      if (proc.stderr) proc.stderr.on('error', () => {});
+
+      let stdoutBuf = '';
+      let stderrBuf = '';
+      let lineBuffer = '';
+      let streamCount = 0;
+      let pending = Promise.resolve();
+
+      let idleTimer = null;
+      const armIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          this._log(`mini-SWE-agent produced no output for ${IDLE_TIMEOUT_MS / 1000}s — terminating`);
+          this._stopProcess(proc);
+        }, IDLE_TIMEOUT_MS);
+      };
+      armIdle();
+
+      if (proc.stderr) {
+        proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString('utf-8'); });
+      }
+
+      const handleLine = async (raw) => {
+        const stripped = raw.replace(ANSI_RE, '').trim();
+        if (!stripped) return;
+        if (streamCount < MAX_STREAM_UPDATES) {
+          streamCount += 1;
+          try { await this.sendThinking(msgChannel, stripped.slice(0, 500)); } catch {}
+        }
+      };
+
+      proc.stdout.on('data', (chunk) => {
+        armIdle();
+        const s = chunk.toString('utf-8');
+        stdoutBuf += s;
+        lineBuffer += s;
+        const lines = lineBuffer.split('\n');
+        lineBuffer = lines.pop();
+        for (const line of lines) {
+          pending = pending.then(() => handleLine(line)).catch(() => {});
+        }
+      });
+
+      proc.on('exit', async (code) => {
+        if (idleTimer) clearTimeout(idleTimer);
+        if (lineBuffer) {
+          pending = pending.then(() => handleLine(lineBuffer)).catch(() => {});
+        }
+        try { await pending; } catch {}
+        delete this._channelProcesses[msgChannel];
+
+        // User asked to stop — swallow output, emit no final answer here (the
+        // stop handler already sent the "stopped" status).
+        if (this._stoppingChannels.has(msgChannel)) {
+          resolve({ text: '', error: null });
+          return;
+        }
+
+        const stdoutText = cleanOutput(stdoutBuf);
+        const stderrText = cleanOutput(stderrBuf);
+        if (stderrText) this._log(`mini-SWE-agent stderr: ${stderrText.length} chars`);
+
+        if (code !== 0) {
+          let diagnostic = classifyError(stderrText, stdoutText);
+          if (!diagnostic) {
+            const tail = (stderrText || stdoutText).split('\n').filter(Boolean);
+            const detail = tail.length ? tail[tail.length - 1] : '';
+            diagnostic = `mini-SWE-agent exited with code ${code}.${detail ? ` ${redactDiagnostic(detail)}` : ''}`;
+          }
+          resolve({ text: '', error: diagnostic });
+          return;
+        }
+
+        // Exit 0: surface the cleaned transcript (tail-capped — mini's closing
+        // summary is at the end). Success ≠ "task definitely fixed", just that
+        // mini ran to completion.
+        let text = stdoutText;
+        if (text.length > FINAL_RESPONSE_MAX) {
+          text = `…(earlier output truncated)…\n\n${text.slice(-FINAL_RESPONSE_MAX)}`;
+        }
+        resolve({ text, error: null });
+      });
+
+      proc.on('error', (err) => {
+        if (idleTimer) clearTimeout(idleTimer);
+        delete this._channelProcesses[msgChannel];
+        reject(err);
+      });
+    });
+  }
+}
+
+module.exports = MiniSweAgentAdapter;

--- a/packages/agent-connector/test/mini.test.js
+++ b/packages/agent-connector/test/mini.test.js
@@ -1,0 +1,519 @@
+'use strict';
+
+/**
+ * Unit tests for the mini-SWE-agent adapter (Node / agent-connector runtime).
+ *
+ * No real `mini` binary, workspace or model is needed: `child_process.spawn` is
+ * faked to emit plain stdout lines and an exit code, and the network helpers
+ * (sendThinking/sendStatus/sendResponse/sendError) are stubbed on the instance.
+ *
+ * Covered: registration under 'mini-swe-agent', readiness/preflight, command
+ * construction (--yolo --exit-immediately --task, stable order, verbatim task
+ * argv, no shell string), the task-prompt wrapper, cwd + env passing
+ * (PYTHONUNBUFFERED/NO_COLOR/PATH/keys), streaming, exit-code handling, error
+ * classification, stop control + process-group kill, and no cross-run leakage.
+ */
+
+const { describe, it, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const EventEmitter = require('node:events');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const cp = require('node:child_process');
+
+// Install a swappable spawn shim BEFORE requiring the adapter, so the
+// module-level `const { spawn } = require('child_process')` binds to it.
+const realSpawn = cp.spawn;
+let spawnImpl = null;
+let lastSpawn = null;
+cp.spawn = (...args) => (spawnImpl ? spawnImpl(...args) : realSpawn(...args));
+
+const { createAdapter, ADAPTER_MAP, MiniSweAgentAdapter } = require('../src/adapters');
+
+after(() => { cp.spawn = realSpawn; });
+
+function makeFakeSpawn(stdoutLines, exitCode = 0, stderr = '') {
+  return (cmd, args, opts) => {
+    const proc = new EventEmitter();
+    proc.pid = 4242;
+    proc.exitCode = null;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = () => {};
+    lastSpawn = { cmd, args, opts };
+    setImmediate(() => {
+      for (const line of stdoutLines) proc.stdout.emit('data', Buffer.from(line, 'utf-8'));
+      if (stderr) proc.stderr.emit('data', Buffer.from(stderr, 'utf-8'));
+      proc.exitCode = exitCode;
+      proc.emit('exit', exitCode);
+    });
+    return proc;
+  };
+}
+
+function makeAdapter(extra = {}) {
+  const adapter = createAdapter('mini-swe-agent', {
+    workspaceId: 'ws',
+    channelName: 'general',
+    token: 'tok',
+    agentName: 'mini-bot',
+    endpoint: 'https://example.invalid',
+    agentType: 'mini-swe-agent',
+    agentEnv: extra.agentEnv || {},
+    workingDir: extra.workingDir || '/tmp/proj',
+  });
+  adapter._miniBin = '/usr/bin/mini';
+  // Keep per-run trajectory files out of the real ~/.openagents.
+  adapter._sessionsDir = path.join(os.tmpdir(), `mini-test-${process.pid}-${Math.floor(process.hrtime()[1])}`);
+  // Stub network + status helpers — record what was streamed / sent.
+  adapter._reportStatus = () => {};
+  adapter._autoTitleChannel = async () => {};
+  adapter._streamed = { thinking: [], status: [], response: [], error: [] };
+  adapter.sendThinking = async (_c, content) => adapter._streamed.thinking.push(content);
+  adapter.sendStatus = async (_c, content) => adapter._streamed.status.push(content);
+  adapter.sendResponse = async (_c, content) => adapter._streamed.response.push(content);
+  adapter.sendError = async (_c, content) => adapter._streamed.error.push(content);
+  return adapter;
+}
+
+describe('mini-SWE-agent adapter — registration', () => {
+  it('is registered under the "mini-swe-agent" agent type', () => {
+    assert.equal('mini-swe-agent' in ADAPTER_MAP, true);
+    assert.equal(typeof MiniSweAgentAdapter, 'function');
+  });
+
+  it('createAdapter("mini-swe-agent") returns a MiniSweAgentAdapter', () => {
+    const a = makeAdapter();
+    assert.equal(a.constructor.name, 'MiniSweAgentAdapter');
+    assert.equal(typeof a._handleMessage, 'function');
+  });
+
+  it('does not disturb the existing adapter map', () => {
+    for (const t of ['claude', 'aider', 'amp', 'goose', 'cline', 'copilot']) {
+      assert.equal(t in ADAPTER_MAP, true, `${t} should still be registered`);
+    }
+  });
+});
+
+describe('mini-SWE-agent adapter — registry metadata / readiness semantics', () => {
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'registry.json'), 'utf-8'),
+  );
+  const entry = registry.find((e) => e.name === 'mini-swe-agent');
+
+  it('is present in the bundled registry with the right label + install', () => {
+    assert.ok(entry, 'mini-swe-agent should be in registry.json');
+    assert.equal(entry.label, 'mini-SWE-agent');
+    assert.equal(entry.install.binary, 'mini');
+    assert.match(entry.install.linux, /pip install mini-swe-agent/);
+  });
+
+  it('treats a configured model alone as a readiness signal (no fixed API key required)', () => {
+    // Readiness must NOT hinge on one specific API key: MSWEA_MODEL_NAME being
+    // present is enough (mini can also be configured via a config file).
+    assert.ok(entry.check_ready.env_vars.includes('MSWEA_MODEL_NAME'));
+    assert.ok(entry.check_ready.env_vars.includes('ANTHROPIC_API_KEY'));
+    assert.ok(entry.check_ready.env_vars.includes('OPENAI_API_KEY'));
+  });
+
+  it('uses MSWEA_MINI_CONFIG_PATH (the real env var) as a FULL-config field that counts as configured', () => {
+    const f = entry.env_config.find((x) => x.name === 'MSWEA_MINI_CONFIG_PATH');
+    assert.ok(f, 'MSWEA_MINI_CONFIG_PATH env field must exist');
+    assert.ok(
+      !entry.env_config.some((x) => x.name === 'MSWEA_CONFIG_PATH'),
+      'the invented MSWEA_CONFIG_PATH field must be gone',
+    );
+    assert.match(f.description, /REPLACES/i, 'must document that it replaces (not merges) the default config');
+    assert.ok(
+      entry.check_ready.env_vars.includes('MSWEA_MINI_CONFIG_PATH'),
+      'a full config file must count as configured',
+    );
+  });
+
+  it('uses a non-blocking "configure a model" hint — never claims the CLI is missing', () => {
+    const msg = entry.check_ready.not_ready_message.toLowerCase();
+    assert.ok(!msg.includes('not installed'), 'must not say "not installed"');
+    assert.ok(!msg.includes('not found'), 'must not say "not found"');
+    assert.match(entry.check_ready.not_ready_message, /Configure a model/);
+  });
+});
+
+describe('mini-SWE-agent adapter — preflight / binary resolution', () => {
+  it('preflight is OK when the CLI resolves', () => {
+    const a = makeAdapter();
+    a._miniBin = '/usr/bin/mini';
+    assert.deepEqual(a.preflight(), { ok: true });
+  });
+
+  it('preflight reports runtime_missing (not not_installed) when the CLI cannot be resolved', () => {
+    const a = makeAdapter();
+    a._miniBin = null;
+    a._findMiniBinary = () => null;
+    const r = a.preflight();
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'runtime_missing');
+    assert.match(r.message, /pip install mini-swe-agent/);
+  });
+});
+
+describe('mini-SWE-agent adapter — command construction', () => {
+  it('builds the bare headless command with no model/config', () => {
+    const a = makeAdapter();
+    assert.deepEqual(
+      a._buildMiniArgs({ task: 'do it' }),
+      ['--yolo', '--exit-immediately', '--task', 'do it'],
+    );
+  });
+
+  it('adds --model before --yolo when a model is set', () => {
+    const a = makeAdapter();
+    assert.deepEqual(
+      a._buildMiniArgs({ model: 'anthropic/claude', task: 'do it' }),
+      ['--model', 'anthropic/claude', '--yolo', '--exit-immediately', '--task', 'do it'],
+    );
+  });
+
+  it('never passes --config (config flows via the MSWEA_MINI_CONFIG_PATH env var)', () => {
+    const a = makeAdapter();
+    assert.ok(!a._buildMiniArgs({ task: 'do it' }).includes('--config'));
+    assert.ok(!a._buildMiniArgs({ model: 'm', task: 'do it' }).includes('--config'));
+  });
+
+  it('keeps a stable order: model, --yolo, --exit-immediately, --task', () => {
+    const a = makeAdapter();
+    assert.deepEqual(
+      a._buildMiniArgs({ model: 'm', task: 't' }),
+      ['--model', 'm', '--yolo', '--exit-immediately', '--task', 't'],
+    );
+  });
+
+  it('always includes --exit-immediately (so the process exits instead of prompting)', () => {
+    const a = makeAdapter();
+    for (const opts of [{ task: 't' }, { model: 'm', task: 't' }, { configPath: '/c', task: 't' }]) {
+      assert.ok(a._buildMiniArgs(opts).includes('--exit-immediately'));
+    }
+  });
+
+  it('adds --cost-limit only when a valid numeric limit is set', () => {
+    const a = makeAdapter();
+    assert.deepEqual(
+      a._buildMiniArgs({ costLimit: '3.5', task: 't' }),
+      ['--yolo', '--exit-immediately', '--cost-limit', '3.5', '--task', 't'],
+    );
+  });
+
+  it('adds --output before --task when a trajectory path is set', () => {
+    const a = makeAdapter();
+    const args = a._buildMiniArgs({ trajectoryPath: '/tmp/traj.json', task: 't' });
+    assert.deepEqual(
+      args,
+      ['--yolo', '--exit-immediately', '--output', '/tmp/traj.json', '--task', 't'],
+    );
+  });
+
+  it('passes the task verbatim as the last argv element (quotes/newlines/shell metachars)', () => {
+    const a = makeAdapter();
+    const nasty = 'fix "the bug"; rm -rf / && echo `whoami`\n$(curl evil) — line2';
+    const args = a._buildMiniArgs({ model: 'm', task: nasty });
+    assert.equal(args[args.length - 2], '--task');
+    assert.equal(args[args.length - 1], nasty, 'task must be a single, unmodified argv element');
+  });
+
+  it('resolves model from MSWEA_MODEL_NAME and cost limit from MSWEA_COST_LIMIT', () => {
+    const a = makeAdapter({ agentEnv: { MSWEA_MODEL_NAME: 'gpt-4o', MSWEA_COST_LIMIT: '2' } });
+    assert.equal(a._model(), 'gpt-4o');
+    assert.equal(a._costLimit(), '2');
+    assert.equal(typeof a._configPath, 'undefined', 'the invented _configPath() helper must be gone');
+  });
+
+  it('ignores a non-numeric cost limit', () => {
+    const a = makeAdapter({ agentEnv: { MSWEA_COST_LIMIT: 'abc' } });
+    assert.equal(a._costLimit(), null);
+  });
+});
+
+describe('mini-SWE-agent adapter — task prompt wrapper', () => {
+  it('wraps the user message without SWE-bench / patch / benchmark wording', async () => {
+    spawnImpl = makeFakeSpawn(['done\n']);
+    const a = makeAdapter();
+    await a._runMini('Please refactor the parser', 'general');
+    const taskIdx = lastSpawn.args.indexOf('--task');
+    const task = lastSpawn.args[taskIdx + 1];
+    assert.match(task, /current workspace directory/);
+    assert.match(task, /Please refactor the parser/);
+    for (const banned of ['swe-bench', 'swebench', 'patch', 'benchmark', 'predictions']) {
+      assert.ok(!task.toLowerCase().includes(banned), `task prompt must not mention "${banned}"`);
+    }
+  });
+});
+
+describe('mini-SWE-agent adapter — spawn cwd / env / shell', () => {
+  beforeEach(() => { lastSpawn = null; });
+
+  it('runs in the workspace directory (not the daemon cwd)', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    const a = makeAdapter({ workingDir: '/tmp/myproject' });
+    await a._runMini('hi', 'general');
+    assert.equal(lastSpawn.opts.cwd, '/tmp/myproject');
+    assert.notEqual(lastSpawn.opts.cwd, process.cwd());
+  });
+
+  it('forwards agent env keys and sets PYTHONUNBUFFERED / NO_COLOR, does not strip PATH', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    // The daemon hands the adapter a full env (incl. PATH) as agentEnv; assert
+    // the adapter forwards it and prepends the enhanced bin dirs rather than
+    // dropping the inherited PATH.
+    const a = makeAdapter({ agentEnv: { ANTHROPIC_API_KEY: 'sk-ant-secret', MSWEA_MODEL_NAME: 'anthropic/claude', PATH: '/usr/bin:/bin' } });
+    await a._runMini('hi', 'general');
+    assert.equal(lastSpawn.opts.env.ANTHROPIC_API_KEY, 'sk-ant-secret');
+    assert.equal(lastSpawn.opts.env.MSWEA_MODEL_NAME, 'anthropic/claude');
+    assert.equal(lastSpawn.opts.env.PYTHONUNBUFFERED, '1');
+    assert.equal(lastSpawn.opts.env.NO_COLOR, '1');
+    assert.ok(lastSpawn.opts.env.PATH.includes('/usr/bin'), 'inherited PATH must be preserved');
+  });
+
+  it('never uses a shell string (argv array + shell:false on POSIX)', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    const a = makeAdapter();
+    await a._runMini('hi', 'general');
+    assert.equal(lastSpawn.opts.shell, false);
+    assert.equal(lastSpawn.cmd, '/usr/bin/mini');
+    assert.ok(Array.isArray(lastSpawn.args));
+  });
+
+  it('sets MSWEA_CONFIGURED=true to skip mini’s interactive first-run wizard', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    const a = makeAdapter();
+    await a._runMini('hi', 'general');
+    assert.equal(lastSpawn.opts.env.MSWEA_CONFIGURED, 'true');
+  });
+
+  it('does not override an explicit MSWEA_CONFIGURED from the agent env', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    const a = makeAdapter({ agentEnv: { MSWEA_CONFIGURED: 'false' } });
+    await a._runMini('hi', 'general');
+    assert.equal(lastSpawn.opts.env.MSWEA_CONFIGURED, 'false');
+  });
+
+  it('forwards MSWEA_MINI_CONFIG_PATH via the env, never as a --config flag', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    const a = makeAdapter({ agentEnv: { MSWEA_MINI_CONFIG_PATH: '/home/u/mini.yaml' } });
+    await a._runMini('hi', 'general');
+    assert.equal(lastSpawn.opts.env.MSWEA_MINI_CONFIG_PATH, '/home/u/mini.yaml');
+    assert.ok(!lastSpawn.args.includes('--config'), 'config must flow via env, not --config');
+  });
+
+  it('never logs a forwarded secret', async () => {
+    spawnImpl = makeFakeSpawn(['ok\n']);
+    const a = makeAdapter({ agentEnv: { ANTHROPIC_API_KEY: 'sk-ant-supersecret' } });
+    const logs = [];
+    a._log = (m) => logs.push(m);
+    await a._runMini('hi', 'general');
+    assert.ok(!logs.join('\n').includes('sk-ant-supersecret'));
+  });
+});
+
+describe('mini-SWE-agent adapter — lifecycle', () => {
+  beforeEach(() => { lastSpawn = null; });
+
+  it('streams stdout as thinking and returns the transcript on exit 0', async () => {
+    spawnImpl = makeFakeSpawn(['step 1: reading files\n', 'step 2: editing\n', 'Done. Summary: fixed it.\n']);
+    const a = makeAdapter();
+    const { text, error } = await a._spawnMini(['/usr/bin/mini', '--yolo', '--exit-immediately', '--task', 't'], 'general');
+    assert.equal(error, null);
+    assert.match(text, /Done\. Summary: fixed it\./);
+    assert.ok(a._streamed.thinking.includes('step 1: reading files'));
+    assert.equal('general' in a._channelProcesses, false, 'process handle must be cleaned up');
+  });
+
+  it('marks a non-zero exit as failed with a diagnostic, no transcript', async () => {
+    spawnImpl = makeFakeSpawn(['starting\n'], 2, 'boom: something broke');
+    const a = makeAdapter();
+    const { text, error } = await a._spawnMini(['/usr/bin/mini', '--yolo', '--exit-immediately', '--task', 't'], 'general');
+    assert.equal(text, '');
+    assert.match(error, /exited with code 2/);
+  });
+
+  it('classifies an authentication failure into an actionable message', async () => {
+    spawnImpl = makeFakeSpawn([], 1, 'litellm.AuthenticationError: invalid api key');
+    const a = makeAdapter();
+    const { error } = await a._spawnMini(['/usr/bin/mini', '--yolo', '--exit-immediately', '--task', 't'], 'general');
+    assert.match(error, /Authentication failed/);
+  });
+
+  it('classifies a cost-limit stop into an actionable message', async () => {
+    spawnImpl = makeFakeSpawn([], 1, 'Cost limit reached before finishing');
+    const a = makeAdapter();
+    const { error } = await a._spawnMini(['/usr/bin/mini', '--yolo', '--exit-immediately', '--task', 't'], 'general');
+    assert.match(error, /cost limit/i);
+  });
+
+  it('_handleMessage sends exactly one final response on success', async () => {
+    spawnImpl = makeFakeSpawn(['working\n', 'All done.\n']);
+    const a = makeAdapter();
+    await a._handleMessage({ content: 'do the thing', sessionId: 'general', senderName: 'user' });
+    assert.equal(a._streamed.response.length, 1, 'exactly one final response');
+    assert.equal(a._streamed.error.length, 0, 'no error on success');
+    assert.match(a._streamed.response[0], /All done\./);
+  });
+
+  it('_handleMessage sends exactly one error on non-zero exit', async () => {
+    spawnImpl = makeFakeSpawn([], 1, 'notfounderror: unknown model foo');
+    const a = makeAdapter();
+    await a._handleMessage({ content: 'do the thing', sessionId: 'general', senderName: 'user' });
+    assert.equal(a._streamed.error.length, 1, 'exactly one error');
+    assert.equal(a._streamed.response.length, 0, 'no success response on failure');
+    assert.match(a._streamed.error[0], /Model not found/);
+  });
+
+  it('reports a missing CLI as an actionable error (never silently)', async () => {
+    const a = makeAdapter();
+    a._miniBin = null;
+    a._findMiniBinary = () => null;
+    await a._handleMessage({ content: 'x', sessionId: 'general', senderName: 'user' });
+    assert.equal(a._streamed.error.length, 1);
+    assert.match(a._streamed.error[0], /pip install mini-swe-agent/);
+  });
+
+  it('does not reuse a stale cwd / process handle across runs', async () => {
+    const a = makeAdapter({ workingDir: '/tmp/first' });
+    spawnImpl = makeFakeSpawn(['one\n']);
+    await a._runMini('a', 'general');
+    assert.equal(lastSpawn.opts.cwd, '/tmp/first');
+    assert.equal('general' in a._channelProcesses, false);
+
+    a.workingDir = '/tmp/second';
+    spawnImpl = makeFakeSpawn(['two\n']);
+    await a._runMini('b', 'general');
+    assert.equal(lastSpawn.opts.cwd, '/tmp/second');
+    assert.equal('general' in a._channelProcesses, false);
+  });
+});
+
+describe('mini-SWE-agent adapter — trajectory retention', () => {
+  beforeEach(() => { lastSpawn = null; });
+
+  // Fake spawn that writes a trajectory file at the --output path (simulating
+  // what real mini does), so retention behaviour can be asserted against the FS.
+  function makeTrajWritingSpawn(exitCode, stderr = '') {
+    return (cmd, args, opts) => {
+      const proc = new EventEmitter();
+      proc.pid = 4242;
+      proc.exitCode = null;
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = () => {};
+      lastSpawn = { cmd, args, opts };
+      const outIdx = args.indexOf('--output');
+      const outPath = outIdx >= 0 ? args[outIdx + 1] : null;
+      setImmediate(() => {
+        if (outPath) {
+          try {
+            fs.mkdirSync(path.dirname(outPath), { recursive: true });
+            fs.writeFileSync(outPath, '{"trajectory":true}');
+          } catch {}
+        }
+        if (stderr) proc.stderr.emit('data', Buffer.from(stderr, 'utf-8'));
+        proc.exitCode = exitCode;
+        proc.emit('exit', exitCode);
+      });
+      return proc;
+    };
+  }
+
+  it('removes the trajectory on a clean success', async () => {
+    spawnImpl = makeTrajWritingSpawn(0);
+    const a = makeAdapter();
+    await a._runMini('hi', 'general');
+    const outPath = lastSpawn.args[lastSpawn.args.indexOf('--output') + 1];
+    assert.equal(fs.existsSync(outPath), false, 'trajectory should be cleaned on success');
+  });
+
+  it('keeps the trajectory and logs its path on failure', async () => {
+    spawnImpl = makeTrajWritingSpawn(1, 'boom: it broke');
+    const a = makeAdapter();
+    const logs = [];
+    a._log = (m) => logs.push(m);
+    await a._runMini('hi', 'general');
+    const outPath = lastSpawn.args[lastSpawn.args.indexOf('--output') + 1];
+    try {
+      assert.equal(fs.existsSync(outPath), true, 'trajectory should be kept on failure');
+      assert.ok(
+        logs.some((l) => l.includes('trajectory kept') && l.includes(outPath)),
+        'the kept trajectory path should be logged',
+      );
+    } finally {
+      try { fs.rmSync(outPath, { force: true }); } catch {}
+    }
+  });
+});
+
+describe('mini-SWE-agent adapter — Windows binary preference', () => {
+  it('prefers mini.exe over a mini.cmd shim when both exist (Windows)', () => {
+    const a = makeAdapter();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-bin-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'mini.exe'), '');
+      fs.writeFileSync(path.join(dir, 'mini.cmd'), '');
+      assert.equal(
+        a._resolveExePreference(path.join(dir, 'mini.cmd'), true),
+        path.join(dir, 'mini.exe'),
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the .cmd shim when no sibling .exe exists (Windows)', () => {
+    const a = makeAdapter();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-bin-'));
+    try {
+      const cmd = path.join(dir, 'mini.cmd');
+      fs.writeFileSync(cmd, '');
+      assert.equal(a._resolveExePreference(cmd, true), cmd);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op off Windows (keeps whatever the resolver returned)', () => {
+    const a = makeAdapter();
+    assert.equal(a._resolveExePreference('/usr/bin/mini', false), '/usr/bin/mini');
+  });
+});
+
+describe('mini-SWE-agent adapter — stop / cancellation', () => {
+  it('terminates the running process and marks the channel stopped', async () => {
+    const a = makeAdapter();
+    const stopped = [];
+    a._stopProcess = async () => stopped.push('killed');
+    const statuses = [];
+    a.sendStatus = async (_c, content) => statuses.push(content);
+
+    const proc = new EventEmitter();
+    proc.pid = 99;
+    proc.exitCode = null;
+    a._channelProcesses.general = proc;
+
+    await a._onControlAction('stop', {});
+
+    assert.equal(stopped.length, 1);
+    assert.equal('general' in a._channelProcesses, false);
+    assert.equal(a._stoppingChannels.has('general'), true);
+    assert.deepEqual(statuses, ['Execution stopped by user']);
+  });
+
+  it('_stopProcess signals the process (group) with SIGTERM', async () => {
+    const a = makeAdapter();
+    const signals = [];
+    const proc = new EventEmitter();
+    // A pid unlikely to map to a real process group, so process.kill(-pid)
+    // throws ESRCH and we fall back to proc.kill(...).
+    proc.pid = 2147483646;
+    proc.exitCode = null;
+    proc.kill = (sig) => { signals.push(sig); if (sig === 'SIGTERM') setImmediate(() => proc.emit('exit', 0)); };
+    await a._stopProcess(proc);
+    assert.ok(signals.includes('SIGTERM'), 'should send SIGTERM');
+  });
+});

--- a/packages/agent-connector/test/mini.test.js
+++ b/packages/agent-connector/test/mini.test.js
@@ -131,6 +131,21 @@ describe('mini-SWE-agent adapter — registry metadata / readiness semantics', (
     );
   });
 
+  it('exposes DEEPSEEK_API_KEY and a per-provider base URL for each of the three providers', () => {
+    const names = entry.env_config.map((x) => x.name);
+    assert.ok(names.includes('DEEPSEEK_API_KEY'), 'DEEPSEEK_API_KEY field must exist');
+    // Per-provider base URLs (litellm reads a different var per provider).
+    for (const baseUrl of ['OPENAI_BASE_URL', 'ANTHROPIC_BASE_URL', 'DEEPSEEK_API_BASE']) {
+      assert.ok(names.includes(baseUrl), `${baseUrl} field must exist`);
+      // A base URL is only an endpoint — never a readiness signal on its own.
+      assert.ok(!entry.check_ready.env_vars.includes(baseUrl), `${baseUrl} must NOT be a readiness signal`);
+    }
+    // A DeepSeek key DOES count as configured.
+    assert.ok(entry.check_ready.env_vars.includes('DEEPSEEK_API_KEY'));
+    const deepseek = entry.env_config.find((x) => x.name === 'DEEPSEEK_API_KEY');
+    assert.equal(deepseek.password, true, 'DEEPSEEK_API_KEY must be a masked field');
+  });
+
   it('uses a non-blocking "configure a model" hint — never claims the CLI is missing', () => {
     const msg = entry.check_ready.not_ready_message.toLowerCase();
     assert.ok(!msg.includes('not installed'), 'must not say "not installed"');

--- a/sdk/src/openagents/registry/mini-swe-agent.yaml
+++ b/sdk/src/openagents/registry/mini-swe-agent.yaml
@@ -1,0 +1,66 @@
+name: mini-swe-agent
+label: mini-SWE-agent
+description: A minimal shell-based coding agent for fixing issues and modifying code in a workspace.
+homepage: https://mini-swe-agent.com
+tags: [coding, cli, shell, autonomous]
+builtin: true
+support:
+  install: true
+  workspace: true
+  collaboration: true
+
+install:
+  binary: mini
+  verify: "mini --help"
+  verify_win: "mini --help"
+  # Installed via pip/pipx/uv; lands `mini` in ~/.local/bin (or the uv/pipx bin
+  # dir), which the adapter's binary resolver and the enhanced PATH both cover.
+  macos: "pip install mini-swe-agent"
+  linux: "pip install mini-swe-agent"
+  windows: "pip install mini-swe-agent"
+
+launch:
+  args: []
+
+# mini-swe-agent is a Node-only adapter (no Python mirror), so there is no
+# `adapter:` block — the Node runtime resolves it via ADAPTER_MAP['mini-swe-agent'].
+#
+# mini routes model calls through LiteLLM, so it is multi-provider and NOT
+# modelled with a single fixed key. The user picks a model (MSWEA_MODEL_NAME or
+# the Model field) and supplies the matching provider key through the agent
+# environment; the adapter passes the model as --model and forwards the env
+# unchanged. `--yolo` auto-executes shell commands in the selected workspace when
+# auto-execution is enabled — consistent with how Goose / Copilot already run.
+env_config:
+  - name: MSWEA_MODEL_NAME
+    description: "Model to use (routed through LiteLLM), e.g. anthropic/claude-sonnet-4-5 or gpt-4o. Optional when a model is already configured via a config file or `mini-extra config setup`. Passed as --model."
+    required: false
+    placeholder: "anthropic/claude-sonnet-4-5"
+  - name: MSWEA_MINI_CONFIG_PATH
+    description: "Path to a FULL mini config file (YAML). Optional. This REPLACES mini's built-in default config (agent prompt templates, step/environment settings) — it does not merge — so provide a complete file (a good starting point is the output of `mini-extra config setup`). Leave blank to use mini's default config."
+    required: false
+    placeholder: "/path/to/mini.yaml"
+  - name: MSWEA_COST_LIMIT
+    description: "Optional per-run cost limit in USD, passed as --cost-limit. Leave blank for mini's default."
+    required: false
+    placeholder: "3.0"
+  - name: ANTHROPIC_API_KEY
+    description: "Anthropic API key — used when the model is an Anthropic model. Leave blank if using another provider or a key already in your environment."
+    required: false
+    password: true
+  - name: OPENAI_API_KEY
+    description: "OpenAI API key — used when the model is an OpenAI model. Leave blank if using another provider or a key already in your environment."
+    required: false
+    password: true
+
+check_ready:
+  # If ANY of these is set we treat mini as ready. mini can also be configured
+  # through a config file / the setup wizard (which we can't detect), so a
+  # missing key is a soft "configure a model" hint (LOGIN_REQUIRED) — NEVER a
+  # hard "not installed". The message must not claim the CLI is missing.
+  env_vars:
+    - MSWEA_MODEL_NAME
+    - MSWEA_MINI_CONFIG_PATH
+    - ANTHROPIC_API_KEY
+    - OPENAI_API_KEY
+  not_ready_message: "mini-SWE-agent CLI detected. Configure a model through environment variables (MSWEA_MODEL_NAME + a provider key), a full config file (MSWEA_MINI_CONFIG_PATH), or the Model field before running a task."

--- a/sdk/src/openagents/registry/mini-swe-agent.yaml
+++ b/sdk/src/openagents/registry/mini-swe-agent.yaml
@@ -48,10 +48,26 @@ env_config:
     description: "Anthropic API key — used when the model is an Anthropic model. Leave blank if using another provider or a key already in your environment."
     required: false
     password: true
+  - name: ANTHROPIC_BASE_URL
+    description: "Custom endpoint for native `anthropic/…` models (an enterprise gateway or Anthropic-protocol relay). Leave blank for hosted Anthropic. Note: most third-party relays are OpenAI-compatible — for those use an `openai/…` model + OPENAI_BASE_URL instead."
+    required: false
+    placeholder: "https://your-anthropic-gateway.example"
   - name: OPENAI_API_KEY
     description: "OpenAI API key — used when the model is an OpenAI model. Leave blank if using another provider or a key already in your environment."
     required: false
     password: true
+  - name: OPENAI_BASE_URL
+    description: "Custom endpoint for OpenAI-compatible models (a relay/proxy or self-hosted gateway) — applies only to `openai/…` models. Leave blank for hosted OpenAI, or for native providers like `deepseek/…` / `anthropic/…`."
+    required: false
+    placeholder: "https://your-relay.example/v1"
+  - name: DEEPSEEK_API_KEY
+    description: "DeepSeek API key — used when the model is a `deepseek/…` model (e.g. deepseek/deepseek-chat or deepseek/deepseek-reasoner). Connects directly to api.deepseek.com; no base URL needed."
+    required: false
+    password: true
+  - name: DEEPSEEK_API_BASE
+    description: "Custom endpoint for native `deepseek/…` models. Leave blank to use DeepSeek's default (api.deepseek.com)."
+    required: false
+    placeholder: "https://api.deepseek.com"
 
 check_ready:
   # If ANY of these is set we treat mini as ready. mini can also be configured
@@ -63,4 +79,5 @@ check_ready:
     - MSWEA_MINI_CONFIG_PATH
     - ANTHROPIC_API_KEY
     - OPENAI_API_KEY
+    - DEEPSEEK_API_KEY
   not_ready_message: "mini-SWE-agent CLI detected. Configure a model through environment variables (MSWEA_MODEL_NAME + a provider key), a full config file (MSWEA_MINI_CONFIG_PATH), or the Model field before running a task."


### PR DESCRIPTION
## What

Adds **mini-SWE-agent** as a Workspace coding-agent adapter.

It follows the existing Cline/Copilot pattern: configured by the Launcher, managed by the daemon, and executed in the user's project directory.

This is **not** a SWE-bench integration. No dataset browsing, Docker harness, evaluation, worktrees, or `predictions.json` support is included.

## Key behavior

* One `mini` process per Workspace message.
* Runs with `--yolo --exit-immediately` in the task workspace.
* Uses `shell: false`, argv arrays, and ignored stdin.
* Sets `MSWEA_CONFIGURED=true` only for the child process to bypass mini's first-run wizard.
* Supports full config files through `MSWEA_MINI_CONFIG_PATH`.
* Streams output as thinking events and emits exactly one final response.
* Handles cancel/timeout by terminating the whole process group.
* Keeps trajectory output on failures for debugging.
* Adds binary and model-configuration readiness checks.

## Files

* Adds `MiniSweAgentAdapter`
* Registers `mini-swe-agent` in the adapter map and registry
* Adds the Node-only SDK registry mirror
* Adds 42 unit tests

## Testing

* Mini adapter tests: **42 passing**
* Full package suite: **660/660 passing**
* Real process smoke test passed for binary resolution, spawn, workspace cwd, wizard bypass, cleanup, and 401 error handling.

A successful model-backed file modification was not tested because the environment does not have a valid model API key.

## Out of scope

* Adding mini-SWE-agent to Launcher `CORE_AGENTS`
* SWE-bench-related features
* Existing `build-registry.js` issues
