### PR TITLE
fix(launcher): auto-download updates, never quit into a dead installe…

### DIFF
--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openagents-launcher",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.8.22",
+      "version": "0.8.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1039,8 +1039,12 @@ function updateTrayMenu(): void {
   // Launcher self-update: once a background download has landed, offer an
   // immediate "restart to update" instead of waiting for the next quit.
   const launcherUpdate = getUpdaterState()
+  // Hidden once the handoff for this version is known to fail: the tray item
+  // would offer a restart that has already proven to install nothing, and
+  // unlike the banner the tray has nowhere to explain that.
   const launcherUpdateItems: Electron.MenuItemConstructorOptions[] =
-    launcherUpdate.status === "downloaded"
+    launcherUpdate.status === "downloaded" &&
+    launcherUpdate.installFailedVersion !== launcherUpdate.latestVersion
       ? [
           { type: "separator" },
           {
@@ -2564,6 +2568,14 @@ app.whenReady().then(async () => {
         if (agentManager) await agentManager.stopAll()
       } catch {}
     },
+    // beforeInstall already stopped the daemon by the time a handoff can fail.
+    // Without this the user is left in a running app with every agent offline
+    // and no way back short of a manual restart.
+    resumeAfterFailedInstall: async () => {
+      try {
+        if (agentManager) await agentManager._ensureDaemon()
+      } catch {}
+    },
     onDownloaded: (version) => {
       // A background auto-download finished. Make it discoverable: notify the
       // user and refresh the tray so "Restart to update" appears. The install
@@ -2852,9 +2864,33 @@ app.whenReady().then(async () => {
     const now = Date.now()
     if (minGapMs > 0 && now - _lastLauncherUpdateCheck < minGapMs) return
     _lastLauncherUpdateCheck = now
-    checkForUpdatesOnStartup().catch(() => {})
+    void checkForUpdatesOnStartup().then((ok) => {
+      // A check that never completed shouldn't hold the throttle window: the
+      // next foreground event should be free to retry immediately rather than
+      // waiting the gap out on the strength of a failure.
+      if (!ok) _lastLauncherUpdateCheck = 0
+    })
   }
-  setTimeout(() => launcherUpdateCheck(), 20000)
+
+  // The first check retries with a backoff instead of firing once and giving
+  // up. On a fresh install the 20s mark lands in the middle of the first-run
+  // Node/core downloads and — for users who bring up a VPN right after
+  // installing — often before the tunnel is. One silent failure there used to
+  // mean no update prompt at all for the next half hour, which reads as "the
+  // launcher never noticed the new version".
+  const STARTUP_CHECK_DELAYS = [20_000, 60_000, 180_000, 600_000]
+  const runStartupCheck = async (attempt = 0): Promise<void> => {
+    const ok = await checkForUpdatesOnStartup().catch(() => false)
+    if (ok) {
+      _lastLauncherUpdateCheck = Date.now()
+      return
+    }
+    const next = attempt + 1
+    if (next < STARTUP_CHECK_DELAYS.length) {
+      setTimeout(() => void runStartupCheck(next), STARTUP_CHECK_DELAYS[next])
+    }
+  }
+  setTimeout(() => void runStartupCheck(), STARTUP_CHECK_DELAYS[0])
   // Every 30 min (was every 4h — too long for a tray-resident app to ever
   // surface a fresh release while it stays open).
   setInterval(() => launcherUpdateCheck(), THIRTY_MIN)

--- a/packages/launcher/src/main/updater.ts
+++ b/packages/launcher/src/main/updater.ts
@@ -17,12 +17,10 @@ import electronUpdater, {
   type ProgressInfo,
   type UpdateDownloadedEvent,
 } from "electron-updater"
-import {
-  hasNonAsciiPathSegment,
-  launchUnicodeWindowsInstaller,
-} from "./windows-update-installer"
+import { launchWindowsUpdateInstaller } from "./windows-update-installer"
 import { DEFAULT_LAUNCHER_FEED, launcherFeedUrl } from "./mirror"
 import {
+  clearInstallAttempt,
   purgePendingUpdateCache,
   readUpdaterCacheDirName,
   recordInstallAttempt,
@@ -120,6 +118,9 @@ let _feedOverridden = false
 // fire for the same install, and double-counting would make a single failure
 // look like the second consecutive one.
 let _attemptRecordedFor: string | null = null
+// Guards against two downloads of the same package running at once — the
+// background auto-download and a user pressing Download can otherwise overlap.
+let _downloadInFlight = false
 
 // Path to the updater config electron-updater will actually read:
 // resources/app-update.yml when packaged, dev-app-update.yml otherwise. Falls
@@ -146,6 +147,10 @@ function noteInstallAttempt(version: string): void {
 // the overwrite silently fails and the relaunch comes back on the OLD version.
 // Must be awaited before handing off to the installer.
 let _beforeInstall: () => Promise<void> = async () => {}
+// Undoes _beforeInstall when the handoff fails and we stay running: the daemon
+// is already stopped at that point, so without this the user is left in a
+// half-torn-down app with every agent offline and no indication why.
+let _resumeAfterFailedInstall: () => Promise<void> = async () => {}
 
 function emit(patch: Partial<UpdaterState>): void {
   _state = { ..._state, ...patch }
@@ -166,6 +171,32 @@ function normalizeReleaseNotes(
     .join("\n\n")
 }
 
+/**
+ * The single place a download starts. electron-updater's own `autoDownload` is
+ * pinned off (see setupAutoUpdater) because it is read inside checkForUpdates(),
+ * which meant the answer to "should this download by itself?" depended on
+ * whichever code path had set the flag last. Opening Settings → Updates runs a
+ * check that used to force it off, so a user with automatic updates ON got
+ * "found v0.8.22" and then nothing — the reported behaviour exactly. Deciding
+ * here, on the event, removes that coupling entirely.
+ */
+async function startDownload(reason: string): Promise<void> {
+  if (_downloadInFlight) return
+  // Already staged — a second download would just re-verify the same file.
+  if (_state.status === "downloaded") return
+  _downloadInFlight = true
+  _log(`[updater] downloading v${_state.latestVersion ?? "?"} (${reason})`)
+  emit({ status: "downloading", percent: 0, error: null })
+  try {
+    await autoUpdater.downloadUpdate()
+  } catch (err) {
+    _log(`[updater] download failed: ${(err as Error).message}`)
+    emit({ status: "error", error: (err as Error).message })
+  } finally {
+    _downloadInFlight = false
+  }
+}
+
 function wireEvents(): void {
   autoUpdater.on("checking-for-update", () => {
     emit({ status: "checking", error: null })
@@ -184,6 +215,12 @@ function wireEvents(): void {
           ? _state.installFailedVersion
           : null,
     })
+    // Applies to every check — background, startup, or the one Settings fires
+    // when the Updates section opens. "Automatic updates" is a user setting
+    // about downloads, not about which screen happened to trigger the check.
+    if (_isAutoUpdateEnabled()) {
+      void startDownload("automatic updates are on")
+    }
   })
   autoUpdater.on("update-not-available", (info: UpdateInfo) => {
     emit({
@@ -218,52 +255,80 @@ function wireEvents(): void {
   })
 }
 
+/**
+ * The handoff failed and we are still running. Put the app back into a usable
+ * state and tell the renderer to stop offering a restart that does nothing —
+ * quitting into an installer that never starts is precisely the "launcher just
+ * exits and nothing happens" the user hit.
+ */
+async function abortInstall(detail: string): Promise<void> {
+  _log(`[updater] ERROR install handoff failed: ${detail}`)
+  ;(app as typeof app & { isQuitting: boolean }).isQuitting = false
+  // A package we could not even start would fail the same way on quit, with the
+  // app already gone and nothing left to report it.
+  autoUpdater.autoInstallOnAppQuit = false
+  // We never reached the installer, so the attempt marker would make the next
+  // launch report a phantom failed install.
+  clearInstallAttempt(app.getPath("userData"))
+  _attemptRecordedFor = null
+  // Keeps `status: "downloaded"`, so the banner and Settings both switch to the
+  // "install it manually" variant instead of silently dropping the update.
+  emit({ error: detail, installFailedVersion: _state.latestVersion })
+  try {
+    await _resumeAfterFailedInstall()
+  } catch (err) {
+    _log(`[updater] failed to resume after aborted install: ${(err as Error).message}`)
+  }
+}
+
 // Tear down agents/daemon, then hand off to the installer. Shared by the
 // Settings "Restart to install" button and the tray item so BOTH paths release
 // the file locks that would otherwise make the Windows overwrite install fail.
-async function quitAndInstallSafely(): Promise<void> {
+// Returns false when the app should stay up because nothing was launched.
+async function quitAndInstallSafely(): Promise<boolean> {
   // Mark quitting so the window `close` handler really quits (instead of hiding
   // to tray) and the before-quit teardown runs.
   ;(app as typeof app & { isQuitting: boolean }).isQuitting = true
-  // Remember what we're about to install. The installer runs after we exit, so
-  // this is the only chance to leave a marker; the next launch compares it
-  // against app.getVersion() to tell a real install from a silent no-op.
-  if (_state.latestVersion) noteInstallAttempt(_state.latestVersion)
   try {
     await _beforeInstall()
   } catch (err) {
     _log(`[updater] beforeInstall failed: ${(err as Error).message}`)
   }
 
-  // electron-updater normally launches the cached NSIS executable directly.
-  // On Windows that cache is below %LOCALAPPDATA%, so a Chinese username makes
-  // the executable path non-ASCII. Some Windows handoff/elevation paths reduce
-  // it through the active OEM code page and report a successful launch even
-  // though the installer never replaces the app. Pass the path in a UTF-16
-  // environment block and use PowerShell's Unicode Start-Process path instead.
-  if (
-    process.platform === "win32" &&
-    _downloadedFile &&
-    hasNonAsciiPathSegment(_downloadedFile)
-  ) {
-    try {
-      await launchUnicodeWindowsInstaller(_downloadedFile)
-      _log("[updater] launched installer through Unicode-safe Windows handoff")
-      // Prevent BaseUpdater's on-quit hook from launching the same installer a
-      // second time through the original (failing) path.
-      autoUpdater.autoInstallOnAppQuit = false
-      app.quit()
-      return
-    } catch (err) {
-      _log(
-        `[updater] Unicode-safe Windows handoff failed, falling back: ${(err as Error).message}`,
-      )
+  // Windows always goes through our own launcher rather than
+  // NsisUpdater.doInstall(). That one spawns the installer, returns true
+  // regardless, and BaseUpdater quits on the next tick — so a failure to start
+  // (elevation required, AV quarantine, a mangled path) is invisible and the
+  // app disappears without updating. launchWindowsUpdateInstaller confirms the
+  // process is actually alive, and escalates through UAC when Windows demands
+  // it, so "we quit" now implies "something is installing".
+  if (process.platform === "win32") {
+    if (!_downloadedFile) {
+      await abortInstall("no staged installer on disk")
+      return false
     }
+    const launch = await launchWindowsUpdateInstaller(_downloadedFile, _log)
+    if (!launch.ok) {
+      await abortInstall(launch.detail)
+      return false
+    }
+    _log(`[updater] ${launch.detail}`)
+    // Only now is an attempt real. The installer runs after we exit, so this is
+    // the last chance to leave a marker; the next launch compares it against
+    // app.getVersion() to tell a real install from a silent no-op.
+    if (_state.latestVersion) noteInstallAttempt(_state.latestVersion)
+    // Stop BaseUpdater's on-quit hook from launching a second copy of the same
+    // installer through the path we deliberately bypassed.
+    autoUpdater.autoInstallOnAppQuit = false
+    app.quit()
+    return true
   }
 
+  if (_state.latestVersion) noteInstallAttempt(_state.latestVersion)
   // Give the OS a tick to release the just-killed child processes' handles
   // before the installer tries to overwrite the app directory.
   setImmediate(() => autoUpdater.quitAndInstall(false, true))
+  return true
 }
 
 function registerIpc(): void {
@@ -275,10 +340,8 @@ function registerIpc(): void {
   ipcMain.handle("updater:check", async () => {
     if (!_state.supported) return _state
     try {
-      // A manual check from Settings is user-driven: never auto-download here,
-      // the page has its own Download button. Background checks
-      // (checkForUpdatesOnStartup) are what honor the auto-update setting.
-      autoUpdater.autoDownload = false
+      // Whether a found update downloads by itself is decided in the
+      // update-available handler, from the live setting — not here.
       await autoUpdater.checkForUpdates()
     } catch (err) {
       emit({ status: "error", error: (err as Error).message })
@@ -288,21 +351,13 @@ function registerIpc(): void {
 
   ipcMain.handle("updater:download", async () => {
     if (!_state.supported) return _state
-    // Guard against a redundant download once we already have the package.
-    if (_state.status === "downloaded") return _state
-    try {
-      emit({ status: "downloading", percent: 0, error: null })
-      await autoUpdater.downloadUpdate()
-    } catch (err) {
-      emit({ status: "error", error: (err as Error).message })
-    }
+    await startDownload("user pressed Download")
     return _state
   })
 
   ipcMain.handle("updater:install", async () => {
     if (!_state.supported || _state.status !== "downloaded") return false
-    await quitAndInstallSafely()
-    return true
+    return await quitAndInstallSafely()
   })
 }
 
@@ -336,6 +391,8 @@ export function setupAutoUpdater(opts: {
   isAutoUpdateEnabled: () => boolean
   onDownloaded: (version: string) => void
   beforeInstall: () => Promise<void>
+  /** Bring the daemon back up when a handoff failed and we stay running. */
+  resumeAfterFailedInstall?: () => Promise<void>
   /** Persisted `updateFeedUrl` — blank means use the packaged origin. */
   feedUrlOverride?: unknown
 }): void {
@@ -344,6 +401,8 @@ export function setupAutoUpdater(opts: {
   _isAutoUpdateEnabled = opts.isAutoUpdateEnabled
   _onDownloaded = opts.onDownloaded
   _beforeInstall = opts.beforeInstall
+  if (opts.resumeAfterFailedInstall)
+    _resumeAfterFailedInstall = opts.resumeAfterFailedInstall
   _state.currentVersion = app.getVersion()
 
   // Unpackaged builds get the SAME update flow as a release: electron-updater
@@ -414,6 +473,9 @@ export function setupAutoUpdater(opts: {
     if (outcome.attempts >= 2) emit({ installFailedVersion: outcome.version })
   }
 
+  // Pinned off for the whole process lifetime. electron-updater reads this
+  // inside checkForUpdates(), which made the download decision depend on
+  // whichever caller set it last; startDownload() owns that decision now.
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
   // Always pull the full installer and verify its sha512 directly, never the
@@ -451,20 +513,23 @@ export function setupAutoUpdater(opts: {
   })
 }
 
-// Fired on launch and on an interval. When "Automatic updates" is on this
-// auto-downloads the new version in the background; electron-updater then
-// installs it on the next quit (autoInstallOnAppQuit), and we also surface a
-// "restart to update now" banner/tray item via _onDownloaded for immediacy.
-// When it's off we still check and still emit `update-available` — the user gets
-// the banner and downloads on their own click. autoDownload is read from the
-// live setting on every call so a mid-session toggle is respected.
-export async function checkForUpdatesOnStartup(): Promise<void> {
-  if (!_state.supported) return
+// Fired on launch and on an interval. When "Automatic updates" is on the
+// update-available handler starts the download in the background; we then
+// surface a "restart to update now" banner/tray item via _onDownloaded, and
+// electron-updater installs on the next quit (autoInstallOnAppQuit). When it's
+// off we still check and still emit `update-available` — the user gets the
+// banner and downloads on their own click.
+//
+// Returns false when the check itself did not complete (offline, DNS, a VPN
+// still coming up), so the caller can retry instead of leaving the user with no
+// update prompt until the next scheduled check.
+export async function checkForUpdatesOnStartup(): Promise<boolean> {
+  if (!_state.supported) return false
   try {
-    autoUpdater.autoDownload = _isAutoUpdateEnabled()
-    await autoUpdater.checkForUpdates()
+    return (await autoUpdater.checkForUpdates()) !== null
   } catch (err) {
-    _log(`[updater] startup check failed: ${(err as Error).message}`)
+    _log(`[updater] update check failed: ${(err as Error).message}`)
+    return false
   }
 }
 

--- a/packages/launcher/src/main/windows-update-installer.test.ts
+++ b/packages/launcher/src/main/windows-update-installer.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest"
+import { EventEmitter } from "events"
+import type { spawn as spawnType } from "child_process"
+
+import {
+  encodedElevatedHandoffCommand,
+  hasNonAsciiPathSegment,
+  launchWindowsUpdateInstaller,
+} from "./windows-update-installer"
+
+const INSTALLER = "C:\\ProgramData\\OpenAgents\\updater-cache\\pending\\update.exe"
+
+/**
+ * Minimal ChildProcess stand-in. `script` decides what the "process" does:
+ * stay alive, exit with a code, or fail to spawn at all.
+ */
+function fakeSpawn(
+  script: (call: number) => { exit?: number; error?: NodeJS.ErrnoException },
+): {
+  spawn: typeof spawnType
+  calls: Array<{ command: string; args: string[] }>
+} {
+  const calls: Array<{ command: string; args: string[] }> = []
+  const spawn = vi.fn((command: string, args: string[]) => {
+    const call = calls.length
+    calls.push({ command, args })
+    const child = new EventEmitter() as EventEmitter & { unref: () => void }
+    child.unref = (): void => {}
+    const outcome = script(call)
+    if (outcome.error) queueMicrotask(() => child.emit("error", outcome.error))
+    else if (outcome.exit !== undefined)
+      queueMicrotask(() => child.emit("exit", outcome.exit))
+    return child
+  })
+  return { spawn: spawn as unknown as typeof spawnType, calls }
+}
+
+describe("hasNonAsciiPathSegment", () => {
+  it("flags a Chinese Windows profile path", () => {
+    expect(
+      hasNonAsciiPathSegment("C:\\Users\\张三\\AppData\\Local\\app\\update.exe"),
+    ).toBe(true)
+    expect(hasNonAsciiPathSegment(INSTALLER)).toBe(false)
+  })
+})
+
+describe("encodedElevatedHandoffCommand", () => {
+  it("encodes the script as UTF-16LE base64 and keeps the path out of it", () => {
+    const decoded = Buffer.from(
+      encodedElevatedHandoffCommand(),
+      "base64",
+    ).toString("utf16le")
+    expect(decoded).toContain("Start-Process")
+    expect(decoded).toContain("-Verb RunAs")
+    expect(decoded).toContain("$env:OPENAGENTS_UPDATE_INSTALLER")
+    // The installer path travels in the environment block, never the command.
+    expect(decoded).not.toContain("C:\\")
+  })
+})
+
+describe("launchWindowsUpdateInstaller", () => {
+  it("reports success once the installer outlives the probe window", async () => {
+    const { spawn, calls } = fakeSpawn(() => ({}))
+    const result = await launchWindowsUpdateInstaller(INSTALLER, () => {}, spawn, 5)
+    expect(result.ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].command).toBe(INSTALLER)
+    expect(calls[0].args).toEqual(["--updated", "--force-run"])
+  })
+
+  it("treats a clean exit inside the window as a handoff", async () => {
+    const { spawn } = fakeSpawn(() => ({ exit: 0 }))
+    const result = await launchWindowsUpdateInstaller(INSTALLER, () => {}, spawn, 5)
+    expect(result.ok).toBe(true)
+  })
+
+  it("escalates through UAC when Windows demands elevation", async () => {
+    const elevationError: NodeJS.ErrnoException = new Error("spawn UNKNOWN")
+    elevationError.code = "UNKNOWN"
+    const { spawn, calls } = fakeSpawn((call) =>
+      call === 0 ? { error: elevationError } : { exit: 0 },
+    )
+    const result = await launchWindowsUpdateInstaller(INSTALLER, () => {}, spawn, 5)
+    expect(result.ok).toBe(true)
+    expect(calls).toHaveLength(2)
+    expect(calls[1].command).toBe("powershell.exe")
+    expect(calls[1].args).toContain("-EncodedCommand")
+  })
+
+  it("fails — rather than reporting a launch — when the elevated retry is refused", async () => {
+    const elevationError: NodeJS.ErrnoException = new Error("spawn EACCES")
+    elevationError.code = "EACCES"
+    const { spawn } = fakeSpawn((call) =>
+      // 1223 is ERROR_CANCELLED: the user dismissed the UAC prompt.
+      call === 0 ? { error: elevationError } : { exit: 1223 },
+    )
+    const result = await launchWindowsUpdateInstaller(INSTALLER, () => {}, spawn, 5)
+    expect(result.ok).toBe(false)
+    expect(result.detail).toContain("1223")
+  })
+
+  it("does not retry elevated when the executable is simply missing", async () => {
+    const missing: NodeJS.ErrnoException = new Error("spawn ENOENT")
+    missing.code = "ENOENT"
+    const { spawn, calls } = fakeSpawn(() => ({ error: missing }))
+    const result = await launchWindowsUpdateInstaller(INSTALLER, () => {}, spawn, 5)
+    expect(result.ok).toBe(false)
+    expect(calls).toHaveLength(1)
+  })
+
+  it("retries elevated when the installer dies on the spot", async () => {
+    const { spawn, calls } = fakeSpawn((call) =>
+      call === 0 ? { exit: 1 } : { exit: 0 },
+    )
+    const result = await launchWindowsUpdateInstaller(INSTALLER, () => {}, spawn, 5)
+    expect(result.ok).toBe(true)
+    expect(calls).toHaveLength(2)
+  })
+})

--- a/packages/launcher/src/main/windows-update-installer.ts
+++ b/packages/launcher/src/main/windows-update-installer.ts
@@ -1,39 +1,170 @@
-import { spawn } from "child_process"
+// ── Windows update installer handoff ──
+//
+// electron-updater's own handoff is fire-and-forget: NsisUpdater.doInstall()
+// spawns the staged NSIS installer, returns `true` immediately, and BaseUpdater
+// quits the app on the very next tick. Everything that can go wrong afterwards —
+// Windows refusing to start the executable, a per-machine install demanding
+// elevation, the user dismissing the UAC prompt — surfaces long after the
+// process is gone. From the user's side the launcher "just exits and nothing
+// installs", which is exactly the reported failure.
+//
+// So we start the installer ourselves, confirm it is actually running, and only
+// then let the caller quit. Two launch paths:
+//
+//   direct    — spawn() goes through CreateProcessW, so a Chinese username in
+//               the path is safe. This is the normal case.
+//   elevated  — a per-machine install (Program Files) needs admin rights;
+//               CreateProcess then fails with ERROR_ELEVATION_REQUIRED, which
+//               Node surfaces as UNKNOWN/EACCES/EPERM. electron-updater falls
+//               back to elevate.exe here, which takes its arguments as ANSI and
+//               mangles non-ASCII paths. PowerShell's Start-Process -Verb RunAs
+//               is Unicode-clean, and the path stays off the command line
+//               entirely — it is passed through the (UTF-16) environment block.
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process"
 
 const INSTALLER_ENV = "OPENAGENTS_UPDATE_INSTALLER"
 
-// PowerShell's -EncodedCommand input is UTF-16LE. Keeping the installer path
-// out of the command text entirely is important: it avoids cmd.exe's OEM code
-// page and PowerShell command-line quoting, both of which can corrupt a path
-// such as C:\Users\张三\AppData\Local\...\update.exe.
-const INSTALLER_HANDOFF_SCRIPT = `
+// What electron-updater passes for a non-silent update install: `--updated`
+// tells the NSIS script this is an upgrade of an existing install, `--force-run`
+// relaunches the app afterwards.
+const INSTALLER_ARGS = ["--updated", "--force-run"]
+
+/**
+ * How long the installer has to stay alive before we believe it started. An
+ * executable Windows refuses to run, or a UAC prompt the user dismisses, dies
+ * well inside this window; a real install is still going after it.
+ */
+const ALIVE_PROBE_MS = 1500
+
+/** Longest we wait for the elevated handoff, which blocks on the UAC prompt. */
+const ELEVATED_TIMEOUT_MS = 120_000
+
+// Node reports ERROR_ELEVATION_REQUIRED inconsistently across Windows versions;
+// all three of these mean "run it as admin instead".
+const ELEVATION_ERROR_CODES = new Set(["EACCES", "EPERM", "UNKNOWN"])
+
+// PowerShell reads -EncodedCommand as UTF-16LE. Keeping the installer path out
+// of the command text is what makes this safe: it avoids cmd.exe's OEM code
+// page and PowerShell quoting, both of which can corrupt a path such as
+// C:\Users\张三\AppData\Local\...\update.exe.
+const ELEVATED_HANDOFF_SCRIPT = `
 $ErrorActionPreference = "Stop"
 $installer = $env:${INSTALLER_ENV}
 if ([string]::IsNullOrWhiteSpace($installer) -or -not (Test-Path -LiteralPath $installer -PathType Leaf)) {
   throw "Downloaded update installer was not found"
 }
-Start-Process -FilePath $installer -ArgumentList @("--updated", "--force-run")
+$proc = Start-Process -FilePath $installer -ArgumentList @(${INSTALLER_ARGS.map(
+  (a) => `"${a}"`,
+).join(", ")}) -Verb RunAs -PassThru
+if ($null -eq $proc) { throw "Installer did not start" }
+Start-Sleep -Milliseconds ${ALIVE_PROBE_MS}
+$proc.Refresh()
+if ($proc.HasExited -and $proc.ExitCode -ne 0) {
+  throw "Installer exited immediately with code $($proc.ExitCode)"
+}
 `.trim()
 
 export function hasNonAsciiPathSegment(filePath: string): boolean {
   return /[^\x00-\x7f]/.test(filePath)
 }
 
-export function encodedInstallerHandoffCommand(): string {
-  return Buffer.from(INSTALLER_HANDOFF_SCRIPT, "utf16le").toString("base64")
+export function encodedElevatedHandoffCommand(): string {
+  return Buffer.from(ELEVATED_HANDOFF_SCRIPT, "utf16le").toString("base64")
+}
+
+export interface InstallerLaunch {
+  ok: boolean
+  /** Human-readable outcome, logged verbatim and shown to the user on failure. */
+  detail: string
+}
+
+type SpawnFn = typeof spawn
+
+/**
+ * Start a process and wait long enough to tell "running" from "died on the
+ * spot". Resolves with the exit code when it ends inside the probe window, or
+ * null when it is still running — the healthy case for an installer.
+ */
+function spawnAndProbe(
+  spawnProcess: SpawnFn,
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+  probeMs: number,
+): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess
+    try {
+      child = spawnProcess(command, args, options)
+    } catch (err) {
+      reject(err)
+      return
+    }
+    let settled = false
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      fn()
+    }
+    const timer = setTimeout(() => {
+      settle(() => {
+        // Still alive: let it outlive us.
+        try {
+          child.unref()
+        } catch {}
+        resolve(null)
+      })
+    }, probeMs)
+    child.once("error", (err) => settle(() => reject(err)))
+    child.once("exit", (code) => settle(() => resolve(code ?? 0)))
+  })
 }
 
 /**
- * Launch an NSIS updater without putting its path on a cmd.exe/PowerShell
- * command line. Windows passes environment variables as UTF-16, and
- * Start-Process ultimately uses ShellExecuteExW, preserving non-ASCII paths.
+ * Launch the staged NSIS installer and report whether it is genuinely running.
+ * A false result means the app must NOT quit — nothing would install it.
  */
-export async function launchUnicodeWindowsInstaller(
+export async function launchWindowsUpdateInstaller(
   installerPath: string,
-  spawnProcess: typeof spawn = spawn,
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const child = spawnProcess(
+  log: (msg: string) => void = () => {},
+  spawnProcess: SpawnFn = spawn,
+  probeMs: number = ALIVE_PROBE_MS,
+): Promise<InstallerLaunch> {
+  const base: SpawnOptions = { detached: true, stdio: "ignore" }
+
+  try {
+    const code = await spawnAndProbe(
+      spawnProcess,
+      installerPath,
+      INSTALLER_ARGS,
+      base,
+      probeMs,
+    )
+    // Exit 0 inside the probe window is fine: the NSIS bootstrapper hands off to
+    // an inner instance and returns. A non-zero code means it gave up.
+    if (code === null) return { ok: true, detail: "installer is running" }
+    if (code === 0) return { ok: true, detail: "installer handed off (exit 0)" }
+    log(
+      `[updater] installer exited immediately with code ${code} — retrying with elevation`,
+    )
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? ""
+    if (!ELEVATION_ERROR_CODES.has(code)) {
+      return {
+        ok: false,
+        detail: `could not start installer (${code || "spawn failed"}): ${(err as Error).message}`,
+      }
+    }
+    log(`[updater] installer needs elevation (${code}) — retrying through UAC`)
+  }
+
+  // The script does its own alive-probe and reports the verdict through its exit
+  // code, so here we wait for PowerShell itself to finish — which also means we
+  // stay up (and installable) for as long as the UAC prompt is on screen.
+  try {
+    const code = await spawnAndProbe(
+      spawnProcess,
       "powershell.exe",
       [
         "-NoLogo",
@@ -42,30 +173,24 @@ export async function launchUnicodeWindowsInstaller(
         "-ExecutionPolicy",
         "Bypass",
         "-EncodedCommand",
-        encodedInstallerHandoffCommand(),
+        encodedElevatedHandoffCommand(),
       ],
       {
-        detached: true,
-        stdio: "ignore",
+        ...base,
         windowsHide: true,
-        env: {
-          ...process.env,
-          [INSTALLER_ENV]: installerPath,
-        },
+        env: { ...process.env, [INSTALLER_ENV]: installerPath },
       },
+      ELEVATED_TIMEOUT_MS,
     )
-
-    child.once("error", reject)
-    child.once("exit", (code) => {
-      if (code === 0) {
-        resolve()
-      } else {
-        reject(
-          new Error(
-            `Unicode-safe installer handoff exited with code ${String(code)}`,
-          ),
-        )
-      }
-    })
-  })
+    if (code === 0) return { ok: true, detail: "installer started through UAC" }
+    if (code === null) {
+      return { ok: false, detail: "elevated handoff timed out" }
+    }
+    return { ok: false, detail: `elevated handoff exited with code ${code}` }
+  } catch (err) {
+    return {
+      ok: false,
+      detail: `elevated handoff failed: ${(err as Error).message}`,
+    }
+  }
 }

--- a/packages/launcher/src/renderer/i18n/locales/en/settings.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/settings.json
@@ -113,6 +113,7 @@
     "bannerViewProgress": "View progress",
     "bannerInstallFailed": "Version {{version}} couldn't install automatically",
     "installFailedDesc": "v{{version}} was downloaded but the installer didn't replace the app — still on v{{current}}. Install it manually from the download page.",
+    "installerDidNotStart": "the installer wouldn't start on this machine",
     "bannerDismiss": "Later",
     "updateFallback": "Update",
     "appUpdate": "App update",

--- a/packages/launcher/src/renderer/i18n/locales/zh/settings.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/settings.json
@@ -113,6 +113,7 @@
     "bannerViewProgress": "查看进度",
     "bannerInstallFailed": "新版本 {{version}} 自动安装失败",
     "installFailedDesc": "v{{version}} 已下载，但安装程序未能替换应用，当前仍为 v{{current}}。请前往下载页手动安装。",
+    "installerDidNotStart": "安装程序未能在这台电脑上启动",
     "bannerDismiss": "稍后",
     "updateFallback": "更新",
     "appUpdate": "应用更新",

--- a/packages/launcher/src/renderer/pages/settings/index.tsx
+++ b/packages/launcher/src/renderer/pages/settings/index.tsx
@@ -227,7 +227,18 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
 
   const installUpdate = async (): Promise<void> => {
     try {
-      await window.api.installLauncherUpdate()
+      // false means main could not start the installer and deliberately stayed
+      // up — otherwise the app would just vanish with nothing installed. The
+      // updater state that arrives alongside it flips this card to the manual
+      // download variant; the toast is what makes the click feel answered.
+      const ok = await window.api.installLauncherUpdate()
+      if (!ok)
+        showToast(
+          t("settings.toasts.installFailed", {
+            error: t("settings.updates.installerDidNotStart"),
+          }),
+          "error",
+        )
     } catch (e) {
       showToast(t("settings.toasts.installFailed", { error: (e as Error).message }), "error")
     }


### PR DESCRIPTION
…r; v0.8.23

Two halves of one report, from a Windows user with a Chinese account name: the launcher found a new version but never downloaded it, and "Restart & install" made the app disappear without installing anything.

Updates that were found but not downloaded
------------------------------------------
`updater:check` hard-disabled autoDownload, and Settings runs that check automatically when the Updates section opens — so the one screen a user visits to ask about updates was also the one that guaranteed they wouldn't start. electron-updater reads autoDownload inside checkForUpdates(), which made "should this download by itself?" depend on whichever caller set the flag last. It's now pinned off for the process lifetime and the decision moved to the update-available handler, where it reads the live setting: every check — startup, interval, foreground, Settings — behaves the same.

The startup check also fired exactly once, 20s in, and swallowed failures until the next half-hourly run; on a fresh install that moment lands in the middle of the first-run Node/core downloads, and for users who bring up a VPN right after installing, often before the tunnel is. It now backs off 20s → 60s → 3min → 10min, and a failed check no longer consumes the foreground-check throttle window.

Quitting into nothing
---------------------
NsisUpdater.doInstall() spawns the installer and returns true regardless; BaseUpdater quits on the next tick. Everything that can go wrong after that — elevation required, AV quarantine, a dismissed UAC prompt — happens with the process already gone, so the failure is silent and total.

Windows now goes through our own launcher: spawn (CreateProcessW, so a non-ASCII profile path is safe), confirm the process outlives a probe window, and escalate through PowerShell Start-Process -Verb RunAs when Windows demands elevation. That replaces electron-updater's elevate.exe fallback, which takes its arguments as ANSI and mangles exactly the paths this user has. A handoff that fails no longer quits: it restores isQuitting, clears the attempt marker, brings the daemon back up, and flags installFailedVersion so the banner, Settings and tray switch to a manual download instead of offering a restart that does nothing.