### PR TITLE
feat(agn): add `agn restart` command (down + up)

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.146",
+  "version": "0.2.147",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -103,6 +103,19 @@ async function cmdDown(connector) {
   }
 }
 
+async function cmdRestart(connector, flags) {
+  // Stop then start. stopDaemon() already SIGTERM/SIGKILLs and waits for the
+  // process to die, but poll getDaemonPid() (which checks liveness) until the
+  // pid clears so the singleton guard in cmdUp can't trip on a not-yet-gone
+  // daemon and refuse to start.
+  const stopped = connector.stopDaemon();
+  print(stopped ? 'Daemon stopped' : 'Daemon was not running');
+  for (let i = 0; i < 25 && connector.getDaemonPid(); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  await cmdUp(connector, flags);
+}
+
 async function cmdStatus(connector) {
   const pid = connector.getDaemonPid();
   if (!pid) {
@@ -720,6 +733,7 @@ async function cmdHelp() {
 Commands:
   up [--foreground]           Start daemon (background by default)
   down                        Stop daemon
+  restart [--foreground]      Restart daemon (down + up)
   status                      Show agent status
   list                        List configured agents
   create <name> [--type T]    Create a new agent
@@ -804,6 +818,7 @@ async function main() {
     tui: () => { const { run } = require('./tui'); run(); },
     up: () => cmdUp(connector, flags),
     down: () => cmdDown(connector),
+    restart: () => cmdRestart(connector, flags),
     status: () => cmdStatus(connector),
     list: () => cmdList(connector),
     create: () => cmdCreate(connector, flags, positional),

--- a/packages/agent-connector/test/cli.test.js
+++ b/packages/agent-connector/test/cli.test.js
@@ -57,6 +57,7 @@ describe('CLI', () => {
     assert.ok(out.includes('Usage: agn'));
     assert.ok(out.includes('up'));
     assert.ok(out.includes('down'));
+    assert.ok(out.includes('restart'));
     assert.ok(out.includes('search'));
   });
 


### PR DESCRIPTION
Adds `agn restart` — a convenience wrapper for `agn down && agn up`, so restarting the daemon (e.g. to pick up a launcher upgrade or config change) is a single command.

## Implementation
Reuses the existing stop/start paths — no new daemon logic:
- `stopDaemon()` already SIGTERM/SIGKILLs and waits for the process to exit.
- `restart` then polls `getDaemonPid()` (which checks liveness) until the pid clears, so the singleton guard in `up` can't trip on a not-yet-gone daemon and refuse to start.
- Honors `--foreground` and `--config`, same as `up`.

Distinct from the per-agent `restart:<name>` daemon command — this restarts the whole daemon.

## Tests
`cli.test.js` help assertion covers the new command (18/18 pass). Full connector suite 628/631 — the 3 failures are the pre-existing environmental `stop-control` process-tree tests (identical on clean HEAD).

Version bumped to **0.2.147** so it publishes on merge to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)