### PR TITLE
fix(launcher): Modal focus stealing during polling-induced re-renders

### DIFF
--- a/packages/launcher/src/renderer/components/ui/Modal.tsx
+++ b/packages/launcher/src/renderer/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import ReactDOM from "react-dom"
 import { cn } from "../../lib/utils"
 
@@ -51,9 +51,15 @@ export function Modal({
   if (idRef.current === null) idRef.current = Symbol("modal")
   const titleId = React.useId()
 
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
   useEffect(() => {
     if (!open) return
     const id = idRef.current as symbol
+    // Avoid pushing duplicates when the effect re-runs
+    const existingIdx = modalStack.indexOf(id)
+    if (existingIdx !== -1) modalStack.splice(existingIdx, 1)
     modalStack.push(id)
 
     // Remember where focus came from so it can be handed back on close —
@@ -71,7 +77,7 @@ export function Modal({
       if (modalStack[modalStack.length - 1] !== id) return
       if (e.key === "Escape") {
         e.stopPropagation()
-        onClose()
+        onCloseRef.current()
         return
       }
       if (e.key !== "Tab") return
@@ -101,7 +107,7 @@ export function Modal({
       if (i !== -1) modalStack.splice(i, 1)
       previouslyFocused?.focus?.()
     }
-  }, [open, onClose])
+  }, [open])
 
   if (!open) return null
 


### PR DESCRIPTION
﻿## Problem

In any dialog (New Agent, Configure, Connect, Delete confirmation, etc.), clicking an input field that is not the first one causes focus to jump back to the first input after a few seconds. This happens on all pages with open dialogs.

## Root Cause

The Modal component useEffect had `[open, onClose]` as dependencies. When parent components pass inline arrow functions as `onClose` (the common pattern across all pages), any parent re-render changes `onClose` reference identity. This triggers:

1. Effect cleanup -> calls `previouslyFocused.focus()` - restores focus to the element outside the dialog
2. Effect re-runs -> detects activeElement is no longer inside the panel -> focuses the first focusable child

Pages like **agents** (5s polling), **workspaces** (8s), and **logs** (3s) all have `setInterval` that triggers re-renders, making the dialog focus jump back to the first input every few seconds while a dialog is open.

## Fix

1. Store `onClose` in a ref (`onCloseRef`) so the effect no longer depends on its reference identity
2. Remove `onClose` from the effect dependency array (`[open]` only)
3. Also deduplicate `modalStack.push` to avoid accumulating duplicate entries on effect re-runs

## Files Changed

- `packages/launcher/src/renderer/components/ui/Modal.tsx`
