### PR TITLE
fix(claude): keep CLAUDE_CODE_OAUTH_TOKEN in the spawned agent env

### DIFF
--- a/packages/agent-connector/src/adapters/claude.js
+++ b/packages/agent-connector/src/adapters/claude.js
@@ -24,6 +24,41 @@ const { defaultAgentWorkdir, whichBinary, whereBinary } = require('../paths');
 
 const IS_WINDOWS = process.platform === 'win32';
 
+/**
+ * Variables that survive the CLAUDE_* strip below: cloud provider auth
+ * (Vertex, Bedrock), model selection, and credentials.
+ */
+const CLAUDE_ENV_KEEP = new Set([
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_MODEL',
+  'CLAUDE_API_KEY',
+  'CLAUDE_CODE_MAX_TURNS',
+  // Subscription auth, written by `claude setup-token`. It is a credential,
+  // not a harness marker, so stripping it leaves a spawned agent with no way to
+  // authenticate short of an API key or on-disk credentials, neither of which
+  // is available in a container or on a headless host.
+  'CLAUDE_CODE_OAUTH_TOKEN',
+]);
+
+/**
+ * Strip CLAUDE_* / AI_AGENT variables that make the spawned `claude` think it
+ * is running under an SDK harness (org-scoped auth path, 403), while keeping
+ * the config and credential vars the child actually needs.
+ *
+ * @param {Record<string, string>} source
+ * @returns {Record<string, string>} a new object; `source` is not mutated
+ */
+function sanitizeClaudeEnv(source) {
+  const cleanEnv = { ...source };
+  for (const k of Object.keys(cleanEnv)) {
+    if ((k.startsWith('CLAUDE_') && !CLAUDE_ENV_KEEP.has(k)) || k === 'CLAUDECODE' || k === 'AI_AGENT') {
+      delete cleanEnv[k];
+    }
+  }
+  return cleanEnv;
+}
+
 class ClaudeAdapter extends BaseAdapter {
   /**
    * @param {object} opts - BaseAdapter opts plus:
@@ -1216,23 +1251,7 @@ class ClaudeAdapter extends BaseAdapter {
     let mcpConfigFile = null;
     let cmd;
 
-    // Clean env: strip CLAUDE_* / AI_AGENT variables that make the spawned
-    // `claude` think it's running under an SDK harness (org-scoped auth
-    // path → 403). But preserve config vars the child needs for cloud
-    // provider auth (Vertex, Bedrock) and model selection.
-    const CLAUDE_ENV_KEEP = new Set([
-      'CLAUDE_CODE_USE_VERTEX',
-      'CLAUDE_CODE_USE_BEDROCK',
-      'CLAUDE_MODEL',
-      'CLAUDE_API_KEY',
-      'CLAUDE_CODE_MAX_TURNS',
-    ]);
-    const cleanEnv = { ...(this.agentEnv || process.env) };
-    for (const k of Object.keys(cleanEnv)) {
-      if ((k.startsWith('CLAUDE_') && !CLAUDE_ENV_KEEP.has(k)) || k === 'CLAUDECODE' || k === 'AI_AGENT') {
-        delete cleanEnv[k];
-      }
-    }
+    const cleanEnv = sanitizeClaudeEnv(this.agentEnv || process.env);
 
     // Third-party Anthropic-compatible relays (the common reason a custom
     // ANTHROPIC_BASE_URL is set) authenticate via `Authorization: Bearer`, which
@@ -1364,3 +1383,5 @@ class ClaudeAdapter extends BaseAdapter {
 }
 
 module.exports = ClaudeAdapter;
+module.exports.sanitizeClaudeEnv = sanitizeClaudeEnv;
+module.exports.CLAUDE_ENV_KEEP = CLAUDE_ENV_KEEP;

--- a/packages/agent-connector/test/claude-env.test.js
+++ b/packages/agent-connector/test/claude-env.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { sanitizeClaudeEnv } = require('../src/adapters/claude');
+
+describe('sanitizeClaudeEnv', () => {
+  it('strips the harness markers that trigger the org-scoped auth path', () => {
+    const out = sanitizeClaudeEnv({
+      CLAUDECODE: '1',
+      AI_AGENT: 'claude',
+      CLAUDE_CODE_ENTRYPOINT: 'sdk',
+      PATH: '/usr/bin',
+    });
+    assert.equal(out.CLAUDECODE, undefined);
+    assert.equal(out.AI_AGENT, undefined);
+    assert.equal(out.CLAUDE_CODE_ENTRYPOINT, undefined);
+    assert.equal(out.PATH, '/usr/bin');
+  });
+
+  it('keeps cloud provider and model configuration', () => {
+    const out = sanitizeClaudeEnv({
+      CLAUDE_CODE_USE_VERTEX: '1',
+      CLAUDE_CODE_USE_BEDROCK: '1',
+      CLAUDE_MODEL: 'claude-sonnet-4-5',
+      CLAUDE_API_KEY: 'sk-test',
+      CLAUDE_CODE_MAX_TURNS: '10',
+    });
+    assert.equal(out.CLAUDE_CODE_USE_VERTEX, '1');
+    assert.equal(out.CLAUDE_CODE_USE_BEDROCK, '1');
+    assert.equal(out.CLAUDE_MODEL, 'claude-sonnet-4-5');
+    assert.equal(out.CLAUDE_API_KEY, 'sk-test');
+    assert.equal(out.CLAUDE_CODE_MAX_TURNS, '10');
+  });
+
+  it('keeps CLAUDE_CODE_OAUTH_TOKEN so subscription auth reaches the agent', () => {
+    const out = sanitizeClaudeEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' });
+    assert.equal(out.CLAUDE_CODE_OAUTH_TOKEN, 'sk-ant-oat01-test');
+  });
+
+  it('leaves unrelated variables alone', () => {
+    const out = sanitizeClaudeEnv({
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      ANTHROPIC_AUTH_TOKEN: 'bearer-test',
+      ANTHROPIC_BASE_URL: 'https://relay.example.com',
+      HOME: '/home/agent',
+    });
+    assert.deepEqual(out, {
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+      ANTHROPIC_AUTH_TOKEN: 'bearer-test',
+      ANTHROPIC_BASE_URL: 'https://relay.example.com',
+      HOME: '/home/agent',
+    });
+  });
+
+  it('does not mutate the source object', () => {
+    const source = { CLAUDECODE: '1', PATH: '/usr/bin' };
+    sanitizeClaudeEnv(source);
+    assert.equal(source.CLAUDECODE, '1');
+  });
+});


### PR DESCRIPTION
The claude adapter strips `CLAUDE_*` variables so the spawned `claude` does not think it is running under an SDK harness and fall onto the org-scoped auth path. That is correct, but the allowlist misses `CLAUDE_CODE_OAUTH_TOKEN`.

It is a credential, not a harness marker. It is what `claude setup-token` writes, and it is the normal way to pass subscription auth. With it stripped, a spawned agent can only authenticate via an API key or credentials already on disk. On a headless host or in a container there is neither: no interactive login to fall back on, and no credentials file.

The allowlist already carves out exactly this category (`CLAUDE_API_KEY`, Vertex, Bedrock), so this looks like an omission rather than intent. Grepping the repo, the name does not appear anywhere else.

## Repro

```bash
export CLAUDE_CODE_OAUTH_TOKEN=...
agn create x --type claude
agn up
```

The agent starts unauthenticated. The variable is gone from its environment.

## Changes

- Add `CLAUDE_CODE_OAUTH_TOKEN` to `CLAUDE_ENV_KEEP`.
- Extract the set and the strip loop into `sanitizeClaudeEnv()` at module scope so the behaviour is testable. No change to what gets stripped otherwise.
- New `test/claude-env.test.js`: harness markers still stripped, existing allowlist entries preserved, OAuth token preserved, unrelated vars untouched, input not mutated.

## Testing

`node --test` in `packages/agent-connector`: 5 new tests pass, 43 adjacent tests still pass.