### PR TITLE
feat(files): folder browsing, folder mutations and a restorable trash

### DIFF
--- a/workspace/backend/alembic/versions/027_add_file_trash.py
+++ b/workspace/backend/alembic/versions/027_add_file_trash.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Add trash columns to files.
+
+Soft-deleted records already existed (status = "deleted") but carried nothing
+about the deletion itself, so they could be neither listed nor restored as a
+unit. These three nullable columns add that:
+
+    deleted_at   when it was trashed — also what a future expiry sweep reads
+    trash_id     groups one delete action, so a folder's files restore together
+    trash_path   what the user deleted: a file's path, or a folder's
+
+Records deleted before this migration keep NULL in all three; the trash listing
+treats each of them as its own single-file entry.
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-07-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "027"
+down_revision = "026"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(inspector, table, column):
+    if table not in inspector.get_table_names():
+        return False
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def _has_index(inspector, table, index):
+    if table not in inspector.get_table_names():
+        return False
+    return any(i["name"] == index for i in inspector.get_indexes(table))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _has_column(inspector, "files", "deleted_at"):
+        op.add_column("files", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+    if not _has_column(inspector, "files", "trash_id"):
+        op.add_column("files", sa.Column("trash_id", sa.Text(), nullable=True))
+    if not _has_column(inspector, "files", "trash_path"):
+        op.add_column("files", sa.Column("trash_path", sa.Text(), nullable=True))
+
+    inspector = sa.inspect(bind)
+    if not _has_index(inspector, "files", "idx_files_trash"):
+        op.create_index("idx_files_trash", "files", ["workspace_id", "trash_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _has_index(inspector, "files", "idx_files_trash"):
+        op.drop_index("idx_files_trash", table_name="files")
+    for column in ("trash_path", "trash_id", "deleted_at"):
+        if _has_column(inspector, "files", column):
+            op.drop_column("files", column)

--- a/workspace/backend/app/file_types.py
+++ b/workspace/backend/app/file_types.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""
+File type classification.
+
+The server-side twin of the frontend's `components/files/file-utils.tsx`. Both
+sides answer the same two questions and must answer them identically, or a
+filter menu written by one will disagree with the list rendered by the other:
+
+  kind  — what a file *is* (pdf, image, code, …); drives glyph and colour
+  group — how a file is *looked for* (documents, images, …); drives filtering
+
+Extension wins over content type: uploads routinely arrive as
+application/octet-stream, and the name is what the user sees.
+"""
+
+from typing import Optional
+
+# --- kinds -----------------------------------------------------------------
+
+KINDS = (
+    "pdf", "doc", "sheet", "slides", "markdown", "text", "code",
+    "image", "audio", "video", "web", "archive", "unknown",
+)
+
+EXTENSION_KINDS: dict[str, str] = {
+    "pdf": "pdf",
+
+    "doc": "doc", "docx": "doc", "odt": "doc", "rtf": "doc", "pages": "doc",
+
+    "xls": "sheet", "xlsx": "sheet", "xlsm": "sheet", "ods": "sheet",
+    "csv": "sheet", "tsv": "sheet", "numbers": "sheet",
+
+    "ppt": "slides", "pptx": "slides", "odp": "slides", "key": "slides",
+
+    "md": "markdown", "markdown": "markdown", "mdx": "markdown",
+
+    "txt": "text", "log": "text", "text": "text",
+
+    "js": "code", "mjs": "code", "cjs": "code", "jsx": "code",
+    "ts": "code", "tsx": "code", "py": "code", "rb": "code", "rs": "code",
+    "go": "code", "java": "code", "kt": "code", "c": "code", "h": "code",
+    "cpp": "code", "hpp": "code", "cs": "code", "swift": "code", "php": "code",
+    "sh": "code", "bash": "code", "zsh": "code", "sql": "code", "r": "code",
+    "json": "code", "yaml": "code", "yml": "code", "toml": "code", "xml": "code",
+    "ini": "code", "cfg": "code", "conf": "code", "env": "code",
+    "css": "code", "scss": "code", "less": "code", "vue": "code",
+    "svelte": "code", "ipynb": "code",
+
+    "png": "image", "jpg": "image", "jpeg": "image", "gif": "image",
+    "webp": "image", "svg": "image", "bmp": "image", "ico": "image",
+    "avif": "image", "heic": "image", "tiff": "image",
+
+    "mp3": "audio", "wav": "audio", "ogg": "audio", "m4a": "audio",
+    "flac": "audio", "aac": "audio", "opus": "audio",
+
+    "mp4": "video", "mov": "video", "avi": "video", "webm": "video",
+    "mkv": "video", "m4v": "video",
+
+    "html": "web", "htm": "web", "url": "web",
+
+    "zip": "archive", "tar": "archive", "gz": "archive", "tgz": "archive",
+    "rar": "archive", "7z": "archive", "bz2": "archive", "xz": "archive",
+}
+
+# --- groups ----------------------------------------------------------------
+
+#: Filter groups, in the order the UI lists them.
+FILTER_GROUPS = (
+    "documents", "sheets", "slides", "images", "audio",
+    "video", "code", "web", "archives", "other",
+)
+
+KIND_GROUPS: dict[str, str] = {
+    "pdf": "documents",
+    "doc": "documents",
+    "markdown": "documents",
+    "text": "documents",
+    "sheet": "sheets",
+    "slides": "slides",
+    "image": "images",
+    "audio": "audio",
+    "video": "video",
+    "code": "code",
+    "web": "web",
+    "archive": "archives",
+    "unknown": "other",
+}
+
+
+def extension_of(filename: str) -> str:
+    """Lowercased extension without the dot — '' when the name has none."""
+    base = filename.rsplit("/", 1)[-1]
+    dot = base.rfind(".")
+    if dot <= 0 or dot == len(base) - 1:
+        return ""
+    return base[dot + 1:].lower()
+
+
+def kind_for(filename: str, content_type: Optional[str] = None) -> str:
+    """Resolve a file to its kind — extension first, content type as fallback."""
+    name = filename or ""
+    lowered = name.lower()
+    if lowered.startswith("http://") or lowered.startswith("https://"):
+        return "web"
+
+    by_extension = EXTENSION_KINDS.get(extension_of(name))
+    if by_extension:
+        return by_extension
+
+    ct = (content_type or "").lower()
+    if ct.startswith("image/"):
+        return "image"
+    if ct.startswith("audio/"):
+        return "audio"
+    if ct.startswith("video/"):
+        return "video"
+    if ct == "application/pdf":
+        return "pdf"
+    if ct == "text/html":
+        return "web"
+    if ct == "text/markdown":
+        return "markdown"
+    if ct == "text/csv" or "spreadsheet" in ct or "excel" in ct:
+        return "sheet"
+    if "presentation" in ct or "powerpoint" in ct:
+        return "slides"
+    if "word" in ct or ct == "application/rtf":
+        return "doc"
+    if "zip" in ct or "compressed" in ct or "tar" in ct:
+        return "archive"
+    if "json" in ct or "javascript" in ct or "xml" in ct or "yaml" in ct:
+        return "code"
+    if ct.startswith("text/"):
+        return "text"
+
+    return "unknown"
+
+
+def group_for(filename: str, content_type: Optional[str] = None) -> str:
+    """The filter group a file belongs to."""
+    return KIND_GROUPS[kind_for(filename, content_type)]

--- a/workspace/backend/app/models.py
+++ b/workspace/backend/app/models.py
@@ -283,8 +283,20 @@ class FileRecord(Base):
     status = Column(Text, nullable=False, default="active")  # active | deleted
     created_at = Column(DateTime(timezone=True), default=_now, server_default=text("NOW()"))
 
+    # Trash. A deleted record keeps its bytes until it's purged; these three
+    # columns are what turn "status = deleted" into something restorable.
+    #   deleted_at  when it went to the trash (and what an expiry sweep reads)
+    #   trash_id    one delete action — deleting a folder trashes N records
+    #               that must come back, or be purged, together
+    #   trash_path  what the user deleted: a file's path, or a folder's
+    # All nullable: records deleted before trash existed simply have none.
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    trash_id = Column(Text, nullable=True)
+    trash_path = Column(Text, nullable=True)
+
     __table_args__ = (
         Index("idx_files_workspace_status", "workspace_id", "status"),
+        Index("idx_files_trash", "workspace_id", "trash_id"),
     )
 
 

--- a/workspace/backend/app/routers/files.py
+++ b/workspace/backend/app/routers/files.py
@@ -2,10 +2,16 @@
 """
 File storage endpoints — upload, list, download, delete shared files.
 
-POST   /v1/files          Upload a file (multipart or base64 JSON)
-GET    /v1/files           List files in a workspace
-GET    /v1/files/{file_id} Download a file
-DELETE /v1/files/{file_id} Soft-delete a file
+POST   /v1/files                 Upload a file (multipart or base64 JSON)
+POST   /v1/files/upload           Upload into a folder, keeping the filename
+GET    /v1/files                  List files in a workspace
+GET    /v1/files/browse           Browse one folder: subfolders, files, counts
+GET    /v1/files/{file_id}        Download a file
+DELETE /v1/files/{file_id}        Soft-delete a file
+POST   /v1/files/trash            Move files/folders to the trash
+GET    /v1/files/trash            List the trash
+POST   /v1/files/trash/restore    Restore trash entries
+POST   /v1/files/trash/purge      Delete trash entries permanently
 """
 
 import asyncio
@@ -25,6 +31,7 @@ from sqlalchemy.orm import Session
 
 from app.config import config
 from app.database import get_db
+from app.file_types import FILTER_GROUPS, KIND_GROUPS, kind_for
 from app.models import FileRecord, Workspace
 from app.response import ResponseCode, json_response, success_response
 from app.routers.network import (
@@ -76,6 +83,217 @@ class Base64UploadRequest(BaseModel):
     channel_name: Optional[str] = None
     network: str
     source: Optional[str] = "human:user"
+
+
+class FolderCreateRequest(BaseModel):
+    """Create an (empty) folder."""
+    network: str
+    path: str
+    source: Optional[str] = "human:user"
+
+
+class FolderRenameRequest(BaseModel):
+    """Rename or move a folder and everything under it."""
+    network: str
+    path: str
+    new_path: str
+    source: Optional[str] = "human:user"
+
+
+# ---------------------------------------------------------------------------
+# Folders
+#
+# Folders are purely logical: there is no folder table, only the path prefix in
+# `FileRecord.filename`. An empty folder is kept alive by a zero-byte `.keep`
+# record, the same convention the UI used to write by hand.
+# ---------------------------------------------------------------------------
+
+KEEP_FILE = ".keep"
+
+
+def _basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def _dirname(path: str) -> str:
+    """The folder a path lives in — '' for a file at the root."""
+    return path.rsplit("/", 1)[0] if "/" in path else ""
+
+
+def _normalize_folder_path(path: str) -> Optional[str]:
+    """Strip stray slashes and reject anything that could escape the workspace."""
+    cleaned = (path or "").strip().strip("/")
+    if not cleaned:
+        return None
+    segments = cleaned.split("/")
+    for segment in segments:
+        if not segment or segment in (".", "..") or "\\" in segment:
+            return None
+    return "/".join(segments)
+
+
+def _folder_records(db: Session, workspace_id: str, path: str) -> list[FileRecord]:
+    """Every active record inside `path` (at any depth)."""
+    return list(
+        db.execute(
+            select(FileRecord)
+            .where(FileRecord.workspace_id == workspace_id)
+            .where(FileRecord.status == "active")
+            # autoescape: `startswith` compiles to LIKE, where `_` matches any
+            # single character — and "uploaded_files/" is a real folder here.
+            .where(FileRecord.filename.startswith(f"{path}/", autoescape=True))
+        ).scalars().all()
+    )
+
+
+@router.post("/files/folders")
+async def create_folder(
+    request: FolderCreateRequest,
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """Create an empty folder, materialised as a zero-byte `.keep` record."""
+    path = _normalize_folder_path(request.path)
+    if not path:
+        return json_response(ResponseCode.BAD_REQUEST, "Invalid folder path")
+
+    workspace = _resolve_workspace(db, request.network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    if _folder_records(db, str(workspace.id), path):
+        return json_response(ResponseCode.BAD_REQUEST, f'Folder "{path}" already exists')
+
+    file_id = str(uuid.uuid4())
+    store = get_file_store()
+    loop = asyncio.get_event_loop()
+    try:
+        storage_key = await loop.run_in_executor(
+            None, store.save, str(workspace.id), file_id, KEEP_FILE, b"",
+        )
+    except ValueError as exc:
+        return json_response(ResponseCode.BAD_REQUEST, str(exc))
+
+    db.add(FileRecord(
+        id=file_id,
+        workspace_id=str(workspace.id),
+        filename=f"{path}/{KEEP_FILE}",
+        content_type="text/plain",
+        size=0,
+        storage_key=storage_key,
+        uploaded_by=request.source or "human:user",
+    ))
+
+    await _emit_event(
+        Event(
+            type="workspace.folder.created",
+            source=request.source or "human:user",
+            target="core",
+            payload={"path": path},
+        ),
+        workspace,
+        db,
+        token=x_workspace_token or workspace.password_hash,
+    )
+
+    return success_response({"path": path})
+
+
+@router.patch("/files/folders")
+async def rename_folder(
+    request: FolderRenameRequest,
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """Rename or move a folder by rewriting the path prefix of its contents."""
+    path = _normalize_folder_path(request.path)
+    new_path = _normalize_folder_path(request.new_path)
+    if not path or not new_path:
+        return json_response(ResponseCode.BAD_REQUEST, "Invalid folder path")
+    if path == new_path:
+        return success_response({"path": new_path, "updated": 0})
+    # Moving a folder inside itself would orphan every record under it
+    if new_path.startswith(f"{path}/"):
+        return json_response(ResponseCode.BAD_REQUEST, "Cannot move a folder into itself")
+
+    workspace = _resolve_workspace(db, request.network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    records = _folder_records(db, str(workspace.id), path)
+    if not records:
+        return json_response(ResponseCode.NOT_FOUND, f'Folder "{path}" not found')
+
+    if _folder_records(db, str(workspace.id), new_path):
+        return json_response(ResponseCode.BAD_REQUEST, f'Folder "{new_path}" already exists')
+
+    for record in records:
+        record.filename = f"{new_path}/{record.filename[len(path) + 1:]}"
+
+    await _emit_event(
+        Event(
+            type="workspace.folder.renamed",
+            source=request.source or "human:user",
+            target="core",
+            payload={"path": path, "new_path": new_path, "count": len(records)},
+        ),
+        workspace,
+        db,
+        token=x_workspace_token or workspace.password_hash,
+    )
+
+    return success_response({"path": new_path, "updated": len(records)})
+
+
+@router.delete("/files/folders")
+async def delete_folder(
+    network: str = Query(..., description="Network (workspace) ID or slug"),
+    path: str = Query(..., description="Folder path to delete"),
+    source: Optional[str] = Query("human:user"),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """Soft-delete a folder and everything inside it."""
+    folder = _normalize_folder_path(path)
+    if not folder:
+        return json_response(ResponseCode.BAD_REQUEST, "Invalid folder path")
+
+    workspace = _resolve_workspace(db, network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    records = _folder_records(db, str(workspace.id), folder)
+    if not records:
+        return json_response(ResponseCode.NOT_FOUND, f'Folder "{folder}" not found')
+
+    for record in records:
+        record.status = "deleted"
+
+    await _emit_event(
+        Event(
+            type="workspace.folder.deleted",
+            source=source or "human:user",
+            target="core",
+            payload={"path": folder, "count": len(records)},
+        ),
+        workspace,
+        db,
+        token=x_workspace_token or workspace.password_hash,
+    )
+
+    return success_response({"path": folder, "deleted": len(records)})
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +471,594 @@ async def upload_file_base64(
 
 
 # ---------------------------------------------------------------------------
+# POST /v1/files/upload — upload into a folder, keeping the name
+#
+# `POST /files` was written for agents dropping a file into the workspace: a
+# bare name is rewritten to uploaded_files/<timestamp>_<name> so nothing ever
+# collides and everything lands in one bucket. A file browser needs the
+# opposite — the file goes where the user is standing, under the name they
+# recognise — so this is a separate endpoint rather than a flag on that one,
+# and the old behaviour stays exactly as agents rely on it.
+# ---------------------------------------------------------------------------
+
+CONFLICT_MODES = ("rename", "replace", "error")
+
+
+def _sanitize_upload_name(raw: str) -> Optional[str]:
+    """
+    A safe leaf name, or None if there isn't one.
+
+    Browsers send bare names, but a client can send anything — the folder comes
+    from `path`, so any directory part here is dropped rather than trusted.
+    """
+    name = (raw or "").replace("\\", "/").rsplit("/", 1)[-1]
+    name = "".join(ch for ch in name if ch.isprintable()).strip()
+    if not name or name in (".", "..") or name == KEEP_FILE:
+        return None
+    return name
+
+
+def _next_free_name(taken: set[str], folder: str, name: str) -> str:
+    """`report.pdf` → `report (2).pdf` → `report (3).pdf`, the way Finder does."""
+    def full(leaf: str) -> str:
+        return f"{folder}/{leaf}" if folder else leaf
+
+    if full(name) not in taken:
+        return full(name)
+
+    stem, dot, ext = name.rpartition(".")
+    if not stem:
+        # A dotfile like ".env" has no stem — suffix the whole name instead of
+        # producing " (2).env".
+        stem, dot, ext = name, "", ""
+    suffix = f".{ext}" if dot else ""
+
+    counter = 2
+    while True:
+        candidate = full(f"{stem} ({counter}){suffix}")
+        if candidate not in taken:
+            return candidate
+        counter += 1
+
+
+@router.post("/files/upload")
+async def upload_files_to_folder(
+    files: list[UploadFile] = File(..., description="One or more files"),
+    network: str = Form(...),
+    path: str = Form("", description="Destination folder; empty is the root"),
+    source: Optional[str] = Form(None),
+    channel_name: Optional[str] = Form(None),
+    on_conflict: str = Form("rename", description="rename | replace | error"),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """
+    Upload one or more files into a folder, under their own names.
+
+    Every file is handled on its own: one that's too large or badly named is
+    reported in `skipped` while the rest still land, because failing a whole
+    drag-and-drop over one bad file in it is worse than a partial result the
+    client can show.
+
+    `on_conflict` decides what an existing name means — `rename` picks the next
+    free "(2)" name, `replace` soft-deletes the old record, `error` skips the
+    file and says so.
+    """
+    if on_conflict not in CONFLICT_MODES:
+        return json_response(
+            ResponseCode.BAD_REQUEST, f"on_conflict must be one of: {', '.join(CONFLICT_MODES)}"
+        )
+
+    folder = _normalize_folder_path(path) if path else None
+    if path and folder is None:
+        return json_response(ResponseCode.BAD_REQUEST, "Invalid path")
+
+    workspace = _resolve_workspace(db, network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    if not files:
+        return json_response(ResponseCode.BAD_REQUEST, "No files in the request")
+
+    uploaded_by = source or "human:user"
+    store = get_file_store()
+    loop = asyncio.get_event_loop()
+
+    # Names already in use, plus the ones this request hands out — two files
+    # named report.pdf in one drop must not both become report.pdf.
+    taken = set(db.execute(
+        select(FileRecord.filename)
+        .where(FileRecord.workspace_id == str(workspace.id))
+        .where(FileRecord.status == "active")
+    ).scalars().all())
+
+    uploaded: list[dict] = []
+    skipped: list[dict] = []
+    pending_events: list[Event] = []
+
+    for upload in files:
+        name = _sanitize_upload_name(upload.filename or "")
+        if not name:
+            skipped.append({"filename": upload.filename, "reason": "invalid_name"})
+            continue
+
+        data = await upload.read()
+        if len(data) > config.MAX_FILE_SIZE:
+            skipped.append({
+                "filename": name,
+                "reason": "too_large",
+                "detail": f"Maximum size: {config.MAX_FILE_SIZE // (1024 * 1024)}MB",
+            })
+            continue
+
+        target = f"{folder}/{name}" if folder else name
+        replaced = False
+
+        if target in taken:
+            if on_conflict == "error":
+                skipped.append({"filename": name, "reason": "exists"})
+                continue
+            if on_conflict == "rename":
+                target = _next_free_name(taken, folder or "", name)
+            else:
+                for old in db.execute(
+                    select(FileRecord)
+                    .where(FileRecord.workspace_id == str(workspace.id))
+                    .where(FileRecord.filename == target)
+                    .where(FileRecord.status == "active")
+                ).scalars().all():
+                    old.status = "deleted"
+                replaced = True
+
+        content_type = upload.content_type or "application/octet-stream"
+        file_id = str(uuid.uuid4())
+        try:
+            storage_key = await loop.run_in_executor(
+                None, store.save, str(workspace.id), file_id, _basename(target), data,
+            )
+        except ValueError as exc:
+            skipped.append({"filename": name, "reason": "storage_error", "detail": str(exc)})
+            continue
+
+        record = FileRecord(
+            id=file_id,
+            workspace_id=str(workspace.id),
+            filename=target,
+            content_type=content_type,
+            size=len(data),
+            storage_key=storage_key,
+            uploaded_by=uploaded_by,
+            channel_name=channel_name,
+        )
+        db.add(record)
+        db.flush()
+        taken.add(target)
+
+        # Same event as POST /files — existing listeners shouldn't have to
+        # learn about a second upload route. They're emitted after the commit
+        # below: a rejected event must not cost the user their upload.
+        pending_events.append(Event(
+            type="workspace.file.uploaded",
+            source=uploaded_by,
+            target=f"channel/{channel_name}" if channel_name else "core",
+            payload={
+                "file_id": file_id,
+                "filename": target,
+                "content_type": content_type,
+                "size": len(data),
+            },
+        ))
+
+        kind = kind_for(target, content_type)
+        payload = _file_payload(record, _basename(target), kind, KIND_GROUPS[kind])
+        payload["replaced"] = replaced
+        payload["renamed_from"] = name if _basename(target) != name else None
+        uploaded.append(payload)
+
+    db.commit()
+
+    for event in pending_events:
+        await _emit_event(event, workspace, db, token=x_workspace_token or workspace.password_hash)
+
+    return success_response({
+        "path": folder or "",
+        "files": uploaded,
+        "skipped": skipped,
+        "uploaded_count": len(uploaded),
+        "skipped_count": len(skipped),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Trash
+#
+# Deleting has always been soft — status flips to "deleted" and the bytes stay
+# — but nothing recorded *when*, or that ten records went away as one folder,
+# so a deleted thing could be neither shown nor brought back. These endpoints
+# add that layer without touching the existing DELETE routes:
+#
+#   POST /files/trash          move files/folders to the trash
+#   GET  /files/trash          list what's in it
+#   POST /files/trash/restore  put entries back
+#   POST /files/trash/purge    delete entries for real, bytes included
+#
+# Purging is the only thing here that destroys anything.
+#
+# Records deleted by the older DELETE routes have no trash metadata; the
+# listing treats each as its own single-file entry, so nothing is stranded.
+#
+# All of these must be declared before /files/{file_id}.
+# ---------------------------------------------------------------------------
+
+class TrashRequest(BaseModel):
+    """Move files and/or folders to the trash."""
+    network: str
+    file_ids: Optional[list[str]] = None
+    paths: Optional[list[str]] = None
+    source: Optional[str] = "human:user"
+
+
+class TrashActionRequest(BaseModel):
+    """Restore or purge trash entries — by id, or the lot."""
+    network: str
+    trash_ids: Optional[list[str]] = None
+    all: bool = False
+    source: Optional[str] = "human:user"
+
+
+#: Files listed inline on a trash entry before it just reports a count.
+TRASH_PREVIEW_FILES = 10
+
+
+def _trash_key(record: FileRecord) -> str:
+    """The entry a deleted record belongs to — its own id if it predates trash."""
+    return record.trash_id or record.id
+
+
+def _trashed_records(db: Session, workspace_id: str) -> list[FileRecord]:
+    return list(db.execute(
+        select(FileRecord)
+        .where(FileRecord.workspace_id == workspace_id)
+        .where(FileRecord.status == "deleted")
+    ).scalars().all())
+
+
+def _trash_entries(records: list[FileRecord]) -> list[dict]:
+    """Group deleted records into the entries a user recognises."""
+    grouped: dict[str, list[FileRecord]] = {}
+    for record in records:
+        grouped.setdefault(_trash_key(record), []).append(record)
+
+    entries = []
+    for trash_id, group in grouped.items():
+        first = group[0]
+        # A folder delete tags every record with the folder it came from; a
+        # file delete tags it with the file itself. Untagged (pre-trash)
+        # records are single files by construction.
+        path = first.trash_path or first.filename
+        is_folder = len(group) > 1 or path != first.filename
+        files = [f for f in group if _basename(f.filename) != KEEP_FILE]
+        deleted_at = max((r.deleted_at for r in group if r.deleted_at), default=None)
+
+        entries.append({
+            "trash_id": trash_id,
+            "kind": "folder" if is_folder else "file",
+            "path": path,
+            "name": _basename(path),
+            "deleted_at": deleted_at.isoformat() if deleted_at else None,
+            "file_count": len(files),
+            "size": sum(f.size or 0 for f in files),
+            "files": [
+                {
+                    "id": f.id,
+                    "filename": f.filename,
+                    "name": _basename(f.filename),
+                    "size": f.size,
+                    "content_type": f.content_type,
+                    "kind": kind_for(f.filename, f.content_type),
+                }
+                for f in sorted(files, key=lambda f: f.filename)[:TRASH_PREVIEW_FILES]
+            ],
+        })
+
+    # Newest first; entries with no timestamp (pre-trash deletes) sort last.
+    entries.sort(key=lambda e: (e["deleted_at"] is not None, e["deleted_at"] or ""), reverse=True)
+    return entries
+
+
+@router.post("/files/trash")
+async def move_to_trash(
+    request: TrashRequest,
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """
+    Move files and folders to the trash.
+
+    Each folder becomes one entry however many files it holds, so restoring is
+    the same gesture as deleting was. Anything already gone is reported in
+    `not_found` rather than failing the request — a stale list on the client
+    shouldn't block deleting the rest.
+    """
+    if not request.file_ids and not request.paths:
+        return json_response(ResponseCode.BAD_REQUEST, "Nothing to delete: pass file_ids or paths")
+
+    workspace = _resolve_workspace(db, request.network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    source = request.source or "human:user"
+    now = datetime.now(timezone.utc)
+    entries: list[dict] = []
+    not_found: list[str] = []
+    pending_events: list[Event] = []
+
+    def _trash(records: list[FileRecord], path: str, kind: str) -> None:
+        trash_id = str(uuid.uuid4())
+        for record in records:
+            record.status = "deleted"
+            record.deleted_at = now
+            record.trash_id = trash_id
+            record.trash_path = path
+        counted = [r for r in records if _basename(r.filename) != KEEP_FILE]
+        entries.append({
+            "trash_id": trash_id,
+            "kind": kind,
+            "path": path,
+            "name": _basename(path),
+            "file_count": len(counted),
+            "size": sum(r.size or 0 for r in counted),
+        })
+
+    for file_id in request.file_ids or []:
+        record = db.execute(
+            select(FileRecord)
+            .where(FileRecord.id == file_id)
+            .where(FileRecord.workspace_id == str(workspace.id))
+            .where(FileRecord.status == "active")
+        ).scalar_one_or_none()
+        if not record:
+            not_found.append(file_id)
+            continue
+        _trash([record], record.filename, "file")
+        pending_events.append(Event(
+            type="workspace.file.deleted",
+            source=source,
+            target="core",
+            payload={"file_id": record.id, "filename": record.filename},
+        ))
+
+    for raw_path in request.paths or []:
+        folder = _normalize_folder_path(raw_path)
+        if not folder:
+            not_found.append(raw_path)
+            continue
+        records = _folder_records(db, str(workspace.id), folder)
+        records = [r for r in records if r.status == "active"]
+        if not records:
+            not_found.append(raw_path)
+            continue
+        _trash(records, folder, "folder")
+        pending_events.append(Event(
+            type="workspace.folder.deleted",
+            source=source,
+            target="core",
+            payload={"path": folder, "count": len(records)},
+        ))
+
+    db.commit()
+
+    for event in pending_events:
+        await _emit_event(event, workspace, db, token=x_workspace_token or workspace.password_hash)
+
+    return success_response({
+        "entries": entries,
+        "not_found": not_found,
+        "trashed_count": sum(e["file_count"] for e in entries),
+    })
+
+
+@router.get("/files/trash")
+def list_trash(
+    network: str = Query(..., description="Network (workspace) ID or slug"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """
+    What's in the trash, newest first.
+
+    One entry per delete action: a deleted folder is a single row holding its
+    files, not N loose ones. `files` previews the first few; `file_count` is
+    the real number. Empty-folder `.keep` placeholders never count.
+    """
+    workspace = _resolve_workspace(db, network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    entries = _trash_entries(_trashed_records(db, str(workspace.id)))
+    page = entries[offset:offset + limit]
+
+    return success_response({
+        "entries": page,
+        "total": len(entries),
+        "file_total": sum(e["file_count"] for e in entries),
+        "size_total": sum(e["size"] for e in entries),
+        "limit": limit,
+        "offset": offset,
+    })
+
+
+@router.post("/files/trash/restore")
+async def restore_from_trash(
+    request: TrashActionRequest,
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """
+    Put trash entries back where they were.
+
+    If something has taken the name in the meantime, the restored file lands
+    beside it as "report (2).pdf" rather than overwriting or failing — the
+    trash's job is to give things back, not to adjudicate names.
+    """
+    workspace = _resolve_workspace(db, request.network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    if not request.all and not request.trash_ids:
+        return json_response(ResponseCode.BAD_REQUEST, "Pass trash_ids or all=true")
+
+    wanted = None if request.all else set(request.trash_ids or [])
+    records = [
+        r for r in _trashed_records(db, str(workspace.id))
+        if wanted is None or _trash_key(r) in wanted
+    ]
+    if not records:
+        return success_response({"entries": [], "restored_count": 0, "not_found": list(wanted or [])})
+
+    taken = set(db.execute(
+        select(FileRecord.filename)
+        .where(FileRecord.workspace_id == str(workspace.id))
+        .where(FileRecord.status == "active")
+    ).scalars().all())
+
+    grouped: dict[str, list[FileRecord]] = {}
+    for record in records:
+        grouped.setdefault(_trash_key(record), []).append(record)
+
+    entries = []
+    for trash_id, group in grouped.items():
+        renamed = 0
+        for record in group:
+            target = record.filename
+            if target in taken:
+                target = _next_free_name(taken, _dirname(record.filename), _basename(record.filename))
+                renamed += 1
+            record.filename = target
+            record.status = "active"
+            record.deleted_at = None
+            record.trash_id = None
+            record.trash_path = None
+            taken.add(target)
+
+        counted = [r for r in group if _basename(r.filename) != KEEP_FILE]
+        entries.append({
+            "trash_id": trash_id,
+            "file_count": len(counted),
+            "renamed_count": renamed,
+            "files": [{"id": r.id, "filename": r.filename} for r in counted],
+        })
+
+    db.commit()
+
+    found = set(grouped)
+    for entry in entries:
+        await _emit_event(
+            Event(
+                type="workspace.file.restored",
+                source=request.source or "human:user",
+                target="core",
+                payload={"trash_id": entry["trash_id"], "count": entry["file_count"]},
+            ),
+            workspace,
+            db,
+            token=x_workspace_token or workspace.password_hash,
+        )
+
+    return success_response({
+        "entries": entries,
+        "restored_count": sum(e["file_count"] for e in entries),
+        "not_found": sorted((wanted or set()) - found),
+    })
+
+
+@router.post("/files/trash/purge")
+async def purge_trash(
+    request: TrashActionRequest,
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete trash entries for real — records and stored bytes, unrecoverable.
+
+    `all=true` is the "empty trash" button. Storage failures don't stop the
+    sweep: a missing object is exactly what we were trying to achieve, and a
+    record left pointing at bytes that can't be removed is worse than an
+    orphaned object.
+    """
+    workspace = _resolve_workspace(db, request.network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    if not request.all and not request.trash_ids:
+        return json_response(ResponseCode.BAD_REQUEST, "Pass trash_ids or all=true")
+
+    wanted = None if request.all else set(request.trash_ids or [])
+    records = [
+        r for r in _trashed_records(db, str(workspace.id))
+        if wanted is None or _trash_key(r) in wanted
+    ]
+
+    store = get_file_store()
+    loop = asyncio.get_event_loop()
+    purged_ids = set()
+    storage_errors = 0
+
+    for record in records:
+        try:
+            await loop.run_in_executor(None, store.delete, record.storage_key)
+        except Exception:  # noqa: BLE001 — see docstring
+            storage_errors += 1
+            logger.warning("Trash purge: could not delete %s", record.storage_key, exc_info=True)
+        purged_ids.add(_trash_key(record))
+        db.delete(record)
+
+    db.commit()
+
+    if records:
+        await _emit_event(
+            Event(
+                type="workspace.trash.purged",
+                source=request.source or "human:user",
+                target="core",
+                payload={"count": len(records)},
+            ),
+            workspace,
+            db,
+            token=x_workspace_token or workspace.password_hash,
+        )
+
+    return success_response({
+        "purged_count": len(records),
+        "entry_count": len(purged_ids),
+        "storage_errors": storage_errors,
+        "not_found": sorted((wanted or set()) - purged_ids),
+    })
+
+
+# ---------------------------------------------------------------------------
 # GET /v1/files — list files
 # ---------------------------------------------------------------------------
 
@@ -310,6 +1116,210 @@ def list_files(
             for f in rows
         ],
         "total": total,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Browsing
+#
+# `GET /files` hands back one flat page of records and leaves the caller to
+# rebuild the folder tree from filename prefixes. That works until the page
+# limit cuts in: the client then derives its folders, counts and type filters
+# from an arbitrary slice of the workspace and has no way to know it.
+#
+# `GET /files/browse` does that derivation server-side, over every record in
+# scope: one folder's worth of subfolders and files, so a client can open the
+# root and walk down a level at a time instead of loading the whole workspace
+# to draw a tree.
+#
+# It must be declared before /files/{file_id}, or FastAPI matches "browse" as
+# a file ID.
+# ---------------------------------------------------------------------------
+
+def _file_payload(record: FileRecord, relative: str, kind: str, group: str) -> dict:
+    return {
+        "id": record.id,
+        "filename": record.filename,
+        "relative_name": relative,
+        "name": _basename(relative),
+        "content_type": record.content_type,
+        "size": record.size,
+        "uploaded_by": record.uploaded_by,
+        "channel_name": record.channel_name,
+        "status": record.status,
+        "created_at": record.created_at.isoformat() if record.created_at else None,
+        "kind": kind,
+        "type_group": group,
+    }
+
+
+@router.get("/files/browse")
+def browse_files(
+    network: str = Query(..., description="Network (workspace) ID or slug"),
+    path: str = Query("", description="Folder to browse; empty is the root"),
+    recursive: bool = Query(
+        False, description="False lists this level only; true flattens the whole subtree"
+    ),
+    include: str = Query("both", description="both | files | folders"),
+    q: Optional[str] = Query(None, description="Filter entries by name, case-insensitive"),
+    type_group: Optional[str] = Query(
+        None, alias="type", description=f"Filter files by group: {', '.join(FILTER_GROUPS)}"
+    ),
+    sort: str = Query("name", description="name | recent | size"),
+    order: Optional[str] = Query(None, description="asc | desc; defaults per sort key"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+):
+    """
+    What's inside one folder: its subfolders and its files.
+
+    Default (`recursive=false`) is one level, the way a file browser opens a
+    directory — the root call gives a client every top-level folder, and each
+    expand is another call. `recursive=true` flattens the whole subtree
+    instead, which is what a search or a "every image under here" filter wants.
+
+    Counts are the point of the endpoint, so they're deliberate:
+
+      per folder   `file_count` sits directly inside, `total_count` includes
+                   its subtree, `folder_count` is how many subfolders it has —
+                   enough to decide whether a node can be expanded
+      `total`      files matching everything (path, q, type), before paging
+      `scope_total` files matching path and q, before the type filter
+      `type_counts` the same set broken down by type, so a filter menu can say
+                   what picking each type would give you
+
+    `.keep` placeholders keep empty folders alive and never count as files.
+    Paging applies to files only; folders come back whole.
+    """
+    workspace = _resolve_workspace(db, network)
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Invalid workspace credentials")
+
+    if include not in ("both", "files", "folders"):
+        return json_response(ResponseCode.BAD_REQUEST, "include must be both, files or folders")
+    if sort not in ("name", "recent", "size"):
+        return json_response(ResponseCode.BAD_REQUEST, "sort must be name, recent or size")
+    if order not in (None, "asc", "desc"):
+        return json_response(ResponseCode.BAD_REQUEST, "order must be asc or desc")
+    if type_group and type_group not in FILTER_GROUPS:
+        return json_response(
+            ResponseCode.BAD_REQUEST, f"type must be one of: {', '.join(FILTER_GROUPS)}"
+        )
+
+    folder = _normalize_folder_path(path) if path else None
+    if path and folder is None:
+        return json_response(ResponseCode.BAD_REQUEST, "Invalid path")
+
+    query = (
+        select(FileRecord)
+        .where(FileRecord.workspace_id == str(workspace.id))
+        .where(FileRecord.status == "active")
+    )
+    if folder:
+        # autoescape: `startswith` compiles to LIKE, where `_` matches any
+        # single character — and "uploaded_files/" is a real folder here.
+        query = query.where(FileRecord.filename.startswith(f"{folder}/", autoescape=True))
+
+    records = db.execute(query).scalars().all()
+
+    # The subtree is fetched whole and walked here. Folder counts need every
+    # descendant record anyway, and type classification can't be expressed in
+    # SQL — the alternative, a `kind` column, would have to be backfilled and
+    # kept in step with the frontend's mapping by hand.
+    prefix = f"{folder}/" if folder else ""
+    needle = q.lower() if q else None
+    want_files = include in ("both", "files")
+    want_folders = include in ("both", "folders")
+
+    direct_counts: dict[str, int] = {}    # relative folder -> files sitting in it
+    total_counts: dict[str, int] = {}     # relative folder -> files in its subtree
+    child_folders: dict[str, set[str]] = {}
+    type_counts: dict[str, int] = {}
+    matched: list[tuple[FileRecord, str, str, str]] = []  # record, relative, kind, group
+
+    for record in records:
+        relative = record.filename[len(prefix):] if prefix else record.filename
+        is_keep = _basename(relative) == KEEP_FILE
+        rel_folder = _dirname(relative)
+
+        if want_folders and rel_folder:
+            segments = rel_folder.split("/")
+            for i in range(len(segments)):
+                ancestor = "/".join(segments[: i + 1])
+                direct_counts.setdefault(ancestor, 0)
+                total_counts.setdefault(ancestor, 0)
+                child_folders.setdefault(ancestor, set())
+                if i > 0:
+                    child_folders["/".join(segments[:i])].add(ancestor)
+                if not is_keep:
+                    total_counts[ancestor] += 1
+            if not is_keep:
+                direct_counts[rel_folder] += 1
+
+        if not want_files or is_keep:
+            continue
+        if not recursive and rel_folder:
+            continue
+        if needle and needle not in relative.lower():
+            continue
+
+        kind = kind_for(record.filename, record.content_type)
+        group = KIND_GROUPS[kind]
+        type_counts[group] = type_counts.get(group, 0) + 1
+
+        if type_group and group != type_group:
+            continue
+        matched.append((record, relative, kind, group))
+
+    descending = (order == "desc") if order else sort in ("recent", "size")
+    if sort == "size":
+        matched.sort(key=lambda m: m[0].size or 0, reverse=descending)
+    elif sort == "recent":
+        matched.sort(
+            key=lambda m: m[0].created_at.timestamp() if m[0].created_at else 0.0,
+            reverse=descending,
+        )
+    else:
+        matched.sort(key=lambda m: m[1].lower(), reverse=descending)
+
+    page = matched[offset:offset + limit]
+
+    # Folders are matched by their own name, not by what's inside them: a
+    # search for "report" should surface a folder called reports, not every
+    # folder that happens to hold a report.
+    folders = []
+    for relative_path in sorted(direct_counts):
+        if not recursive and "/" in relative_path:
+            continue
+        if needle and needle not in _basename(relative_path).lower():
+            continue
+        folders.append({
+            "name": _basename(relative_path),
+            "path": f"{folder}/{relative_path}" if folder else relative_path,
+            "relative_path": relative_path,
+            "depth": relative_path.count("/"),
+            "file_count": direct_counts[relative_path],
+            "folder_count": len(child_folders.get(relative_path, ())),
+            "total_count": total_counts[relative_path],
+        })
+
+    return success_response({
+        "path": folder or "",
+        "recursive": recursive,
+        "folders": folders,
+        "folder_total": len(folders),
+        "files": [_file_payload(*entry) for entry in page],
+        "total": len(matched),
+        "scope_total": sum(type_counts.values()),
+        "type_counts": type_counts,
+        "limit": limit,
+        "offset": offset,
     })
 
 

--- a/workspace/backend/tests/test_file_browse.py
+++ b/workspace/backend/tests/test_file_browse.py
@@ -1,0 +1,559 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the folder-aware file endpoints:
+
+    GET  /v1/files/browse   list one folder — its subfolders and its files
+    POST /v1/files/upload   upload into a folder, keeping the filename
+
+Both are additions. `GET /v1/files` pages at 50 records and leaves the client
+to rebuild folders and counts from whatever slice it got; `POST /v1/files`
+rewrites bare names into uploaded_files/<timestamp>_<name>. Neither behaviour
+changes — these tests cover the new endpoints alongside them.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.file_types import group_for, kind_for
+from app.models import FileRecord
+
+BASE_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _headers(workspace):
+    return {"X-Workspace-Token": workspace["token"]}
+
+
+def _add_files(db, workspace, entries):
+    """
+    Insert file records directly.
+
+    Going through the upload API would add indirection these read-only
+    endpoints don't exercise — and a storage round-trip per fixture file.
+    `entries` is (filename, content_type, size); created_at increases with the
+    index so ordering has something to sort on.
+    """
+    for i, (filename, content_type, size) in enumerate(entries):
+        db.add(FileRecord(
+            workspace_id=workspace["id"],
+            filename=filename,
+            content_type=content_type,
+            size=size,
+            storage_key=f"test/{workspace['id']}/{i}",
+            uploaded_by="human:user",
+            status="active",
+            created_at=BASE_TIME + timedelta(minutes=i),
+        ))
+    db.commit()
+
+
+def _browse(client, workspace, **params):
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    resp = client.get(
+        f"/v1/files/browse?network={workspace['id']}{'&' + query if query else ''}",
+        headers=_headers(workspace),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.fixture
+def populated(db, workspace):
+    """
+    A small tree:
+
+        docs/report.pdf
+        docs/notes.md
+        docs/deep/data.csv
+        media/shot.png
+        media/clip.mp4
+        empty/.keep          (an empty folder)
+        top.txt              (at the root)
+    """
+    _add_files(db, workspace, [
+        ("docs/report.pdf", "application/pdf", 300),
+        ("docs/notes.md", "text/markdown", 40),
+        ("docs/deep/data.csv", "text/csv", 120),
+        ("media/shot.png", "image/png", 900),
+        ("media/clip.mp4", "video/mp4", 5000),
+        ("top.txt", "text/plain", 10),
+        ("empty/.keep", "application/octet-stream", 0),
+    ])
+    return workspace
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/files/browse — one level at a time
+# ---------------------------------------------------------------------------
+
+class TestBrowseOneLevel:
+
+    def test_root_lists_top_level_folders_only(self, client, populated):
+        data = _browse(client, populated)["data"]
+
+        assert [f["path"] for f in data["folders"]] == ["docs", "empty", "media"]
+        # docs/deep is a level down — it belongs to the next call
+        assert "docs/deep" not in [f["path"] for f in data["folders"]]
+
+    def test_root_lists_root_files_only(self, client, populated):
+        data = _browse(client, populated)["data"]
+
+        assert [f["relative_name"] for f in data["files"]] == ["top.txt"]
+        assert data["total"] == 1
+
+    def test_expanding_a_folder_returns_its_own_level(self, client, populated):
+        data = _browse(client, populated, path="docs")["data"]
+
+        assert data["path"] == "docs"
+        assert [f["path"] for f in data["folders"]] == ["docs/deep"]
+        assert [f["relative_name"] for f in data["files"]] == ["notes.md", "report.pdf"]
+
+    def test_folder_counts_describe_the_subtree(self, client, populated):
+        folders = {f["path"]: f for f in _browse(client, populated)["data"]["folders"]}
+
+        assert folders["docs"]["file_count"] == 2      # report.pdf, notes.md
+        assert folders["docs"]["total_count"] == 3     # + deep/data.csv
+        assert folders["docs"]["folder_count"] == 1    # deep — so it can expand
+        assert folders["media"]["folder_count"] == 0   # a leaf: no expander
+        assert folders["docs"]["name"] == "docs"
+
+    def test_empty_folder_is_listed_but_holds_nothing(self, client, populated):
+        folders = {f["path"]: f for f in _browse(client, populated)["data"]["folders"]}
+
+        assert folders["empty"]["file_count"] == 0
+        assert folders["empty"]["total_count"] == 0
+        assert folders["empty"]["folder_count"] == 0
+
+    def test_keep_placeholders_are_never_files(self, client, populated):
+        data = _browse(client, populated, path="empty")["data"]
+
+        assert data["files"] == []
+        assert data["total"] == 0
+
+    def test_nested_folder_paths_are_absolute_and_relative(self, client, populated):
+        folder = _browse(client, populated, path="docs")["data"]["folders"][0]
+
+        assert folder["path"] == "docs/deep"          # what to browse next
+        assert folder["relative_path"] == "deep"      # where it sits in this call
+        assert folder["depth"] == 0
+
+    def test_rejects_a_path_that_escapes_the_workspace(self, client, populated):
+        resp = client.get(
+            f"/v1/files/browse?network={populated['id']}&path=../etc",
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+    def test_requires_a_valid_token(self, client, populated):
+        resp = client.get(f"/v1/files/browse?network={populated['id']}")
+        assert resp.json()["code"] == 401
+
+
+class TestBrowseRecursive:
+
+    def test_flattens_the_whole_subtree(self, client, populated):
+        data = _browse(client, populated, recursive="true")["data"]
+
+        assert {f["relative_name"] for f in data["files"]} == {
+            "docs/report.pdf", "docs/notes.md", "docs/deep/data.csv",
+            "media/shot.png", "media/clip.mp4", "top.txt",
+        }
+        assert data["total"] == 6
+
+    def test_returns_every_descendant_folder(self, client, populated):
+        data = _browse(client, populated, recursive="true")["data"]
+
+        assert [f["path"] for f in data["folders"]] == [
+            "docs", "docs/deep", "empty", "media",
+        ]
+        assert {f["path"]: f["depth"] for f in data["folders"]}["docs/deep"] == 1
+
+    def test_names_stay_relative_to_the_browsed_folder(self, client, populated):
+        data = _browse(client, populated, path="docs", recursive="true")["data"]
+
+        assert {f["relative_name"] for f in data["files"]} == {
+            "report.pdf", "notes.md", "deep/data.csv",
+        }
+        # the absolute path is still there to download or delete by
+        assert {f["filename"] for f in data["files"]} == {
+            "docs/report.pdf", "docs/notes.md", "docs/deep/data.csv",
+        }
+
+
+class TestBrowseInclude:
+
+    def test_files_only(self, client, populated):
+        data = _browse(client, populated, include="files")["data"]
+
+        assert data["folders"] == []
+        assert data["files"]
+
+    def test_folders_only(self, client, populated):
+        data = _browse(client, populated, include="folders")["data"]
+
+        assert data["folders"]
+        assert data["files"] == []
+        assert data["total"] == 0
+
+    def test_rejects_an_unknown_value(self, client, populated):
+        resp = client.get(
+            f"/v1/files/browse?network={populated['id']}&include=everything",
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+
+class TestBrowseSearch:
+
+    def test_matches_files_by_name(self, client, populated):
+        data = _browse(client, populated, recursive="true", q="report")["data"]
+
+        assert [f["relative_name"] for f in data["files"]] == ["docs/report.pdf"]
+
+    def test_is_case_insensitive(self, client, populated):
+        data = _browse(client, populated, recursive="true", q="REPORT")["data"]
+
+        assert data["total"] == 1
+
+    def test_matches_folders_by_their_own_name(self, client, populated):
+        """A folder matches on what it's called, not on what's inside it."""
+        data = _browse(client, populated, recursive="true", q="report")["data"]
+
+        # docs holds report.pdf, but docs isn't called "report"
+        assert data["folders"] == []
+        assert [f["relative_name"] for f in data["files"]] == ["docs/report.pdf"]
+
+    def test_matches_files_on_their_path_too(self, client, populated):
+        """Searching a folder's name is a reasonable way to ask for its files."""
+        data = _browse(client, populated, recursive="true", q="deep")["data"]
+
+        assert [f["path"] for f in data["folders"]] == ["docs/deep"]
+        assert [f["relative_name"] for f in data["files"]] == ["docs/deep/data.csv"]
+
+    def test_combines_with_the_type_filter(self, client, populated):
+        data = _browse(client, populated, recursive="true", q="docs", type="documents")["data"]
+
+        assert data["total"] == 2      # report.pdf + notes.md, not deep/data.csv
+        assert data["type_counts"] == {"documents": 2, "sheets": 1}
+
+    def test_wildcards_are_literal(self, client, db, workspace):
+        _add_files(db, workspace, [
+            ("logs/100%_done.txt", "text/plain", 10),
+            ("logs/other.txt", "text/plain", 10),
+        ])
+        data = _browse(client, workspace, recursive="true", q="100%25_")["data"]
+
+        assert [f["name"] for f in data["files"]] == ["100%_done.txt"]
+
+
+class TestBrowseTypeCounts:
+
+    def test_counts_cover_the_whole_scope(self, client, populated):
+        data = _browse(client, populated, recursive="true")["data"]
+
+        assert data["type_counts"] == {
+            "documents": 3,   # report.pdf, notes.md, top.txt
+            "sheets": 1,      # data.csv
+            "images": 1,      # shot.png
+            "video": 1,       # clip.mp4
+        }
+        assert data["scope_total"] == 6
+
+    def test_filtering_narrows_files_but_not_counts(self, client, populated):
+        data = _browse(client, populated, recursive="true", type="images")["data"]
+
+        assert data["total"] == 1
+        assert data["files"][0]["relative_name"] == "media/shot.png"
+        # the menu still has to say what the other types would give you
+        assert data["type_counts"]["documents"] == 3
+        assert data["scope_total"] == 6
+
+    def test_counts_follow_the_folder(self, client, populated):
+        data = _browse(client, populated, path="media")["data"]
+
+        assert data["type_counts"] == {"images": 1, "video": 1}
+
+    def test_counts_respect_the_level(self, client, populated):
+        """Non-recursive counts describe this level, not the subtree."""
+        assert _browse(client, populated, path="docs")["data"]["type_counts"] == {
+            "documents": 2,
+        }
+        assert _browse(client, populated, path="docs", recursive="true")["data"]["type_counts"] == {
+            "documents": 2, "sheets": 1,
+        }
+
+    def test_reports_kind_and_group_per_file(self, client, populated):
+        files = {f["name"]: f for f in _browse(client, populated, path="docs")["data"]["files"]}
+
+        assert files["report.pdf"]["kind"] == "pdf"
+        assert files["report.pdf"]["type_group"] == "documents"
+        assert files["notes.md"]["kind"] == "markdown"
+
+    def test_rejects_an_unknown_type(self, client, populated):
+        resp = client.get(
+            f"/v1/files/browse?network={populated['id']}&type=spreadsheets",
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+
+class TestBrowseSortingAndPaging:
+
+    def test_sorts_by_name_ascending_by_default(self, client, populated):
+        data = _browse(client, populated, path="docs", recursive="true")["data"]
+
+        assert [f["relative_name"] for f in data["files"]] == [
+            "deep/data.csv", "notes.md", "report.pdf",
+        ]
+
+    def test_sorts_by_size_largest_first(self, client, populated):
+        data = _browse(client, populated, recursive="true", sort="size")["data"]
+        sizes = [f["size"] for f in data["files"]]
+
+        assert sizes == sorted(sizes, reverse=True)
+
+    def test_sorts_by_recency_newest_first(self, client, populated):
+        data = _browse(client, populated, recursive="true", sort="recent")["data"]
+        stamps = [f["created_at"] for f in data["files"]]
+
+        assert stamps == sorted(stamps, reverse=True)
+
+    def test_order_overrides_the_default_direction(self, client, populated):
+        data = _browse(client, populated, recursive="true", sort="size", order="asc")["data"]
+        sizes = [f["size"] for f in data["files"]]
+
+        assert sizes == sorted(sizes)
+
+    def test_rejects_an_unknown_sort_key(self, client, populated):
+        resp = client.get(
+            f"/v1/files/browse?network={populated['id']}&sort=colour",
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+    def test_paging_walks_the_whole_scope(self, client, populated):
+        seen = []
+        for offset in (0, 2, 4, 6):
+            data = _browse(client, populated, recursive="true", limit=2, offset=offset)["data"]
+            assert data["total"] == 6      # total is the scope, not the page
+            seen.extend(f["relative_name"] for f in data["files"])
+
+        assert len(seen) == 6 and len(set(seen)) == 6
+
+    def test_sees_past_the_flat_list_page_limit(self, client, db, workspace):
+        """The whole point: GET /v1/files caps at 50, browse doesn't."""
+        _add_files(db, workspace, [
+            (f"bulk/file-{i:03d}.txt", "text/plain", 10) for i in range(60)
+        ])
+
+        flat = client.get(
+            f"/v1/files?network={workspace['id']}", headers=_headers(workspace)
+        ).json()["data"]
+        assert len(flat["files"]) == 50        # unchanged, still paging
+
+        data = _browse(client, workspace, path="bulk", limit=500)["data"]
+        assert data["total"] == 60
+        assert len(data["files"]) == 60
+
+        folder = _browse(client, workspace)["data"]["folders"][0]
+        assert folder["file_count"] == 60
+        assert folder["total_count"] == 60
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/files/upload
+# ---------------------------------------------------------------------------
+
+def _upload(client, workspace, files, **fields):
+    """files: list of (filename, content, content_type)."""
+    resp = client.post(
+        "/v1/files/upload",
+        data={"network": workspace["id"], **fields},
+        files=[("files", f) for f in files],
+        headers=_headers(workspace),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestUploadToFolder:
+
+    def test_keeps_the_filename_and_lands_in_the_folder(self, client, workspace):
+        body = _upload(
+            client, workspace,
+            [("report.pdf", b"pdf-bytes", "application/pdf")],
+            path="docs",
+        )
+        uploaded = body["data"]["files"][0]
+
+        # POST /v1/files would have made this uploaded_files/<stamp>_report.pdf
+        assert uploaded["filename"] == "docs/report.pdf"
+        assert uploaded["name"] == "report.pdf"
+        assert uploaded["kind"] == "pdf"
+        assert uploaded["type_group"] == "documents"
+        assert body["data"]["uploaded_count"] == 1
+
+    def test_no_path_lands_at_the_root(self, client, workspace):
+        body = _upload(client, workspace, [("top.txt", b"x", "text/plain")])
+
+        assert body["data"]["files"][0]["filename"] == "top.txt"
+
+    def test_uploads_several_files_at_once(self, client, workspace):
+        body = _upload(
+            client, workspace,
+            [
+                ("a.txt", b"a", "text/plain"),
+                ("b.png", b"b", "image/png"),
+                ("c.csv", b"c", "text/csv"),
+            ],
+            path="batch",
+        )
+
+        assert body["data"]["uploaded_count"] == 3
+        assert {f["name"] for f in body["data"]["files"]} == {"a.txt", "b.png", "c.csv"}
+
+    def test_the_file_shows_up_in_browse(self, client, workspace):
+        _upload(client, workspace, [("note.md", b"# hi", "text/markdown")], path="docs")
+        data = _browse(client, workspace, path="docs")["data"]
+
+        assert [f["name"] for f in data["files"]] == ["note.md"]
+
+    def test_directory_parts_in_the_name_are_dropped(self, client, workspace):
+        """The folder comes from `path`; a name is only ever a leaf."""
+        body = _upload(
+            client, workspace,
+            [("../../etc/passwd", b"x", "text/plain")],
+            path="docs",
+        )
+
+        assert body["data"]["files"][0]["filename"] == "docs/passwd"
+
+    def test_rejects_an_invalid_path(self, client, workspace):
+        resp = client.post(
+            "/v1/files/upload",
+            data={"network": workspace["id"], "path": "../escape"},
+            files=[("files", ("a.txt", b"a", "text/plain"))],
+            headers=_headers(workspace),
+        )
+        assert resp.json()["code"] == 400
+
+    def test_requires_a_valid_token(self, client, workspace):
+        resp = client.post(
+            "/v1/files/upload",
+            data={"network": workspace["id"]},
+            files=[("files", ("a.txt", b"a", "text/plain"))],
+        )
+        assert resp.json()["code"] == 401
+
+    def test_skips_a_reserved_name_and_keeps_the_rest(self, client, workspace):
+        body = _upload(
+            client, workspace,
+            [(".keep", b"", "text/plain"), ("real.txt", b"x", "text/plain")],
+            path="docs",
+        )
+        data = body["data"]
+
+        assert data["uploaded_count"] == 1
+        assert data["files"][0]["name"] == "real.txt"
+        assert data["skipped"] == [{"filename": ".keep", "reason": "invalid_name"}]
+
+
+class TestUploadConflicts:
+
+    def test_renames_by_default(self, client, workspace):
+        _upload(client, workspace, [("report.pdf", b"v1", "application/pdf")], path="docs")
+        body = _upload(client, workspace, [("report.pdf", b"v2", "application/pdf")], path="docs")
+        uploaded = body["data"]["files"][0]
+
+        assert uploaded["filename"] == "docs/report (2).pdf"
+        assert uploaded["renamed_from"] == "report.pdf"
+
+    def test_renaming_counts_up(self, client, workspace):
+        for _ in range(3):
+            _upload(client, workspace, [("a.txt", b"x", "text/plain")], path="docs")
+
+        names = {f["name"] for f in _browse(client, workspace, path="docs")["data"]["files"]}
+        assert names == {"a.txt", "a (2).txt", "a (3).txt"}
+
+    def test_two_files_of_the_same_name_in_one_request(self, client, workspace):
+        body = _upload(
+            client, workspace,
+            [("dup.txt", b"1", "text/plain"), ("dup.txt", b"2", "text/plain")],
+            path="docs",
+        )
+
+        assert {f["name"] for f in body["data"]["files"]} == {"dup.txt", "dup (2).txt"}
+
+    def test_a_dotfile_keeps_its_whole_name(self, client, workspace):
+        _upload(client, workspace, [(".env", b"1", "text/plain")], path="cfg")
+        body = _upload(client, workspace, [(".env", b"2", "text/plain")], path="cfg")
+
+        assert body["data"]["files"][0]["name"] == ".env (2)"
+
+    def test_replace_soft_deletes_the_old_record(self, client, workspace):
+        first = _upload(client, workspace, [("r.txt", b"v1", "text/plain")], path="docs")
+        body = _upload(
+            client, workspace,
+            [("r.txt", b"v2", "text/plain")],
+            path="docs", on_conflict="replace",
+        )
+        uploaded = body["data"]["files"][0]
+
+        assert uploaded["filename"] == "docs/r.txt"
+        assert uploaded["replaced"] is True
+        assert uploaded["id"] != first["data"]["files"][0]["id"]
+        # one live file under that name, not two
+        assert [f["name"] for f in _browse(client, workspace, path="docs")["data"]["files"]] == ["r.txt"]
+
+    def test_error_mode_skips_the_clashing_file(self, client, workspace):
+        _upload(client, workspace, [("r.txt", b"v1", "text/plain")], path="docs")
+        body = _upload(
+            client, workspace,
+            [("r.txt", b"v2", "text/plain"), ("new.txt", b"x", "text/plain")],
+            path="docs", on_conflict="error",
+        )
+        data = body["data"]
+
+        assert data["skipped"] == [{"filename": "r.txt", "reason": "exists"}]
+        assert [f["name"] for f in data["files"]] == ["new.txt"]
+
+    def test_rejects_an_unknown_conflict_mode(self, client, workspace):
+        resp = client.post(
+            "/v1/files/upload",
+            data={"network": workspace["id"], "on_conflict": "merge"},
+            files=[("files", ("a.txt", b"a", "text/plain"))],
+            headers=_headers(workspace),
+        )
+        assert resp.json()["code"] == 400
+
+
+# ---------------------------------------------------------------------------
+# Classification — the mapping the frontend mirrors in file-utils.tsx
+# ---------------------------------------------------------------------------
+
+class TestClassification:
+
+    @pytest.mark.parametrize("filename,content_type,kind,group", [
+        ("a.pdf", "application/pdf", "pdf", "documents"),
+        ("REPORT.DOCX", "application/octet-stream", "doc", "documents"),
+        ("data.csv", "text/csv", "sheet", "sheets"),
+        ("deck.pptx", "", "slides", "slides"),
+        ("notes.md", "", "markdown", "documents"),
+        ("main.py", "application/octet-stream", "code", "code"),
+        ("shot.PNG", "", "image", "images"),
+        ("song.mp3", "", "audio", "audio"),
+        ("clip.mov", "", "video", "video"),
+        ("page.html", "text/html", "web", "web"),
+        ("https://example.com", "", "web", "web"),
+        ("bundle.tar.gz", "", "archive", "archives"),
+        ("mystery", "application/octet-stream", "unknown", "other"),
+        ("noext", "image/png", "image", "images"),
+    ])
+    def test_kind_and_group(self, filename, content_type, kind, group):
+        assert kind_for(filename, content_type) == kind
+        assert group_for(filename, content_type) == group
+
+    def test_extension_beats_content_type(self):
+        """Uploads routinely arrive as octet-stream; the name is what shows."""
+        assert kind_for("report.pdf", "application/octet-stream") == "pdf"

--- a/workspace/backend/tests/test_file_trash.py
+++ b/workspace/backend/tests/test_file_trash.py
@@ -1,0 +1,434 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the trash:
+
+    POST /v1/files/trash          move files/folders to the trash
+    GET  /v1/files/trash          list it
+    POST /v1/files/trash/restore  put entries back
+    POST /v1/files/trash/purge    destroy them for good
+
+All four are additions. The existing DELETE routes still soft-delete exactly as
+they did; what's new is that a deletion now records when it happened and which
+records went away together, so it can be shown and undone. Records deleted the
+old way (no trash metadata) must still show up — there's a test for that.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models import FileRecord
+from app.storage import get_file_store
+
+BASE_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _headers(workspace):
+    return {"X-Workspace-Token": workspace["token"]}
+
+
+def _add_files(db, workspace, entries):
+    """Insert active file records directly. `entries` is (filename, content_type, size)."""
+    for i, (filename, content_type, size) in enumerate(entries):
+        db.add(FileRecord(
+            workspace_id=workspace["id"],
+            filename=filename,
+            content_type=content_type,
+            size=size,
+            storage_key=f"test/{workspace['id']}/{i}",
+            uploaded_by="human:user",
+            status="active",
+            created_at=BASE_TIME + timedelta(minutes=i),
+        ))
+    db.commit()
+
+
+def _file_id(db, workspace, filename):
+    return db.query(FileRecord).filter(
+        FileRecord.workspace_id == workspace["id"],
+        FileRecord.filename == filename,
+        FileRecord.status == "active",
+    ).one().id
+
+
+def _trash(client, workspace, **body):
+    resp = client.post(
+        "/v1/files/trash",
+        json={"network": workspace["id"], **body},
+        headers=_headers(workspace),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _list_trash(client, workspace):
+    resp = client.get(
+        f"/v1/files/trash?network={workspace['id']}", headers=_headers(workspace)
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+def _restore(client, workspace, **body):
+    resp = client.post(
+        "/v1/files/trash/restore",
+        json={"network": workspace["id"], **body},
+        headers=_headers(workspace),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _purge(client, workspace, **body):
+    resp = client.post(
+        "/v1/files/trash/purge",
+        json={"network": workspace["id"], **body},
+        headers=_headers(workspace),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _browse_names(client, workspace, path=""):
+    resp = client.get(
+        f"/v1/files/browse?network={workspace['id']}&path={path}&recursive=true",
+        headers=_headers(workspace),
+    )
+    return [f["relative_name"] for f in resp.json()["data"]["files"]]
+
+
+@pytest.fixture
+def populated(db, workspace):
+    """
+        docs/report.pdf
+        docs/notes.md
+        docs/deep/data.csv
+        media/shot.png
+        top.txt
+        empty/.keep
+    """
+    _add_files(db, workspace, [
+        ("docs/report.pdf", "application/pdf", 300),
+        ("docs/notes.md", "text/markdown", 40),
+        ("docs/deep/data.csv", "text/csv", 120),
+        ("media/shot.png", "image/png", 900),
+        ("top.txt", "text/plain", 10),
+        ("empty/.keep", "application/octet-stream", 0),
+    ])
+    return workspace
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/files/trash
+# ---------------------------------------------------------------------------
+
+class TestMoveToTrash:
+
+    def test_trashes_a_single_file(self, client, db, populated):
+        file_id = _file_id(db, populated, "top.txt")
+        entry = _trash(client, populated, file_ids=[file_id])["data"]["entries"][0]
+
+        assert entry["kind"] == "file"
+        assert entry["path"] == "top.txt"
+        assert entry["file_count"] == 1
+        assert "top.txt" not in _browse_names(client, populated)
+
+    def test_trashes_a_folder_as_one_entry(self, client, populated):
+        data = _trash(client, populated, paths=["docs"])["data"]
+        entry = data["entries"][0]
+
+        assert len(data["entries"]) == 1        # one entry, not three files
+        assert entry["kind"] == "folder"
+        assert entry["path"] == "docs"
+        assert entry["file_count"] == 3         # includes docs/deep/data.csv
+        assert entry["size"] == 460
+        assert _browse_names(client, populated) == ["media/shot.png", "top.txt"]
+
+    def test_trashes_files_and_folders_together(self, client, db, populated):
+        file_id = _file_id(db, populated, "top.txt")
+        data = _trash(client, populated, file_ids=[file_id], paths=["media"])["data"]
+
+        assert {e["kind"] for e in data["entries"]} == {"file", "folder"}
+        assert data["trashed_count"] == 2
+
+    def test_empty_folder_is_trashable(self, client, populated):
+        entry = _trash(client, populated, paths=["empty"])["data"]["entries"][0]
+
+        assert entry["kind"] == "folder"
+        assert entry["file_count"] == 0         # the .keep is not a file
+
+    def test_reports_what_it_could_not_find(self, client, populated):
+        data = _trash(client, populated, file_ids=["no-such-id"], paths=["nope"])["data"]
+
+        assert data["entries"] == []
+        assert set(data["not_found"]) == {"no-such-id", "nope"}
+
+    def test_a_stale_id_does_not_block_the_rest(self, client, db, populated):
+        file_id = _file_id(db, populated, "top.txt")
+        data = _trash(client, populated, file_ids=[file_id, "gone"])["data"]
+
+        assert data["trashed_count"] == 1
+        assert data["not_found"] == ["gone"]
+
+    def test_requires_something_to_delete(self, client, populated):
+        resp = client.post(
+            "/v1/files/trash",
+            json={"network": populated["id"]},
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+    def test_requires_a_valid_token(self, client, populated):
+        resp = client.post("/v1/files/trash", json={"network": populated["id"], "paths": ["docs"]})
+        assert resp.json()["code"] == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/files/trash
+# ---------------------------------------------------------------------------
+
+class TestListTrash:
+
+    def test_empty_to_begin_with(self, client, populated):
+        data = _list_trash(client, populated)
+
+        assert data["entries"] == []
+        assert data["total"] == 0
+
+    def test_one_entry_per_delete_action(self, client, db, populated):
+        _trash(client, populated, paths=["docs"])
+        _trash(client, populated, file_ids=[_file_id(db, populated, "top.txt")])
+        data = _list_trash(client, populated)
+
+        assert data["total"] == 2               # not 4 loose files
+        assert data["file_total"] == 4
+        assert {e["kind"] for e in data["entries"]} == {"folder", "file"}
+
+    def test_newest_first(self, client, db, populated):
+        _trash(client, populated, paths=["docs"])
+        _trash(client, populated, file_ids=[_file_id(db, populated, "top.txt")])
+        entries = _list_trash(client, populated)["entries"]
+
+        assert entries[0]["path"] == "top.txt"
+
+    def test_folder_entry_previews_its_files(self, client, populated):
+        _trash(client, populated, paths=["docs"])
+        entry = _list_trash(client, populated)["entries"][0]
+
+        assert entry["name"] == "docs"
+        assert [f["filename"] for f in entry["files"]] == [
+            "docs/deep/data.csv", "docs/notes.md", "docs/report.pdf",
+        ]
+        assert entry["files"][0]["kind"] == "sheet"
+
+    def test_records_deleted_the_old_way_still_show_up(self, client, db, populated):
+        """DELETE /v1/files/{id} predates the trash and writes no metadata."""
+        file_id = _file_id(db, populated, "top.txt")
+        resp = client.delete(f"/v1/files/{file_id}", headers=_headers(populated))
+        assert resp.status_code == 200
+
+        entries = _list_trash(client, populated)["entries"]
+        assert len(entries) == 1
+        assert entries[0]["kind"] == "file"
+        assert entries[0]["path"] == "top.txt"
+        assert entries[0]["deleted_at"] is None     # nothing recorded it
+        assert entries[0]["trash_id"] == file_id    # its own id stands in
+
+    def test_old_folder_deletes_stay_loose(self, client, populated):
+        """DELETE /files/folders tags nothing, so its files can't be regrouped."""
+        resp = client.delete(
+            f"/v1/files/folders?network={populated['id']}&path=docs",
+            headers=_headers(populated),
+        )
+        assert resp.status_code == 200
+
+        data = _list_trash(client, populated)
+        assert data["total"] == 3               # three separate file entries
+        assert data["file_total"] == 3
+
+    def test_requires_a_valid_token(self, client, populated):
+        resp = client.get(f"/v1/files/trash?network={populated['id']}")
+        assert resp.json()["code"] == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/files/trash/restore
+# ---------------------------------------------------------------------------
+
+class TestRestore:
+
+    def test_restores_a_file(self, client, db, populated):
+        file_id = _file_id(db, populated, "top.txt")
+        trash_id = _trash(client, populated, file_ids=[file_id])["data"]["entries"][0]["trash_id"]
+
+        data = _restore(client, populated, trash_ids=[trash_id])["data"]
+
+        assert data["restored_count"] == 1
+        assert "top.txt" in _browse_names(client, populated)
+        assert _list_trash(client, populated)["total"] == 0
+
+    def test_restores_a_folder_whole(self, client, populated):
+        trash_id = _trash(client, populated, paths=["docs"])["data"]["entries"][0]["trash_id"]
+
+        _restore(client, populated, trash_ids=[trash_id])
+
+        assert sorted(_browse_names(client, populated, "docs")) == [
+            "deep/data.csv", "notes.md", "report.pdf",
+        ]
+
+    def test_restores_everything(self, client, db, populated):
+        _trash(client, populated, paths=["docs"])
+        _trash(client, populated, file_ids=[_file_id(db, populated, "top.txt")])
+
+        data = _restore(client, populated, all=True)["data"]
+
+        assert data["restored_count"] == 4
+        assert _list_trash(client, populated)["total"] == 0
+
+    def test_renames_around_a_name_taken_since(self, client, db, populated):
+        file_id = _file_id(db, populated, "top.txt")
+        trash_id = _trash(client, populated, file_ids=[file_id])["data"]["entries"][0]["trash_id"]
+        _add_files(db, populated, [("top.txt", "text/plain", 99)])   # a new file took the name
+
+        data = _restore(client, populated, trash_ids=[trash_id])["data"]
+
+        assert data["entries"][0]["renamed_count"] == 1
+        assert data["entries"][0]["files"][0]["filename"] == "top (2).txt"
+        # both survive — restoring never overwrites
+        assert sorted(n for n in _browse_names(client, populated) if n.startswith("top")) == [
+            "top (2).txt", "top.txt",
+        ]
+
+    def test_restores_a_folder_that_no_longer_exists(self, client, populated):
+        """Folders are path prefixes, so restoring the files rebuilds the folder."""
+        trash_id = _trash(client, populated, paths=["media"])["data"]["entries"][0]["trash_id"]
+        assert "media" not in [
+            f["path"] for f in
+            client.get(
+                f"/v1/files/browse?network={populated['id']}", headers=_headers(populated)
+            ).json()["data"]["folders"]
+        ]
+
+        _restore(client, populated, trash_ids=[trash_id])
+
+        folders = client.get(
+            f"/v1/files/browse?network={populated['id']}", headers=_headers(populated)
+        ).json()["data"]["folders"]
+        assert "media" in [f["path"] for f in folders]
+
+    def test_restores_an_old_style_delete(self, client, db, populated):
+        file_id = _file_id(db, populated, "top.txt")
+        client.delete(f"/v1/files/{file_id}", headers=_headers(populated))
+
+        _restore(client, populated, trash_ids=[file_id])
+
+        assert "top.txt" in _browse_names(client, populated)
+
+    def test_reports_unknown_ids(self, client, populated):
+        _trash(client, populated, paths=["docs"])
+        data = _restore(client, populated, trash_ids=["nope"])["data"]
+
+        assert data["restored_count"] == 0
+        assert data["not_found"] == ["nope"]
+
+    def test_requires_ids_or_all(self, client, populated):
+        resp = client.post(
+            "/v1/files/trash/restore",
+            json={"network": populated["id"]},
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+    def test_requires_a_valid_token(self, client, populated):
+        resp = client.post("/v1/files/trash/restore", json={"network": populated["id"], "all": True})
+        assert resp.json()["code"] == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/files/trash/purge
+# ---------------------------------------------------------------------------
+
+class TestPurge:
+
+    def test_purges_one_entry(self, client, db, populated):
+        _trash(client, populated, paths=["docs"])
+        file_id = _file_id(db, populated, "top.txt")
+        keep = _trash(client, populated, file_ids=[file_id])["data"]["entries"][0]["trash_id"]
+        docs = [e for e in _list_trash(client, populated)["entries"] if e["kind"] == "folder"][0]
+
+        data = _purge(client, populated, trash_ids=[docs["trash_id"]])["data"]
+
+        assert data["purged_count"] == 3
+        remaining = _list_trash(client, populated)["entries"]
+        assert [e["trash_id"] for e in remaining] == [keep]
+
+    def test_empties_the_whole_trash(self, client, db, populated):
+        _trash(client, populated, paths=["docs"], file_ids=[_file_id(db, populated, "top.txt")])
+
+        data = _purge(client, populated, all=True)["data"]
+
+        assert data["entry_count"] == 2
+        assert _list_trash(client, populated)["total"] == 0
+
+    def test_purged_records_are_gone_from_the_database(self, client, db, populated):
+        _trash(client, populated, paths=["docs"])
+        _purge(client, populated, all=True)
+
+        assert db.query(FileRecord).filter(
+            FileRecord.workspace_id == populated["id"],
+            FileRecord.filename.like("docs/%"),
+        ).count() == 0
+
+    def test_purge_removes_the_stored_bytes(self, client, workspace):
+        """Soft delete keeps the bytes; purge is what actually frees them."""
+        resp = client.post(
+            "/v1/files/upload",
+            data={"network": workspace["id"], "path": "docs"},
+            files=[("files", ("real.txt", b"payload", "text/plain"))],
+            headers=_headers(workspace),
+        )
+        file_id = resp.json()["data"]["files"][0]["id"]
+
+        store = get_file_store()
+        key = f"{workspace['id']}/{file_id}/real.txt"
+        assert store.exists(key)
+
+        _trash(client, workspace, file_ids=[file_id])
+        assert store.exists(key)        # still recoverable
+
+        _purge(client, workspace, all=True)
+        assert not store.exists(key)
+
+    def test_purging_does_not_touch_live_files(self, client, db, populated):
+        _trash(client, populated, paths=["docs"])
+        _purge(client, populated, all=True)
+
+        assert sorted(_browse_names(client, populated)) == ["media/shot.png", "top.txt"]
+
+    def test_purged_entries_cannot_be_restored(self, client, populated):
+        trash_id = _trash(client, populated, paths=["docs"])["data"]["entries"][0]["trash_id"]
+        _purge(client, populated, all=True)
+
+        data = _restore(client, populated, trash_ids=[trash_id])["data"]
+
+        assert data["restored_count"] == 0
+        assert data["not_found"] == [trash_id]
+
+    def test_reports_unknown_ids(self, client, populated):
+        _trash(client, populated, paths=["docs"])
+        data = _purge(client, populated, trash_ids=["nope"])["data"]
+
+        assert data["purged_count"] == 0
+        assert data["not_found"] == ["nope"]
+
+    def test_requires_ids_or_all(self, client, populated):
+        resp = client.post(
+            "/v1/files/trash/purge",
+            json={"network": populated["id"]},
+            headers=_headers(populated),
+        )
+        assert resp.json()["code"] == 400
+
+    def test_requires_a_valid_token(self, client, populated):
+        resp = client.post("/v1/files/trash/purge", json={"network": populated["id"], "all": True})
+        assert resp.json()["code"] == 401


### PR DESCRIPTION
Backend-only. The workspace frontend work that consumes these endpoints stays on its own branch.

Folders remain purely logical — a path prefix on `FileRecord.filename`, with a zero-byte `.keep` record holding an empty one open — so all of this is prefix work over existing records rather than a new table.

## What's new

- **`GET /files/browse`** — walks one folder server-side and returns its subfolders, its files, per-folder counts (`file_count` / `folder_count` / `total_count`) and a type breakdown. The flat `GET /files` pages at 50 records and left the client rebuilding folders and counts from whatever slice it got, with no way to tell the slice was partial. `recursive=true` flattens a whole subtree for search.
- **`POST` / `PATCH` / `DELETE /files/folders`** — create, move and soft-delete a folder and everything under it. Moving a folder into itself is rejected; renaming rewrites the path prefix of every record under it.
- **`POST /files/upload`** — puts files in the folder the caller names, under their own names, with Finder-style `report (2).pdf` on collision (`on_conflict=rename|replace|error`). `POST /files` keeps its `uploaded_files/<ts>_<name>` rewriting, which agents rely on — hence a second route rather than a flag on the first.
- **Trash** — `files.deleted_at` / `trash_id` / `trash_path` (migration `027`) turn the existing soft delete into something listable and restorable:
  - `POST /files/trash` (move), `GET /files/trash` (list), `POST /files/trash/restore`, `POST /files/trash/purge`.
  - One entry per delete action, so a deleted folder comes back in one gesture. Restore renames around a taken name instead of overwriting.
  - Purge is the only route here that destroys anything.
  - Records deleted before the migration carry no trash metadata and list as their own single-file entries, so nothing is stranded.
- **`app/file_types.py`** — kind (`pdf`, `image`, `code`, …) and filter-group classification server-side, mirroring the frontend's `file-utils.tsx`, so a filter menu and a listing can't disagree. Extension wins over content type, since uploads routinely arrive as `application/octet-stream`.

## Notes

- The new `/files/browse` and `/files/trash*` routes are declared before `/files/{file_id}`; otherwise FastAPI matches `browse` as a file ID.
- Migration `027` revises `026` (`026_browser_tab_session_tracking`) and is idempotent — every add/drop is guarded by an inspector check.
- All new endpoints keep the existing auth path (`X-Workspace-Token` / bearer) and emit the same `workspace.file.*` events existing listeners already handle.

## Tests

97 tests across `tests/test_file_browse.py` and `tests/test_file_trash.py`, all passing locally (Python 3.12, sqlite).

The backend suite already has 20 failures on `develop` — browser contexts, events, login sessions, and `test_migration_schema` (the init SQL at `workspace/scripts/insforge-migration/0001_initial_schema.sql` still stamps `015`). Verified against a clean `develop` worktree: the same 20 fail there, and this branch changes none of them. `ruff check` / `ruff format --check` are likewise already non-clean on the backend files this touches; the new files follow the conventions of their neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)