### PR TITLE
fix(agent-connector): run opencode in the configured working directory (#435)

### DIFF
--- a/packages/agent-connector/src/adapters/opencode.js
+++ b/packages/agent-connector/src/adapters/opencode.js
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 const { execSync, spawn } = require('child_process');
 
 const BaseAdapter = require('./base');
@@ -64,7 +65,7 @@ const FAILURE_MESSAGES = {
   stream_parse_error: 'OpenCode produced output this version could not parse. Update to a supported OpenCode version, or open diagnostics.',
   empty_response: 'OpenCode finished without producing a final reply. Retry; if it persists, open diagnostics.',
   process_crashed: 'OpenCode exited unexpectedly. Open diagnostics or retry.',
-  cwd_unavailable: "OpenCode's working directory is not accessible. Check the agent home directory's permissions.",
+  cwd_unavailable: "OpenCode's working directory is not accessible. Check the agent's configured path (or agent home) permissions.",
   unknown_error: 'OpenCode failed for an undetermined reason. Open diagnostics or retry.',
 };
 
@@ -78,12 +79,15 @@ class OpenCodeAdapter extends BaseAdapter {
     super(opts);
     this.disabledModules = opts.disabledModules || new Set();
 
-    // Agent home directory: ~/.openagents/agents/{agentName}/
+    // Agent home directory: ~/.openagents/agents/{agentName}/ — scratch storage
+    // for sessions, skills, and opencode config. This is NOT the directory
+    // opencode runs in; opencode runs in the configured workingDir (see
+    // _resolveCwd) so it can actually reach the project's files. (issue #435)
     this.agentHome = path.join(os.homedir(), '.openagents', 'agents', this.agentName);
     fs.mkdirSync(this.agentHome, { recursive: true });
 
     this._channelSessions = {};
-    this._sessionsFile = path.join(this.agentHome, 'sessions.json');
+    this._sessionsFile = this._sessionsFileFor();
     this._migrateSessionsFile();
     this._loadSessions();
 
@@ -103,6 +107,11 @@ class OpenCodeAdapter extends BaseAdapter {
    * Migrate sessions file from old location to agent home.
    */
   _migrateSessionsFile() {
+    // Only the legacy sessions.json (no workingDir → opencode still runs in
+    // agentHome) inherits sessions from the pre-agentHome location. A scoped
+    // file belongs to a different --dir, so seeding it with IDs created under
+    // agentHome would make every later resume 404.
+    if (path.basename(this._sessionsFile) !== 'sessions.json') return;
     const oldPath = path.join(
       os.homedir(), '.openagents', 'sessions',
       `${this.workspaceId}_${this.agentName}_opencode.json`
@@ -135,6 +144,38 @@ class OpenCodeAdapter extends BaseAdapter {
       fs.mkdirSync(path.dirname(this._sessionsFile), { recursive: true });
       fs.writeFileSync(this._sessionsFile, JSON.stringify(this._channelSessions));
     } catch {}
+  }
+
+  /**
+   * Effective working directory for `opencode run --dir` and the spawn cwd.
+   *
+   * opencode confines an agent's file access to its --dir worktree root; in
+   * headless mode a tool call that reaches outside it is auto-rejected with
+   * "user rejected permission". So opencode must run in the agent's configured
+   * project path (workingDir), not the per-agent scratch dir (agentHome). With
+   * no path configured, fall back to agentHome so pre-existing agents keep
+   * running where they always did. (issue #435)
+   */
+  _resolveCwd() {
+    return this.workingDir || this.agentHome;
+  }
+
+  /**
+   * Persisted-session-store path, scoped per working directory.
+   *
+   * An opencode session ID is only resumable against the --dir it was created
+   * under. If an agent's workingDir changes (or an agent that previously ran in
+   * agentHome gets a path configured), resuming a stored ID under the new --dir
+   * 404s with a confusing error. Scope the store by working dir so each project
+   * keeps its own IDs; the default (no workingDir) keeps the legacy
+   * sessions.json so existing agents retain their context. Files always live
+   * under agentHome — never inside the project tree. Mirrors the sha256[:16]
+   * per-cwd idiom used by the goose and nanoclaw adapters.
+   */
+  _sessionsFileFor() {
+    if (!this.workingDir) return path.join(this.agentHome, 'sessions.json');
+    const slug = crypto.createHash('sha256').update(this.workingDir).digest('hex').slice(0, 16);
+    return path.join(this.agentHome, `sessions-${slug}.json`);
   }
 
   async _onControlAction(action, payload) {
@@ -642,7 +683,8 @@ class OpenCodeAdapter extends BaseAdapter {
     }
 
     const binary = this._opencodeBinary;
-    const cmd = [binary, 'run', '--format', 'json', '--dir', this.agentHome];
+    const runCwd = this._resolveCwd();
+    const cmd = [binary, 'run', '--format', 'json', '--dir', runCwd];
 
     // Preflight guarantees a resolvable model; pin it explicitly — without it
     // opencode hangs waiting for interactive provider/model selection.
@@ -660,7 +702,7 @@ class OpenCodeAdapter extends BaseAdapter {
       fullPrompt = `${context}\n\n---\n\n${content}`;
     }
 
-    this._log(`CLI: ${binary} run --format json --dir … --model ${model || '(none)'}`);
+    this._log(`CLI: ${binary} run --format json --dir ${runCwd} --model ${model || '(none)'}`);
 
     const spawnEnv = { ...(this.agentEnv || process.env) };
 
@@ -677,7 +719,7 @@ class OpenCodeAdapter extends BaseAdapter {
       const proc = spawn(spawnBinary, spawnArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: spawnEnv,
-        cwd: this.agentHome,
+        cwd: runCwd,
         timeout: TIMEOUT_MS,
         detached: !IS_WINDOWS,
         // Never let a console window appear. Besides being ugly, an attached
@@ -825,10 +867,11 @@ class OpenCodeAdapter extends BaseAdapter {
     const cred = this._credentialState();
     if (cred === 'missing') return { ok: false, category: 'credential_missing' };
 
+    const runCwd = this._resolveCwd();
     try {
-      fs.accessSync(this.agentHome, fs.constants.R_OK | fs.constants.W_OK);
+      fs.accessSync(runCwd, fs.constants.R_OK | fs.constants.W_OK);
     } catch {
-      return { ok: false, category: 'cwd_unavailable', diagnostic: `cannot access ${this.agentHome}` };
+      return { ok: false, category: 'cwd_unavailable', diagnostic: `cannot access ${runCwd}` };
     }
 
     return { ok: true, version: probe.version, versionClass: vclass, model, credential: cred };

--- a/packages/agent-connector/test/opencode-workingdir.test.js
+++ b/packages/agent-connector/test/opencode-workingdir.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * Tests for the OpenCode working-directory fix (issue #435).
+ *
+ * opencode only lets an agent touch files inside the `--dir` worktree root; in
+ * headless mode a tool call outside it is auto-rejected. The adapter used to
+ * hardcode `--dir`/`cwd` to the per-agent scratch dir (agentHome), ignoring the
+ * configured `path` (workingDir) — so the agent ran in an empty dir and could
+ * never reach the project. These tests pin: opencode runs in the configured
+ * working dir, and stored session IDs (which are tied to `--dir`) are scoped per
+ * working dir so a path change can't poison a run with a stale, unresumable ID.
+ *
+ * `child_process.spawn` is faked (installed before the adapter is required, like
+ * test/aider.test.js) so the real `--dir`/`cwd` passed to the subprocess can be
+ * asserted without a CLI, network, or model.
+ */
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+const EventEmitter = require('node:events');
+const crypto = require('node:crypto');
+const os = require('node:os');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+// Swappable spawn shim installed BEFORE requiring the adapter so the
+// module-level `const { spawn } = require('child_process')` binds to it.
+const realSpawn = cp.spawn;
+let spawnImpl = null;
+let lastSpawn = null;
+cp.spawn = (...args) => spawnImpl(...args);
+
+const OpenCodeAdapter = require('../src/adapters/opencode');
+
+after(() => { cp.spawn = realSpawn; });
+
+function makeAdapter(overrides = {}) {
+  const adapter = new OpenCodeAdapter({
+    workspaceId: 'ws',
+    channelName: 'thread',
+    token: 'token',
+    agentName: 'opencode-wd-test',
+    ...overrides,
+  });
+  adapter._log = () => {};
+  return adapter;
+}
+
+// Minimal opencode stdout: one assistant text event, then the adapter resolves.
+function makeFakeSpawn() {
+  return (cmd, args, opts) => {
+    const proc = new EventEmitter();
+    proc.pid = 4242;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.stdin = new EventEmitter();
+    proc.stdin.write = () => true;
+    proc.stdin.end = () => {};
+    lastSpawn = { cmd, args, opts };
+    setImmediate(() => {
+      proc.stdout.emit('data', Buffer.from('{"type":"text","part":{"text":"ok"}}\n', 'utf-8'));
+      proc.emit('close', 0, null);
+    });
+    return proc;
+  };
+}
+
+// Drive `_runOpencode` with preflight stubbed to pass + spawn faked.
+async function captureRun(adapter, channel = 'thread') {
+  spawnImpl = makeFakeSpawn();
+  lastSpawn = null;
+  adapter._opencodeBinary = '/fake/opencode';
+  adapter._preflight = () => ({ ok: true, model: 'openai/gpt-4o', credential: 'present' });
+  adapter._resolveModel = () => 'openai/gpt-4o';
+  adapter._ensureWorkspaceSkill = () => {};
+  adapter._buildSystemContext = () => '';
+  adapter._persistSessionId = () => {};
+  await adapter._runOpencode('hi', channel);
+  return lastSpawn;
+}
+
+describe('OpenCode — working directory (#435)', () => {
+  it('_resolveCwd uses the configured workingDir', () => {
+    const a = makeAdapter({ workingDir: '/tmp/proj-435' });
+    assert.equal(a._resolveCwd(), '/tmp/proj-435');
+  });
+
+  it('_resolveCwd falls back to agentHome when no workingDir is configured', () => {
+    const a = makeAdapter();
+    assert.equal(a._resolveCwd(), a.agentHome);
+  });
+
+  it('spawns opencode with --dir and cwd set to the configured workingDir', async () => {
+    const a = makeAdapter({ workingDir: '/tmp/proj-435' });
+    const spawn = await captureRun(a);
+    assert.ok(spawn, 'opencode was spawned');
+    const dirIdx = spawn.args.indexOf('--dir');
+    assert.ok(dirIdx >= 0, '--dir is on the command line');
+    assert.equal(spawn.args[dirIdx + 1], '/tmp/proj-435', '--dir is the configured workingDir');
+    assert.equal(spawn.opts.cwd, '/tmp/proj-435', 'spawn cwd is the configured workingDir');
+  });
+
+  it('falls back to agentHome for --dir/cwd when no workingDir is configured (back-compat)', async () => {
+    const a = makeAdapter();
+    const spawn = await captureRun(a);
+    const dirIdx = spawn.args.indexOf('--dir');
+    assert.equal(spawn.args[dirIdx + 1], a.agentHome);
+    assert.equal(spawn.opts.cwd, a.agentHome);
+  });
+
+  it('scopes the persisted session store per working dir', () => {
+    const legacy = makeAdapter(); // no workingDir → back-compat legacy file
+    assert.equal(
+      path.basename(legacy._sessionsFile),
+      'sessions.json',
+      'no workingDir keeps the legacy sessions.json so existing agents keep their context',
+    );
+
+    const projA = makeAdapter({ workingDir: '/tmp/proj-a' });
+    const projB = makeAdapter({ workingDir: '/tmp/proj-b' });
+    const slugA = crypto.createHash('sha256').update('/tmp/proj-a').digest('hex').slice(0, 16);
+    assert.equal(
+      path.basename(projA._sessionsFile),
+      `sessions-${slugA}.json`,
+      'a workingDir gets a per-dir scoped file',
+    );
+    assert.notEqual(projA._sessionsFile, projB._sessionsFile, 'different dirs → different files');
+    assert.equal(
+      path.dirname(projA._sessionsFile),
+      projA.agentHome,
+      'scoped files still live under agentHome, never inside the project',
+    );
+  });
+
+  it('preflight reports cwd_unavailable (naming the configured dir) when the workingDir is inaccessible', () => {
+    const a = makeAdapter({ workingDir: '/definitely/not/a/real/path/opencode-435' });
+    a._opencodeBinary = '/fake/opencode';
+    a._findOpencodeBinary = () => '/fake/opencode';
+    a._detectCliVersion = () => ({ version: '1.17.11', executable: true });
+    a.agentEnv = { LLM_MODEL: 'gpt-4o', OPENAI_API_KEY: 'x' };
+    const r = a._preflight('thread');
+    assert.equal(r.ok, false);
+    assert.equal(r.category, 'cwd_unavailable');
+    assert.match(r.diagnostic || '', /opencode-435/, 'diagnostic names the inaccessible working dir');
+  });
+
+  it('preflight passes when the configured workingDir is accessible', () => {
+    const accessible = os.tmpdir();
+    const a = makeAdapter({ workingDir: accessible });
+    a._opencodeBinary = '/fake/opencode';
+    a._findOpencodeBinary = () => '/fake/opencode';
+    a._detectCliVersion = () => ({ version: '1.17.11', executable: true });
+    a.agentEnv = { LLM_MODEL: 'gpt-4o', OPENAI_API_KEY: 'x' };
+    const r = a._preflight('thread');
+    assert.equal(r.ok, true);
+  });
+});


### PR DESCRIPTION
## Fixes #435

`agn create <name> --type opencode --path <project>` ignored the configured path: the opencode adapter documented `opts.workingDir` but never used it, hardcoding `--dir` and `cwd` to the per-agent scratch dir (`~/.openagents/agents/<name>`).

opencode confines an agent's file access to its `--dir` worktree root, so in headless mode any read/edit tool call against a real project file is auto-rejected with *"The user rejected permission to use this specific tool call."* — on every platform, not only Windows.

## Fix

- **Run opencode in the configured `workingDir`** (both `--dir` and the spawn `cwd`) via a new `_resolveCwd()` helper. When no path is configured it falls back to `agentHome`, so pre-existing agents keep running exactly where they always did.
- **Scope the persisted session store per working directory** (`sessions-<sha256[:16]>.json`). An opencode session ID is only resumable against the `--dir` it was created under, so without scoping a path change (or an agent that previously ran in `agentHome` getting a path configured) would poison the next run with a stale ID that 404s. The default (no `workingDir`) keeps the legacy `sessions.json` so existing agents retain their context. Files always live under `agentHome`, never inside the project tree. This mirrors the `sha256[:16]` per-cwd idiom already used by the goose and nanoclaw adapters.
- **Preflight now access-checks the resolved working dir** and surfaces `cwd_unavailable` (naming the configured path) when it is missing or unreadable, instead of silently running in `agentHome`.

`this.workingDir` is already populated by `BaseAdapter` and passed by `daemon.js` (`workingDir: agentCfg.path || defaultAgentWorkdir(name)`), so no daemon changes are needed — the adapter just had to use it.

## Test plan

- [x] `node --test test/opencode-workingdir.test.js` — 7/7 new tests pass. Covers `_resolveCwd` (configured vs fallback), `--dir`/`cwd` passed to the real subprocess (asserted via a `child_process.spawn` shim installed before require, same pattern as `test/aider.test.js`), per-working-dir session-store scoping, and the preflight `cwd_unavailable`/pass cases.
- [x] `node --test test/opencode.test.js` — existing 8.1–8.5 suites pass. (Two preflight credential tests are non-hermetic — they inspect the real home dir and fail when a real `~/.config/opencode/opencode.json` exists on the machine; identical failures occur on `develop`, unrelated to this change.)
- [ ] Manual: `agn create demo --type opencode --path /path/to/project`; connect to a workspace; @mention it to read or edit a project file and confirm the *"user rejected permission"* error is gone; send a second message in the same channel and confirm context is retained.
