### PR TITLE
feat(launcher): platform-specific download URLs + bump agent-launcher…

### DIFF
--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "openagents-launcher",
-  "version": "0.8.13",
+  "version": "0.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.8.13",
+      "version": "0.8.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@openagents-org/agent-launcher": "0.2.145",
+        "@openagents-org/agent-launcher": "0.2.148",
         "clsx": "^2.1.1",
         "electron-updater": "^6.8.9",
         "i18next": "^25.10.10",
@@ -24,6 +24,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.0.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1689,9 +1690,9 @@
       }
     },
     "node_modules/@openagents-org/agent-launcher": {
-      "version": "0.2.145",
-      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.145.tgz",
-      "integrity": "sha512-IQNg4AIfpBSNNgCkdAzStTCLXmpmyAYUGeF3gaL6gKKVEJjhb6+dPAoMl6lB08ckM55wciFu+iz0Dssfxy3sCA==",
+      "version": "0.2.148",
+      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.148.tgz",
+      "integrity": "sha512-hcNtEypeHmue8VkNho4Xfjugv7rSHTQGG1ScAx/e1QLRFZXhHglflV35c8Sbs38jWcQ2CQtURhzLU/3kfnjBwg==",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",
@@ -2023,6 +2024,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@posthog/core": {
@@ -7343,6 +7360,53 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",
@@ -31,7 +31,7 @@
     "dist": "npm run build && electron-builder --publish always"
   },
   "dependencies": {
-    "@openagents-org/agent-launcher": "0.2.145",
+    "@openagents-org/agent-launcher": "0.2.148",
     "clsx": "^2.1.1",
     "electron-updater": "^6.8.9",
     "i18next": "^25.10.10",

--- a/packages/launcher/src/main/updater.ts
+++ b/packages/launcher/src/main/updater.ts
@@ -40,6 +40,27 @@ export interface UpdaterState {
   // false when self-update can't run (dev build, no update metadata, etc.) —
   // the renderer falls back to a "download from website" hint.
   supported: boolean
+  // Platform-specific "get the latest build" link, used by the renderer's
+  // download-page fallback. Resolved in main where process.platform/arch are
+  // authoritative (the renderer can't reliably tell Apple Silicon from Intel).
+  downloadUrl: string
+}
+
+// Where the download-page fallback points, per OS/arch. Linux has no dedicated
+// endpoint yet, so it keeps the GitHub Releases page.
+const GITHUB_RELEASES_URL =
+  "https://github.com/openagents-org/openagents/releases"
+
+function resolveDownloadUrl(): string {
+  if (process.platform === "win32") {
+    return "https://openagents.org/api/download/launcher/windows"
+  }
+  if (process.platform === "darwin") {
+    return process.arch === "arm64"
+      ? "https://openagents.org/api/download/launcher/mac"
+      : "https://openagents.org/api/download/launcher/mac-intel"
+  }
+  return GITHUB_RELEASES_URL
 }
 
 let _state: UpdaterState = {
@@ -51,6 +72,7 @@ let _state: UpdaterState = {
   releaseNotes: null,
   error: null,
   supported: false,
+  downloadUrl: resolveDownloadUrl(),
 }
 
 let _getWindow: () => BrowserWindow | null = () => null

--- a/packages/launcher/src/renderer/pages/settings/index.tsx
+++ b/packages/launcher/src/renderer/pages/settings/index.tsx
@@ -762,7 +762,8 @@ function LauncherUpdate({
           size="sm"
           onClick={() =>
             window.api.openExternal(
-              "https://github.com/openagents-org/openagents/releases",
+              state.downloadUrl ||
+                "https://github.com/openagents-org/openagents/releases",
             )
           }
         >

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -246,6 +246,7 @@ export interface UpdaterState {
   releaseNotes: string | null
   error: string | null
   supported: boolean
+  downloadUrl: string
 }
 
 // ── Chat ──


### PR DESCRIPTION
… to 0.2.148

- Settings 'download page' button now points at openagents.org/api/download/launcher/{windows,mac,mac-intel} (linux keeps GitHub Releases), resolved in main by platform/arch and surfaced to the renderer via UpdaterState.downloadUrl.
- Bump @openagents-org/agent-launcher 0.2.145 -> 0.2.148 (opencode adapter getEnhancedEnv preflight fix) and launcher 0.8.14 -> 0.8.15.