### PR TITLE
feat(frontend): unify workspace dialogs with responsive drawer + fixe…

### DIFF
--- a/workspace/frontend/app/layout.tsx
+++ b/workspace/frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'next-themes';
 import { Toaster } from '@/components/ui/sonner';
 import { AuthProvider } from '@/lib/auth-context';
 import { OpenAgentsAuthProvider } from '@/lib/openagents-auth-context';
+import { DialogsProvider } from '@/components/ui/dialogs-provider';
 import '@/styles/globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -75,7 +76,9 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           <AuthProvider>
             <OpenAgentsAuthProvider>
-              {children}
+              <DialogsProvider>
+                {children}
+              </DialogsProvider>
             </OpenAgentsAuthProvider>
           </AuthProvider>
           <Toaster />

--- a/workspace/frontend/components/browser/browser-tab-list.tsx
+++ b/workspace/frontend/components/browser/browser-tab-list.tsx
@@ -6,6 +6,7 @@ import { useWorkspace } from '@/lib/workspace-context';
 import { useLayout } from '@/components/layout/layout-context';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useConfirm, usePrompt } from '@/components/ui/dialogs-provider';
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -35,6 +36,8 @@ export function BrowserTabList() {
     browserContexts, openBrowserTabWithContext, deleteBrowserContext,
   } = useWorkspace();
   const { isMobile, openMobileDetail } = useLayout();
+  const confirm = useConfirm();
+  const prompt = usePrompt();
   const [opening, setOpening] = useState(false);
 
   // Split tabs into persistent (on top) and regular
@@ -46,7 +49,13 @@ export function BrowserTabList() {
   const idleContexts = browserContexts.filter((c) => !activeContextIds.has(c.id));
 
   const handleOpen = async () => {
-    const url = prompt('Enter URL (or leave blank for about:blank):', 'https://');
+    const url = await prompt({
+      title: 'Open a browser tab',
+      description: 'Enter a URL, or leave blank for about:blank.',
+      placeholder: 'https://',
+      defaultValue: 'https://',
+      confirmText: 'Open',
+    });
     if (url === null) return;
     setOpening(true);
     try {
@@ -87,7 +96,13 @@ export function BrowserTabList() {
 
   const handleDeleteContext = async (e: React.MouseEvent, contextId: string, name: string) => {
     e.stopPropagation();
-    if (!confirm(`Delete saved session "${name}"? This will permanently remove the stored cookies and login state.`)) return;
+    const ok = await confirm({
+      title: 'Delete saved session?',
+      description: `"${name}" will be permanently removed, including its stored cookies and login state.`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await deleteBrowserContext(contextId);
       toast.success('Saved session deleted');

--- a/workspace/frontend/components/browser/browser-view.tsx
+++ b/workspace/frontend/components/browser/browser-view.tsx
@@ -7,8 +7,11 @@ import { useLayout } from '@/components/layout/layout-context';
 import { workspaceApi } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useConfirm, usePrompt } from '@/components/ui/dialogs-provider';
 
 export function BrowserView() {
+  const confirm = useConfirm();
+  const prompt = usePrompt();
   const {
     browserTabs, selectedBrowserTabId, setSelectedBrowserTabId,
     closeBrowserTab, navigateBrowserTab, reconnectBrowserTab, persistBrowserTab, unpersistBrowserTab, browserContexts,
@@ -166,7 +169,12 @@ export function BrowserView() {
 
   const handlePersist = async () => {
     if (!tab || tab.contextId) return;
-    const name = prompt('Give this session a name (e.g. "LinkedIn Account", "Google Search Console"):');
+    const name = await prompt({
+      title: 'Save this session',
+      description: 'Give it a name so you can reuse the saved login later.',
+      placeholder: 'e.g. LinkedIn Account, Google Search Console',
+      confirmText: 'Save',
+    });
     if (!name?.trim()) return;
     try {
       await persistBrowserTab(tab.id, name.trim());
@@ -180,7 +188,13 @@ export function BrowserView() {
     if (!tab || !tab.contextId) return;
     const ctx = browserContexts.find((c) => c.id === tab.contextId);
     const label = ctx?.name || 'this tab';
-    if (!confirm(`Remove persistent state from "${label}"? The saved cookies and login state will be deleted.`)) return;
+    const ok = await confirm({
+      title: 'Remove persistent state?',
+      description: `The saved cookies and login state for "${label}" will be deleted.`,
+      confirmText: 'Remove',
+      destructive: true,
+    });
+    if (!ok) return;
     try {
       await unpersistBrowserTab(tab.id);
       toast.success('Tab is now temporal');

--- a/workspace/frontend/components/chat/orchestration-control.tsx
+++ b/workspace/frontend/components/chat/orchestration-control.tsx
@@ -17,8 +17,9 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
+  DialogBody,
   DialogFooter,
-} from '@/components/ui/dialog';
+} from '@/components/ui/responsive-dialog';
 import { cn } from '@/lib/utils';
 import type { WorkspaceSession, WorkspaceAgent } from '@/lib/types';
 
@@ -241,7 +242,7 @@ function WorkflowPlanDialog({ open, onOpenChange, agents, initialValue, onSave }
           </DialogDescription>
         </DialogHeader>
 
-        <div className="relative">
+        <DialogBody className="relative py-1 overflow-visible">
           <textarea
             ref={textareaRef}
             value={value}
@@ -282,13 +283,13 @@ function WorkflowPlanDialog({ open, onOpenChange, agents, initialValue, onSave }
               ))}
             </div>
           )}
-        </div>
+        </DialogBody>
 
         <DialogFooter>
-          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button size="sm" onClick={save}>
+          <Button onClick={save}>
             Save plan
           </Button>
         </DialogFooter>

--- a/workspace/frontend/components/chat/share-dialog.tsx
+++ b/workspace/frontend/components/chat/share-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Check, Copy, Link, Loader2 } from 'lucide-react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/responsive-dialog';
 import { Button } from '@/components/ui/button';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { workspaceApi } from '@/lib/api';
@@ -52,7 +52,7 @@ export function ShareDialog({ open, onOpenChange, sessionId }: ShareDialogProps)
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <DialogBody className="space-y-4 py-1">
           {!shareUrl && !loading && !error && (
             <Button onClick={handleCreateShare} className="w-full">
               <Link className="size-4 mr-2" />
@@ -109,7 +109,7 @@ export function ShareDialog({ open, onOpenChange, sessionId }: ShareDialogProps)
               </p>
             </div>
           )}
-        </div>
+        </DialogBody>
       </DialogContent>
     </Dialog>
   );

--- a/workspace/frontend/components/invitations/invitation-dialog.tsx
+++ b/workspace/frontend/components/invitations/invitation-dialog.tsx
@@ -5,9 +5,10 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogBody,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog';
+} from '@/components/ui/responsive-dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -94,7 +95,7 @@ export function InvitationDialog() {
           <DialogTitle>Invite Agent</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
+        <DialogBody className="space-y-4 py-1">
           {/* Create invitation */}
           <div className="space-y-2">
             <Label>Agent Name</Label>
@@ -152,7 +153,7 @@ export function InvitationDialog() {
               </div>
             </div>
           )}
-        </div>
+        </DialogBody>
       </DialogContent>
     </Dialog>
   );

--- a/workspace/frontend/components/knowledge/knowledge-editor.tsx
+++ b/workspace/frontend/components/knowledge/knowledge-editor.tsx
@@ -6,8 +6,9 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogBody,
   DialogFooter,
-} from '@/components/ui/dialog';
+} from '@/components/ui/responsive-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -71,12 +72,12 @@ export function KnowledgeEditor({ open, entry, onClose, onSaved }: KnowledgeEdit
 
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent className="sm:max-w-2xl max-h-[85vh] flex flex-col">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Knowledge Entry' : 'New Knowledge Entry'}</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4 flex-1 overflow-y-auto py-2">
+        <DialogBody className="space-y-4 py-1">
           <div className="space-y-2">
             <Label htmlFor="kb-title">Title</Label>
             <Input
@@ -107,7 +108,7 @@ export function KnowledgeEditor({ open, entry, onClose, onSaved }: KnowledgeEdit
               className="w-full min-h-[300px] rounded-md border border-input bg-background px-3 py-2 text-sm font-mono resize-y focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             />
           </div>
-        </div>
+        </DialogBody>
 
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={saving}>

--- a/workspace/frontend/components/layout/mobile-header.tsx
+++ b/workspace/frontend/components/layout/mobile-header.tsx
@@ -60,11 +60,11 @@ export function MobileHeader() {
                   <Menu className="size-4" />
                 </Button>
               </SheetTrigger>
-              <SheetContent className="p-0 gap-0 w-[280px]" side="left" close={false}>
+              <SheetContent className="p-0 gap-0 w-[280px] h-dvh bottom-auto pt-[calc(0.75rem+env(safe-area-inset-top))]" side="left" close={false}>
                 <SheetHeader className="p-0 space-y-0">
                   <SheetTitle className="sr-only">Navigation</SheetTitle>
                 </SheetHeader>
-                <SheetBody className="flex grow p-0">
+                <SheetBody className="grow flex flex-col min-h-0 p-0">
                   <SidebarContent />
                 </SheetBody>
               </SheetContent>

--- a/workspace/frontend/components/layout/sidebar-content.tsx
+++ b/workspace/frontend/components/layout/sidebar-content.tsx
@@ -14,8 +14,17 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogBody,
   DialogFooter,
 } from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerBody,
+  DrawerFooter,
+} from '@/components/ui/drawer';
 import { Input } from '@/components/ui/input';
 
 import { Label } from '@/components/ui/label';
@@ -83,15 +92,32 @@ export function SidebarContent() {
   const isDark = mounted && theme === 'dark';
   const toggleTheme = () => setTheme(isDark ? 'light' : 'dark');
 
-  const handleCopyToken = () => {
+  const handleCopyToken = async () => {
     if (!token) {
       toast.error('No management token available');
       return;
     }
-    navigator.clipboard.writeText(token);
-    setTokenCopied(true);
-    toast.success('Management token copied');
-    setTimeout(() => setTokenCopied(false), 2000);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(token);
+      } else {
+        // Fallback for in-app browsers / insecure contexts without the Clipboard API
+        const ta = document.createElement('textarea');
+        ta.value = token;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      setTokenCopied(true);
+      toast.success('Management token copied');
+      setTimeout(() => setTokenCopied(false), 2000);
+    } catch {
+      toast.error('Failed to copy token');
+    }
   };
 
   // Always open the agent picker so the user chooses which agents join the
@@ -297,7 +323,7 @@ export function SidebarContent() {
             <NavButton active={viewMode === 'connect'} icon={<PlusSquare className="size-[15px]" />} label="Connect Agent" onClick={() => setViewMode('connect')} />
           )}
         </div>
-        <div className="shrink-0 border-t border-border px-2.5 py-2.5 space-y-1">
+        <div className="shrink-0 border-t border-border px-2.5 pt-2.5 pb-[calc(0.625rem+env(safe-area-inset-bottom))] space-y-1">
           {/* Logged-in user details */}
           {isOpenAgentsDomain && user && (
             <div className="px-2 py-1.5 space-y-2">
@@ -388,7 +414,7 @@ function SettingsDialogPortal({ open, onOpenChange, workspace, refreshWorkspace 
   const { isCopied: urlCopied, copyToClipboard: copyUrl } = useCopyToClipboard();
   const { isCopied: tokenCopied, copyToClipboard: copyToken } = useCopyToClipboard();
   const { notificationSound, setNotificationSound } = useWorkspace();
-  const { splitBrowser, setSplitBrowser } = useLayout();
+  const { splitBrowser, setSplitBrowser, isMobile } = useLayout();
   const [collabEmail, setCollabEmail] = useState('');
   const [collabAdding, setCollabAdding] = useState(false);
   const [collaborators, setCollaborators] = useState<WorkspaceCollaborator[]>([]);
@@ -430,11 +456,8 @@ function SettingsDialogPortal({ open, onOpenChange, workspace, refreshWorkspace 
     }
   };
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg max-h-[85vh] overflow-y-auto">
-        <DialogHeader><DialogTitle>Workspace Settings</DialogTitle></DialogHeader>
-        <div className="space-y-6 py-4">
+  const formBody = (
+        <div className="space-y-6 py-1">
           <div className="space-y-2">
             <Label>Workspace Name</Label>
             <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="My Workspace" />
@@ -598,6 +621,32 @@ function SettingsDialogPortal({ open, onOpenChange, workspace, refreshWorkspace 
           </div>
 
         </div>
+  );
+
+  // ── Mobile: bottom drawer with pull-down-to-close (vaul) ──
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="max-h-[90vh] pb-[env(safe-area-inset-bottom)]">
+          <DrawerHeader>
+            <DrawerTitle>Workspace Settings</DrawerTitle>
+          </DrawerHeader>
+          <DrawerBody>{formBody}</DrawerBody>
+          <DrawerFooter className="flex-row pt-4 pb-2">
+            <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button className="flex-1" onClick={handleSave} disabled={saving || !name.trim()}>{saving ? 'Saving...' : 'Save'}</Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  // ── Desktop: centered dialog ──
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader><DialogTitle>Workspace Settings</DialogTitle></DialogHeader>
+        <DialogBody>{formBody}</DialogBody>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
           <Button onClick={handleSave} disabled={saving || !name.trim()}>{saving ? 'Saving...' : 'Save'}</Button>

--- a/workspace/frontend/components/routines/create-routine-dialog.tsx
+++ b/workspace/frontend/components/routines/create-routine-dialog.tsx
@@ -4,9 +4,12 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
   DialogTitle,
   DialogDescription,
-} from '@/components/ui/dialog';
+} from '@/components/ui/responsive-dialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Loader2 } from 'lucide-react';
@@ -121,13 +124,15 @@ export function CreateRoutineDialog({ open, onOpenChange, agents, conversationHi
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
-        <DialogTitle>Create Routine</DialogTitle>
-        <DialogDescription className="text-sm text-muted-foreground">
-          Set up a recurring task for an agent.
-        </DialogDescription>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Create Routine</DialogTitle>
+          <DialogDescription>
+            Set up a recurring task for an agent.
+          </DialogDescription>
+        </DialogHeader>
 
-        <div className="mt-3 space-y-4">
+        <DialogBody className="space-y-4 py-1">
           {/* Task description */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">What should the agent do?</label>
@@ -295,13 +300,13 @@ export function CreateRoutineDialog({ open, onOpenChange, agents, conversationHi
           {error && (
             <p className="text-xs text-red-500">{error}</p>
           )}
-        </div>
+        </DialogBody>
 
-        <div className="flex justify-end gap-2 mt-4">
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={submitting}>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
             Cancel
           </Button>
-          <Button size="sm" onClick={handleSubmit} disabled={!isValid || submitting}>
+          <Button onClick={handleSubmit} disabled={!isValid || submitting}>
             {submitting ? (
               <>
                 <Loader2 className="size-3.5 animate-spin mr-1.5" />
@@ -311,7 +316,7 @@ export function CreateRoutineDialog({ open, onOpenChange, agents, conversationHi
               'Create Routine'
             )}
           </Button>
-        </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/workspace/frontend/components/settings/settings-dialog.tsx
+++ b/workspace/frontend/components/settings/settings-dialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogBody,
   DialogFooter,
   DialogTrigger,
 } from '@/components/ui/dialog';
@@ -90,12 +91,12 @@ export function SettingsDialog({ workspace }: SettingsDialogProps) {
           <Settings className="size-4" />
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg max-h-[85vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Workspace Settings</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6 py-4">
+        <DialogBody className="space-y-6 py-1">
           {/* Workspace name */}
           <div className="space-y-2">
             <Label>Workspace Name</Label>
@@ -189,7 +190,7 @@ export function SettingsDialog({ workspace }: SettingsDialogProps) {
             </div>
           )}
 
-        </div>
+        </DialogBody>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>

--- a/workspace/frontend/components/skills/skills-view.tsx
+++ b/workspace/frontend/components/skills/skills-view.tsx
@@ -10,10 +10,11 @@ import { AgentAvatar } from '@/components/agents/agent-avatar';
 import {
   Dialog,
   DialogContent,
+  DialogBody,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
+} from '@/components/ui/responsive-dialog';
 import { toast } from 'sonner';
 
 // ---------------------------------------------------------------------------
@@ -711,7 +712,7 @@ function UploadSkillDialog({
           <DialogTitle>Upload custom skill</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-3">
+        <DialogBody className="space-y-3 py-1">
           {/* File picker */}
           <div>
             <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
@@ -789,7 +790,7 @@ function UploadSkillDialog({
               <p className="text-[11px] text-red-600 dark:text-red-400">{error}</p>
             </div>
           )}
-        </div>
+        </DialogBody>
 
         <DialogFooter>
           <button

--- a/workspace/frontend/components/threads/new-thread-dialog.tsx
+++ b/workspace/frontend/components/threads/new-thread-dialog.tsx
@@ -4,12 +4,15 @@ import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
   DialogTitle,
   DialogDescription,
-} from '@/components/ui/dialog';
+} from '@/components/ui/responsive-dialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { History, Check, Minus } from 'lucide-react';
+import { History, Check, Minus, Users } from 'lucide-react';
 import type { WorkspaceAgent, WorkspaceSession } from '@/lib/types';
 import { AgentAvatar } from '@/components/agents/agent-avatar';
 
@@ -81,122 +84,126 @@ export function NewThreadDialog({ open, onOpenChange, agents, sessions, onCreate
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
-        <DialogTitle>New Thread</DialogTitle>
-        <DialogDescription className="text-sm text-muted-foreground">
-          {multipleAgents
-            ? 'Pick which agents join this conversation.'
-            : 'Start a new conversation with your agent.'}
-        </DialogDescription>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>New Thread</DialogTitle>
+          <DialogDescription>
+            {multipleAgents
+              ? 'Pick which agents join this conversation.'
+              : 'Start a new conversation with your agent.'}
+          </DialogDescription>
+        </DialogHeader>
 
-        {/* Select All Control */}
-        {onlineAgents.length > 0 && (
-          <button
-            type="button"
-            className="mt-3 flex w-full items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer text-left transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/40"
-            onClick={toggleAll}
-          >
-            <div className={cn(
-              'size-4 rounded shrink-0 flex items-center justify-center border transition-colors',
-              isAllSelected || isPartiallySelected
-                ? 'bg-blue-500 border-blue-500 text-white'
-                : 'border-zinc-300 dark:border-zinc-600'
-            )}>
-              {isAllSelected && <Check className="size-3" strokeWidth={3} />}
-              {isPartiallySelected && <Minus className="size-3" strokeWidth={3} />}
-            </div>
-            <span className="text-sm font-medium">
-              {isAllSelected
-                ? 'All agents selected'
-                : isPartiallySelected
-                  ? `${selected.size} of ${onlineAgents.length} agents selected`
-                  : 'Select all agents'}
-            </span>
-          </button>
-        )}
-        {offlineAgentCount > 0 && (
-          <p className={cn(
-            'px-3 text-[11px] text-muted-foreground/70',
-            onlineAgents.length > 0 ? 'mt-1' : 'mt-3'
-          )}>
-            {offlineAgentCount} offline {offlineAgentCount === 1 ? 'agent' : 'agents'} not included
-          </p>
-        )}
-
-        {/* Agent list */}
-        <div className={cn(
-          'space-y-1.5 max-h-64 overflow-y-auto',
-          onlineAgents.length === 0 ? 'mt-3' : 'mt-1.5'
-        )}>
-          {onlineAgents.length === 0 && (
-            <p className="text-sm text-muted-foreground py-4 text-center">No agents are currently online.</p>
-          )}
-          {onlineAgents.map((agent) => {
-            const isSelected = selected.has(agent.agentName);
-
-            return (
-              <div
-                key={agent.agentName}
-                className={cn(
-                  'flex items-center gap-2.5 px-3 py-2.5 rounded-lg cursor-pointer transition-all border',
-                  isSelected
-                    ? 'bg-zinc-50 dark:bg-zinc-800/80 border-zinc-200 dark:border-zinc-700'
-                    : 'border-transparent opacity-50 hover:opacity-75 hover:bg-zinc-50 dark:hover:bg-zinc-800/40'
-                )}
-                onClick={() => toggleAgent(agent.agentName)}
-              >
-                {/* Checkbox */}
-                <div className={cn(
-                  'size-4 rounded shrink-0 flex items-center justify-center border transition-colors',
-                  isSelected
-                    ? 'bg-blue-500 border-blue-500 text-white'
-                    : 'border-zinc-300 dark:border-zinc-600'
-                )}>
-                  {isSelected && <Check className="size-3" strokeWidth={3} />}
-                </div>
-
-                {/* Avatar */}
-                <AgentAvatar name={agent.agentName} size={24} />
-
-                {/* Name */}
-                <div className="flex-1 min-w-0">
-                  <span className="text-sm font-medium truncate">{agent.agentName}</span>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Resume from past session — show when there are resumable sessions */}
-        {hasClaudeAgent && resumableSessions.length > 0 && (
-          <div className="mt-3">
-            <label className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground mb-1.5">
-              <History className="size-3" />
-              Resume from past session
-            </label>
-            <select
-              value={resumeFrom}
-              onChange={(e) => setResumeFrom(e.target.value)}
-              className="w-full text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        <DialogBody className="space-y-2 py-1">
+          {/* Select All Control */}
+          {onlineAgents.length > 0 && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2.5 px-3 py-2 rounded-md cursor-pointer text-left transition-colors hover:bg-muted/60"
+              onClick={toggleAll}
             >
-              <option value="">New conversation (no context)</option>
-              {resumableSessions.map((s) => (
-                <option key={s.sessionId} value={s.sessionId}>
-                  {s.title || s.sessionId}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
+              <div className={cn(
+                'size-4 rounded-sm shrink-0 flex items-center justify-center border transition-colors',
+                isAllSelected || isPartiallySelected
+                  ? 'bg-primary border-primary text-primary-foreground'
+                  : 'border-input'
+              )}>
+                {isAllSelected && <Check className="size-3" strokeWidth={3} />}
+                {isPartiallySelected && <Minus className="size-3" strokeWidth={3} />}
+              </div>
+              <span className="text-sm font-medium">
+                {isAllSelected
+                  ? 'All agents selected'
+                  : isPartiallySelected
+                    ? `${selected.size} of ${onlineAgents.length} agents selected`
+                    : 'Select all agents'}
+              </span>
+            </button>
+          )}
+          {offlineAgentCount > 0 && (
+            <p className="px-3 text-[11px] text-muted-foreground/70">
+              {offlineAgentCount} offline {offlineAgentCount === 1 ? 'agent' : 'agents'} not included
+            </p>
+          )}
 
-        <div className="flex justify-end gap-2 mt-4">
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+          {/* Agent list */}
+          {onlineAgents.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+              <div className="flex size-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                <Users className="size-5" />
+              </div>
+              <p className="text-sm text-muted-foreground">No agents are currently online.</p>
+            </div>
+          ) : (
+            <div className="space-y-1.5 max-h-64 overflow-y-auto">
+              {onlineAgents.map((agent) => {
+                const isSelected = selected.has(agent.agentName);
+
+                return (
+                  <div
+                    key={agent.agentName}
+                    className={cn(
+                      'flex items-center gap-2.5 px-3 py-2.5 rounded-md cursor-pointer transition-all border',
+                      isSelected
+                        ? 'bg-muted/50 border-border'
+                        : 'border-transparent opacity-60 hover:opacity-100 hover:bg-muted/40'
+                    )}
+                    onClick={() => toggleAgent(agent.agentName)}
+                  >
+                    {/* Checkbox */}
+                    <div className={cn(
+                      'size-4 rounded-sm shrink-0 flex items-center justify-center border transition-colors',
+                      isSelected
+                        ? 'bg-primary border-primary text-primary-foreground'
+                        : 'border-input'
+                    )}>
+                      {isSelected && <Check className="size-3" strokeWidth={3} />}
+                    </div>
+
+                    {/* Avatar */}
+                    <AgentAvatar name={agent.agentName} size={24} />
+
+                    {/* Name */}
+                    <div className="flex-1 min-w-0">
+                      <span className="text-sm font-medium truncate">{agent.agentName}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Resume from past session — show when there are resumable sessions */}
+          {hasClaudeAgent && resumableSessions.length > 0 && (
+            <div className="pt-1">
+              <label className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground mb-1.5">
+                <History className="size-3" />
+                Resume from past session
+              </label>
+              <select
+                value={resumeFrom}
+                onChange={(e) => setResumeFrom(e.target.value)}
+                className="w-full h-8.5 text-[0.8125rem] rounded-md border border-input bg-background px-3 shadow-xs shadow-black/5 transition-[color,box-shadow] focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30"
+              >
+                <option value="">New conversation (no context)</option>
+                {resumableSessions.map((s) => (
+                  <option key={s.sessionId} value={s.sessionId}>
+                    {s.title || s.sessionId}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button size="sm" onClick={handleCreate} disabled={selected.size === 0}>
+          <Button onClick={handleCreate} disabled={selected.size === 0}>
             {resumeFrom ? 'Resume Thread' : 'Start Thread'}
           </Button>
-        </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/workspace/frontend/components/ui/dialog.tsx
+++ b/workspace/frontend/components/ui/dialog.tsx
@@ -7,12 +7,16 @@ import { Dialog as DialogPrimitive } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const dialogContentVariants = cva(
-  'flex flex-col fixed outline-0 z-50 border border-border bg-background p-6 shadow-lg shadow-black/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
+  // Standard dialog layout: the content box itself never scrolls (overflow-hidden) —
+  // it's a flex column so <DialogHeader> and <DialogFooter> stay pinned while the
+  // scrollable middle lives in <DialogBody>. This keeps the title/footer fixed and
+  // avoids the white overscroll strip you get when the whole padded box scrolls.
+  'flex flex-col fixed outline-0 z-60 overflow-hidden border border-border bg-background shadow-lg shadow-black/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
   {
     variants: {
       variant: {
         default:
-          'left-[50%] top-[50%] max-w-lg translate-x-[-50%] translate-y-[-50%] w-full',
+          'left-[50%] top-[50%] max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] w-full',
         fullscreen: 'inset-5',
       },
     },
@@ -54,7 +58,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/30 [backdrop-filter:blur(4px)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'fixed inset-0 z-60 bg-black/30 [backdrop-filter:blur(4px)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className,
       )}
       {...props}
@@ -103,7 +107,9 @@ const DialogHeader = ({
   <div
     data-slot="dialog-header"
     className={cn(
-      'flex flex-col space-y-1 text-center sm:text-start mb-5',
+      // shrink-0 keeps the header pinned; padding lives here (not on DialogContent)
+      // so the scrollable DialogBody can sit flush beneath it.
+      'flex flex-col space-y-1 text-center sm:text-start shrink-0 px-6 pt-6 pb-4',
       className,
     )}
     {...props}
@@ -117,7 +123,8 @@ const DialogFooter = ({
   <div
     data-slot="dialog-footer"
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end pt-5 sm:space-x-2.5',
+      // shrink-0 pins the footer to the bottom while DialogBody scrolls.
+      'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2.5 shrink-0 px-6 pt-4 pb-6',
       className,
     )}
     {...props}
@@ -144,7 +151,16 @@ const DialogBody = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div data-slot="dialog-body" className={cn('grow', className)} {...props} />
+  <div
+    data-slot="dialog-body"
+    className={cn(
+      // The only scrollable region. min-h-0 lets it shrink inside the flex column;
+      // the scrollbar is hidden (design spec) but scrolling/overscroll still works.
+      'grow min-h-0 overflow-y-auto overscroll-contain px-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+      className,
+    )}
+    {...props}
+  />
 );
 
 function DialogDescription({

--- a/workspace/frontend/components/ui/dialogs-provider.tsx
+++ b/workspace/frontend/components/ui/dialogs-provider.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * Imperative, promise-based replacements for the browser-native window.confirm /
+ * window.prompt — which render as ugly OS/webview popups (especially inside the
+ * WeChat in-app browser). Backed by the responsive Dialog, so they show as a
+ * centered dialog on desktop and a bottom drawer on mobile.
+ *
+ *   const confirm = useConfirm();
+ *   if (!(await confirm({ title: '...', destructive: true }))) return;
+ *
+ *   const prompt = usePrompt();
+ *   const name = await prompt({ title: '...', placeholder: '...' });
+ *   if (name == null) return; // cancelled
+ */
+
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/responsive-dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface ConfirmOptions {
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  destructive?: boolean;
+}
+
+interface PromptOptions {
+  title: string;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+type Pending =
+  | ({ kind: 'confirm' } & ConfirmOptions)
+  | ({ kind: 'prompt' } & PromptOptions);
+
+interface DialogsApi {
+  confirm: (opts: ConfirmOptions) => Promise<boolean>;
+  prompt: (opts: PromptOptions) => Promise<string | null>;
+}
+
+const DialogsContext = React.createContext<DialogsApi | null>(null);
+
+export function useConfirm() {
+  const ctx = React.useContext(DialogsContext);
+  if (!ctx) throw new Error('useConfirm must be used within <DialogsProvider>');
+  return ctx.confirm;
+}
+
+export function usePrompt() {
+  const ctx = React.useContext(DialogsContext);
+  if (!ctx) throw new Error('usePrompt must be used within <DialogsProvider>');
+  return ctx.prompt;
+}
+
+export function DialogsProvider({ children }: { children: React.ReactNode }) {
+  const [pending, setPending] = React.useState<Pending | null>(null);
+  const [value, setValue] = React.useState('');
+  const resolverRef = React.useRef<((result: boolean | string | null) => void) | null>(null);
+
+  const settle = React.useCallback((result: boolean | string | null) => {
+    resolverRef.current?.(result);
+    resolverRef.current = null;
+    setPending(null);
+  }, []);
+
+  const confirm = React.useCallback(
+    (opts: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        resolverRef.current = resolve as (r: boolean | string | null) => void;
+        setPending({ kind: 'confirm', ...opts });
+      }),
+    [],
+  );
+
+  const prompt = React.useCallback(
+    (opts: PromptOptions) =>
+      new Promise<string | null>((resolve) => {
+        resolverRef.current = resolve as (r: boolean | string | null) => void;
+        setValue(opts.defaultValue ?? '');
+        setPending({ kind: 'prompt', ...opts });
+      }),
+    [],
+  );
+
+  const api = React.useMemo<DialogsApi>(() => ({ confirm, prompt }), [confirm, prompt]);
+
+  // Cancel-on-dismiss resolves to the "declined" value for each kind.
+  const cancelResult = pending?.kind === 'prompt' ? null : false;
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) settle(cancelResult);
+  };
+
+  const submit = () => {
+    if (pending?.kind === 'prompt') settle(value);
+    else settle(true);
+  };
+
+  return (
+    <DialogsContext.Provider value={api}>
+      {children}
+      <Dialog open={!!pending} onOpenChange={handleOpenChange}>
+        {pending && (
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle>{pending.title}</DialogTitle>
+              {pending.description && (
+                <DialogDescription>{pending.description}</DialogDescription>
+              )}
+            </DialogHeader>
+
+            {pending.kind === 'prompt' && (
+              <DialogBody className="py-1">
+                <Input
+                  autoFocus
+                  value={value}
+                  placeholder={pending.placeholder}
+                  onChange={(e) => setValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      submit();
+                    }
+                  }}
+                />
+              </DialogBody>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => settle(cancelResult)}>
+                {pending.cancelText ?? 'Cancel'}
+              </Button>
+              <Button
+                variant={pending.kind === 'confirm' && pending.destructive ? 'destructive' : 'primary'}
+                onClick={submit}
+              >
+                {pending.confirmText ?? (pending.kind === 'prompt' ? 'OK' : 'Confirm')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+    </DialogsContext.Provider>
+  );
+}

--- a/workspace/frontend/components/ui/drawer.tsx
+++ b/workspace/frontend/components/ui/drawer.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+import { cn } from '@/lib/utils';
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        'fixed inset-0 z-60 bg-black/40 [backdrop-filter:blur(2px)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  showHandle = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  showHandle?: boolean;
+}) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          'group/drawer-content fixed inset-x-0 bottom-0 z-60 flex h-auto max-h-[92vh] flex-col rounded-t-2xl border-t border-border bg-background outline-0',
+          className,
+        )}
+        {...props}
+      >
+        {showHandle && (
+          <div className="mx-auto mt-3 mb-1 h-1.5 w-11 shrink-0 rounded-full bg-muted-foreground/25" />
+        )}
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn('flex flex-col space-y-1 shrink-0 px-5 pt-2 pb-3 text-start', className)}
+      {...props}
+    />
+  );
+}
+
+// The only scrollable region of a drawer — header/footer stay pinned around it.
+// Scrollbar is hidden (design spec) but scroll/overscroll still work.
+function DrawerBody({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-body"
+      className={cn(
+        'grow min-h-0 overflow-y-auto overscroll-contain px-5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn(
+        'mt-auto flex flex-col gap-2 px-5 pt-3 pb-[calc(1rem+env(safe-area-inset-bottom))]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn('text-base font-semibold text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/workspace/frontend/components/ui/responsive-dialog.tsx
+++ b/workspace/frontend/components/ui/responsive-dialog.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+/**
+ * Responsive dialog — renders a centered <Dialog> on desktop and a bottom
+ * <Drawer> (with pull-down-to-close) on mobile. The exports are named to mirror
+ * `@/components/ui/dialog` 1:1, so a component can opt in by changing only its
+ * import path. Desktop appearance is delegated to the real Dialog primitives and
+ * therefore stays byte-for-byte identical; only the mobile branch is new.
+ */
+
+import * as React from 'react';
+import { useIsMobile } from '@/hooks/use-mobile';
+import * as D from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer';
+import { cn } from '@/lib/utils';
+
+const MobileContext = React.createContext(false);
+const useResponsiveMobile = () => React.useContext(MobileContext);
+
+function Dialog(props: React.ComponentProps<typeof D.Dialog>) {
+  const isMobile = useIsMobile();
+  const Root = isMobile ? Drawer : D.Dialog;
+  return (
+    <MobileContext.Provider value={isMobile}>
+      <Root {...props} />
+    </MobileContext.Provider>
+  );
+}
+
+function DialogTrigger(props: React.ComponentProps<typeof D.DialogTrigger>) {
+  return useResponsiveMobile() ? <DrawerTrigger {...props} /> : <D.DialogTrigger {...props} />;
+}
+
+function DialogClose(props: React.ComponentProps<typeof D.DialogClose>) {
+  return useResponsiveMobile() ? <DrawerClose {...props} /> : <D.DialogClose {...props} />;
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof D.DialogContent>) {
+  const isMobile = useResponsiveMobile();
+  if (isMobile) {
+    // The desktop-oriented className (fixed widths, max-h) is intentionally
+    // dropped — the drawer manages its own sizing. DrawerContent is a flex
+    // column, so <DialogHeader>/<DialogFooter> stay pinned and only the
+    // <DialogBody> in between scrolls (mirroring the desktop dialog).
+    return (
+      <DrawerContent className="pb-[env(safe-area-inset-bottom)]">
+        {children}
+      </DrawerContent>
+    );
+  }
+  return (
+    <D.DialogContent className={className} {...props}>
+      {children}
+    </D.DialogContent>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const isMobile = useResponsiveMobile();
+  if (isMobile) {
+    return (
+      <div
+        data-slot="dialog-header"
+        className={cn('flex flex-col space-y-1 text-start shrink-0 px-5 pt-1 pb-4', className)}
+        {...props}
+      />
+    );
+  }
+  return <D.DialogHeader className={className} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const isMobile = useResponsiveMobile();
+  if (isMobile) {
+    return (
+      <div
+        data-slot="dialog-footer"
+        className={cn('flex flex-row gap-2 shrink-0 px-5 pt-4 pb-2 [&>*]:flex-1', className)}
+        {...props}
+      />
+    );
+  }
+  return <D.DialogFooter className={className} {...props} />;
+}
+
+function DialogTitle(props: React.ComponentProps<typeof D.DialogTitle>) {
+  return useResponsiveMobile() ? <DrawerTitle {...props} /> : <D.DialogTitle {...props} />;
+}
+
+function DialogDescription(props: React.ComponentProps<typeof D.DialogDescription>) {
+  return useResponsiveMobile() ? (
+    <DrawerDescription {...props} />
+  ) : (
+    <D.DialogDescription {...props} />
+  );
+}
+
+function DialogBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const isMobile = useResponsiveMobile();
+  if (isMobile) {
+    return (
+      <div
+        data-slot="dialog-body"
+        className={cn(
+          'grow min-h-0 overflow-y-auto overscroll-contain px-5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+          className,
+        )}
+        {...props}
+      />
+    );
+  }
+  return <D.DialogBody className={className} {...props} />;
+}
+
+export {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/workspace/frontend/package-lock.json
+++ b/workspace/frontend/package-lock.json
@@ -27,7 +27,8 @@
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.17",
@@ -150,7 +151,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -217,7 +217,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -233,8 +232,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -685,7 +683,6 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3634,7 +3631,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3645,7 +3641,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3915,7 +3910,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4316,7 +4310,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6501,7 +6494,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6511,7 +6503,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7205,6 +7196,19 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vfile": {

--- a/workspace/frontend/package.json
+++ b/workspace/frontend/package.json
@@ -27,7 +27,8 @@
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.17",


### PR DESCRIPTION
…d header/footer layout

Standardize the dialog layout so the title and action bar stay pinned while only the body scrolls, and mobile gets a native bottom-sheet.

Layout spec (components/ui/dialog.tsx):
- DialogContent is a flex column with overflow-hidden + max-h-[85vh] and no padding of its own, so it never scrolls.
- DialogHeader / DialogFooter are shrink-0 and stay pinned; padding moved onto them (px-6, pt/pb).
- DialogBody is the only scroll region (overflow-y-auto + overscroll-contain) with the scrollbar hidden. Fixes the fixed white overscroll strip and the header/footer scrolling away with the content.

Responsive + primitives:
- Add responsive-dialog: centered Dialog on desktop, bottom Drawer (vaul) on mobile with the same Header/Body/Footer structure and full-width footer.
- Add drawer primitive (+ DrawerBody) and the vaul dependency.
- Add DialogsProvider with imperative useConfirm/usePrompt; wire it in the root layout and replace native window.confirm/prompt in the browser views.

Dialog migration:
- Move every dialog to responsive-dialog + DialogBody: settings, workspace settings (sidebar), new-thread, create-routine, knowledge-editor, invitation, share, skills upload, orchestration workflow-plan, confirm/prompt.
- Restyle the New Thread dialog to design tokens (primary / border-input / muted) instead of hardcoded blue/zinc, add a proper empty state, and use DialogHeader/DialogFooter for consistent spacing.
- mobile-header: sheet safe-area + full-height fix.