### PR TITLE
Route messages to all mentioned agents so tasks run in parallel

### DIFF
--- a/workspace/backend/app/config.py
+++ b/workspace/backend/app/config.py
@@ -77,6 +77,9 @@ class Config:
     # Cloud agents
     CLOUD_AGENT_MAX_CONTEXT_MESSAGES: int = int(os.environ.get("CLOUD_AGENT_MAX_CONTEXT_MESSAGES", "10"))
     CLOUD_AGENT_MAX_DEPTH: int = int(os.environ.get("CLOUD_AGENT_MAX_DEPTH", "3"))
+    # Max cloud agents invoked concurrently for one message — bounds DB
+    # connections and provider calls when a message fans out to many agents.
+    CLOUD_AGENT_MAX_CONCURRENCY: int = int(os.environ.get("CLOUD_AGENT_MAX_CONCURRENCY", "4"))
 
     # Google OAuth (for "Sign in with Google" Gemini integration)
     GOOGLE_OAUTH_CLIENT_ID: str = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")

--- a/workspace/backend/app/mods/workspace_mod.py
+++ b/workspace/backend/app/mods/workspace_mod.py
@@ -582,10 +582,19 @@ def _fallback_targets(event, channel, mentions: List[str], online_names: set = N
     Priority: explicit @mentions → master (for human/member msgs) → online
     participant → any participant. When ``online_names`` is provided, an online
     participant is chosen over an offline one so messages aren't stranded on a
-    dead agent. An explicit @mention is always honored as-is (the user chose it).
+    dead agent. Explicit @mentions are always honored as-is (the sender chose
+    them) — ALL of them, so "@a do X @b do Y" fans out and the mentioned
+    agents work in parallel instead of only the first one being targeted.
     """
     if mentions:
-        return [mentions[0]]
+        targets = list(dict.fromkeys(mentions))  # dedupe, keep order
+        if event.source.startswith("openagents:"):
+            # An agent mentioning itself must not self-trigger.
+            sender = event.source[len("openagents:"):]
+            targets = [t for t in targets if t != sender]
+        # All mentions were self-mentions → nobody should respond. Return
+        # here (not fall through) so a self-note never re-routes to master.
+        return targets
     if channel.master_agent:
         if event.source.startswith("openagents:"):
             sender = event.source[len("openagents:"):]
@@ -884,9 +893,15 @@ async def _route_with_llm(
         logger.info("LLM router decision: %s (channel=%s, sender=%s, provider=%s)", raw_result, channel.name, sender, provider)
 
         if result.startswith("next:"):
-            # Preserve the original case from the model output so we can
-            # match against participant names, which ARE case-sensitive.
-            agent_name = raw_result[len("next:"):].strip().split(",")[0].strip()
+            # The router may name several agents ("next: a, b") — honor all
+            # of them so independent tasks run in parallel. Preserve the
+            # original case from the model output so we can match against
+            # participant names, which ARE case-sensitive.
+            requested = [
+                n.strip()
+                for n in raw_result[len("next:"):].split(",")
+                if n.strip()
+            ]
             # Case-insensitive participant lookup, then canonicalize to
             # the stored case.
             # Validate against the candidate set (online participants when any
@@ -895,30 +910,32 @@ async def _route_with_llm(
             participants_by_lower = {
                 name.lower(): name for name in candidate_names
             }
-            canonical = participants_by_lower.get(agent_name.lower())
-            if canonical is None:
-                logger.warning(
-                    "LLM router returned unknown agent: %r (valid: %s)",
-                    agent_name, list(participants_by_lower.values()),
-                )
-                # For human senders, fall through to the safety net below
-                # so the user always gets a reply.
-                if not (new_event.source or "").startswith("human:"):
-                    return []
-                agent_name = None
-            else:
-                agent_name = canonical
+            sender_name = None
+            if (new_event.source or "").startswith("openagents:"):
+                sender_name = new_event.source[len("openagents:"):]
+            targets: List[str] = []
+            for name in requested:
+                canonical = participants_by_lower.get(name.lower())
+                if canonical is None:
+                    logger.warning(
+                        "LLM router returned unknown agent: %r (valid: %s)",
+                        name, list(participants_by_lower.values()),
+                    )
+                    continue
                 # Reject self-loops — router sometimes picks the agent
                 # who just spoke. Sender's adapter skips own messages but
                 # legacy clients would still see the target and retry.
-                if (new_event.source or "").startswith("openagents:"):
-                    sender = new_event.source[len("openagents:"):]
-                    if agent_name == sender:
-                        logger.info("LLM router self-loop rejected: %s", sender)
-                        return []
-                return [agent_name]
-        else:
-            agent_name = None  # "stop" or unrecognized
+                if canonical == sender_name:
+                    logger.info("LLM router self-loop rejected: %s", sender_name)
+                    continue
+                if canonical not in targets:
+                    targets.append(canonical)
+            if targets:
+                return targets
+            # No valid target survived — for human senders fall through to
+            # the safety net below so the user always gets a reply.
+            if not (new_event.source or "").startswith("human:"):
+                return []
 
         # Safety net: humans ALWAYS get a response. If the router said
         # "stop" (or returned an invalid agent) for a human message,
@@ -1129,6 +1146,13 @@ async def _handle_message_posted(event: Event, ctx: PipelineContext) -> Optional
                 targets = _master_targets(event, channel, mentions)
             else:
                 targets = _fallback_targets(event, channel, mentions, online_names)
+        elif mentions and event.source.startswith("human:"):
+            # A human explicitly @mentioned agents — honor the mentions
+            # as-is (all of them) without consulting the LLM router. The
+            # user already chose the targets, and the router used to pick a
+            # single agent for "@a task1 @b task2", collapsing parallel work
+            # onto one agent whose queue then serialized the tasks.
+            targets = _fallback_targets(event, channel, mentions, online_names)
         elif mode == "workflow" and config.ROUTER_LLM_ENABLED and _get_router_api_key():
             # LLM router steered by the user's natural-language plan.
             targets = await _route_with_llm(

--- a/workspace/backend/app/mods/workspace_mod.py
+++ b/workspace/backend/app/mods/workspace_mod.py
@@ -634,10 +634,12 @@ def _master_targets(event, channel, mentions: List[str]) -> List[str]:
         sender = source[len("openagents:"):]
         if sender == master:
             # Master is delegating. Route to any mentioned sub-agents
-            # (never itself); no mention → the master answered, so stop.
+            # (never itself, deduped); no mention → the master answered,
+            # so stop.
             participants = {p.agent_name for p in (channel.participants or [])}
             delegated = [
-                m for m in mentions if m != master and m in participants
+                m for m in dict.fromkeys(mentions)
+                if m != master and m in participants
             ]
             return delegated
         # A sub-agent spoke → return control to the master hub.
@@ -671,9 +673,14 @@ subject being asked to do/say something. If the agent is merely referenced \
 pick the addressed agent, not the mentioned one.
 
 B. If the LATEST message is from a HUMAN:
-   - Always pick exactly one agent. Humans expect a reply — never output \
+   - Always pick at least one agent. Humans expect a reply — never output \
 "stop" for a human message.
    - Prefer whoever is directly addressed.
+   - If the message assigns separate, independent tasks to SEVERAL agents \
+("@alice do X and @bob do Y"), pick ALL of them (comma-separated) so they \
+work in parallel. Pick several agents only for genuinely independent \
+tasks — if one task depends on another's result, pick only the agent \
+whose task comes first.
    - If nobody is directly addressed, check CONVERSATIONAL CONTINUITY: \
 if the user was just conversing with a specific agent (the last agent \
 reply was from agent X, or X asked the user a question that this message \
@@ -682,8 +689,9 @@ appears to answer), continue with that agent X.
 fall back to the master agent.
 
 C. If the LATEST message is from an AGENT:
-   - If it delegates or hands off to another agent ("@Alice please do X", \
-"Alice, could you check X"), route to that agent.
+   - If it delegates or hands off to other agents ("@Alice please do X", \
+"Alice, could you check X"), route to them — ALL of the delegated agents \
+(comma-separated) when it hands independent tasks to several at once.
    - If it reports back to the master or asks the master to decide, route to the master.
    - If it is a FINAL answer to the previous human question or an \
 acknowledgement ("done", "saved", "sounds good"), output "stop".
@@ -692,9 +700,11 @@ acknowledgement ("done", "saved", "sounds good"), output "stop".
 
 EXAMPLES:
   Human: "@alice what's the status?"                → next:alice
+  Human: "@alice check the logs, @bob fix the tests" → next:alice,bob (independent tasks, parallel)
   Human: "check @alice's notes, @bob"                → next:bob       (bob is addressed)
   Human: "how about julia?"  (julia is not an agent) → next:<master>  (who owns that topic)
   Agent alice: "@bob can you verify?"                → next:bob
+  Agent alice: "@bob run the tests and @carol update the docs" → next:bob,carol
   Agent alice: "Done — results attached."            → stop
   Agent bob (master): "Here's the final answer ..."  → stop
 
@@ -705,8 +715,9 @@ EXAMPLES:
     alice: "I pulled these results: [...]."
     Human: "thanks, can you also check Y?"           → next:alice     (follow-up to alice)
 
-Output EXACTLY one line, lowercase, no punctuation or explanation:
+Output EXACTLY one line, lowercase, no spaces or explanation:
   next:<agent_name>
+  next:<agent_name>,<agent_name>   (several agents, comma-separated)
   stop"""
 
 
@@ -873,14 +884,14 @@ async def _route_with_llm(
         if provider == "openai":
             response = client.chat.completions.create(
                 model=model,
-                max_tokens=30,
+                max_tokens=64,
                 messages=[{"role": "user", "content": prompt}],
             )
             raw_result = response.choices[0].message.content.strip()
         else:
             response = client.messages.create(
                 model=model,
-                max_tokens=30,
+                max_tokens=64,
                 messages=[{"role": "user", "content": prompt}],
             )
             raw_result = response.content[0].text.strip()

--- a/workspace/backend/app/mods/workspace_mod.py
+++ b/workspace/backend/app/mods/workspace_mod.py
@@ -611,6 +611,55 @@ def _fallback_targets(event, channel, mentions: List[str], online_names: set = N
     return [participants[0]] if participants else []
 
 
+# How far back to look for the human message that assigned the current task.
+# Bounded so a long thread doesn't scan the whole channel on every agent turn.
+_ASSIGNMENT_LOOKBACK = 20
+
+
+def _human_assignment_holds(db, workspace, channel, sender: str,
+                            known_agents: List[str]) -> bool:
+    """True when a human directly @assigned ``sender`` and that assignment stands.
+
+    Walks the channel's recent human messages newest → oldest:
+      • one that @mentions ``sender``   → the assignment holds
+      • one with no @mention at all     → free-form chat reopened routing
+      • one that @mentions only others  → keep looking further back (parallel
+        assignments arrive as separate messages, one per agent)
+
+    Callers use this to keep a directly-addressed agent's own output from
+    being handed to a peer. When the human picked the agent, its progress
+    notes and results belong to the human — not to whichever bystander the
+    LLM router happens to choose. With several agents working in parallel
+    that misrouting is not an edge case: every worker's "starting now…"
+    note becomes a spurious turn for every other worker, which then answers
+    a task it was never given (and only after its own 60s job drains).
+    """
+    from app.models import EventRecord
+
+    rows = db.execute(
+        select(EventRecord)
+        .where(
+            EventRecord.network_id == workspace.id,
+            EventRecord.target == f"channel/{channel.name}",
+            EventRecord.type == "workspace.message.posted",
+            EventRecord.source.like("human:%"),
+        )
+        .order_by(EventRecord.timestamp.desc())
+        .limit(_ASSIGNMENT_LOOKBACK)
+    ).scalars().all()
+
+    for evt in rows:
+        payload = evt.payload or {}
+        if payload.get("message_type", "chat") in ("thinking", "status", "todos"):
+            continue
+        mentions = _extract_mentions(payload.get("content") or "", known_agents)
+        if not mentions:
+            return False
+        if sender in mentions:
+            return True
+    return False
+
+
 def _master_targets(event, channel, mentions: List[str]) -> List[str]:
     """Deterministic routing for "master" orchestration mode (star topology).
 
@@ -695,6 +744,11 @@ C. If the LATEST message is from an AGENT:
    - If it reports back to the master or asks the master to decide, route to the master.
    - If it is a FINAL answer to the previous human question or an \
 acknowledgement ("done", "saved", "sounds good"), output "stop".
+   - If it is progress narration about work the sender is doing right now \
+("running the command now", "on it", "this will take about a minute"), \
+output "stop". Nobody else should act on it — several agents often work \
+in parallel, and each one's progress note must not become a turn for the \
+others.
    - Never route back to the same agent that just spoke (no self-loops).
    - When unsure, prefer "stop" to avoid infinite agent-to-agent loops.
 
@@ -1149,6 +1203,12 @@ async def _handle_message_posted(event: Event, ctx: PipelineContext) -> Optional
         from app.config import config
         mode = (getattr(channel, "orchestration_mode", None) or "dynamic").lower()
 
+        sender_agent = (
+            event.source[len("openagents:"):]
+            if event.source.startswith("openagents:") else None
+        )
+        peer_mentions = [m for m in mentions if m != sender_agent]
+
         if mode == "master":
             # Deterministic star topology — no LLM. If the channel somehow
             # has no master, fall back to the generic mention/online logic
@@ -1164,6 +1224,25 @@ async def _handle_message_posted(event: Event, ctx: PipelineContext) -> Optional
             # single agent for "@a task1 @b task2", collapsing parallel work
             # onto one agent whose queue then serialized the tasks.
             targets = _fallback_targets(event, channel, mentions, online_names)
+        elif (
+            mode != "workflow"
+            and sender_agent
+            and not peer_mentions
+            and _human_assignment_holds(
+                db, workspace, channel, sender_agent, known_agents,
+            )
+        ):
+            # The sender is working a task a human handed it by name, and it
+            # is not handing off to anyone (no @mention of a peer). Its
+            # output goes back to the human — do not consult the router,
+            # which has no way to tell "I'm starting the job now" from a
+            # handoff and would wake a bystander agent for someone else's
+            # task. The mirror image of the human-mention bypass above.
+            logger.info(
+                "Direct assignment holds for %s — not routing its message to a peer",
+                sender_agent,
+            )
+            targets = []
         elif mode == "workflow" and config.ROUTER_LLM_ENABLED and _get_router_api_key():
             # LLM router steered by the user's natural-language plan.
             targets = await _route_with_llm(

--- a/workspace/backend/app/services/cloud_agent.py
+++ b/workspace/backend/app/services/cloud_agent.py
@@ -43,38 +43,53 @@ async def invoke_cloud_agents(workspace_id: str, event_data: dict) -> None:
         logger.warning("cloud_agent: max depth %d reached, skipping", depth)
         return
 
+    names = [n for n in target_agents if n != "__no_response__"]
+    if not names:
+        return
+
+    # Invoke all targeted cloud agents concurrently — a message like
+    # "@a task1 @b task2" must not make b wait for a's API round-trip.
+    # Each invocation gets its own DB session because SQLAlchemy sessions
+    # are not safe to share across concurrently running tasks.
+    await asyncio.gather(
+        *(_invoke_guarded(workspace_id, event_data, name, depth) for name in names)
+    )
+
+
+async def _invoke_guarded(
+    workspace_id: str, event_data: dict, agent_name: str, depth: int,
+) -> None:
+    """Look up one cloud agent's config and invoke it, posting an error
+    message to the channel on failure. Owns its DB session so concurrent
+    invocations don't share one."""
     db = SessionLocal()
     try:
-        for agent_name in target_agents:
-            if agent_name == "__no_response__":
-                continue
+        cloud_config = db.execute(
+            select(CloudAgentConfig).where(
+                CloudAgentConfig.workspace_id == workspace_id,
+                CloudAgentConfig.agent_name == agent_name,
+                CloudAgentConfig.status == "active",
+            )
+        ).scalar_one_or_none()
 
-            cloud_config = db.execute(
-                select(CloudAgentConfig).where(
-                    CloudAgentConfig.workspace_id == workspace_id,
-                    CloudAgentConfig.agent_name == agent_name,
-                    CloudAgentConfig.status == "active",
-                )
-            ).scalar_one_or_none()
+        if not cloud_config:
+            return
 
-            if not cloud_config:
-                continue
-
-            try:
-                await _invoke_single(db, workspace_id, event_data, cloud_config, depth)
-            except Exception as exc:
-                logger.exception(
-                    "cloud_agent: failed to invoke %s (%s/%s)",
-                    agent_name, cloud_config.provider, cloud_config.model,
-                )
-                error_detail = str(exc)[:200] if str(exc) else "Unknown error"
-                # Use a fresh DB session for error posting — the original
-                # session may be stale after a long async API call.
-                await _post_error_message(
-                    workspace_id, event_data, agent_name,
-                    f"Failed to get a response from {cloud_config.provider}/{cloud_config.model}: "
-                    f"{error_detail}",
-                )
+        try:
+            await _invoke_single(db, workspace_id, event_data, cloud_config, depth)
+        except Exception as exc:
+            logger.exception(
+                "cloud_agent: failed to invoke %s (%s/%s)",
+                agent_name, cloud_config.provider, cloud_config.model,
+            )
+            error_detail = str(exc)[:200] if str(exc) else "Unknown error"
+            # Use a fresh DB session for error posting — the original
+            # session may be stale after a long async API call.
+            await _post_error_message(
+                workspace_id, event_data, agent_name,
+                f"Failed to get a response from {cloud_config.provider}/{cloud_config.model}: "
+                f"{error_detail}",
+            )
     finally:
         db.close()
 

--- a/workspace/backend/app/services/cloud_agent.py
+++ b/workspace/backend/app/services/cloud_agent.py
@@ -43,25 +43,33 @@ async def invoke_cloud_agents(workspace_id: str, event_data: dict) -> None:
         logger.warning("cloud_agent: max depth %d reached, skipping", depth)
         return
 
-    names = [n for n in target_agents if n != "__no_response__"]
+    # Dedupe (order preserved) — duplicate mentions must not invoke the
+    # same cloud agent twice with duplicate, billable provider requests.
+    names = list(dict.fromkeys(n for n in target_agents if n != "__no_response__"))
     if not names:
         return
 
-    # Invoke all targeted cloud agents concurrently — a message like
+    # Invoke the targeted cloud agents concurrently — a message like
     # "@a task1 @b task2" must not make b wait for a's API round-trip.
-    # Each invocation gets its own DB session because SQLAlchemy sessions
-    # are not safe to share across concurrently running tasks.
-    await asyncio.gather(
-        *(_invoke_guarded(workspace_id, event_data, name, depth) for name in names)
-    )
+    # The semaphore bounds the fan-out so a message mentioning many agents
+    # can't exhaust the DB connection pool or hammer provider APIs.
+    semaphore = asyncio.Semaphore(max(1, config.CLOUD_AGENT_MAX_CONCURRENCY))
+
+    async def _bounded(name: str) -> None:
+        async with semaphore:
+            await _invoke_guarded(workspace_id, event_data, name, depth)
+
+    await asyncio.gather(*(_bounded(name) for name in names))
 
 
 async def _invoke_guarded(
     workspace_id: str, event_data: dict, agent_name: str, depth: int,
 ) -> None:
     """Look up one cloud agent's config and invoke it, posting an error
-    message to the channel on failure. Owns its DB session so concurrent
-    invocations don't share one."""
+    message to the channel on failure. DB sessions are short-lived — the
+    config lookup releases its connection before the (slow) provider call
+    so concurrent invocations don't pin pool connections while waiting on
+    external APIs."""
     db = SessionLocal()
     try:
         cloud_config = db.execute(
@@ -71,54 +79,55 @@ async def _invoke_guarded(
                 CloudAgentConfig.status == "active",
             )
         ).scalar_one_or_none()
-
-        if not cloud_config:
-            return
-
-        try:
-            await _invoke_single(db, workspace_id, event_data, cloud_config, depth)
-        except Exception as exc:
-            logger.exception(
-                "cloud_agent: failed to invoke %s (%s/%s)",
-                agent_name, cloud_config.provider, cloud_config.model,
-            )
-            error_detail = str(exc)[:200] if str(exc) else "Unknown error"
-            # Use a fresh DB session for error posting — the original
-            # session may be stale after a long async API call.
-            await _post_error_message(
-                workspace_id, event_data, agent_name,
-                f"Failed to get a response from {cloud_config.provider}/{cloud_config.model}: "
-                f"{error_detail}",
-            )
     finally:
         db.close()
 
+    if not cloud_config:
+        return
+
+    try:
+        await _invoke_single(workspace_id, event_data, cloud_config, depth)
+    except Exception as exc:
+        logger.exception(
+            "cloud_agent: failed to invoke %s (%s/%s)",
+            agent_name, cloud_config.provider, cloud_config.model,
+        )
+        error_detail = str(exc)[:200] if str(exc) else "Unknown error"
+        # _post_error_message opens its own fresh DB session.
+        await _post_error_message(
+            workspace_id, event_data, agent_name,
+            f"Failed to get a response from {cloud_config.provider}/{cloud_config.model}: "
+            f"{error_detail}",
+        )
+
 
 async def _invoke_single(
-    db, workspace_id: str, event_data: dict,
+    workspace_id: str, event_data: dict,
     cloud_config: CloudAgentConfig, depth: int,
 ) -> None:
     """Invoke a single cloud agent and post the response."""
-    channel_target = event_data.get("target", "")
-    agent_name = cloud_config.agent_name
-
     if cloud_config.category == "image":
-        await _invoke_image_agent(db, workspace_id, event_data, cloud_config)
+        await _invoke_image_agent(workspace_id, event_data, cloud_config)
     elif cloud_config.category == "audio":
-        await _invoke_audio_agent(db, workspace_id, event_data, cloud_config)
+        await _invoke_audio_agent(workspace_id, event_data, cloud_config)
     else:
-        await _invoke_chat_agent(db, workspace_id, event_data, cloud_config, depth)
+        await _invoke_chat_agent(workspace_id, event_data, cloud_config, depth)
 
 
 async def _invoke_chat_agent(
-    db, workspace_id: str, event_data: dict,
+    workspace_id: str, event_data: dict,
     cloud_config: CloudAgentConfig, depth: int,
 ) -> None:
     """Invoke a chat cloud agent."""
     channel_target = event_data.get("target", "")
     agent_name = cloud_config.agent_name
 
-    messages = _build_conversation_context(db, workspace_id, channel_target, agent_name)
+    # Short session for the context read — released before the provider call.
+    db = SessionLocal()
+    try:
+        messages = _build_conversation_context(db, workspace_id, channel_target, agent_name)
+    finally:
+        db.close()
 
     content = event_data.get("payload", {}).get("content", "")
     if content:
@@ -142,14 +151,18 @@ async def _invoke_chat_agent(
         base_url=cloud_config.base_url,
     )
 
-    await _post_response(
-        db, workspace_id, channel_target, agent_name,
-        response_text, depth,
-    )
+    db = SessionLocal()
+    try:
+        await _post_response(
+            db, workspace_id, channel_target, agent_name,
+            response_text, depth,
+        )
+    finally:
+        db.close()
 
 
 async def _invoke_image_agent(
-    db, workspace_id: str, event_data: dict,
+    workspace_id: str, event_data: dict,
     cloud_config: CloudAgentConfig,
 ) -> None:
     """Invoke an image generation cloud agent."""
@@ -166,7 +179,7 @@ async def _invoke_image_agent(
     # concrete prompt using recent channel history. Falls back to the raw
     # instruction when no router LLM / no context is available.
     prompt = await _compose_image_prompt(
-        db, workspace_id, channel_target, agent_name, instruction,
+        workspace_id, channel_target, agent_name, instruction,
     )
     if not prompt:
         return
@@ -184,30 +197,35 @@ async def _invoke_image_agent(
         base_url=cloud_config.base_url,
     )
 
-    file_id = await _upload_image(
-        db, workspace_id, channel_target, agent_name,
-        image_bytes, image_format, prompt,
-    )
+    # Session opened only after the (slow) generation call — upload and
+    # response posting share it so the FileRecord commits with the message.
+    db = SessionLocal()
+    try:
+        file_id = await _upload_image(
+            db, workspace_id, channel_target, agent_name,
+            image_bytes, image_format, prompt,
+        )
 
-    channel_name = channel_target.replace("channel/", "") if channel_target.startswith("channel/") else None
-    content_type = f"image/{image_format}"
-    filename = f"generated_{file_id[:8]}.{image_format}"
+        content_type = f"image/{image_format}"
+        filename = f"generated_{file_id[:8]}.{image_format}"
 
-    await _post_response(
-        db, workspace_id, channel_target, agent_name,
-        f"Here's the generated image for: *{instruction[:100]}*",
-        depth=0,
-        attachments=[{
-            "file_id": file_id,
-            "filename": filename,
-            "content_type": content_type,
-            "size": len(image_bytes),
-        }],
-    )
+        await _post_response(
+            db, workspace_id, channel_target, agent_name,
+            f"Here's the generated image for: *{instruction[:100]}*",
+            depth=0,
+            attachments=[{
+                "file_id": file_id,
+                "filename": filename,
+                "content_type": content_type,
+                "size": len(image_bytes),
+            }],
+        )
+    finally:
+        db.close()
 
 
 async def _invoke_audio_agent(
-    db, workspace_id: str, event_data: dict,
+    workspace_id: str, event_data: dict,
     cloud_config: CloudAgentConfig,
 ) -> None:
     """Invoke a text-to-speech cloud agent."""
@@ -230,24 +248,28 @@ async def _invoke_audio_agent(
         text=text,
     )
 
-    file_id = await _upload_image(
-        db, workspace_id, channel_target, agent_name,
-        audio_bytes, audio_format, text,
-    )
+    db = SessionLocal()
+    try:
+        file_id = await _upload_image(
+            db, workspace_id, channel_target, agent_name,
+            audio_bytes, audio_format, text,
+        )
 
-    filename = f"speech_{file_id[:8]}.{audio_format}"
+        filename = f"speech_{file_id[:8]}.{audio_format}"
 
-    await _post_response(
-        db, workspace_id, channel_target, agent_name,
-        f"Generated speech for: *{text[:100]}*",
-        depth=0,
-        attachments=[{
-            "file_id": file_id,
-            "filename": filename,
-            "content_type": f"audio/{audio_format}",
-            "size": len(audio_bytes),
-        }],
-    )
+        await _post_response(
+            db, workspace_id, channel_target, agent_name,
+            f"Generated speech for: *{text[:100]}*",
+            depth=0,
+            attachments=[{
+                "file_id": file_id,
+                "filename": filename,
+                "content_type": f"audio/{audio_format}",
+                "size": len(audio_bytes),
+            }],
+        )
+    finally:
+        db.close()
 
 
 def _build_conversation_context(
@@ -292,7 +314,7 @@ def _build_conversation_context(
 
 
 async def _compose_image_prompt(
-    db, workspace_id: str, channel_target: str, agent_name: str, instruction: str,
+    workspace_id: str, channel_target: str, agent_name: str, instruction: str,
 ) -> str:
     """Turn a (possibly referential) instruction like "make an image of
     cherie's brief above" into a concrete, self-contained image prompt by
@@ -312,7 +334,12 @@ async def _compose_image_prompt(
     if not (config.ROUTER_LLM_ENABLED and api_key):
         return instruction
 
-    context = _build_conversation_context(db, workspace_id, channel_target, agent_name)
+    # Short session for the context read — released before the LLM call.
+    db = SessionLocal()
+    try:
+        context = _build_conversation_context(db, workspace_id, channel_target, agent_name)
+    finally:
+        db.close()
     if not context:
         return instruction
 

--- a/workspace/backend/tests/test_cloud_agent.py
+++ b/workspace/backend/tests/test_cloud_agent.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for concurrent cloud agent invocation.
+
+invoke_cloud_agents fans out to every targeted agent, but must dedupe
+duplicate targets (duplicate mentions would double-invoke a billable
+provider API) and bound the concurrency so a large mention list can't
+exhaust the DB connection pool.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from app.config import config
+from app.services import cloud_agent
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _event(targets, depth=0):
+    metadata = {"target_agents": targets}
+    if depth:
+        metadata["cloud_agent_depth"] = depth
+    return {
+        "target": "channel/general",
+        "payload": {"content": "hi"},
+        "metadata": metadata,
+    }
+
+
+class TestInvokeCloudAgents:
+
+    def test_duplicate_targets_invoked_once(self):
+        calls = []
+
+        async def fake(workspace_id, event_data, name, depth):
+            calls.append(name)
+
+        with patch.object(cloud_agent, "_invoke_guarded", side_effect=fake):
+            _run(cloud_agent.invoke_cloud_agents(
+                "ws1", _event(["agent-a", "agent-b", "agent-a", "agent-a"]),
+            ))
+        assert calls == ["agent-a", "agent-b"]
+
+    def test_sentinel_only_no_invocations(self):
+        mock = MagicMock()
+        with patch.object(cloud_agent, "_invoke_guarded", mock):
+            _run(cloud_agent.invoke_cloud_agents("ws1", _event(["__no_response__"])))
+        mock.assert_not_called()
+
+    def test_sentinel_mixed_with_real_targets_is_dropped(self):
+        calls = []
+
+        async def fake(workspace_id, event_data, name, depth):
+            calls.append(name)
+
+        with patch.object(cloud_agent, "_invoke_guarded", side_effect=fake):
+            _run(cloud_agent.invoke_cloud_agents(
+                "ws1", _event(["agent-a", "__no_response__"]),
+            ))
+        assert calls == ["agent-a"]
+
+    def test_concurrency_is_capped(self):
+        current = 0
+        peak = 0
+        calls = []
+
+        async def fake(workspace_id, event_data, name, depth):
+            nonlocal current, peak
+            current += 1
+            peak = max(peak, current)
+            await asyncio.sleep(0.005)
+            current -= 1
+            calls.append(name)
+
+        names = [f"agent-{i}" for i in range(6)]
+        with patch.object(config, "CLOUD_AGENT_MAX_CONCURRENCY", 2), \
+                patch.object(cloud_agent, "_invoke_guarded", side_effect=fake):
+            _run(cloud_agent.invoke_cloud_agents("ws1", _event(names)))
+
+        assert sorted(calls) == sorted(names), "every target must still be invoked"
+        assert peak <= 2, f"concurrency exceeded the cap (peak={peak})"
+
+    def test_depth_limit_skips_all(self):
+        mock = MagicMock()
+        with patch.object(cloud_agent, "_invoke_guarded", mock):
+            _run(cloud_agent.invoke_cloud_agents(
+                "ws1", _event(["agent-a"], depth=config.CLOUD_AGENT_MAX_DEPTH),
+            ))
+        mock.assert_not_called()

--- a/workspace/backend/tests/test_llm_router.py
+++ b/workspace/backend/tests/test_llm_router.py
@@ -10,7 +10,12 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from app.models import Channel, ChannelMember, WorkspaceMember, Workspace
-from app.mods.workspace_mod import _route_with_llm, _master_targets, _handle_message_posted
+from app.mods.workspace_mod import (
+    _fallback_targets,
+    _handle_message_posted,
+    _master_targets,
+    _route_with_llm,
+)
 from openagents.core.onm_events import Event
 from openagents.core.onm_mods import PipelineContext
 
@@ -111,19 +116,37 @@ class TestRouteWithLLM:
     @patch("app.mods.workspace_mod._get_llm_client")
     @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
     @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
-    def test_router_multiple_agents_picks_first(self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace):
-        """When the LLM returns comma-separated agents, only the first is used."""
+    def test_router_multiple_agents_all_targeted(self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace):
+        """When the LLM returns comma-separated agents, ALL of them are
+        targeted so their tasks run in parallel."""
         mock_client = MagicMock()
         mock_client.messages.create.return_value = _mock_anthropic_response("next:agent-master,agent-worker")
         mock_get_client.return_value = (mock_client, "anthropic")
 
         ws = multi_agent_workspace["workspace"]
         ch = multi_agent_workspace["channel"]
-        # Human sender so the first of the comma-list isn't a self-loop.
+        # Human sender so no name in the comma-list is a self-loop.
         event = _make_event("human:user", "channel/session-test", "Both agents need to act")
 
         result = _run(_route_with_llm(ch, event, db, ws))
-        assert result == ["agent-master"]
+        assert result == ["agent-master", "agent-worker"]
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_router_multiple_agents_self_loop_dropped_others_kept(self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace):
+        """A multi-name router answer that includes the sender keeps the
+        other agents and only drops the self-loop."""
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = _mock_anthropic_response("next:agent-master,agent-worker")
+        mock_get_client.return_value = (mock_client, "anthropic")
+
+        ws = multi_agent_workspace["workspace"]
+        ch = multi_agent_workspace["channel"]
+        event = _make_event("openagents:agent-master", "channel/session-test", "delegating work")
+
+        result = _run(_route_with_llm(ch, event, db, ws))
+        assert result == ["agent-worker"]
 
     @patch("app.mods.workspace_mod._get_llm_client")
     @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
@@ -372,6 +395,73 @@ class TestRouteWithOpenAI:
 
         result = _run(_route_with_llm(ch, event, db, ws))
         assert result == []
+
+
+class TestParallelMentionRouting:
+    """Explicit @mentions fan out to ALL mentioned agents so tasks assigned
+    to different agents in one channel run in parallel instead of being
+    funneled through the single-target LLM router and queued on one agent."""
+
+    def test_fallback_returns_all_mentions(self, db, multi_agent_workspace):
+        ch = multi_agent_workspace["channel"]
+        event = _make_event("human:user", "channel/session-test",
+                            "@agent-master do X and @agent-worker do Y")
+        result = _fallback_targets(event, ch, ["agent-master", "agent-worker"])
+        assert result == ["agent-master", "agent-worker"]
+
+    def test_fallback_dedupes_repeated_mentions(self, db, multi_agent_workspace):
+        ch = multi_agent_workspace["channel"]
+        event = _make_event("human:user", "channel/session-test",
+                            "@agent-worker do X, @agent-worker also do Y")
+        result = _fallback_targets(event, ch, ["agent-worker", "agent-worker"])
+        assert result == ["agent-worker"]
+
+    def test_fallback_filters_agent_self_mention(self, db, multi_agent_workspace):
+        ch = multi_agent_workspace["channel"]
+        event = _make_event("openagents:agent-master", "channel/session-test",
+                            "@agent-master note to self, @agent-worker take over")
+        result = _fallback_targets(event, ch, ["agent-master", "agent-worker"])
+        assert result == ["agent-worker"]
+
+    def test_fallback_all_self_mentions_returns_empty(self, db, multi_agent_workspace):
+        ch = multi_agent_workspace["channel"]
+        event = _make_event("openagents:agent-master", "channel/session-test",
+                            "@agent-master note to self")
+        result = _fallback_targets(event, ch, ["agent-master"])
+        assert result == []
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_human_mentions_bypass_llm_router(
+        self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace,
+    ):
+        """Dynamic mode, human message with explicit @mentions → all
+        mentioned agents targeted directly; the LLM router is never called."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = (mock_client, "anthropic")
+
+        ws = multi_agent_workspace["workspace"]
+        event = _make_event("human:user", "channel/session-test",
+                            "@agent-master analyze the logs @agent-worker fix the tests")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="human:user", db=db, workspace=ws)
+
+        out = _run(_handle_message_posted(event, ctx))
+        assert out.metadata.get("target_agents") == ["agent-master", "agent-worker"]
+        mock_client.messages.create.assert_not_called()
+
+    def test_master_mode_still_routes_human_to_master(self, db, multi_agent_workspace):
+        """Master mode keeps its star topology — a human @mentioning a
+        sub-agent still goes through the master hub."""
+        ws = multi_agent_workspace["workspace"]
+        ch = multi_agent_workspace["channel"]
+        ch.orchestration_mode = "master"
+        db.flush()
+        event = _make_event("human:user", "channel/session-test",
+                            "@agent-worker please handle this")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="human:user", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+        assert out.metadata.get("target_agents") == ["agent-master"]
 
 
 class TestMessagePostedTargetAgents:

--- a/workspace/backend/tests/test_llm_router.py
+++ b/workspace/backend/tests/test_llm_router.py
@@ -258,6 +258,12 @@ class TestMasterMode:
                             "@agent-worker please handle this")
         assert _master_targets(event, ch, ["agent-worker"]) == ["agent-worker"]
 
+    def test_master_duplicate_delegation_deduped(self, db, multi_agent_workspace):
+        ch = multi_agent_workspace["channel"]
+        event = _make_event("openagents:agent-master", "channel/session-test",
+                            "@agent-worker do X, and @agent-worker also do Y")
+        assert _master_targets(event, ch, ["agent-worker", "agent-worker"]) == ["agent-worker"]
+
     def test_master_no_mention_stops(self, db, multi_agent_workspace):
         ch = multi_agent_workspace["channel"]
         # Master answered the human directly (no delegation) → stop

--- a/workspace/backend/tests/test_llm_router.py
+++ b/workspace/backend/tests/test_llm_router.py
@@ -470,6 +470,155 @@ class TestParallelMentionRouting:
         assert out.metadata.get("target_agents") == ["agent-master"]
 
 
+class TestDirectAssignmentNotReroutedToPeers:
+    """While agents work in parallel on tasks a human handed them by name,
+    their own progress notes and results must not be routed to a peer.
+
+    Without this, each worker's "running the command now" note is handed to
+    the LLM router, which cannot tell it from a handoff and wakes a
+    bystander agent — who then answers a task it was never given, once its
+    own job drains off the queue.
+    """
+
+    def _record_human(self, db, ws, content, ts):
+        from app.models import EventRecord
+        db.add(EventRecord(
+            id=f"evt-{ts}",
+            network_id=ws.id,
+            type="workspace.message.posted",
+            source="human:user",
+            target="channel/session-test",
+            payload={"content": content, "message_type": "chat"},
+            metadata_={},
+            timestamp=ts,
+        ))
+        db.flush()
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_assigned_agents_progress_note_stops(
+        self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace,
+    ):
+        mock_client = MagicMock()
+        mock_get_client.return_value = (mock_client, "anthropic")
+        ws = multi_agent_workspace["workspace"]
+        self._record_human(db, ws, "@agent-worker run task B", 1000)
+
+        event = _make_event("openagents:agent-worker", "channel/session-test",
+                            "Running the command now, back in a minute.")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="openagents:agent-worker", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+
+        assert out.metadata.get("target_agents") == ["__no_response__"]
+        mock_client.messages.create.assert_not_called()
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_assignment_survives_a_later_task_for_another_agent(
+        self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace,
+    ):
+        """Parallel assignments arrive as separate messages, one per agent.
+        A newer "@agent-master do X" must not cancel agent-worker's own
+        assignment — that is exactly the case that produced the misroute."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = (mock_client, "anthropic")
+        ws = multi_agent_workspace["workspace"]
+        self._record_human(db, ws, "@agent-worker run task B", 1000)
+        self._record_human(db, ws, "@agent-master run task A", 1001)
+
+        event = _make_event("openagents:agent-worker", "channel/session-test",
+                            "Task B done: 60.00s.")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="openagents:agent-worker", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+
+        assert out.metadata.get("target_agents") == ["__no_response__"]
+        mock_client.messages.create.assert_not_called()
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_explicit_handoff_still_routes(
+        self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace,
+    ):
+        """An assigned agent that @mentions a peer is delegating — the
+        router still decides, so handoffs keep working."""
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = _mock_anthropic_response("next:agent-master")
+        mock_get_client.return_value = (mock_client, "anthropic")
+        ws = multi_agent_workspace["workspace"]
+        self._record_human(db, ws, "@agent-worker run task B", 1000)
+
+        event = _make_event("openagents:agent-worker", "channel/session-test",
+                            "@agent-master can you review this?")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="openagents:agent-worker", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+
+        assert out.metadata.get("target_agents") == ["agent-master"]
+        mock_client.messages.create.assert_called_once()
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_unaddressed_human_message_reopens_routing(
+        self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace,
+    ):
+        """Free-form human chat (no @mention) ends the direct-assignment
+        window — agent replies go back through the router."""
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = _mock_anthropic_response("next:agent-master")
+        mock_get_client.return_value = (mock_client, "anthropic")
+        ws = multi_agent_workspace["workspace"]
+        self._record_human(db, ws, "@agent-worker run task B", 1000)
+        self._record_human(db, ws, "what does everyone think?", 1002)
+
+        event = _make_event("openagents:agent-worker", "channel/session-test",
+                            "I think we should ship it.")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="openagents:agent-worker", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+
+        assert out.metadata.get("target_agents") == ["agent-master"]
+        mock_client.messages.create.assert_called_once()
+
+    @patch("app.mods.workspace_mod._get_llm_client")
+    @patch("app.mods.workspace_mod._get_router_api_key", return_value="test-key")
+    @patch("app.mods.workspace_mod._get_router_model", return_value="claude-haiku-4-5-20251001")
+    def test_never_assigned_agent_still_routes(
+        self, _mock_model, _mock_key, mock_get_client, db, multi_agent_workspace,
+    ):
+        """An agent the human never addressed by name is unaffected."""
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = _mock_anthropic_response("next:agent-master")
+        mock_get_client.return_value = (mock_client, "anthropic")
+        ws = multi_agent_workspace["workspace"]
+        self._record_human(db, ws, "@agent-master run task A", 1000)
+
+        event = _make_event("openagents:agent-worker", "channel/session-test",
+                            "Here are my findings.")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="openagents:agent-worker", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+
+        assert out.metadata.get("target_agents") == ["agent-master"]
+        mock_client.messages.create.assert_called_once()
+
+    def test_master_mode_unaffected(self, db, multi_agent_workspace):
+        """Master mode's star topology still returns sub-agent output to
+        the hub — the assignment rule only applies to dynamic mode."""
+        ws = multi_agent_workspace["workspace"]
+        ch = multi_agent_workspace["channel"]
+        ch.orchestration_mode = "master"
+        db.flush()
+        self._record_human(db, ws, "@agent-worker run task B", 1000)
+
+        event = _make_event("openagents:agent-worker", "channel/session-test",
+                            "Task B done.")
+        ctx = PipelineContext(network_id=str(ws.id), agent_address="openagents:agent-worker", db=db, workspace=ws)
+        out = _run(_handle_message_posted(event, ctx))
+
+        assert out.metadata.get("target_agents") == ["agent-master"]
+
+
 class TestMessagePostedTargetAgents:
     """_handle_message_posted must ALWAYS set target_agents, even when
     routing decides nobody should respond. Otherwise legacy clients


### PR DESCRIPTION
## The problem, and where it came from

Reported during manual multi-agent testing: **assigning a different task to each
agent in the same channel did not run them in parallel.** The UI showed a
`"message queued"` badge and results came back one after another. The channel
was in `dynamic` orchestration mode with tasks assigned by explicit human
`@mention`.

Two independent routing defects produce that symptom. They have different
repro steps, so they are described separately below.

### Defect 1 — explicit assignments collapsed to a single target

**Repro:** in a `dynamic` channel with two agents, send **one** message naming
both:

```text
@agent-a do X, @agent-b do Y
```

**Before:** only one agent was targeted. Three separate causes, all
single-target:

- `_fallback_targets` returned `mentions[0]` and discarded the rest;
- in `dynamic` mode a human message with explicit `@mentions` still went
  through the LLM router, so the router could override a target the user had
  already chosen;
- the router truncated its own answer with `.split(",")[0]`, so even a correct
  multi-name decision collapsed to one name.

Both tasks then landed on one agent, whose per-channel adapter queue
(`BaseAdapter._channelBusy`) serialized them. That queue is what surfaces in
the UI as the `"message queued"` badge.

### Defect 2 — peer progress messages woke agents that were already working

**Repro:** in a `dynamic` channel with three agents, send three messages
back-to-back, one ~60s task each:

```text
@agent-a  task PARALLEL-A … <60s command> … report START/END
@agent-b  task PARALLEL-B … <60s command> … report START/END
@agent-c  task PARALLEL-C … <60s command> … report START/END
```

Each command was equivalent to:

```bash
python -c "import time,datetime; print('START', datetime.datetime.now().isoformat()); time.sleep(60); print('END', datetime.datetime.now().isoformat())"
```

**Before:** each agent posts a progress message when it starts ("Starting the
command now…", "Executing command…"). Those messages `@mention` nobody, so they
fell through to the LLM router, which cannot distinguish progress narration
from a handoff and picked a bystander agent as the next target.

Observed with `claude-test-001` / `codex-test-001` / `kimi-test-001`
(A→claude, B→codex, C→kimi): **`claude-test-001` answered PARALLEL-A three
times** — once legitimately, then twice more after being handed `codex`'s and
`kimi`'s progress messages. Both spurious turns queued behind its own running
job, so they surfaced ~60s late as duplicate answers.

In a second run one of those spurious replies opened with *"you seem to be
describing the PARALLEL-B run"* — the agent was visibly reacting to a message
addressed to someone else.

This is systematic, not flaky: N agents working in parallel produce up to N−1
spurious turns per round, so the symptom gets worse the more parallelism works.

## After

Re-tested in a `dynamic` channel with three `claude`-adapter agents (all three
can actually execute shell commands, unlike the original mixed set):
`claude-test-001`, `claude-dp-002`, `claude-dp-003`. Three separate messages,
one task each.

| Agent | Task | START | END | Duration |
|---|---|---|---|---|
| `claude-test-001` | PARALLEL-A | `17:17:23.247326` | `17:18:23.248152` | 60.00s |
| `claude-dp-002` | PARALLEL-B | `17:17:48.765432` | `17:18:48.766026` | 60.00s |
| `claude-dp-003` | PARALLEL-C | `17:18:04.496977` | `17:19:04.497673` | 60.00s |

(2026-08-04, times UTC as reported by each agent.)

**The decisive number: `PARALLEL-B` starts at 17:17:48, while `PARALLEL-A` is
still running until 17:18:23.** Under the old behaviour B could not have
started until A's turn had finished. Same for C, which starts at 17:18:04.

All three intervals overlap between `17:18:04.496977` and `17:18:23.248152` —
18.75s with three agents executing concurrently. Pairwise overlap is larger
(A∩B = 34.5s, B∩C = 44.3s).

The staggered starts are the human send interval plus per-agent startup, not
queueing.

Also confirmed in the same run:

- each agent returned exactly one result, for its own task only;
- no agent answered another agent's assignment;
- no duplicate results;
- no queue badge.

## The fix

### Routing — `workspace_mod.py`

- `_fallback_targets` returns **all** explicit `@mentions` (deduplicated,
  sender's self-mention filtered) instead of `mentions[0]`.
- A human message with explicit `@mentions` skips the LLM router — the user has
  already chosen the targets.
- The router accepts multi-name answers (`next:agent-a,agent-b`); each name is
  validated against the candidate set, and unknown names and self-loops are
  dropped. `_ROUTER_PROMPT` documents the format and `max_tokens` goes 30 → 64
  so a multi-name answer is not truncated.
- Master-mode delegation mentions are deduplicated at the source.

### Direct-assignment hold — `workspace_mod.py`

New `_human_assignment_holds()`. When all of these hold:

- the message came from an agent,
- that agent was directly addressed by a human,
- the message `@mentions` no peer,
- the channel is not in `workflow` mode,

the message targets nobody and skips the router entirely. An assigned agent can
post progress notes and status without creating work for a peer.

The assignment window ends when a human posts a message with **no** `@mention`
at all. A newer assignment naming a *different* agent does **not** end it —
parallel assignments arrive as separate messages (`@a …`, `@b …`, `@c …`), so
ending the window on any later assignment would defeat the rule for exactly the
case it exists to handle.

Explicit agent-to-agent handoffs still route normally: a message that mentions
a peer is not progress narration and goes through the router as before.

`_ROUTER_PROMPT` additionally treats progress narration as `stop` — a second
line of defence for the paths the deterministic rule does not cover
(`workflow` mode, free-form chat).

### Cloud agents — `cloud_agent.py`

- Targeted cloud agents are invoked concurrently instead of in a sequential
  `await` loop.
- Fan-out bounded by a semaphore; new `CLOUD_AGENT_MAX_CONCURRENCY` config,
  default `4`.
- Targets deduplicated before the gather, so a duplicated mention cannot invoke
  — or bill — the same agent twice. Sentinel targets are filtered before
  invocation; depth-limit behaviour is unchanged.
- DB work is split into short-lived sessions released before every provider API
  call, so a large mention list can no longer pin pool connections for the
  duration of multiple external round-trips. Image/audio file records and their
  response message still commit in one transaction.

## Blast radius

| Area | Effect |
|---|---|
| Single-agent channels | Unchanged — the `len(real_participants) < 2` path is untouched. |
| `master` mode | Unchanged except delegation-mention dedupe; star topology intact. |
| `dynamic` mode | Where the fix lives: explicit-human-mention bypass + direct-assignment hold. |
| `workflow` mode | **Behaviour change** — an explicit human `@mention` now bypasses the plan-steered router. The agent-side hold is deliberately scoped to `mode != "workflow"`, so the plan still drives agent→agent hops. |
| Router cost | `max_tokens` 30 → 64 per call, but two paths now skip the call entirely, so net router calls go **down**. |
| Legacy clients | `["__no_response__"]` sentinel semantics unchanged. |
| Local agents | One agent still processes one task at a time per channel — parallelism is *across* agents, not within one. |
| Cloud agents | Concurrent invocation + shorter DB session lifetime. Highest-risk part of the diff. |

## Worth a reviewer's attention

1. **`workflow`-mode ordering.** Explicit human mentions now take precedence
   over the plan-steered router. Deliberate — the human picked the target — but
   it is a routing-policy decision, not a mechanical fix.

2. **`_ASSIGNMENT_LOOKBACK = 20`.** `_human_assignment_holds()` scans at most 20
   recent human messages. How far back a direct assignment stays relevant is a
   judgement call.

3. **The termination rule.** An unaddressed human message reopens routing; a
   later assignment for another agent does not. Required for back-to-back
   parallel assignments, but still a policy choice.

4. **The `cloud_agent.py` session split.** Correctness depends on provider-call
   code never touching unloaded attributes on a detached ORM object. This is the
   part that most deserves a close read — it combines concurrent provider calls,
   transaction boundaries, file records and response-message creation.

5. **`CLOUD_AGENT_MAX_CONCURRENCY = 4`.** An operational default; may need
   tuning per deployment.

## Intentionally unchanged

One agent still processes one task at a time within a channel. The per-channel
adapter queue stays, because a single agent's session context must stay
ordered. This PR makes *different* agents run concurrently; it does not make one
agent run two tasks at once. The fix stops unrelated assignments from being
misrouted into the same queue — it does not remove the queue.

## Tests

**Router suite: 25 → 39 tests** (+14) covering explicit-mention fan-out,
dedupe, self-mention filtering, human-mention router bypass, master-mode
preservation, multi-name router answers, unknown-target and self-loop
filtering, and the six direct-assignment cases (progress note stops; assignment
survives a later task for another agent; explicit handoff still routes;
unaddressed human message reopens routing; never-assigned agent unaffected;
master mode unaffected).

**New `test_cloud_agent.py`** (5 tests): duplicate targets invoked once;
sentinel-only produces no invocation; sentinel mixed with real targets is
dropped; concurrency cap enforced; depth limit skips all.

**Full backend suite**, rebased onto `origin/develop` `c3a18260`:

| Revision | Result |
|---|---|
| Base `c3a18260` | 64 failed, 529 passed, 16 skipped |
| Branch head `c027149c` | 64 failed, **548** passed, 16 skipped |

`548 − 529 = 19` — exactly the tests added here. The 64 failures are
**byte-identical** between the two revisions: pre-existing environmental
failures (filesystem-permission errors) in `test_skill_install`,
`test_knowledge`, `test_browser_contexts`, `test_events`,
`test_login_session_auth` and `test_migration_schema`.

CI's other gate, `test_onm_addressing` / `test_onm_events` /
`test_onm_pipeline`: 65 passed.

## Known CI noise — pre-existing, not from this PR

CI lints only *changed* Python files, and the files this PR touches were never
`ruff`-clean, so the lint job will go red. On `origin/develop` those same files
already produce **17** `ruff check` errors; on this branch they produce **14** —
a strict subset (rewriting `cloud_agent.py` removed three `F841`s). The new
`test_cloud_agent.py` is clean. `ruff format --check` already fails on those
files on `develop` too.

No new violation is introduced here. Auto-fixing would add ~660 lines of pure
formatting churn on top of a 623-line functional diff, so it is deliberately
left for a separate formatting PR.

