### PR TITLE
perf(events): scope target_agents untargeted-fallback to human senders

### DIFF
--- a/workspace/backend/app/routers/events.py
+++ b/workspace/backend/app/routers/events.py
@@ -441,29 +441,43 @@ def poll_events(
     if target_agents:
         # Return only events routed to this agent — mirrors the adapter's
         # client-side `target_agents` filter so agents stop pulling the whole
-        # network's traffic and discarding ~(N-1)/N of it. This is a *safe
-        # superset*: we also return untargeted events (no target_agents key),
-        # so nothing the client would have kept is dropped — the adapter's
-        # client-side filter (kept for backward-compat with older backends)
-        # then narrows to the exact set. Sentinel `["__no_response__"]` and
-        # events targeted at *other* agents are excluded here.
+        # network's traffic and discarding ~(N-1)/N of it.
+        #
+        # The set matches exactly what the adapter keeps (verified against live
+        # traffic — this filter == the client filter for every agent):
+        #   • events whose metadata.target_agents contains this agent, PLUS
+        #   • *untargeted human* messages (no target_agents key) — the adapter
+        #     broadcasts those.
+        # Untargeted *agent/system* messages are the bulk of a busy workspace's
+        # traffic (agent-to-agent chatter) and the adapter always discards them
+        # when they carry no target list, so returning them was the difference
+        # between "filter is correct" and "filter actually reduces load". They
+        # are excluded here. Events targeted at *other* agents and the
+        # `["__no_response__"]` sentinel are excluded too.
         if db.bind.dialect.name == "postgresql":
-            # `@>` array containment + GIN-friendly; `? 'target_agents'`
-            # detects the untargeted-event fallback.
+            # `@>` array containment (GIN-friendly); `? 'target_agents'` detects
+            # the untargeted case, scoped to human senders.
             query = query.where(
                 or_(
                     EventRecord.metadata_.contains({"target_agents": [target_agents]}),
-                    ~EventRecord.metadata_.has_key("target_agents"),
+                    and_(
+                        EventRecord.source.startswith("human:"),
+                        ~EventRecord.metadata_.has_key("target_agents"),
+                    ),
                 )
             )
         else:
             # SQLite (tests): no JSONB operators — fall back to a text match.
-            # Over-inclusive but safe; the adapter re-filters client-side.
+            # Over-inclusive on the containment side but safe; the adapter
+            # re-filters client-side.
             meta_text = cast(EventRecord.metadata_, Text)
             query = query.where(
                 or_(
                     meta_text.like(f'%"{target_agents}"%'),
-                    meta_text.notlike('%target_agents%'),
+                    and_(
+                        EventRecord.source.startswith("human:"),
+                        meta_text.notlike('%target_agents%'),
+                    ),
                 )
             )
 

--- a/workspace/backend/tests/test_events.py
+++ b/workspace/backend/tests/test_events.py
@@ -330,31 +330,34 @@ class TestPollTargetAgents:
     """GET /v1/events?target_agents= — server-side per-agent filtering.
 
     The adapter's `pollPending` sends this so agents stop pulling the whole
-    network's traffic. The filter is a safe superset: matching + untargeted
-    events are returned; events for *other* agents and the `__no_response__`
-    sentinel are excluded.
+    network's traffic. The filter matches exactly what the adapter keeps:
+    events targeting the agent + untargeted *human* messages. Events for other
+    agents, the `__no_response__` sentinel, and untargeted *agent* messages
+    (agent-to-agent chatter the adapter discards) are excluded.
     """
 
     def _seed(self, db, workspace):
-        """Insert message events with assorted target_agents into a channel."""
+        """Insert message events with assorted target_agents + sources."""
         from app.models import EventRecord
 
         net = workspace["id"]
         ch = f"channel/{workspace['channel']['name']}"
         rows = [
-            ("ev-a", ["alpha"]),                 # for alpha
-            ("ev-b", ["beta"]),                  # for beta only
-            ("ev-ab", ["alpha", "beta"]),        # for both
-            ("ev-none", None),                   # untargeted (no key)
-            ("ev-noresp", ["__no_response__"]),  # routed-to-nobody sentinel
+            # (id, target_agents, source)
+            ("ev-a", ["alpha"], "human:user1"),           # for alpha
+            ("ev-b", ["beta"], "human:user1"),            # for beta only
+            ("ev-ab", ["alpha", "beta"], "human:user1"),  # for both
+            ("ev-human-none", None, "human:user1"),       # untargeted human → broadcast
+            ("ev-agent-none", None, "openagents:beta"),   # untargeted agent → discarded
+            ("ev-noresp", ["__no_response__"], "human:user1"),  # routed-to-nobody
         ]
-        for i, (eid, targets) in enumerate(rows):
+        for i, (eid, targets, source) in enumerate(rows):
             meta = {} if targets is None else {"target_agents": targets}
             db.add(EventRecord(
                 id=eid,
                 network_id=net,
                 type="workspace.message.posted",
-                source="human:user1",
+                source=source,
                 target=ch,
                 payload={"content": eid, "message_type": "chat"},
                 metadata_=meta,
@@ -362,7 +365,7 @@ class TestPollTargetAgents:
             ))
         db.commit()
 
-    def test_filters_to_targeted_plus_untargeted(self, client, workspace, db):
+    def test_filters_to_targeted_plus_untargeted_human(self, client, workspace, db):
         self._seed(db, workspace)
 
         resp = client.get("/v1/events", params={
@@ -373,12 +376,14 @@ class TestPollTargetAgents:
         assert resp.status_code == 200
         ids = {e["id"] for e in resp.json()["data"]["events"]}
 
-        # alpha's events + untargeted broadcast, never beta-only or the sentinel
+        # alpha's events + untargeted *human* broadcast
         assert "ev-a" in ids
         assert "ev-ab" in ids
-        assert "ev-none" in ids
+        assert "ev-human-none" in ids
+        # never beta-only, the sentinel, or untargeted *agent* chatter
         assert "ev-b" not in ids
         assert "ev-noresp" not in ids
+        assert "ev-agent-none" not in ids
 
     def test_next_cursor_skips_ahead_to_stream_tip(self, client, workspace, db):
         """When an agent has drained its own events, next_cursor jumps to the
@@ -408,5 +413,5 @@ class TestPollTargetAgents:
         }, headers={"X-Workspace-Token": workspace["token"]})
         data = resp.json()["data"]
         ids = {e["id"] for e in data["events"]}
-        assert {"ev-a", "ev-b", "ev-ab", "ev-none", "ev-noresp"} <= ids
+        assert {"ev-a", "ev-b", "ev-ab", "ev-human-none", "ev-agent-none", "ev-noresp"} <= ids
         assert "next_cursor" not in data


### PR DESCRIPTION
Follow-up to #544. Live testing revealed the `target_agents` filter shipped in #544 is **correct but not yet effective** — this makes it effective.

## Finding (from live prod testing, 9-agent workspace)

`next_cursor` present → the #544 backend is deployed and the filter runs. But comparing per-poll payloads with vs. without `target_agents`:

- **~82% of `message.posted` events are untargeted agent-to-agent chatter** (agent-sourced, no `target_agents` key).
- The "safe superset" fallback returned **all** untargeted events to every agent → each agent still pulled ~410–485 of 500 events. Reduction ≈ 0–18%.
- But the adapter's client-side filter **discards** untargeted agent/system messages (only untargeted *human* messages are broadcast) — so those were transferred and thrown away.

## Fix

Scope the untargeted fallback to **human senders only**. Verified against live traffic that the result equals exactly what the adapter keeps, for every agent (lossless):

| agent | before (returned/poll) | after | client actually needs |
|---|---|---|---|
| quiet agents (openagents-coder, pm, …) | 410 | **0** | 0 |
| mac-tester | 421 | **11** | 11 |
| sdk-agent | 485 | **75** | 75 |

~85–97% fewer events per poll for active agents; full elimination of wasted transfer for quiet ones. Untargeted agent/system messages are safely excluded (the adapter never delivers them without a target list).

## Tests
`TestPollTargetAgents` updated: untargeted **agent** message excluded, untargeted **human** kept, targeting + `next_cursor` + backward-compat unchanged — 3/3 pass on SQLite.

## Deploy
Backend-only, no migration, no connector change. Backward compatible (agents without the param are unaffected). Needs merge → release FF to take effect on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)