### PR TITLE
test(agent-connector): tests for the three agn reliability fixes (#542)

### DIFF
--- a/packages/agent-connector/test/daemon.test.js
+++ b/packages/agent-connector/test/daemon.test.js
@@ -287,3 +287,84 @@ describe('Daemon', () => {
     assert.ok(elapsed < 100, `should return immediately, took ${elapsed}ms`);
   });
 });
+
+// Regression guard for the orphaned-daemon bug: a live daemon whose pid only
+// survives in the status file (stale/clobbered pid file) must still be seen by
+// `agn status` and killed by `agn down`, instead of being reported "stopped"
+// and left running to block every subsequent `agn up`.
+describe('Daemon pid resolution (dual-source)', () => {
+  const { spawn } = require('node:child_process');
+
+  // A child we can control: it ignores nothing, so SIGTERM terminates it.
+  function spawnDummy() {
+    return spawn(process.execPath, ['-e', 'setInterval(() => {}, 1e9)'], { stdio: 'ignore' });
+  }
+  // Kill a child and wait until it is fully reaped, so process.kill(pid, 0)
+  // reports ESRCH (a reaped pid is genuinely dead, not a zombie).
+  function killAndReap(proc) {
+    return new Promise((resolve) => {
+      proc.once('exit', resolve);
+      try { proc.kill('SIGKILL'); } catch { resolve(); }
+    });
+  }
+
+  it('stopDaemon kills the live daemon from the status file when the pid file is stale', async () => {
+    const dead = spawnDummy();
+    const deadPid = dead.pid;
+    await killAndReap(dead); // deadPid is now a genuinely dead pid
+
+    const live = spawnDummy();
+    const livePid = live.pid;
+    const liveExited = new Promise((r) => live.once('exit', r));
+
+    fs.writeFileSync(path.join(tmpDir, 'daemon.pid'), String(deadPid), 'utf-8');
+    fs.writeFileSync(
+      path.join(tmpDir, 'daemon.status.json'),
+      JSON.stringify({ pid: livePid, agents: {} }),
+      'utf-8',
+    );
+
+    try {
+      const result = Daemon.stopDaemon(tmpDir);
+      await liveExited;
+      assert.equal(result, true);
+      assert.equal(Daemon._isAlive(livePid), false, 'live daemon should have been killed');
+      assert.ok(!fs.existsSync(path.join(tmpDir, 'daemon.pid')), 'pid file should be cleaned');
+      assert.ok(!fs.existsSync(path.join(tmpDir, 'daemon.status.json')), 'status file should be cleaned');
+    } finally {
+      if (Daemon._isAlive(livePid)) await killAndReap(live);
+    }
+  });
+
+  it('readDaemonPid falls back to the status file when the pid file is stale', async () => {
+    const dead = spawnDummy();
+    const deadPid = dead.pid;
+    await killAndReap(dead);
+
+    const live = spawnDummy();
+    const livePid = live.pid;
+
+    fs.writeFileSync(path.join(tmpDir, 'daemon.pid'), String(deadPid), 'utf-8');
+    fs.writeFileSync(
+      path.join(tmpDir, 'daemon.status.json'),
+      JSON.stringify({ pid: livePid, agents: {} }),
+      'utf-8',
+    );
+
+    try {
+      assert.equal(Daemon.readDaemonPid(tmpDir), livePid);
+    } finally {
+      await killAndReap(live);
+    }
+  });
+
+  it('readDaemonPid returns null and cleans up when nothing is alive', async () => {
+    const dead = spawnDummy();
+    const deadPid = dead.pid;
+    await killAndReap(dead);
+
+    fs.writeFileSync(path.join(tmpDir, 'daemon.pid'), String(deadPid), 'utf-8');
+    assert.equal(Daemon.readDaemonPid(tmpDir), null);
+    assert.ok(!fs.existsSync(path.join(tmpDir, 'daemon.pid')), 'stale pid file should be cleaned');
+  });
+});

--- a/packages/agent-connector/test/update-check.test.js
+++ b/packages/agent-connector/test/update-check.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { findNpmBin, runUpdate } = require('../src/update-check');
+const { findNpmBin, runUpdate, npmPrefixFromBin } = require('../src/update-check');
 
 // Capture everything written to process.stderr while `fn` runs.
 function captureStderr(fn) {
@@ -115,5 +115,61 @@ describe('runUpdate', () => {
       }));
     assert.equal(captured.cmd, '/usr/local/bin/npm');
     assert.equal(captured.args[0], 'install');
+  });
+
+  // Regression: the derived --prefix must be the npm PREFIX ROOT, not the
+  // directory containing node_modules. On Unix npm appends lib/node_modules to
+  // --prefix, so passing `{prefix}/lib` produced `{prefix}/lib/lib/node_modules`
+  // and the update silently no-op'd. When prefix is left undefined, runUpdate
+  // must derive it from the npm bin location.
+  it('derives the correct --prefix on non-Windows (parent of the bin dir)', () => {
+    let captured = null;
+    captureStderr(() =>
+      runUpdate({
+        platform: 'linux',
+        npmBin: '/home/u/.nvm/versions/node/v24.15.0/bin/npm', // prefix is undefined → derive
+        spawn: (cmd, args) => { captured = { cmd, args }; return { status: 0 }; },
+      }));
+    const i = captured.args.indexOf('--prefix');
+    assert.ok(i !== -1, 'expected a --prefix arg');
+    assert.equal(captured.args[i + 1], '/home/u/.nvm/versions/node/v24.15.0');
+  });
+
+  it('derives the correct --prefix on Windows (the bin dir itself)', () => {
+    let captured = null;
+    captureStderr(() =>
+      runUpdate({
+        platform: 'win32',
+        npmBin: 'C:\\Program Files\\nodejs\\npm.cmd',
+        spawn: (cmd, args) => { captured = { cmd, args }; return { status: 0 }; },
+      }));
+    const i = captured.args.indexOf('--prefix');
+    assert.ok(i !== -1, 'expected a --prefix arg');
+    assert.equal(captured.args[i + 1], 'C:\\Program Files\\nodejs');
+  });
+});
+
+describe('npmPrefixFromBin', () => {
+  it('returns the parent of the bin dir on Unix', () => {
+    assert.equal(
+      npmPrefixFromBin('/home/u/.nvm/versions/node/v24.15.0/bin/npm', 'linux'),
+      '/home/u/.nvm/versions/node/v24.15.0',
+    );
+  });
+
+  it('returns the bin dir itself on Windows', () => {
+    assert.equal(
+      npmPrefixFromBin('C:\\Program Files\\nodejs\\npm.cmd', 'win32'),
+      'C:\\Program Files\\nodejs',
+    );
+  });
+
+  it('returns null for a bare npm name (PATH fallback) so npm uses its default', () => {
+    assert.equal(npmPrefixFromBin('npm', 'linux'), null);
+    assert.equal(npmPrefixFromBin('npm.cmd', 'win32'), null);
+  });
+
+  it('returns null when no npm bin is given', () => {
+    assert.equal(npmPrefixFromBin(null, 'linux'), null);
   });
 });

--- a/packages/agent-connector/test/workspace-client.test.js
+++ b/packages/agent-connector/test/workspace-client.test.js
@@ -104,3 +104,28 @@ describe('WorkspaceClient', () => {
       });
   });
 });
+
+// Regression guard for the "online but deaf" wedge: a request whose socket
+// never receives a response must reject within its deadline instead of hanging
+// forever and stalling the caller's single poll loop. (AbortSignal.timeout ALSO
+// covers the DNS/connect phase, which the socket `timeout` option cannot —
+// it is not armed until a socket exists — but exercising that needs real
+// unroutable network state, which isn't hermetic across CI platforms. The
+// deterministic local case below is what we assert; the DNS/connect rationale
+// lives in the workspace-client.js comment.)
+describe('WorkspaceClient request deadlines', () => {
+  it('_get rejects promptly when the server accepts but never responds', { timeout: 10000 }, async () => {
+    const server = http.createServer(() => { /* intentionally never respond */ });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    const client = new WorkspaceClient(`http://127.0.0.1:${port}`);
+    const start = Date.now();
+    try {
+      await assert.rejects(() => client._get('/v1/events', {}, 400));
+      const elapsed = Date.now() - start;
+      assert.ok(elapsed < 5000, `expected reject within 5s, took ${elapsed}ms`);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
Tests for the three reliability fixes merged in #542, split into their own PR per request so the fixes could land quickly.

Coverage:
- **workspace-client**: a request rejects within its deadline (server accepts but never responds) instead of hanging — guards the `AbortSignal.timeout` addition.
- **daemon**: `stopDaemon` kills a daemon whose pid is only in `daemon.status.json` (stale pid file), `readDaemonPid` falls back to the status file, and stale-file cleanup.
- **update-check**: `npmPrefixFromBin` derives the correct npm prefix on Unix vs Windows, plus bare-name/empty fallbacks.

Verified green on Ubuntu/macOS/Windows × Node 18/20/22 (as part of the combined branch before the split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)