### PR TITLE
fix(launcher): agn update + install.sh break the isolated ~/.openagents/nodejs runtime

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -228,6 +228,13 @@ if [ -n "$LATEST_VER" ] && [ "$LATEST_VER" != "$INSTALLED_VER" ]; then
     BIN_SHIM_DIR="$PREFIX_DIR/node_modules/.bin"
     mkdir -p "$BIN_SHIM_DIR"
     for name in agn openagents agent-connector; do
+        # rm first: `npm install` may have created "$name" as a SYMLINK into the
+        # package's bin (…/agent-launcher/bin/agent-connector.js). A bare `>`
+        # redirect follows that symlink and overwrites the real JS entrypoint
+        # with this shell shim — which then fails to parse as JS ("SyntaxError:
+        # Unexpected string") and breaks every `agn` invocation. Removing it
+        # first makes the redirect create a fresh regular file (the shim).
+        rm -f "$BIN_SHIM_DIR/$name"
         printf '#!/bin/sh\nexec "$(dirname "$0")/../../bin/node" "$(dirname "$0")/../@openagents-org/agent-launcher/bin/agent-connector.js" "$@"\n' > "$BIN_SHIM_DIR/$name"
         chmod +x "$BIN_SHIM_DIR/$name"
     done

--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.149",
+  "version": "0.2.150",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/update-check.js
+++ b/packages/agent-connector/src/update-check.js
@@ -116,6 +116,41 @@ function npmPrefixFromBin(npmBin, platform = process.platform) {
 }
 
 /**
+ * Detect when the running launcher lives in an *isolated runtime* — the local
+ * npm project install.sh creates at `~/.openagents/nodejs`, where the package
+ * is at `<dir>/node_modules/@openagents-org/agent-launcher` and `<dir>` has its
+ * own `package.json`.
+ *
+ * This matters because a `-g` install (what a normal global/nvm install needs)
+ * lands in `<dir>/lib/node_modules`, but the isolated runtime's daemon loads
+ * from `<dir>/node_modules` — so `agn update` would report success while the
+ * running code never changed (the acen "update no-op" incident). For an
+ * isolated runtime we must do a *local* install into `<dir>` instead.
+ *
+ * Returns the project dir (`<dir>`) for an isolated runtime, else null (caller
+ * falls back to the global `-g` path). Global/nvm layouts are excluded: their
+ * package sits under `.../lib/node_modules` (basename 'lib') and the prefix
+ * root has no package.json.
+ */
+function isolatedRuntimeDir(opts = {}) {
+  const dir = opts.dir || __dirname; // <pkgRoot>/src
+  const exists = opts.exists || fs.existsSync;
+  try {
+    const pkgRoot = path.resolve(dir, '..');              // .../agent-launcher
+    const nodeModules = path.resolve(pkgRoot, '..', '..'); // .../node_modules
+    if (path.basename(nodeModules) !== 'node_modules') return null;
+    const projectDir = path.resolve(nodeModules, '..');    // dir containing node_modules
+    // Global npm layout is <prefix>/lib/node_modules — not an isolated project.
+    if (path.basename(projectDir) === 'lib') return null;
+    // A real local project has its own package.json; a global prefix does not.
+    if (!exists(path.join(projectDir, 'package.json'))) return null;
+    return projectDir;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Locate the npm executable next to the running node binary, falling back to
  * a PATH lookup. On Windows the runnable file is `npm.cmd`; the extensionless
  * `npm` shipped alongside it is a Unix shell script that cmd.exe / PowerShell
@@ -150,15 +185,28 @@ function runUpdate(opts = {}) {
   const platform = opts.platform || process.platform;
   const spawn = opts.spawn || spawnSync;
   const npmBin = opts.npmBin || findNpmBin({ platform });
-  const prefix = opts.prefix !== undefined ? opts.prefix : npmPrefixFromBin(npmBin, platform);
-  // Use a GLOBAL install (-g). A LOCAL install (`npm install <pkg> --prefix
-  // <dir>`) treats <dir> as a project root and prunes every node_modules entry
-  // not reachable from its package.json. When the prefix is the portable node
-  // dir, that deletes node's own bundled npm/corepack (and other agent runtimes),
-  // breaking every subsequent `agn` command. A global install only adds/updates
-  // the named package into <prefix>/node_modules and never prunes its siblings.
-  const args = ['install', '-g', `${PKG_NAME}@latest`];
-  if (prefix) args.push('--prefix', prefix);
+  const isoDir = opts.isolatedDir !== undefined ? opts.isolatedDir : isolatedRuntimeDir();
+
+  let args;
+  if (isoDir) {
+    // Isolated runtime (install.sh's ~/.openagents/nodejs): a LOCAL npm project
+    // whose package lives in <dir>/node_modules — NOT <dir>/lib/node_modules.
+    // A `-g` install lands in lib/node_modules and silently no-ops the running
+    // launcher/daemon (which loads from node_modules). Install locally into the
+    // project dir instead. `--no-save` leaves package.json untouched (install.sh
+    // owns it), and because <dir>'s package.json already lists our deps npm has
+    // nothing extraneous to prune.
+    args = ['install', '--no-save', `${PKG_NAME}@latest`, '--prefix', isoDir];
+  } else {
+    // Global / nvm install. A LOCAL install (`npm install <pkg> --prefix <dir>`)
+    // here would treat <dir> as a project root and prune every node_modules
+    // entry not reachable from its package.json — deleting node's own bundled
+    // npm/corepack. A global install only adds/updates the named package into
+    // <prefix>/node_modules and never prunes its siblings.
+    const prefix = opts.prefix !== undefined ? opts.prefix : npmPrefixFromBin(npmBin, platform);
+    args = ['install', '-g', `${PKG_NAME}@latest`];
+    if (prefix) args.push('--prefix', prefix);
+  }
 
   // On Windows, npm.cmd is a batch file and must be invoked through cmd.exe.
   // Passing the args via cmd.exe with shell:false lets Node quote paths that
@@ -240,5 +288,6 @@ module.exports = {
   runUpdate,
   findNpmBin,
   npmPrefixFromBin,
+  isolatedRuntimeDir,
   currentVersion,
 };

--- a/packages/agent-connector/src/update-check.js
+++ b/packages/agent-connector/src/update-check.js
@@ -135,15 +135,18 @@ function npmPrefixFromBin(npmBin, platform = process.platform) {
 function isolatedRuntimeDir(opts = {}) {
   const dir = opts.dir || __dirname; // <pkgRoot>/src
   const exists = opts.exists || fs.existsSync;
+  // Path impl is injectable so tests can force POSIX/Windows semantics
+  // regardless of the host OS (mirrors npmPrefixFromBin's `platform`).
+  const p = opts.path || path;
   try {
-    const pkgRoot = path.resolve(dir, '..');              // .../agent-launcher
-    const nodeModules = path.resolve(pkgRoot, '..', '..'); // .../node_modules
-    if (path.basename(nodeModules) !== 'node_modules') return null;
-    const projectDir = path.resolve(nodeModules, '..');    // dir containing node_modules
+    const pkgRoot = p.resolve(dir, '..');              // .../agent-launcher
+    const nodeModules = p.resolve(pkgRoot, '..', '..'); // .../node_modules
+    if (p.basename(nodeModules) !== 'node_modules') return null;
+    const projectDir = p.resolve(nodeModules, '..');    // dir containing node_modules
     // Global npm layout is <prefix>/lib/node_modules — not an isolated project.
-    if (path.basename(projectDir) === 'lib') return null;
+    if (p.basename(projectDir) === 'lib') return null;
     // A real local project has its own package.json; a global prefix does not.
-    if (!exists(path.join(projectDir, 'package.json'))) return null;
+    if (!exists(p.join(projectDir, 'package.json'))) return null;
     return projectDir;
   } catch {
     return null;

--- a/packages/agent-connector/test/update-check.test.js
+++ b/packages/agent-connector/test/update-check.test.js
@@ -175,23 +175,24 @@ describe('npmPrefixFromBin', () => {
 });
 
 describe('isolatedRuntimeDir', () => {
+  const posix = require('node:path').posix; // force POSIX semantics on any host (incl. Windows CI)
   const A = '/@openagents-org/agent-launcher/src';
 
   it('detects the isolated ~/.openagents/nodejs local project', () => {
     // package at <dir>/node_modules/@openagents-org/agent-launcher, <dir> has package.json
     const dir = '/home/u/.openagents/nodejs/node_modules' + A;
-    const got = isolatedRuntimeDir({ dir, exists: (p) => p === '/home/u/.openagents/nodejs/package.json' });
+    const got = isolatedRuntimeDir({ dir, path: posix, exists: (p) => p === '/home/u/.openagents/nodejs/package.json' });
     assert.equal(got, '/home/u/.openagents/nodejs');
   });
 
   it('returns null for a global/nvm layout (…/lib/node_modules)', () => {
     const dir = '/home/u/.nvm/versions/node/v24.15.0/lib/node_modules' + A;
-    assert.equal(isolatedRuntimeDir({ dir, exists: () => true }), null);
+    assert.equal(isolatedRuntimeDir({ dir, path: posix, exists: () => true }), null);
   });
 
   it('returns null when the prefix root has no package.json (bare global prefix)', () => {
     const dir = '/usr/local/node_modules' + A;
-    assert.equal(isolatedRuntimeDir({ dir, exists: () => false }), null);
+    assert.equal(isolatedRuntimeDir({ dir, path: posix, exists: () => false }), null);
   });
 });
 

--- a/packages/agent-connector/test/update-check.test.js
+++ b/packages/agent-connector/test/update-check.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { findNpmBin, runUpdate, npmPrefixFromBin } = require('../src/update-check');
+const { findNpmBin, runUpdate, npmPrefixFromBin, isolatedRuntimeDir } = require('../src/update-check');
 
 // Capture everything written to process.stderr while `fn` runs.
 function captureStderr(fn) {
@@ -171,5 +171,57 @@ describe('npmPrefixFromBin', () => {
 
   it('returns null when no npm bin is given', () => {
     assert.equal(npmPrefixFromBin(null, 'linux'), null);
+  });
+});
+
+describe('isolatedRuntimeDir', () => {
+  const A = '/@openagents-org/agent-launcher/src';
+
+  it('detects the isolated ~/.openagents/nodejs local project', () => {
+    // package at <dir>/node_modules/@openagents-org/agent-launcher, <dir> has package.json
+    const dir = '/home/u/.openagents/nodejs/node_modules' + A;
+    const got = isolatedRuntimeDir({ dir, exists: (p) => p === '/home/u/.openagents/nodejs/package.json' });
+    assert.equal(got, '/home/u/.openagents/nodejs');
+  });
+
+  it('returns null for a global/nvm layout (…/lib/node_modules)', () => {
+    const dir = '/home/u/.nvm/versions/node/v24.15.0/lib/node_modules' + A;
+    assert.equal(isolatedRuntimeDir({ dir, exists: () => true }), null);
+  });
+
+  it('returns null when the prefix root has no package.json (bare global prefix)', () => {
+    const dir = '/usr/local/node_modules' + A;
+    assert.equal(isolatedRuntimeDir({ dir, exists: () => false }), null);
+  });
+});
+
+describe('runUpdate isolated runtime', () => {
+  it('does a LOCAL install into the runtime dir (no -g) when isolated', () => {
+    let captured = null;
+    captureStderr(() =>
+      runUpdate({
+        platform: 'linux',
+        npmBin: '/home/u/.openagents/nodejs/bin/npm',
+        isolatedDir: '/home/u/.openagents/nodejs',
+        spawn: (cmd, args) => { captured = { cmd, args }; return { status: 0 }; },
+      }));
+    assert.ok(!captured.args.includes('-g'), 'must NOT be a global install for an isolated runtime');
+    const i = captured.args.indexOf('--prefix');
+    assert.ok(i !== -1, 'expected --prefix');
+    assert.equal(captured.args[i + 1], '/home/u/.openagents/nodejs'); // → <dir>/node_modules
+    assert.ok(captured.args.includes('--no-save'));
+  });
+
+  it('still does a GLOBAL install when not isolated', () => {
+    let captured = null;
+    captureStderr(() =>
+      runUpdate({
+        platform: 'linux',
+        npmBin: '/usr/local/bin/npm',
+        isolatedDir: null,
+        prefix: '/usr/local',
+        spawn: (cmd, args) => { captured = { cmd, args }; return { status: 0 }; },
+      }));
+    assert.ok(captured.args.includes('-g'), 'non-isolated install must stay global');
   });
 });

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -270,8 +270,14 @@ if ($latestVer -and ($latestVer -ne $installedVer)) {
     $shimDir = Join-Path $prefixDir "node_modules\.bin"
     New-Item -ItemType Directory -Force -Path $shimDir | Out-Null
     foreach ($name in @("agn", "openagents", "agent-connector")) {
+        # We write a distinct "$name.cmd" (not the package's .js bin), so unlike
+        # the POSIX shim we can't clobber the real entrypoint. Remove any
+        # pre-existing file first anyway, so a stale/read-only shim from an older
+        # install can't block the overwrite.
+        $shimPath = Join-Path $shimDir "$name.cmd"
+        Remove-Item -Force -ErrorAction SilentlyContinue -Path $shimPath
         $shimContent = "@echo off`r`n`"%~dp0..\..\node.exe`" `"%~dp0..\@openagents-org\agent-launcher\bin\agent-connector.js`" %*`r`n"
-        Set-Content -Path (Join-Path $shimDir "$name.cmd") -Value $shimContent -NoNewline
+        Set-Content -Path $shimPath -Value $shimContent -NoNewline
     }
     Ok "$NPM_PACKAGE v$latestVer installed"
 } elseif ($installedVer) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -230,6 +230,13 @@ if [ -n "$LATEST_VER" ] && [ "$LATEST_VER" != "$INSTALLED_VER" ]; then
     BIN_SHIM_DIR="$PREFIX_DIR/node_modules/.bin"
     mkdir -p "$BIN_SHIM_DIR"
     for name in agn openagents agent-connector; do
+        # rm first: `npm install` may have created "$name" as a SYMLINK into the
+        # package's bin (…/agent-launcher/bin/agent-connector.js). A bare `>`
+        # redirect follows that symlink and overwrites the real JS entrypoint
+        # with this shell shim — which then fails to parse as JS ("SyntaxError:
+        # Unexpected string") and breaks every `agn` invocation. Removing it
+        # first makes the redirect create a fresh regular file (the shim).
+        rm -f "$BIN_SHIM_DIR/$name"
         printf '#!/bin/sh\nexec "$(dirname "$0")/../../bin/node" "$(dirname "$0")/../@openagents-org/agent-launcher/bin/agent-connector.js" "$@"\n' > "$BIN_SHIM_DIR/$name"
         chmod +x "$BIN_SHIM_DIR/$name"
     done


### PR DESCRIPTION
Fixes the two bugs behind the acen incident: `agn update` reported success but `agn version` never changed, and then `install.sh` left `agn` unrunnable (`SyntaxError: Unexpected string`).

## Bug 1 — `agn update` targets the wrong dir for the isolated runtime
The daemon runtime `install.sh` creates at `~/.openagents/nodejs` is a **local npm project** (package in `<dir>/node_modules`). But `runUpdate` always did a **global** install (`npm install -g --prefix <dir>`), which lands in `<dir>/lib/node_modules` — so the running launcher/daemon (loaded from `node_modules`) never changed.

**Regression from `723b6541` (2026-06-10)**, which switched to `-g` to stop a local install from pruning siblings; `2c7b3db6` only fixed the global "double-lib" facet.

**Fix:** detect the isolated runtime (package under `<dir>/node_modules` with a sibling `package.json`, excluding `.../lib/node_modules` global layouts and bare prefixes) and do a **local** install into `<dir>` for it — `--no-save` so `install.sh` keeps owning `package.json` and npm has nothing extraneous to prune. Global/nvm installs keep `-g`.

## Bug 2 — `install.sh` clobbered the real JS entrypoint
`npm install` creates `.bin/agn` as a **symlink** into `…/agent-launcher/bin/agent-connector.js`. `install.sh` then wrote its shell shim with `> "$BIN_SHIM_DIR/$name"`, and the redirect **followed the symlink**, overwriting the real JS bin with a `#!/bin/sh` script — which node can't parse (the `SyntaxError`), breaking every `agn` call and any daemon restart.

**Fix:** `rm -f` the target before writing, so the redirect creates a fresh regular file (the shim). Applied to both `install.sh` copies. `install.ps1` writes distinct `.cmd` files (not the JS bin, so no clobber) — given a defensive `Remove-Item` for parity.

## Recovery note
Already-broken daemons can't `agn update` their way out (same chicken-and-egg that hit acen) — they need the **fixed `install.sh` re-run**, or a manual bin restore (what I did on acen). Version bumped to **0.2.150** so the `runUpdate` fix publishes.

## Tests
`isolatedRuntimeDir` detection (isolated / global-nvm / bare-prefix) + `runUpdate` local-vs-global branch. `update-check` 19/19; full connector suite 635/638 (the 3 fails are the pre-existing environmental `stop-control` process-tree tests).

## Not in this PR
The `public/` copies of `install.sh` (`workspace/frontend/public`, `packages/go/web/public`) predate the shim block entirely (no bug, but stale) — separate cleanup. And confirm which copy `openagents.org/install.sh` actually serves; both shim-bearing copies (root + `scripts/`) are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)