### PR TITLE
fix(agent-connector): three agn reliability bugs (poll wedge, zombie daemon, agn update no-op)

### DIFF
--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -235,15 +235,17 @@ class Daemon {
     // Refuse to start if an existing daemon is already running.
     // Without this check, repeated `agn up` invocations would spawn
     // multiple daemons that each process the same message → duplicate
-    // bot replies.
-    const existingPid = Daemon._readPid(pidFile);
-    if (existingPid && Daemon._isAlive(existingPid)) {
+    // bot replies. Check BOTH the pid file and the status file (a live daemon
+    // rewrites the latter every 5s with its own pid): a clobbered/stale pid
+    // file must not let a duplicate slip past this guard.
+    const existingPid = Daemon.runningDaemonPid(configDir);
+    if (existingPid) {
       console.error(`Daemon already running (PID ${existingPid}).`);
       console.error(`Run 'agn down' first, or 'agn status' to check.`);
       process.exit(1);
     }
     // Stale pid file — clean up before spawning fresh
-    if (existingPid) {
+    if (Daemon._readPid(pidFile)) {
       try { fs.unlinkSync(pidFile); } catch {}
     }
 
@@ -287,41 +289,53 @@ class Daemon {
     const pidFile = path.join(configDir, 'daemon.pid');
     const statusFile = path.join(configDir, 'daemon.status.json');
 
-    const pid = Daemon._readPid(pidFile);
-    if (!pid) return false;
+    // Resolve the REAL running daemon(s) from BOTH the pid file and the status
+    // file. A live daemon rewrites the status file every 5s with its own pid,
+    // so when the pid file is stale/clobbered the status file is the only
+    // record of the actual process. The old code trusted only the pid file:
+    // `agn down` would signal a dead pid, delete the files, report "Daemon
+    // stopped", and leave the real daemon orphaned — which then blocked every
+    // subsequent `agn up` ("already running") and kept its agents wedged.
+    const pids = Daemon._liveDaemonPids(configDir);
 
-    try {
-      if (IS_WINDOWS) {
-        execSync(`taskkill /F /PID ${pid}`, { stdio: 'ignore', timeout: 5000 });
-      } else {
-        process.kill(pid, 'SIGTERM');
-      }
-    } catch {}
-
-    // Always clean up PID and status files after kill attempt
-    try { fs.unlinkSync(pidFile); } catch {}
-    try { fs.unlinkSync(statusFile); } catch {}
-
-    // Wait briefly for process to die
-    for (let i = 0; i < 5; i++) {
-      if (!Daemon._isAlive(pid)) return true;
-      execSync(IS_WINDOWS ? 'ping -n 2 127.0.0.1 >nul' : 'sleep 0.5', {
-        stdio: 'ignore', timeout: 5000,
-      });
+    // SIGTERM every distinct live pid.
+    for (const pid of pids) {
+      try {
+        if (IS_WINDOWS) {
+          execSync(`taskkill /F /PID ${pid}`, { stdio: 'ignore', timeout: 5000 });
+        } else {
+          process.kill(pid, 'SIGTERM');
+        }
+      } catch {}
     }
 
-    // Force kill
-    try {
-      if (IS_WINDOWS) {
-        execSync(`taskkill /F /PID ${pid}`, { stdio: 'ignore', timeout: 5000 });
-      } else {
-        process.kill(pid, 'SIGKILL');
+    // Wait briefly, then SIGKILL any survivor that ignored SIGTERM (this is
+    // what today's zombie required — a foreground daemon that didn't exit on
+    // SIGTERM).
+    for (const pid of pids) {
+      let alive = Daemon._isAlive(pid);
+      for (let i = 0; alive && i < 5; i++) {
+        execSync(IS_WINDOWS ? 'ping -n 2 127.0.0.1 >nul' : 'sleep 0.5', {
+          stdio: 'ignore', timeout: 5000,
+        });
+        alive = Daemon._isAlive(pid);
       }
-    } catch {}
+      if (alive) {
+        try {
+          if (IS_WINDOWS) {
+            execSync(`taskkill /F /PID ${pid}`, { stdio: 'ignore', timeout: 5000 });
+          } else {
+            process.kill(pid, 'SIGKILL');
+          }
+        } catch {}
+      }
+    }
 
+    // Always clear BOTH sources of truth so a fresh `agn up` starts clean.
     try { fs.unlinkSync(pidFile); } catch {}
     try { fs.unlinkSync(statusFile); } catch {}
-    return true;
+
+    return pids.length > 0;
   }
 
   /**
@@ -331,14 +345,18 @@ class Daemon {
     const pidFile = path.join(configDir, 'daemon.pid');
     const statusFile = path.join(configDir, 'daemon.status.json');
     const pid = Daemon._readPid(pidFile);
-    if (!pid) return null;
+    if (pid && Daemon._isAlive(pid)) return pid;
 
-    if (!Daemon._isAlive(pid)) {
-      Daemon._cleanupStaleDaemonFiles(pidFile, statusFile);
-      return null;
-    }
+    // pid file missing or stale — fall back to the status file so `agn status`
+    // reports the SAME live daemon the `agn up` singleton guard detects.
+    // Otherwise status says "not running" (dead pid file) while up refuses
+    // ("already running", from the status file) — the exact contradiction that
+    // hid today's orphaned daemon.
+    const live = Daemon.runningDaemonPid(configDir);
+    if (live) return live;
 
-    return pid;
+    Daemon._cleanupStaleDaemonFiles(pidFile, statusFile);
+    return null;
   }
 
   // ---------------------------------------------------------------------------
@@ -997,12 +1015,27 @@ class Daemon {
    * stopped for a legitimate restart doesn't block the replacement.
    */
   static runningDaemonPid(configDir) {
-    const self = process.pid;
-    const isOtherAlive = (pid) =>
-      pid && pid !== self && Daemon._isAlive(pid);
+    return Daemon._liveDaemonPids(configDir)[0] || null;
+  }
 
-    const pidFromFile = Daemon._readPid(path.join(configDir, 'daemon.pid'));
-    if (isOtherAlive(pidFromFile)) return pidFromFile;
+  /**
+   * Return all distinct live daemon PIDs for this configDir (never including
+   * the calling process), gathered from BOTH the pid file and the status file.
+   * The pid file is considered first so its PID sorts ahead of the status
+   * file's. Used by the singleton guard, `agn status`, and `agn down` so every
+   * command agrees on which process(es) are the daemon — the divergence that
+   * let a stale pid file orphan a running daemon.
+   */
+  static _liveDaemonPids(configDir) {
+    const self = process.pid;
+    const pids = [];
+    const consider = (pid) => {
+      if (pid && pid !== self && Daemon._isAlive(pid) && !pids.includes(pid)) {
+        pids.push(pid);
+      }
+    };
+
+    consider(Daemon._readPid(path.join(configDir, 'daemon.pid')));
 
     try {
       const statusFile = path.join(configDir, 'daemon.status.json');
@@ -1011,11 +1044,11 @@ class Daemon {
       // unrelated process can't masquerade as a live daemon.
       if (age < 30000) {
         const raw = JSON.parse(fs.readFileSync(statusFile, 'utf-8'));
-        const pid = raw && raw.pid;
-        if (isOtherAlive(pid)) return pid;
+        consider(raw && raw.pid);
       }
     } catch {}
-    return null;
+
+    return pids;
   }
 }
 

--- a/packages/agent-connector/src/update-check.js
+++ b/packages/agent-connector/src/update-check.js
@@ -88,20 +88,31 @@ async function checkForUpdate() {
 }
 
 /**
- * Walk up from __dirname until we find the enclosing node_modules; the
- * directory containing node_modules is the install prefix.
+ * Derive the npm `--prefix` for a global install from the npm binary location.
+ *
+ * npm resolves `-g` installs relative to a PREFIX, and the layout differs by
+ * platform:
+ *   Unix:    packages → {prefix}/lib/node_modules   (npm bin at {prefix}/bin)
+ *   Windows: packages → {prefix}/node_modules        (npm bin at {prefix})
+ *
+ * So the prefix is the PARENT of npm's bin dir on Unix, and the bin dir itself
+ * on Windows. The previous implementation walked up to the enclosing
+ * node_modules and returned the directory containing it — which on Unix is
+ * `{prefix}/lib`. Passing THAT as `--prefix` made npm append `lib/node_modules`
+ * again, installing into `{prefix}/lib/lib/node_modules` while the running `agn`
+ * (loaded from `{prefix}/lib/node_modules`) never changed: `agn update` reported
+ * success but silently no-op'd on every Unix host.
  */
-function detectInstallPrefix() {
-  let dir = __dirname;
-  for (let i = 0; i < 10; i++) {
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    if (path.basename(parent) === 'node_modules') {
-      return path.dirname(parent);
-    }
-    dir = parent;
-  }
-  return null;
+function npmPrefixFromBin(npmBin, platform = process.platform) {
+  if (!npmBin) return null;
+  // Use the target platform's path semantics so a Windows path resolves
+  // correctly even when this runs on a POSIX host (and vice versa).
+  const p = platform === 'win32' ? path.win32 : path.posix;
+  const binDir = p.dirname(npmBin);
+  // A bare name (e.g. 'npm' from the PATH hard-fallback) has no usable
+  // directory — let npm resolve its own default global prefix instead.
+  if (binDir === '.' || binDir === '') return null;
+  return platform === 'win32' ? binDir : p.dirname(binDir);
 }
 
 /**
@@ -139,7 +150,7 @@ function runUpdate(opts = {}) {
   const platform = opts.platform || process.platform;
   const spawn = opts.spawn || spawnSync;
   const npmBin = opts.npmBin || findNpmBin({ platform });
-  const prefix = opts.prefix !== undefined ? opts.prefix : detectInstallPrefix();
+  const prefix = opts.prefix !== undefined ? opts.prefix : npmPrefixFromBin(npmBin, platform);
   // Use a GLOBAL install (-g). A LOCAL install (`npm install <pkg> --prefix
   // <dir>`) treats <dir> as a project root and prunes every node_modules entry
   // not reachable from its package.json. When the prefix is the portable node
@@ -228,5 +239,6 @@ module.exports = {
   notifyAndMaybeUpdate,
   runUpdate,
   findNpmBin,
+  npmPrefixFromBin,
   currentVersion,
 };

--- a/packages/agent-connector/src/workspace-client.js
+++ b/packages/agent-connector/src/workspace-client.js
@@ -802,6 +802,14 @@ class WorkspaceClient {
         method: 'GET',
         headers,
         timeout,
+        // Hard end-to-end deadline. The `timeout` option above is only a SOCKET
+        // inactivity timeout — it is NOT armed until a socket exists, so it does
+        // not bound DNS resolution or TCP connect. During a network partition a
+        // request stuck in getaddrinfo/connect never fires 'timeout', so the
+        // await never settles and the caller's single poll loop wedges forever
+        // (the agent stays "online" via its separate heartbeat but stops
+        // consuming messages). AbortSignal.timeout fires in ANY phase.
+        signal: AbortSignal.timeout(timeout),
       }, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
@@ -836,6 +844,7 @@ class WorkspaceClient {
         method: 'GET',
         headers,
         timeout,
+        signal: AbortSignal.timeout(timeout), // hard deadline (covers DNS/connect); see _get
       }, (res) => {
         const chunks = [];
         res.on('data', (chunk) => { chunks.push(chunk); });
@@ -868,6 +877,7 @@ class WorkspaceClient {
         method: 'POST',
         headers: { ...headers, 'Content-Length': Buffer.byteLength(jsonBody) },
         timeout,
+        signal: AbortSignal.timeout(timeout), // hard deadline (covers DNS/connect); see _get
       }, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
@@ -910,6 +920,7 @@ class WorkspaceClient {
         method: 'PUT',
         headers: { ...headers, 'Content-Length': Buffer.byteLength(jsonBody) },
         timeout,
+        signal: AbortSignal.timeout(timeout), // hard deadline (covers DNS/connect); see _get
       }, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
@@ -952,6 +963,7 @@ class WorkspaceClient {
         method: 'PATCH',
         headers: { ...headers, 'Content-Length': Buffer.byteLength(jsonBody) },
         timeout,
+        signal: AbortSignal.timeout(timeout), // hard deadline (covers DNS/connect); see _get
       }, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });
@@ -987,6 +999,7 @@ class WorkspaceClient {
         method: 'DELETE',
         headers,
         timeout: 15000,
+        signal: AbortSignal.timeout(15000), // hard deadline (covers DNS/connect); see _get
       }, (res) => {
         let data = '';
         res.on('data', (chunk) => { data += chunk; });


### PR DESCRIPTION
Source-only fixes for three independent `@openagents-org/agent-launcher` (`agn`) reliability bugs, found while debugging why self-hosted agents stopped responding while still showing **online**. Tests for all three are in a companion PR so this one can land quickly.

### 1. Poll loop wedges forever → "online but deaf" agent
`workspace-client.js` request helpers set only Node's socket `timeout`, which isn't armed until a socket exists and so does not bound DNS/connect. A poll stuck in `getaddrinfo`/connect never settled and permanently wedged the adapter's single poll loop (`adapters/base.js`), while the separate heartbeat kept the agent `online`. **Fix:** `signal: AbortSignal.timeout(timeout)` on all six request helpers.

### 2. Stale pid file orphans a running daemon
`agn status`/`down` trusted only `daemon.pid`; the `agn up` guard also trusted `daemon.status.json` (rewritten every 5s with the live pid). On a stale pid file they disagreed: `down` killed a dead pid, said "stopped", and orphaned the real daemon — which then blocked every `up`. **Fix:** `Daemon._liveDaemonPids()` reads both sources; the guard, `readDaemonPid`, and `stopDaemon` all use it; `stopDaemon` SIGTERMs then SIGKILLs every live pid.

### 3. `agn update` silently no-op'd on Unix
`detectInstallPrefix` returned `{prefix}/lib`; `npm -g --prefix` appends `lib/node_modules` on Unix, so updates installed to `{prefix}/lib/lib/node_modules` while the running `agn` was untouched. **Fix:** `npmPrefixFromBin()` derives the true prefix from the npm binary location (platform-correct).

### Notes
- **Tests:** in a companion PR (kept separate per request); this PR is source-only.
- Full test suite (with those tests) passes on Ubuntu/macOS/Windows × Node 18/20/22.
- Merging lands on `develop` only — agents keep running the published 0.2.145 until a 0.2.146 publish + `agn update`.
- Supersedes #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)