### PR TITLE
fix(files): let the download route serve trashed files

### DIFF
--- a/workspace/backend/app/routers/files.py
+++ b/workspace/backend/app/routers/files.py
@@ -1385,12 +1385,20 @@ async def download_file(
     authorization: Optional[str] = Header(None),
     db: Session = Depends(get_db),
 ):
-    """Download a file by ID."""
+    """
+    Download a file by ID.
+
+    Trashed files stay readable. "deleted" means in the trash, not gone: the
+    Trash view lists those records and draws a thumbnail for the images among
+    them, which is what you decide a restore on. The bytes only disappear on
+    purge, and purge deletes the record too — so a purged file 404s here on the
+    record being missing, with no status check needed.
+    """
     record = db.execute(
         select(FileRecord).where(FileRecord.id == file_id)
     ).scalar_one_or_none()
 
-    if not record or record.status != "active":
+    if not record or record.status not in ("active", "deleted"):
         return json_response(ResponseCode.NOT_FOUND, "File not found")
 
     workspace = _resolve_workspace(db, str(record.workspace_id))


### PR DESCRIPTION
GET /v1/files/{file_id} rejected anything whose status wasn't "active", so every record in the trash 404'd. "deleted" means in the trash, not gone: the Trash view lists those records, and the images among them are the ones you decide a restore on — with the route closed they all fall back to a generic type glyph and there is no client-side fix, since this is the only route that serves bytes.

Purge is unaffected: it deletes the record along with the object, so a purged file still 404s here on the record being missing.

Not a widening of access. The workspace token check is untouched, the trash listing already returns these files' names, sizes and types to the same callers, and restoring one is a single request away. GET /files/{id}/info is left strict — nothing needs it for trashed records.