### PR TITLE
perf(events): serve poll workspace-resolve+auth from Redis (no DB on idle polls)

### DIFF
--- a/workspace/backend/app/routers/events.py
+++ b/workspace/backend/app/routers/events.py
@@ -119,6 +119,57 @@ def _invalidate_poll_cache(workspace_id: str, event_type: str = ""):
             pass
 
 
+def _resolve_and_auth_cached(db, network, token, authorization):
+    """Resolve a workspace id and authorize the caller, serving the
+    workspace-token path from Redis so the hot poll path never touches
+    Postgres when the client is already at head.
+
+    Returns ``(workspace_id, error_response)`` — exactly one is non-None.
+
+    Only the workspace-token path (the one agents use, `token ==
+    password_hash`) is cache-served. Bearer/collaborator auth, cache misses,
+    and token mismatches fall through to the DB and repopulate the cache.
+    We store a SHA-256 of the token (not the token itself) and a short TTL so
+    a rotated/revoked token is honored within the window; freshness of *events*
+    is unaffected because the head/at-head caches are still invalidated on every
+    post.
+    """
+    ck = "v1ws:resolve:" + hashlib.sha1(network.encode("utf-8")).hexdigest()
+    cached = cache.get_bytes(ck)
+    if cached is not None:
+        try:
+            meta = _json.loads(cached)
+        except Exception:
+            meta = None
+        if meta and meta.get("id"):
+            ph_sha = meta.get("ph_sha")
+            if ph_sha is None:
+                # Public workspace (no password) — token path grants access.
+                return meta["id"], None
+            if token and hashlib.sha256(token.encode("utf-8")).hexdigest() == ph_sha:
+                return meta["id"], None
+            # token missing/mismatch → fall through for bearer/collaborator auth
+
+    workspace = db.execute(
+        select(Workspace).where(_workspace_filter(network))
+    ).scalar_one_or_none()
+    if not workspace:
+        return None, json_response(ResponseCode.NOT_FOUND, "Network not found")
+    if not _verify_workspace_access(workspace, token, authorization):
+        return None, json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    ph = workspace.password_hash
+    meta = {
+        "id": str(workspace.id),
+        "ph_sha": hashlib.sha256(ph.encode("utf-8")).hexdigest() if ph else None,
+    }
+    try:
+        cache.set_bytes(ck, _json.dumps(meta).encode("utf-8"), ttl_seconds=30.0)
+    except Exception:
+        pass
+    return str(workspace.id), None
+
+
 # ---------------------------------------------------------------------------
 # POST /v1/events — send an event through the pipeline
 # ---------------------------------------------------------------------------
@@ -287,16 +338,13 @@ def poll_events(
     Supports filtering by target, channel, type, and cursor-based pagination
     using the `after` parameter (event ID — events are sorted by timestamp).
     """
-    # Resolve workspace
-    workspace = db.execute(
-        select(Workspace).where(_workspace_filter(network))
-    ).scalar_one_or_none()
-
-    if not workspace:
-        return json_response(ResponseCode.NOT_FOUND, "Network not found")
-
-    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
-        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+    # Resolve workspace + authorize. Served from Redis for the workspace-token
+    # path so an at-head poll (the common idle case) never checks out a Postgres
+    # connection — the DB `SELECT workspace` used to run on every poll, before
+    # the cache, so even a cached-empty response cost a pooled connection.
+    workspace_id, err = _resolve_and_auth_cached(db, network, x_workspace_token, authorization)
+    if err is not None:
+        return err
 
     # Two-level read-through cache for poll traffic.
     #
@@ -325,7 +373,7 @@ def poll_events(
     # cache for these polls, same as `member`; the filtered query is cheap.
     if not search and not member and not target_agents:
         key_parts = [
-            str(workspace.id), target or "", channel or "",
+            workspace_id, target or "", channel or "",
             type or "", conversation or "",
             after or "", before or "",
             sort or "asc", str(limit),
@@ -337,7 +385,7 @@ def poll_events(
         # Per-filter head cursor marker (what the newest event id was for
         # this filter the last time we saw any events). Cursor-free.
         filter_parts = [
-            str(workspace.id), target or "", channel or "",
+            workspace_id, target or "", channel or "",
             type or "", conversation or "",
             sort or "asc", str(limit),
         ]
@@ -371,13 +419,13 @@ def poll_events(
                         except Exception:
                             pass
 
-    query = select(EventRecord).where(EventRecord.network_id == workspace.id)
+    query = select(EventRecord).where(EventRecord.network_id == workspace_id)
 
     # Filter events to only channels where the agent is a member
     if member:
         member_channel_names = db.execute(
             select(Channel.name).where(
-                Channel.workspace_id == workspace.id,
+                Channel.workspace_id == workspace_id,
                 Channel.id.in_(
                     select(ChannelMember.channel_id).where(ChannelMember.agent_name == member)
                 ),
@@ -498,7 +546,7 @@ def poll_events(
     # event the main query didn't get to see (at worst a harmless re-scan).
     head_id_snapshot = None
     if target_agents:
-        head_q = select(EventRecord.id).where(EventRecord.network_id == workspace.id)
+        head_q = select(EventRecord.id).where(EventRecord.network_id == workspace_id)
         if type:
             head_q = head_q.where(EventRecord.type.startswith(type))
         if channel:
@@ -521,7 +569,7 @@ def poll_events(
     composing = False
     if not search and not conversation:
         from app.composing import has_any_composing
-        composing = has_any_composing(str(workspace.id))
+        composing = has_any_composing(workspace_id)
 
     response_data = {
         "events": [

--- a/workspace/backend/tests/test_events.py
+++ b/workspace/backend/tests/test_events.py
@@ -415,3 +415,38 @@ class TestPollTargetAgents:
         ids = {e["id"] for e in data["events"]}
         assert {"ev-a", "ev-b", "ev-ab", "ev-human-none", "ev-agent-none", "ev-noresp"} <= ids
         assert "next_cursor" not in data
+
+
+class TestPollResolveCache:
+    """The workspace resolve+auth is served from Redis so at-head polls don't
+    hit Postgres. The cache must never bypass auth.
+    """
+
+    def _use_memory_cache(self, monkeypatch):
+        """Swap the Redis helpers for an in-memory dict so the cache-hit path
+        (normally a no-op in tests, where Redis is disabled) is exercised."""
+        from app import cache as _cache
+        store = {}
+        monkeypatch.setattr(_cache, "get_bytes", lambda k: store.get(k))
+        monkeypatch.setattr(_cache, "set_bytes", lambda k, v, ttl_seconds=0.0: store.__setitem__(k, v))
+        monkeypatch.setattr(_cache, "delete_key", lambda k: store.pop(k, None))
+        return store
+
+    def test_cache_hit_still_enforces_token(self, client, workspace, monkeypatch):
+        store = self._use_memory_cache(monkeypatch)
+        params = {"network": workspace["id"], "type": "workspace.message.posted"}
+        good = {"X-Workspace-Token": workspace["token"]}
+
+        # 1) first poll resolves via DB and populates the resolve cache
+        r1 = client.get("/v1/events", params=params, headers=good)
+        assert r1.status_code == 200
+        assert any(k.startswith("v1ws:resolve:") for k in store), "resolve cache should be populated"
+
+        # 2) second poll is served with the cache warm — still authorized
+        r2 = client.get("/v1/events", params=params, headers=good)
+        assert r2.status_code == 200
+
+        # 3) a wrong token with the cache warm is STILL rejected — the cached
+        # token-hash must not let a bad token through (it falls through to DB auth)
+        r3 = client.get("/v1/events", params=params, headers={"X-Workspace-Token": "wrong-token"})
+        assert r3.status_code == 401


### PR DESCRIPTION
## Problem

`poll_events` did a `SELECT workspace` on **Postgres for every poll — *before* the Redis cache check** — to resolve slug→id and verify the token. So even an at-head "nothing new" poll (the common idle case across the whole agent fleet) checked out a pooled DB connection + a threadpool slot. **That per-tick Postgres touch — not polling itself — is what pressures the connection pool as the fleet grows.**

## Fix

Cache the workspace resolution + token auth in Redis (`v1ws:resolve:<net>`, 30s TTL). On a hit for the **workspace-token path** (what agents use), the poll resolves + authorizes with **zero Postgres**, and the existing Level-2 at-head cache returns the empty response entirely from Redis.

Verified `get_db` is lazy — `SessionLocal()` grabs no connection until the first query, and `pool_pre_ping` only fires on checkout — so a cache-hit poll checks out **no connection at all** (not just "no query").

## Safety

- **Auth is never bypassed:** we store a SHA-256 of the token (not the token), and compare hashes. Bearer/collaborator auth, cache misses, and token mismatches **fall through to the DB** and full `_verify_workspace_access`, then repopulate.
- **Redis down → transparent DB fallback** (`get_bytes` returns `None`).
- **Message latency unchanged:** per-post head/at-head invalidation still fires, so a new message still makes the next poll miss → fetch from DB. The 30s TTL only bounds staleness of *workspace metadata* (e.g. token rotation), not event freshness.

## Why it's safe to lean on Redis

Prod Redis is at **<1% utilization** (39/10000 clients, 1.5 MB, ~400 ops/s), while the Postgres pool is the near-limited resource. This moves load off Postgres onto Redis.

## Scope / tests

Backend-only, **no migration, no client change.** New `TestPollResolveCache` (cache-hit still enforces token; wrong token rejected with cache warm) + existing auth/poll tests pass. The pre-existing `aioapns` failures are unrelated (confirmed identical on clean develop: baseline 17 fail/56 pass → this branch 17 fail/57 pass, +1 new test).

Follow-up option: tighten token-rotation staleness by invalidating `v1ws:resolve:*` on workspace token change (currently bounded by the 30s TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)