### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security issues privately, not in public issues, pull requests or
+Discussions.
+
+Use GitHub's [private vulnerability
+reporting](https://github.com/openagents-org/openagents/security/advisories/new).
+If that page is unavailable, email **team@openagents.org** with `SECURITY` in
+the subject.
+
+Please include:
+
+- what the issue is and which component it affects (network, workspace backend,
+  workspace frontend, launcher, SDK)
+- the version, tag or commit you tested against
+- steps to reproduce, ideally the smallest set that shows the problem
+- what an attacker gains, and what they need first (a workspace token, a
+  workspace id, an account somewhere else)
+
+You will get an acknowledgement within 5 working days. Please give us 90 days
+before public disclosure, or less if a fix ships sooner.
+
+## Scope
+
+In scope:
+
+- the network and its transports (HTTP, gRPC, MCP, A2A)
+- the workspace backend and frontend
+- the launcher and agent adapters
+- the published container image and npm packages
+
+Out of scope:
+
+- vulnerabilities in an agent runtime the launcher shells out to (Claude Code,
+  Codex, Cursor and so on). Report those to their maintainers.
+- anything requiring a workspace token you were already given. The token is the
+  credential for a workspace.
+- findings against `workspace.openagents.org` that only affect your own
+  workspace.
+
+## Notes for self-hosted deployments
+
+Two properties of the current design are worth stating plainly, because they
+shape what does and does not count as a vulnerability.
+
+**A workspace token is a single shared credential.** Every agent in a workspace
+sends the same `X-Workspace-Token`, and `agent_name` is self-declared. There is
+no per-agent identity and revocation is all or nothing. Use one workspace per
+trust boundary rather than one workspace for everything.
+
+**Identity providers must be configured explicitly.** `FIREBASE_PROJECT_ID` and
+`APPLE_CLIENT_IDS` control which identity tenant this deployment trusts. Setting
+them to a tenant you do not operate means accepting logins minted there. Leave
+them empty unless you own the tenant.
+
+## Supported Versions
+
+Fixes land on `develop` and ship in the next release. Only the latest release is
+supported; there are no backports to older tags.


### PR DESCRIPTION
GitHub reports this project has no `SECURITY.md`, so the repo shows no policy and the reporting route is undocumented outside the issue template.

`.github/ISSUE_TEMPLATE/config.yml` already says:

> 🔒 Report a Security Vulnerability, `security/advisories/new`. Please report security issues privately, NOT in public issues.

This writes that down properly and fills in the parts the template cannot: what to include, response and disclosure timelines, and scope.

## One thing worth checking

The private reporting form linked from that template is currently **disabled**. An external report returns:

```
POST /repos/openagents-org/openagents/security-advisories/reports
403: Repository does not have private vulnerability reporting enabled
```

So the policy asks people to report privately through a door that is not open, and the only remaining routes are public. Enabling it under Settings > Code security would fix that. Until then the policy lists `team@openagents.org` (from `packages/launcher/package.json`) as a fallback. Happy to swap that for a different address.

## Contents

- where to report and what to include
- acknowledgement within 5 working days, 90 day disclosure window
- scope, including that vulnerabilities in agent runtimes the launcher shells out to belong to their own maintainers, and that holding a workspace token you were given is not a finding
- two notes for self-hosters: a workspace token is a single shared credential with no per-agent identity, and `FIREBASE_PROJECT_ID` / `APPLE_CLIENT_IDS` decide which identity tenant a deployment trusts

All of it is a description of current behaviour. Adjust the timelines and the contact address to whatever you actually want to commit to.