### PR TITLE
fix(launcher): stop daemon before self-update install + check for upd…

### DIFF
--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -2421,6 +2421,19 @@ app.whenReady().then(async () => {
     // "Automatic updates" ON (default) = background checks auto-download and
     // electron-updater installs on the next quit. OFF = no check at all.
     isAutoUpdateEnabled: () => store.get("autoUpdate") !== false,
+    // Stop chat polling + the daemon/agent subprocesses before the installer
+    // runs. On Windows a live daemon holds locks under the install dir, so the
+    // NSIS overwrite silently fails and the relaunch comes back on the old
+    // version. before-quit also calls stopAll, but that fires without being
+    // awaited during quit — here we await it so teardown completes first.
+    beforeInstall: async () => {
+      try {
+        if (agentManager) agentManager.stopAllChatPolling()
+      } catch {}
+      try {
+        if (agentManager) await agentManager.stopAll()
+      } catch {}
+    },
     onDownloaded: (version) => {
       // A background auto-download finished. Make it discoverable: notify the
       // user and refresh the tray so "Restart to update" appears. The install
@@ -2687,15 +2700,29 @@ app.whenReady().then(async () => {
   setInterval(() => checkCoreUpdate().catch(() => {}), FOUR_HOURS)
   setTimeout(() => checkCoreUpdate().catch(() => {}), 30000)
 
-  // Launcher self-update: check shortly after launch and every few hours, but
-  // only when the user hasn't turned automatic updates off. Surfaces a banner
-  // in the renderer; the actual download/install is user-driven.
-  const launcherUpdateCheck = (): void => {
+  // Launcher self-update: check shortly after launch and every half hour
+  // thereafter, but only when the user hasn't turned automatic updates off.
+  // Surfaces a banner in the renderer; the actual download/install is
+  // user-driven. Also throttled so the window-focus trigger below can't spam
+  // the update server.
+  const THIRTY_MIN = 30 * 60 * 1000
+  let _lastLauncherUpdateCheck = 0
+  const launcherUpdateCheck = (minGapMs = 0): void => {
     if (store.get("autoUpdate") === false) return
+    const now = Date.now()
+    if (minGapMs > 0 && now - _lastLauncherUpdateCheck < minGapMs) return
+    _lastLauncherUpdateCheck = now
     checkForUpdatesOnStartup().catch(() => {})
   }
-  setTimeout(launcherUpdateCheck, 20000)
-  setInterval(launcherUpdateCheck, FOUR_HOURS)
+  setTimeout(() => launcherUpdateCheck(), 20000)
+  // Every 30 min (was every 4h — too long for a tray-resident app to ever
+  // surface a fresh release while it stays open).
+  setInterval(() => launcherUpdateCheck(), THIRTY_MIN)
+  // Also check whenever the user brings the window back to the foreground, so a
+  // release published while they had it in the tray is discovered the moment
+  // they look, not up to half an hour later. Throttled to at most once per 10 min.
+  const onWindowForeground = (): void => launcherUpdateCheck(10 * 60 * 1000)
+  app.on("browser-window-focus", onWindowForeground)
 
   setTimeout(() => refreshAgentUpdates(), 45000)
   setInterval(() => refreshAgentUpdates(), ONE_HOUR)

--- a/packages/launcher/src/main/updater.ts
+++ b/packages/launcher/src/main/updater.ts
@@ -84,6 +84,12 @@ let _isAutoUpdateEnabled: () => boolean = () => false
 // Fired once a background auto-download finishes, so the main process can notify
 // the user and offer a "restart to update now" affordance (tray + banner).
 let _onDownloaded: (version: string) => void = () => {}
+// Runs right before quitAndInstall so the daemon + agent subprocesses are torn
+// down first. On Windows the NSIS installer can't overwrite the app while a
+// child process (the daemon) still holds a lock on files under the install dir —
+// the overwrite silently fails and the relaunch comes back on the OLD version.
+// Must be awaited before handing off to the installer.
+let _beforeInstall: () => Promise<void> = async () => {}
 
 function emit(patch: Partial<UpdaterState>): void {
   _state = { ..._state, ...patch }
@@ -149,6 +155,23 @@ function wireEvents(): void {
   })
 }
 
+// Tear down agents/daemon, then hand off to the installer. Shared by the
+// Settings "Restart to install" button and the tray item so BOTH paths release
+// the file locks that would otherwise make the Windows overwrite install fail.
+async function quitAndInstallSafely(): Promise<void> {
+  // Mark quitting so the window `close` handler really quits (instead of hiding
+  // to tray) and the before-quit teardown runs.
+  ;(app as typeof app & { isQuitting: boolean }).isQuitting = true
+  try {
+    await _beforeInstall()
+  } catch (err) {
+    _log(`[updater] beforeInstall failed: ${(err as Error).message}`)
+  }
+  // Give the OS a tick to release the just-killed child processes' handles
+  // before the installer tries to overwrite the app directory.
+  setImmediate(() => autoUpdater.quitAndInstall(false, true))
+}
+
 function registerIpc(): void {
   if (_ipcRegistered) return
   _ipcRegistered = true
@@ -182,12 +205,9 @@ function registerIpc(): void {
     return _state
   })
 
-  ipcMain.handle("updater:install", () => {
+  ipcMain.handle("updater:install", async () => {
     if (!_state.supported || _state.status !== "downloaded") return false
-    // Mark quitting so the app's before-quit teardown (stop agents / polling)
-    // still runs before electron-updater relaunches into the installer.
-    ;(app as typeof app & { isQuitting: boolean }).isQuitting = true
-    setImmediate(() => autoUpdater.quitAndInstall(false, true))
+    await quitAndInstallSafely()
     return true
   })
 }
@@ -197,11 +217,13 @@ export function setupAutoUpdater(opts: {
   log: (msg: string) => void
   isAutoUpdateEnabled: () => boolean
   onDownloaded: (version: string) => void
+  beforeInstall: () => Promise<void>
 }): void {
   _getWindow = opts.getWindow
   _log = opts.log
   _isAutoUpdateEnabled = opts.isAutoUpdateEnabled
   _onDownloaded = opts.onDownloaded
+  _beforeInstall = opts.beforeInstall
   _state.currentVersion = app.getVersion()
 
   // Dev builds have no app-update.yml — calling autoUpdater would throw. Still
@@ -261,7 +283,6 @@ export function getUpdaterState(): UpdaterState {
 // now"). No-op unless a package is actually downloaded and ready.
 export function installDownloadedUpdate(): boolean {
   if (!_state.supported || _state.status !== "downloaded") return false
-  ;(app as typeof app & { isQuitting: boolean }).isQuitting = true
-  setImmediate(() => autoUpdater.quitAndInstall(false, true))
+  void quitAndInstallSafely()
   return true
 }


### PR DESCRIPTION
…ates more eagerly; v0.8.18

Two update-flow bugs:

1. Install left the app on the old version. updater:install called quitAndInstall while the daemon + agent subprocesses were still running; on Windows the live children hold locks under the install dir, so the NSIS overwrite silently fails and the relaunch comes back on the previous version. Route both the Settings button and the tray item through quitAndInstallSafely, which awaits a beforeInstall hook (stopAllChatPolling + stopAll) before handing off to the installer.

2. New releases surfaced late. The self-update check ran only at launch +20s and every 4h, so a tray-resident app rarely noticed a fresh release until it was restarted. Check every 30 min instead, and also on browser-window-focus (throttled to 10 min) so a release is discovered the moment the user reopens the window.