### PR TITLE
fix(workspace/db): repair channels stuck at alembic 025 (missing orchestration columns)

### DIFF
--- a/workspace/backend/alembic/versions/026_ensure_channel_orchestration.py
+++ b/workspace/backend/alembic/versions/026_ensure_channel_orchestration.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Ensure channel orchestration columns exist (repair for stuck revision 025).
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-07-09
+
+Background
+----------
+Two divergent migrations were both authored as revision "025":
+
+  - ``025_add_channel_orchestration`` (this lineage / origin/develop /
+    release) adds ``channels.orchestration_mode`` and
+    ``channels.orchestration_instruction``.
+  - ``025_add_evaluation_jobs`` (an experimental SWE-bench lineage) creates
+    the ``evaluation_jobs`` table.
+
+Because both declared ``revision = "025"``, any database that ran the
+evaluation-jobs variant first got stamped ``alembic_version = '025'``. When
+the orchestration code later deployed, ``alembic upgrade head`` saw the DB
+already at "025" and became a no-op — so the orchestration columns were
+never created. Every channel-list / ``/v1/discover`` query then 500s with
+``column channels.orchestration_mode does not exist``.
+
+This migration re-applies the orchestration columns idempotently so a
+database stuck at "025" (missing the columns) is repaired on the next
+deploy, while a database that already has them is left untouched. Uses
+Postgres ``ADD COLUMN IF NOT EXISTS`` for true idempotency.
+"""
+
+from alembic import op
+
+
+revision = "026"
+down_revision = "025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: repairs DBs stuck at "025" without the columns, and is a
+    # no-op where 025_add_channel_orchestration already applied them.
+    op.execute(
+        "ALTER TABLE channels "
+        "ADD COLUMN IF NOT EXISTS orchestration_mode TEXT NOT NULL DEFAULT 'dynamic'"
+    )
+    op.execute(
+        "ALTER TABLE channels "
+        "ADD COLUMN IF NOT EXISTS orchestration_instruction TEXT"
+    )
+
+
+def downgrade() -> None:
+    # No-op: leave the columns in place. 025's downgrade owns dropping them,
+    # and dropping here would fight that revision on a normal downgrade path.
+    pass


### PR DESCRIPTION
## Production incident
`workspace-backend` prod was 500ing on every channel-list / `/v1/discover` query:

```
psycopg2.errors.UndefinedColumn: column channels.orchestration_mode does not exist
```

## Root cause
Two migrations were both authored as **revision `025`**:
- `025_add_channel_orchestration` (this lineage / develop / release) → adds `channels.orchestration_mode` + `orchestration_instruction`
- `025_add_evaluation_jobs` (experimental SWE-bench lineage) → creates `evaluation_jobs`

The prod DB had run the evaluation-jobs variant first and was stamped `alembic_version='025'`. When the orchestration code deployed, `alembic upgrade head` saw the DB already at `025` and became a **no-op** — so the orchestration columns were never created. Confirmed on prod: `alembic_version='025'` but `orchestration%` columns absent.

## Fix
- **Prod DB already repaired live** (idempotent `ADD COLUMN IF NOT EXISTS`); `/v1/discover` now returns 401 (auth) instead of 500. 17,071 channel rows intact.
- This PR adds **migration `026`** that idempotently ensures both columns exist, so the alembic history is consistent and any other environment stuck at `025` self-repairs on next deploy. No-op where `025` applied cleanly.

## Deploy
Fast-forward `release` from `develop` after merge; Railway `preDeployCommand = alembic upgrade head` will apply `026` (025→026, no-op DDL, stamps 026).

## Follow-up (not in this PR)
The duplicate revision `025` should be de-conflicted at the source: the SWE-bench `025_add_evaluation_jobs` needs renumbering before that lineage ever merges, or the collision recurs.

## Verification
- Reproduced the stuck state on a throwaway Postgres 15; `026`'s SQL creates the correct columns and is a clean no-op on re-run.
- Prod endpoints that were 500ing now return 401 (past the DB layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)