### PR TITLE
fix(workspace): make agent removal sticky so removed agents can't reappear (#347)

### DIFF
--- a/workspace/backend/app/mods/workspace_mod.py
+++ b/workspace/backend/app/mods/workspace_mod.py
@@ -67,6 +67,19 @@ async def _handle_agent_join(event: Event, ctx: PipelineContext) -> Optional[Eve
         )
     ).scalar_one_or_none()
 
+    # A removed agent must not resurrect itself by re-joining. Its daemon
+    # reconnects and re-POSTs /v1/join, which would otherwise upsert the row
+    # back to status='online' — exactly the "removed agent still appears" bug.
+    # Re-adding is a human action (POST /v1/cloud-agents reactivates the row).
+    # Raising EventRejected makes _emit_event return None → /v1/join 401s.
+    # (issue #347)
+    if existing and existing.status == "removed":
+        logger.info(
+            "workspace_mod: refused re-join of removed agent %s in %s",
+            agent_name, workspace.id,
+        )
+        raise EventRejected("workspace_mod", "agent_removed")
+
     now = datetime.now(timezone.utc)
 
     agent_type = event.payload.get("agent_type") if event.payload else None
@@ -198,16 +211,22 @@ async def _handle_agent_remove(event: Event, ctx: PipelineContext) -> Optional[E
         return None
 
     was_master = member.role == "master"
-    db.delete(member)
+    # Soft-delete: keep the row (status='removed') so a re-add can reactivate
+    # the agent and so _handle_agent_join can refuse to resurrect it. Hard-
+    # deleting left nothing to stop a still-running daemon from re-joining and
+    # upserting the membership back to online — the removed agent reappeared.
+    # (issue #347)
+    member.status = "removed"
     db.flush()
 
     new_master_name = None
 
-    # If removed agent was master, promote the next available agent
+    # If removed agent was master, promote the next available (non-removed) agent
     if was_master:
         next_master = db.execute(
             select(WorkspaceMember).where(
                 WorkspaceMember.workspace_id == workspace.id,
+                WorkspaceMember.status != "removed",
             ).order_by(WorkspaceMember.joined_at.asc())
         ).scalar_one_or_none()
 
@@ -269,6 +288,17 @@ async def _handle_ping(event: Event, ctx: PipelineContext) -> Optional[Event]:
 
     if not member:
         return None
+
+    # A removed agent's still-running daemon keeps heartbeating; without this
+    # guard the line below would flip it back to status='online'. Surface
+    # session_revoked so the caller stops its adapter for this agent. (issue #347)
+    if member.status == "removed":
+        event.metadata["session_error"] = "session_revoked"
+        logger.info(
+            "workspace_mod: rejected heartbeat for removed agent %s in %s",
+            agent_name, workspace.id,
+        )
+        return event
 
     now = datetime.now(timezone.utc)
     member.status = "online"

--- a/workspace/backend/app/routers/cloud_agents.py
+++ b/workspace/backend/app/routers/cloud_agents.py
@@ -111,7 +111,7 @@ async def add_cloud_agent(
             WorkspaceMember.agent_name == body.agent_name,
         )
     ).scalar_one_or_none()
-    if existing:
+    if existing and existing.status != "removed":
         return json_response(
             ResponseCode.BAD_REQUEST,
             f"Agent '{body.agent_name}' already exists in this workspace",
@@ -122,6 +122,36 @@ async def add_cloud_agent(
             ResponseCode.BAD_REQUEST,
             "Custom provider requires a base_url",
         )
+
+    # Re-adding a previously-removed cloud agent: reactivate the soft-deleted
+    # member and refresh its retained CloudAgentConfig rather than failing with
+    # "already exists". (issue #347)
+    if existing and existing.status == "removed":
+        existing.status = "online"
+        existing.last_heartbeat = None
+        existing.agent_type = f"cloud:{body.provider}"
+        existing.description = f"Cloud agent: {model_info.label} ({body.provider})"
+        cfg = db.execute(
+            select(CloudAgentConfig).where(
+                CloudAgentConfig.workspace_id == str(workspace.id),
+                CloudAgentConfig.agent_name == body.agent_name,
+            )
+        ).scalar_one_or_none()
+        if cfg is not None:
+            cfg.provider = body.provider
+            cfg.model = body.model
+            cfg.category = model_info.category
+            cfg.api_key = body.api_key
+            cfg.base_url = body.base_url
+            cfg.system_prompt = body.system_prompt
+            cfg.max_tokens = body.max_tokens
+            cfg.status = "active"
+        db.commit()
+        logger.info(
+            "cloud_agents: reactivated %s (%s/%s) in workspace %s",
+            body.agent_name, body.provider, body.model, workspace.id,
+        )
+        return success_response(_format_cloud_agent(cfg))
 
     cfg = CloudAgentConfig(
         workspace_id=str(workspace.id),

--- a/workspace/backend/app/routers/network.py
+++ b/workspace/backend/app/routers/network.py
@@ -387,8 +387,15 @@ def discover(
 
     now = datetime.now(timezone.utc)
 
+    # Hide removed agents — removal is a soft-delete (status='removed') so a
+    # re-add can reactivate them. Offline members are intentionally kept: the
+    # mobile clients key the "connect an agent" prompt off membership, not
+    # online status. (issue #347)
     members = db.execute(
-        select(WorkspaceMember).where(WorkspaceMember.workspace_id == workspace.id)
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace.id,
+            WorkspaceMember.status != "removed",
+        )
     ).scalars().all()
 
     agents = []

--- a/workspace/backend/tests/test_agent_removal.py
+++ b/workspace/backend/tests/test_agent_removal.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for sticky agent removal (issue #347).
+
+Background: /v1/remove used to hard-delete the WorkspaceMember, but a still-running
+agent daemon would re-POST /v1/join on reconnect and _handle_agent_join blindly
+upserted the row back to status="online" — so a removed agent reappeared in
+/v1/discover. Removal must be sticky: a removed agent cannot resurrect itself by
+re-joining or heartbeating, and must not show in discovery. Re-adding a cloud
+agent through POST /v1/cloud-agents reactivates it.
+
+Offline members are a separate, intentional concept (mobile clients rely on
+membership, not online status) and must keep appearing in discovery — these
+tests pin that the "removed" filter does not over-filter offline members.
+"""
+
+from app.models import WorkspaceMember
+
+
+def _join(client, workspace, agent_name):
+    return client.post(
+        "/v1/join",
+        json={
+            "agent_name": agent_name,
+            "token": workspace["token"],
+            "network": workspace["id"],
+        },
+    )
+
+
+def _remove(client, workspace, agent_name):
+    return client.post(
+        "/v1/remove",
+        json={
+            "agent_name": agent_name,
+            "network": workspace["id"],
+        },
+        headers={"X-Workspace-Token": workspace["token"]},
+    )
+
+
+def _heartbeat(client, workspace, agent_name, session_id=None):
+    payload = {"agent_name": agent_name, "network": workspace["id"]}
+    if session_id:
+        payload["session_id"] = session_id
+    return client.post("/v1/heartbeat", json=payload)
+
+
+def _discover_agents(client, workspace):
+    resp = client.get(
+        "/v1/discover", params={"network": workspace["id"]}, headers={"X-Workspace-Token": workspace["token"]}
+    )
+    assert resp.status_code == 200
+    return [a["address"] for a in resp.json()["data"]["agents"]]
+
+
+class TestStickyAgentRemoval:
+    """Removal must not be reversible by the removed agent's own daemon."""
+
+    def test_removed_agent_excluded_from_discover(self, client, workspace):
+        _join(client, workspace, "agent-beta")
+        assert "openagents:agent-beta" in _discover_agents(client, workspace)
+
+        resp = _remove(client, workspace, "agent-beta")
+        assert resp.status_code == 200
+
+        names = _discover_agents(client, workspace)
+        assert "openagents:agent-beta" not in names
+        # Other agents are unaffected.
+        assert "openagents:agent-alpha" in names
+
+    def test_removed_agent_cannot_rejoin(self, client, workspace):
+        _join(client, workspace, "agent-beta")
+        _remove(client, workspace, "agent-beta")
+
+        # The daemon reconnects and tries to re-join — must be refused, and the
+        # membership must NOT come back.
+        resp = _join(client, workspace, "agent-beta")
+        assert resp.status_code >= 400, "re-join after removal must be refused"
+
+        names = _discover_agents(client, workspace)
+        assert "openagents:agent-beta" not in names, "re-join must not resurrect a removed agent"
+
+    def test_heartbeat_does_not_resurrect_removed_agent(self, client, workspace):
+        join_resp = _join(client, workspace, "agent-beta")
+        session_id = join_resp.json()["data"].get("session_id")
+        _remove(client, workspace, "agent-beta")
+
+        # A still-running daemon keeps heartbeating — that must not flip the
+        # removed member back to online.
+        _heartbeat(client, workspace, "agent-beta", session_id)
+
+        names = _discover_agents(client, workspace)
+        assert "openagents:agent-beta" not in names
+
+    def test_removed_member_row_marked_removed_not_deleted(self, client, workspace, db):
+        """Removal is a soft-delete (status='removed'), so a re-add can reactivate."""
+        _join(client, workspace, "agent-beta")
+        _remove(client, workspace, "agent-beta")
+
+        member = (
+            db.query(WorkspaceMember)
+            .filter_by(
+                workspace_id=workspace["id"],
+                agent_name="agent-beta",
+            )
+            .one_or_none()
+        )
+        assert member is not None, "removed member row is retained (soft-delete)"
+        assert member.status == "removed"
+
+    def test_offline_member_still_listed_in_discover(self, client, workspace, db):
+        """A stale (offline) member is NOT removed — mobile clients rely on
+        membership, not online status. The 'removed' filter must not catch it."""
+        from datetime import datetime, timedelta, timezone
+
+        from app.config import config
+
+        _join(client, workspace, "agent-beta")
+        member = (
+            db.query(WorkspaceMember)
+            .filter_by(
+                workspace_id=workspace["id"],
+                agent_name="agent-beta",
+            )
+            .one()
+        )
+        member.last_heartbeat = datetime.now(timezone.utc) - timedelta(
+            seconds=config.AGENT_TIMEOUT_SECONDS + 60,
+        )
+        db.commit()
+
+        assert "openagents:agent-beta" in _discover_agents(client, workspace)
+
+
+class TestReaddCloudAgent:
+    """A cloud agent removed via /v1/remove can be re-added (reactivated)."""
+
+    def _add_cloud_agent(self, client, workspace, name="cloud-bot"):
+        return client.post(
+            "/v1/cloud-agents",
+            json={
+                "network": workspace["id"],
+                "agent_name": name,
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "sk-test-435",
+            },
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+
+    def test_readd_reactivates_removed_cloud_agent(self, client, workspace):
+        add_resp = self._add_cloud_agent(client, workspace)
+        assert add_resp.status_code == 200, add_resp.text
+        assert "openagents:cloud-bot" in _discover_agents(client, workspace)
+
+        _remove(client, workspace, "cloud-bot")
+        assert "openagents:cloud-bot" not in _discover_agents(client, workspace)
+
+        # Re-adding must reactivate (not 400 "already exists").
+        readd_resp = self._add_cloud_agent(client, workspace)
+        assert readd_resp.status_code == 200, readd_resp.text
+        assert "openagents:cloud-bot" in _discover_agents(client, workspace)


### PR DESCRIPTION
## Fixes #347

A removed agent reappeared in the workspace sidebar. The online count was correct ("Agents (2/4)"), but the agent list kept showing every agent that had ever been added.

## Root cause

`POST /v1/remove` hard-deleted the `WorkspaceMember` row, but a still-running agent daemon reconnects and re-POSTs `/v1/join`, and `_handle_agent_join` blindly upserted the row back to `status='online'`. So removal wasn't sticky — the daemon resurrected its own membership, and `/v1/discover` (which the sidebar renders) listed it again. `/v1/profile`'s online count already filtered `status='online'`, so the count was right while the list was wrong — exactly the reported symptom.

## Fix

Make removal a soft-delete (`status='removed'`) and refuse self-resurrection:

- **`_handle_agent_remove`** — mark `status='removed'` (keep the row) instead of `db.delete`; exclude removed members when reassigning a channel master.
- **`_handle_agent_join`** — raise `EventRejected` when a removed agent tries to re-join, so `/v1/join` 401s instead of upserting the membership back to online.
- **`_handle_ping`** — don't flip a removed member back to online; surface `session_revoked` so the daemon stops its adapter for that agent.
- **`/v1/discover`** — hide removed members. Offline members are intentionally kept (mobile clients key the "connect an agent" prompt off membership, not online status — pinned by `test_discover_keeps_stale_members_as_offline`).
- **`POST /v1/cloud-agents`** — re-adding a previously-removed cloud agent reactivates it (refreshes its retained `CloudAgentConfig`) instead of rejecting with "already exists", so removal is reversible by a human re-invite rather than permanent.

Re-adding a self-joined (token) agent remains intentionally blocked — only a human re-invite (cloud-agents) clears the removed state, which is what makes removal sticky against a rogue/reconnecting daemon.

## Test plan

- [x] `pytest tests/test_agent_removal.py` — 6/6 new tests pass: removed agent excluded from discover; re-join refused (401) and doesn't resurrect; heartbeat doesn't resurrect; removed row retained as `status='removed'`; offline member still listed (back-compat); cloud re-add reactivates.
- [x] `pytest workspace/backend/tests/` — no new regressions. 20 tests fail on this machine both on `develop` and with this branch (browser-contexts, event-routing auth, migration-schema) — they're pre-existing local-env failures (SQLAlchemy/alembic/SQLite version drift), unrelated to this change; verified identical before/after via `git stash` diff.
- [x] `ruff` — the changed source files introduce **zero** new violations (rule counts equal-or-fewer than `develop`); the new test file is ruff-clean.
- [ ] Manual: connect an agent to a workspace, remove it from the sidebar, and confirm it disappears and stays gone (no reappearance on the next discover poll) even while its daemon is still running; re-add it via "add cloud agent" and confirm it returns.
