### PR TITLE
fix(workspace): do not default identity providers to a live tenant

### DIFF
--- a/workspace/backend/app/config.py
+++ b/workspace/backend/app/config.py
@@ -20,8 +20,17 @@ class Config:
     # Auth mode: "workspace_token" (self-hosted) or "firebase" (hosted)
     AUTH_MODE: str = os.environ.get("AUTH_MODE", "workspace_token")
 
-    # Firebase (used for user login on workspace.openagents.org)
-    FIREBASE_PROJECT_ID: str = os.environ.get("FIREBASE_PROJECT_ID", "openagentsweb")
+    # Firebase (used for user login on workspace.openagents.org).
+    #
+    # Intentionally empty by default. A project id is all _init_firebase() needs
+    # to verify tokens (no service account required), so a non-empty default
+    # makes every deployment trust identity tokens issued by that project. For a
+    # self-hosted instance that means accepting logins from an identity tenant
+    # its operator does not control: any holder of an account there can call
+    # POST /v1/workspaces/{id}/claim, which takes a bearer and no workspace
+    # token, and claim any workspace whose creator_email is unset. The hosted
+    # deployment sets this explicitly via the environment.
+    FIREBASE_PROJECT_ID: str = os.environ.get("FIREBASE_PROJECT_ID", "")
 
     # Optional: Firebase service account credentials as JSON string
     FIREBASE_CREDENTIALS_JSON: str = os.environ.get("FIREBASE_CREDENTIALS_JSON", "")
@@ -29,11 +38,11 @@ class Config:
     # Sign in with Apple. Native ("Sign in with Apple" on the iOS app) issues an
     # identity token whose `aud` is the app's bundle id; web/services flows use
     # the Services ID instead. Accept a comma-separated allowlist so both work.
-    # Defaults to the iOS bundle id so the OpenAgents Go app validates out of the
-    # box without extra env config.
-    APPLE_CLIENT_IDS: str = os.environ.get(
-        "APPLE_CLIENT_IDS", "org.openagents.workspace"
-    )
+    #
+    # Empty by default for the same reason as FIREBASE_PROJECT_ID: a bundle id
+    # baked in here is an identity tenant every deployment would trust. Set it
+    # in the environment for the deployment that owns that bundle id.
+    APPLE_CLIENT_IDS: str = os.environ.get("APPLE_CLIENT_IDS", "")
 
     # APNs (Apple Push Notification service) — direct, no FCM in between.
     # Token-based auth via a .p8 key generated at

--- a/workspace/backend/tests/test_identity_defaults.py
+++ b/workspace/backend/tests/test_identity_defaults.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Identity providers must be opt-in.
+
+A project id is all firebase_auth._init_firebase() needs to verify tokens (no
+service account required), so a baked-in default would make every deployment
+trust identity tokens minted by that tenant. That matters because
+POST /v1/workspaces/{id}/claim accepts a bearer with no workspace token and
+claims any workspace whose creator_email is unset, after which
+_verify_workspace_access grants that email full access.
+"""
+
+import importlib
+import os
+
+
+def _fresh_config(monkeypatch, **env):
+    """Re-import the config module with a controlled environment."""
+    for key in ("FIREBASE_PROJECT_ID", "APPLE_CLIENT_IDS"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    import app.config as config_module
+    return importlib.reload(config_module).config
+
+
+def test_firebase_project_id_defaults_to_empty(monkeypatch):
+    assert _fresh_config(monkeypatch).FIREBASE_PROJECT_ID == ""
+
+
+def test_apple_client_ids_defaults_to_empty(monkeypatch):
+    assert _fresh_config(monkeypatch).APPLE_CLIENT_IDS == ""
+
+
+def test_identity_providers_still_configurable(monkeypatch):
+    cfg = _fresh_config(
+        monkeypatch,
+        FIREBASE_PROJECT_ID="my-project",
+        APPLE_CLIENT_IDS="com.example.app,com.example.svc",
+    )
+    assert cfg.FIREBASE_PROJECT_ID == "my-project"
+    assert cfg.APPLE_CLIENT_IDS == "com.example.app,com.example.svc"
+
+
+def test_firebase_verification_fails_closed_without_a_project(monkeypatch):
+    """With no project configured, token verification must not initialize."""
+    _fresh_config(monkeypatch)
+    import app.firebase_auth as firebase_auth
+    importlib.reload(firebase_auth)
+    monkeypatch.setattr(firebase_auth, "_firebase_initialized", False, raising=False)
+    assert firebase_auth.verify_firebase_token("any.token.value") is None


### PR DESCRIPTION
Two identity settings ship with defaults that point at a live identity tenant:

```python
FIREBASE_PROJECT_ID: str = os.environ.get("FIREBASE_PROJECT_ID", "openagentsweb")
APPLE_CLIENT_IDS:  str = os.environ.get("APPLE_CLIENT_IDS", "org.openagents.workspace")
```

`_init_firebase()` needs no service account. A project id plus Google public certs is enough for `verify_id_token`, so any deployment that does not override these will verify identity tokens issued by that tenant.

## Why it matters for self-hosted instances

`POST /v1/workspaces/{id}/claim` accepts a bearer and **no workspace token**, and claims any workspace whose `creator_email` is unset:

```python
if workspace.creator_email and workspace.creator_email != email:
    return json_response(ResponseCode.FORBIDDEN, "Workspace already claimed by another user")
workspace.creator_email = email
```

Afterwards `_verify_workspace_access` grants that email full access to the workspace with no workspace token at all.

So on a default self-hosted deployment, a holder of an account on the tenant named above can claim any unclaimed workspace on that instance. `AUTH_MODE=workspace_token` does not gate either path. The workspace id is a slug that appears in URLs rather than a secret.

Confirmed on a self-hosted instance running the current `develop`: `config.FIREBASE_PROJECT_ID` resolved to `openagentsweb` with nothing set in the environment, and `firebase-admin` was installed and importable.

## Change

Both default to empty. That routes `_init_firebase()` into its existing `"No Firebase config, skipping init"` branch, so `verify_firebase_token` returns `None` and the bearer paths fail closed. Deployments that use these providers set them in the environment.

Note this flips the default for the hosted deployment too, so it will need the values set explicitly if it was relying on them.

## A stronger fix, left to maintainers

Gating the bearer branch in `_verify_workspace_access` and `claim_workspace` on `AUTH_MODE != "firebase"` would make the documented self-host mode actually disable the hosted auth path. I did not include it because I cannot see which `AUTH_MODE` the hosted deployment runs with, and getting that wrong would break login there.

## Testing

`tests/test_identity_defaults.py`: both defaults empty, still configurable via env, and verification fails closed with no project set.

Full backend suite before and after: the same 20 pre-existing failures and 544 passes, plus the 4 added here.