### PR TITLE
fix(launcher): theme the rail and window frame, fix tray icon and log jumps

### DIFF
--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",
@@ -107,7 +107,8 @@
         "from": "assets",
         "to": "assets",
         "filter": [
-          "tray-icon*.png"
+          "tray-icon*.png",
+          "icon.ico"
         ]
       }
     ],

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -5,6 +5,7 @@ import {
   Menu,
   ipcMain,
   nativeImage,
+  nativeTheme,
   session,
   shell,
 } from "electron"
@@ -980,14 +981,34 @@ function createPlaceholderIcon(): Electron.NativeImage {
   return nativeImage.createFromBuffer(canvas, { width: size, height: size })
 }
 
+/**
+ * Point Electron's native theme at the app's own theme setting.
+ *
+ * Only the three values `nativeTheme.themeSource` accepts are honoured; an
+ * absent or unrecognised stored value falls back to `system`, which is the
+ * renderer's default too.
+ */
+function applyThemeSource(mode: unknown): void {
+  nativeTheme.themeSource =
+    mode === "dark" || mode === "light" ? mode : "system"
+}
+
 function createTray(): void {
-  // White glyph everywhere, but macOS needs its own padded variant. The
-  // menu-bar canvas is 22pt and AppKit draws the image at that size, while
-  // other menu-bar extras keep their glyph around 18pt inside it — so the
-  // full-bleed 22pt art reads as noticeably oversized next to them.
-  // tray-icon-mac.png is the same glyph inset to 18pt. Windows/Linux scale
-  // the icon down into a ~16px slot, where full-bleed is correct.
-  // Electron auto-loads the matching @2x file as the Retina representation.
+  // macOS: a white glyph, inset to 18pt. The menu-bar canvas is 22pt and AppKit
+  // draws the image at that size, while other menu-bar extras keep their glyph
+  // around 18pt inside it — full-bleed 22pt art reads as oversized next to
+  // them. Electron auto-loads the matching @2x file as the Retina rep.
+  //
+  // Windows: the app icon, not a glyph. The notification area follows the
+  // "Windows mode" setting independently of the app's own theme, so it can be
+  // light or dark and a monochrome glyph is invisible against one of them —
+  // a white glyph on a light taskbar was the bug. The 1.0 mark cannot solve it
+  // in colour either: its top-right arc and bottom-right dot are black and
+  // vanish on a dark taskbar. The opaque tile carries its own background and
+  // so reads on both, and matches what Windows already shows for this app on
+  // the taskbar and in the Start menu.
+  //
+  // Linux: panels are conventionally dark, so the white glyph stands.
   //
   // Path: in dev, assets/ sits two levels above out/main. In packaged builds
   // that directory is NOT inside app.asar — it is `directories.buildResources`,
@@ -997,7 +1018,11 @@ function createTray(): void {
     ? path.join(process.resourcesPath, "assets")
     : path.join(__dirname, "../../assets")
   const trayIconFile =
-    process.platform === "darwin" ? "tray-icon-mac.png" : "tray-icon-light.png"
+    process.platform === "darwin"
+      ? "tray-icon-mac.png"
+      : process.platform === "win32"
+        ? "icon.ico"
+        : "tray-icon-light.png"
   let trayIcon = nativeImage.createFromPath(
     path.join(assetsDir, trayIconFile),
   )
@@ -1862,6 +1887,14 @@ function setupIPC(): void {
     requireManager().registerWorkspaceFromToken(input),
   )
 
+  // The renderer owns the theme; this is how the OS-drawn window frame hears
+  // about it. Persisted so the next launch can set it before the first window
+  // opens (see the whenReady call).
+  ipcMain.handle("theme:set-source", (_e, mode: unknown) => {
+    applyThemeSource(mode)
+    store.set("themeMode", nativeTheme.themeSource)
+  })
+
   ipcMain.handle("settings:get", (_e, key) => store.get(key))
   ipcMain.handle("settings:set", (_e, key, value) => {
     store.set(key, value)
@@ -2698,6 +2731,20 @@ if (!gotLock) {
 
 app.whenReady().then(async () => {
   if (process.platform !== "darwin") Menu.setApplicationMenu(null)
+
+  // The window frame is drawn by the OS, so the OS has to be told which way the
+  // app is themed — otherwise a dark app keeps a light Windows title bar, which
+  // is what it looked like. Electron turns this into DWMWA_USE_IMMERSIVE_DARK_MODE
+  // on Windows and the equivalent appearance on macOS.
+  //
+  // Applied here, before the first window exists, and mirrored into settings.json
+  // by the `theme:set-source` handler below: the renderer keeps its own copy in
+  // localStorage (read synchronously, so the page never flashes the wrong theme),
+  // but that is unreachable from the main process at startup. Without a
+  // main-side copy the frame would open in the system theme and only correct
+  // itself once the renderer booted and called in — a visible flicker on every
+  // launch for anyone not on the system default.
+  applyThemeSource(store.get("themeMode"))
 
   // Apply user settings that must reach the OS / network layer on every launch
   // (the renderer only writes them to the store; the main process is what makes

--- a/packages/launcher/src/preload/index.ts
+++ b/packages/launcher/src/preload/index.ts
@@ -63,6 +63,10 @@ contextBridge.exposeInMainWorld('api', {
 
   getSetting: (key: string) => ipcRenderer.invoke('settings:get', key),
   setSetting: (key: string, value: unknown) => ipcRenderer.invoke('settings:set', key, value),
+  // Themes the OS-drawn window frame (Windows title bar, macOS appearance) to
+  // match the app. Fire-and-forget from the theme store.
+  setThemeSource: (mode: 'light' | 'dark' | 'system') =>
+    ipcRenderer.invoke('theme:set-source', mode),
   getAllSettings: () => ipcRenderer.invoke('settings:get-all'),
   exportSettings: () => ipcRenderer.invoke('settings:export'),
   exportSettingsToFile: () => ipcRenderer.invoke('settings:export-to-file'),

--- a/packages/launcher/src/renderer/components/layout/app-sidebar.tsx
+++ b/packages/launcher/src/renderer/components/layout/app-sidebar.tsx
@@ -23,14 +23,15 @@ function Brand(): React.JSX.Element {
 
   return (
     <div className="flex min-w-0 items-center gap-2.5 px-1 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-2 group-data-[collapsible=icon]:px-0">
-      {/* The rail keeps its near-black surface in both themes, so the mark is
-          pinned to the white cut-out rather than following the theme. */}
-      <BrandMark variant="white" className="size-7" />
+      {/* Follows the theme, like the rail behind it. Pinning this to the white
+          cut-out was right only while the rail was always dark — on the light
+          rail it disappears into the background. */}
+      <BrandMark className="size-7" />
       {/* Same key the About card uses, so the rail and Settings never disagree
           about what the app is called. It stays on one line at every UI scale
           because the rail is sized in rem — see RAIL_WIDTH. */}
       <span
-        className="truncate text-base font-semibold tracking-tight text-white group-data-[collapsible=icon]:hidden"
+        className="truncate text-base font-semibold tracking-tight text-sidebar-accent-foreground group-data-[collapsible=icon]:hidden"
         title={t("settings.about.productName")}
       >
         {t("settings.about.productName")}

--- a/packages/launcher/src/renderer/components/onboarding/onboarding-rail.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/onboarding-rail.tsx
@@ -8,17 +8,19 @@ import { cn } from "@renderer/lib/utils"
 import { STEP_IDS, type Step } from "./onboarding-shared"
 
 /**
- * The wizard's left rail: brand and the vertical step tracker. It paints the
- * fixed dark sidebar surface in both themes, the same way the app rail frames
- * the main window.
+ * The wizard's left rail: brand and the vertical step tracker.
+ *
+ * Painted from the always-dark `panel` tokens, so it stays dark in both themes.
+ * Unlike the app rail — which now follows the theme — this one frames a
+ * full-screen, one-time flow with no app around it to disagree with.
  */
 export function OnboardingRail({ step }: { step: Step }): React.JSX.Element {
   const { t } = useTranslation()
   return (
-    <aside className="hidden w-72 shrink-0 flex-col border-r border-sidebar-border bg-sidebar px-7 py-7 lg:flex xl:w-80">
+    <aside className="panel-dark hidden w-72 shrink-0 flex-col border-r border-panel-border bg-panel px-7 py-7 lg:flex xl:w-80">
       <div className="flex items-center gap-2.5">
         <BrandMark variant="white" className="size-8 rounded-lg" />
-        <span className="text-lg font-bold tracking-tight text-sidebar-accent-foreground">
+        <span className="text-lg font-bold tracking-tight text-panel-accent-foreground">
           OpenAgents Launcher
         </span>
       </div>
@@ -34,10 +36,10 @@ export function OnboardingRail({ step }: { step: Step }): React.JSX.Element {
                 <span
                   className={cn(
                     "flex size-7 items-center justify-center rounded-full font-mono text-2xs font-bold transition-colors",
-                    done && "bg-sidebar-primary/20 text-sidebar-primary",
+                    done && "bg-panel-primary/20 text-panel-primary",
                     current &&
-                      "bg-sidebar-primary text-sidebar-primary-foreground",
-                    !done && !current && "bg-white/5 text-sidebar-muted",
+                      "bg-panel-primary text-panel-primary-foreground",
+                    !done && !current && "bg-white/5 text-panel-muted",
                   )}
                 >
                   {done ? (
@@ -50,7 +52,7 @@ export function OnboardingRail({ step }: { step: Step }): React.JSX.Element {
                   <span
                     className={cn(
                       "my-1.5 w-px flex-1",
-                      done ? "bg-sidebar-primary/40" : "bg-sidebar-border",
+                      done ? "bg-panel-primary/40" : "bg-panel-border",
                     )}
                   />
                 )}
@@ -60,13 +62,13 @@ export function OnboardingRail({ step }: { step: Step }): React.JSX.Element {
                   className={cn(
                     "text-sm font-semibold",
                     done || current
-                      ? "text-sidebar-accent-foreground"
-                      : "text-sidebar-muted",
+                      ? "text-panel-accent-foreground"
+                      : "text-panel-muted",
                   )}
                 >
                   {t(`onboarding.flow.progress.${id}`)}
                 </div>
-                <p className="m-0 mt-1 text-2xs leading-relaxed text-sidebar-muted">
+                <p className="m-0 mt-1 text-2xs leading-relaxed text-panel-muted">
                   {t(`onboarding.flow.rail.steps.${id}`)}
                 </p>
               </div>

--- a/packages/launcher/src/renderer/components/setup-wizard/wizard-summary-panels.tsx
+++ b/packages/launcher/src/renderer/components/setup-wizard/wizard-summary-panels.tsx
@@ -37,7 +37,7 @@ export function AuthSummary({
             {steps.map((label) => (
               <li
                 key={label}
-                className="border-b border-sidebar-border py-3 text-sm font-semibold text-sidebar-accent-foreground last:border-b-0"
+                className="border-b border-panel-border py-3 text-sm font-semibold text-panel-accent-foreground last:border-b-0"
               >
                 {label}
               </li>
@@ -69,11 +69,11 @@ export function AuthSummary({
           }
         />
       </SummarySection>
-      <p className="m-0 text-xs leading-relaxed text-sidebar-muted">
+      <p className="m-0 text-xs leading-relaxed text-panel-muted">
         {t("onboarding.wizard.summary.verify.modelNote")}
       </p>
       <SummarySection label={t("onboarding.wizard.summary.verify.storageLabel")}>
-        <code className="font-mono text-xs text-sidebar-accent-foreground">
+        <code className="font-mono text-xs text-panel-accent-foreground">
           ~/.openagents/env/
         </code>
       </SummarySection>
@@ -107,16 +107,16 @@ export function CreateSummary({
             <AgentIcon type={agentType} size={18} />
           </span>
           <div className="min-w-0">
-            <div className="truncate text-sm font-semibold text-sidebar-accent-foreground">
+            <div className="truncate text-sm font-semibold text-panel-accent-foreground">
               {agentName}
             </div>
-            <div className="mt-0.5 truncate text-2xs text-sidebar-muted">
+            <div className="mt-0.5 truncate text-2xs text-panel-muted">
               {t("onboarding.wizard.summary.create.ready")}
             </div>
           </div>
         </div>
       </SummarySection>
-      <p className="m-0 text-xs leading-relaxed text-sidebar-muted">
+      <p className="m-0 text-xs leading-relaxed text-panel-muted">
         {t("onboarding.wizard.summary.create.renameNote")}
       </p>
     </WizardSummary>

--- a/packages/launcher/src/renderer/components/setup-wizard/wizard-summary.tsx
+++ b/packages/launcher/src/renderer/components/setup-wizard/wizard-summary.tsx
@@ -9,9 +9,11 @@ import { cn } from "@renderer/lib/utils"
  * a full page that told the user one thing, and this is that one thing, parked
  * beside the form instead of in front of it.
  *
- * It paints the fixed dark surface in both themes, the same way the onboarding
- * rail and the app rail do, so "this is the frame, not the form" needs no
- * further explaining.
+ * It paints the always-dark `panel` surface, the same as the onboarding rail,
+ * so "this is the frame, not the form" needs no further explaining. It keeps
+ * that in light mode too — here the contrast against the form beside it is the
+ * whole point, which is exactly why it does not follow the theme the way the
+ * app rail now does.
  */
 export function WizardSummary({
   badge,
@@ -26,23 +28,23 @@ export function WizardSummary({
   children?: React.ReactNode
 }): React.JSX.Element {
   return (
-    <aside className="hidden min-w-0 flex-col rounded-xl bg-sidebar p-6 md:flex">
+    <aside className="panel-dark hidden min-w-0 flex-col rounded-xl bg-panel p-6 md:flex">
       <div className="flex items-start gap-3.5">
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-sidebar-primary font-mono text-2xs font-bold text-sidebar-primary-foreground">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-panel-primary font-mono text-2xs font-bold text-panel-primary-foreground">
           {badge}
         </span>
         <div className="min-w-0">
-          <h3 className="m-0 text-base font-bold text-sidebar-accent-foreground">
+          <h3 className="m-0 text-base font-bold text-panel-accent-foreground">
             {title}
           </h3>
-          <p className="m-0 mt-1 text-xs leading-relaxed text-sidebar-muted">
+          <p className="m-0 mt-1 text-xs leading-relaxed text-panel-muted">
             {description}
           </p>
         </div>
       </div>
       {children && (
         <>
-          <span className="my-5 h-px shrink-0 bg-sidebar-border" />
+          <span className="my-5 h-px shrink-0 bg-panel-border" />
           <div className="flex min-w-0 flex-col gap-4">{children}</div>
         </>
       )}
@@ -60,7 +62,7 @@ export function SummarySection({
 }): React.JSX.Element {
   return (
     <div className="min-w-0">
-      <div className="text-2xs text-sidebar-muted">{label}</div>
+      <div className="text-2xs text-panel-muted">{label}</div>
       <div className="mt-2 min-w-0">{children}</div>
     </div>
   )
@@ -79,15 +81,18 @@ export function VerifyStatus({
   message: string
 }): React.JSX.Element {
   const tone = {
-    idle: "border-sidebar-border bg-white/5 text-sidebar-muted",
-    running: "border-sidebar-border bg-white/5 text-sidebar-accent-foreground",
+    idle: "border-panel-border bg-white/5 text-panel-muted",
+    running: "border-panel-border bg-white/5 text-panel-accent-foreground",
     ok: "border-(--success-border) bg-success/15 text-success",
     failed: "border-(--danger-border) bg-destructive/15 text-destructive",
   }[state]
 
-  const Icon = { idle: null, running: Loader2, ok: CheckCircle2, failed: AlertCircle }[
-    state
-  ]
+  const Icon = {
+    idle: null,
+    running: Loader2,
+    ok: CheckCircle2,
+    failed: AlertCircle,
+  }[state]
 
   return (
     <div
@@ -98,11 +103,14 @@ export function VerifyStatus({
     >
       {Icon && (
         <Icon
-          className={cn("mt-px size-4 shrink-0", state === "running" && "animate-spin")}
+          className={cn(
+            "mt-px size-4 shrink-0",
+            state === "running" && "animate-spin",
+          )}
           strokeWidth={2}
         />
       )}
-      <span className="min-w-0 leading-relaxed break-words">{message}</span>
+      <span className="min-w-0 leading-relaxed wrap-break-word">{message}</span>
     </div>
   )
 }

--- a/packages/launcher/src/renderer/components/ui/sidebar.tsx
+++ b/packages/launcher/src/renderer/components/ui/sidebar.tsx
@@ -424,7 +424,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-hover hover:text-sidebar-hover-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
@@ -472,13 +472,13 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-hover hover:text-sidebar-hover-foreground focus-visible:ring-2 active:bg-sidebar-hover active:text-sidebar-hover-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-active data-[active=true]:font-medium data-[active=true]:text-sidebar-active-foreground data-[state=open]:hover:bg-sidebar-hover data-[state=open]:hover:text-sidebar-hover-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        default: "hover:bg-sidebar-hover hover:text-sidebar-hover-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-hover hover:text-sidebar-hover-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",
@@ -559,7 +559,7 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-hover-foreground hover:bg-sidebar-hover hover:text-sidebar-hover-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "peer-data-[size=sm]/menu-button:top-1",
@@ -567,7 +567,7 @@ function SidebarMenuAction({
         "peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-active-foreground data-[state=open]:opacity-100 md:opacity-0",
         className
       )}
       {...props}
@@ -585,7 +585,7 @@ function SidebarMenuBadge({
       data-sidebar="menu-badge"
       className={cn(
         "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
-        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-hover/menu-button:text-sidebar-hover-foreground peer-data-[active=true]/menu-button:text-sidebar-active-foreground",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
         "peer-data-[size=lg]/menu-button:top-2.5",
@@ -684,8 +684,8 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
-        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-hover hover:text-sidebar-hover-foreground focus-visible:ring-2 active:bg-sidebar-hover active:text-sidebar-hover-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "data-[active=true]:bg-sidebar-active data-[active=true]:text-sidebar-active-foreground",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",
         "group-data-[collapsible=icon]:hidden",

--- a/packages/launcher/src/renderer/globals.css
+++ b/packages/launcher/src/renderer/globals.css
@@ -284,11 +284,24 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-hover-foreground: var(--sidebar-hover-foreground);
+  --color-sidebar-hover: var(--sidebar-hover);
+  --color-sidebar-active-foreground: var(--sidebar-active-foreground);
+  --color-sidebar-active: var(--sidebar-active);
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
   --color-sidebar-muted: var(--sidebar-muted);
+
+  /* The always-dark panel — see the token block near the bottom of this file. */
+  --color-panel: var(--panel);
+  --color-panel-foreground: var(--panel-foreground);
+  --color-panel-accent-foreground: var(--panel-accent-foreground);
+  --color-panel-primary: var(--panel-primary);
+  --color-panel-primary-foreground: var(--panel-primary-foreground);
+  --color-panel-border: var(--panel-border);
+  --color-panel-muted: var(--panel-muted);
 }
 
 /* ===========================================================
@@ -497,9 +510,11 @@ textarea:focus-visible {
   outline: none;
 }
 
-/* The sidebar paints its own near-black surface regardless of theme, so the
-   themed accent does not read against it — use a light ring inside that region. */
-[data-sidebar="dark"] :focus-visible {
+/* The always-dark panels keep their near-black surface in light mode too, so a
+   light-theme accent outline does not read against them — use a light ring
+   inside that region. (Previously keyed off `[data-sidebar="dark"]`, an
+   attribute nothing ever set, so it had never applied to anything.) */
+.panel-dark :focus-visible {
   outline-color: #818cf8;
 }
 
@@ -782,23 +797,92 @@ select optgroup {
 /* ===========================================================
    shadcn Sidebar tokens
    ===========================================================
-   Deliberately NOT aliased to the theme tokens: the rail stays dark in both
-   light and dark mode because it frames the app like window chrome rather than
-   page content. Holding the palette here — instead of hex values inside the
-   components — is what lets every child use semantic utilities (`bg-sidebar`,
+   The rail follows the theme. It used to be pinned dark in both modes on the
+   grounds that it frames the app like window chrome — but a light app with a
+   near-black rail down one side reads as a rendering fault, not as chrome.
+   Holding the palette here — instead of hex values inside the components — is
+   what lets every child use semantic utilities (`bg-sidebar`,
    `text-sidebar-foreground`, `hover:bg-sidebar-accent`) and keeps the rail free
-   of arbitrary colour values. */
+   of arbitrary colour values.
+
+   Placement matters. These sit AFTER the `[data-theme="dark"]` theme block, and
+   both selectors carry the same specificity, so the dark values have to be
+   restated below rather than folded in up there — last one wins. The one
+   exception is `--sidebar-primary` / `--sidebar-ring`, which
+   `:root[data-accent]` (higher specificity) overrides with the user's accent
+   preset in either theme; the values here only ever paint the first frame.
+
+   Three row states, three token pairs — stock shadcn collapses hover and
+   selected onto `--sidebar-accent`, which cannot express a design where they
+   differ. They are split so the nav can carry the accent tint on both while
+   `--sidebar-accent` goes back to meaning what the rest of the rail needs it
+   for: the neutral chrome fill behind the search field, the status chip and
+   the icon buttons, none of which should take on a hue.
+
+     --sidebar-accent   neutral fill      (search field, status chip, ⋯ hover)
+     --sidebar-hover    accent, light     (nav row under the pointer)
+     --sidebar-active   accent, stronger  (the selected nav row)
+
+   Both nav states mix from `--accent`, so they track the user's accent preset
+   (Settings → Appearance) the way every other selected thing in the app does —
+   the mock shows the default preset, not a fixed violet. `--accent` is the
+   right base because it is defined both with and without `data-accent` on the
+   root, so even the first frame has a colour to mix. */
 :root {
-  --sidebar: #0e1117;
-  --sidebar-foreground: #a8aabb;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #3a3a3c;
   --sidebar-primary: #6366f1;
   --sidebar-primary-foreground: #ffffff;
-  /* Row background for hover and the active item. */
-  --sidebar-accent: #1a1d2a;
-  --sidebar-accent-foreground: #ffffff;
-  --sidebar-border: rgb(255 255 255 / 0.05);
+  /* Neutral chrome fill — NOT the nav row states. */
+  --sidebar-accent: #f0f0f5;
+  --sidebar-accent-foreground: #1c1c1e;
+  /* Nav rows. The label takes the accent too, so hover and selection read as
+     the same gesture at two strengths rather than two different treatments. */
+  --sidebar-hover: color-mix(in srgb, var(--accent) 7%, transparent);
+  --sidebar-hover-foreground: var(--accent);
+  --sidebar-active: color-mix(in srgb, var(--accent) 12%, transparent);
+  --sidebar-active-foreground: var(--accent);
+  --sidebar-border: rgb(0 0 0 / 0.08);
   --sidebar-ring: #6366f1;
   /* Section headings and the daemon/version strip — dimmer than body text. */
+  --sidebar-muted: #8e8e93;
+}
+
+[data-theme="dark"] {
+  --sidebar: #0e1117;
+  --sidebar-foreground: #a8aabb;
+  --sidebar-accent: #1a1d2a;
+  --sidebar-accent-foreground: #ffffff;
+  /* Heavier mixes than light mode: the same percentages over a near-black rail
+     would barely separate from it. The labels go white rather than accent —
+     the dark theme's accent is already a light violet, and putting it on a fill
+     made of itself is the one pairing that does not read. */
+  --sidebar-hover: color-mix(in srgb, var(--accent) 14%, transparent);
+  --sidebar-hover-foreground: #ffffff;
+  --sidebar-active: color-mix(in srgb, var(--accent) 30%, transparent);
+  --sidebar-active-foreground: #ffffff;
+  --sidebar-border: rgb(255 255 255 / 0.05);
   --sidebar-muted: #6b7080;
+}
+
+/* ===========================================================
+   Always-dark panel tokens
+   ===========================================================
+   The surfaces that really are chrome and stay dark in both themes: the
+   onboarding rail and the setup wizard's summary aside. They used to borrow the
+   sidebar tokens, which worked only for as long as those were pinned dark.
+   Same palette the rail carried before, under a name that says what it is. */
+:root {
+  --panel: #0e1117;
+  --panel-foreground: #a8aabb;
+  --panel-primary: #6366f1;
+  --panel-primary-foreground: #ffffff;
+  --panel-accent-foreground: #ffffff;
+  --panel-border: rgb(255 255 255 / 0.05);
+  --panel-muted: #6b7080;
+}
+
+:root[data-accent] {
+  --panel-primary: var(--accent-base);
 }
 

--- a/packages/launcher/src/renderer/i18n/locales/en/dashboard.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/dashboard.json
@@ -12,7 +12,8 @@
       "running": "Running",
       "workspaces": "Active workspaces",
       "messages": "Messages today"
-    }
+    },
+    "messagesToday_zero": "No new messages today."
   },
   "updates": {
     "oneAvailable": "Update available for {{name}}",

--- a/packages/launcher/src/renderer/i18n/locales/zh/dashboard.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/dashboard.json
@@ -10,7 +10,8 @@
       "running": "运行中",
       "workspaces": "活跃工作区",
       "messages": "今日消息"
-    }
+    },
+    "messagesToday_zero": "今天还没有新消息。"
   },
   "updates": {
     "oneAvailable": "{{name}} 有可用更新",

--- a/packages/launcher/src/renderer/pages/dashboard/components/welcome-hero.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/components/welcome-hero.tsx
@@ -89,7 +89,10 @@ export function WelcomeHero({
 
         <dl className="m-0 grid shrink-0 grid-cols-3 gap-6 lg:gap-8">
           {STATS.map((stat) => (
-            <div key={stat.key} className="flex flex-col gap-1.5">
+            // Centred, not leading-edge aligned: the label carries an icon and
+            // the value is one or two glyphs, so left-aligning the two put the
+            // number visibly off under its own heading.
+            <div key={stat.key} className="flex flex-col items-center gap-1.5">
               <dt className="flex items-center gap-1.5 text-2xs text-muted-foreground">
                 <stat.icon className="size-3.5" />
                 {t(`dashboard.welcome.stats.${stat.key}`)}

--- a/packages/launcher/src/renderer/pages/logs/components/log-table.tsx
+++ b/packages/launcher/src/renderer/pages/logs/components/log-table.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useRef } from "react"
 import { ChevronDown, ChevronRight, ChevronsUpDown } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -61,6 +61,16 @@ export function LogTable({
   const { t } = useTranslation()
   const cell = DENSITY_CLASS[density]
 
+  // Bring the highlighted row into view. Arriving here from the timeline's
+  // "Open in list" already switched the view, paged to the entry and expanded
+  // it — but none of that moves the scroll container, so an entry anywhere
+  // below the fold left the jump looking like it had only changed tabs.
+  const highlightRef = useRef<HTMLTableRowElement | null>(null)
+  useEffect(() => {
+    if (highlightId === null) return
+    highlightRef.current?.scrollIntoView({ block: "center" })
+  }, [highlightId, entries])
+
   return (
     <Table>
       <TableHeader className="sticky top-0 z-10 bg-card">
@@ -90,6 +100,7 @@ export function LogTable({
           return (
             <React.Fragment key={entry.id}>
               <TableRow
+                ref={highlightId === entry.id ? highlightRef : undefined}
                 onClick={() => onToggleExpand(entry.id)}
                 className={cn(
                   "cursor-pointer",

--- a/packages/launcher/src/renderer/pages/logs/components/timeline-lanes.tsx
+++ b/packages/launcher/src/renderer/pages/logs/components/timeline-lanes.tsx
@@ -67,6 +67,47 @@ function pct(value: number, span: TimeSpan): number {
   return ((value - span.start) / width) * 100
 }
 
+/**
+ * The "correlated failure" annotation, anchored so it can never leave the track.
+ *
+ * A fixed `-translate-x-1/2` centres the label on the incident, which is right
+ * in the middle of the chart and wrong at either end: an incident near the last
+ * bucket put half the label past the right edge, and since the track scrolls
+ * (`overflow-auto`), that overhang became real scroll width — a slab of empty
+ * space to the right and a scrollbar under the whole panel.
+ *
+ * Sliding the anchor with the position fixes it without measuring anything:
+ * at 0% the label is left-aligned, at 50% centred, at 100% right-aligned, and
+ * in between it eases from one to the other. The label stays inside the track
+ * for any incident and still points at the right place.
+ */
+function IncidentTag({
+  incident,
+  span,
+}: {
+  incident: Incident
+  span: TimeSpan
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  const p = Math.min(100, Math.max(0, pct((incident.start + incident.end) / 2, span)))
+
+  return (
+    <div
+      className="pointer-events-none absolute -top-1 z-20 rounded-md border border-(--danger-border) bg-(--danger-bg) px-2 py-0.5 text-3xs whitespace-nowrap text-(--danger-text)"
+      style={{
+        // The 10rem offset skips the sticky lane-label column.
+        left: `calc(10rem + (100% - 10rem) * ${p / 100})`,
+        transform: `translateX(${-p}%)`,
+      }}
+    >
+      {t("logs.timeline.incident", {
+        agents: incident.agents,
+        events: incident.events,
+      })}
+    </div>
+  )
+}
+
 export function TimelineLanes({
   lanes,
   span,
@@ -138,19 +179,7 @@ export function TimelineLanes({
         />
       )}
 
-      {headline && (
-        <div
-          className="pointer-events-none absolute -top-1 z-20 -translate-x-1/2 rounded-md border border-(--danger-border) bg-(--danger-bg) px-2 py-0.5 text-3xs whitespace-nowrap text-(--danger-text)"
-          style={{
-            left: `calc(10rem + (100% - 10rem) * ${pct((headline.start + headline.end) / 2, span) / 100})`,
-          }}
-        >
-          {t("logs.timeline.incident", {
-            agents: headline.agents,
-            events: headline.events,
-          })}
-        </div>
-      )}
+      {headline && <IncidentTag incident={headline} span={span} />}
     </div>
   )
 }

--- a/packages/launcher/src/renderer/store/theme.ts
+++ b/packages/launcher/src/renderer/store/theme.ts
@@ -30,6 +30,22 @@ function apply(resolved: ResolvedTheme): void {
   root.style.colorScheme = resolved
 }
 
+/**
+ * Hand the mode to the main process, which themes the OS-drawn window frame —
+ * without this a dark app keeps a light Windows title bar.
+ *
+ * The *mode* goes over, not the resolved theme: `system` is a value
+ * `nativeTheme.themeSource` understands, and letting Electron follow the OS
+ * itself keeps the frame in step even while this window is asleep.
+ */
+function syncNativeFrame(mode: ThemeMode): void {
+  try {
+    void window.api?.setThemeSource?.(mode)
+  } catch {
+    /* Older preload, or no bridge in tests — the page still themes itself. */
+  }
+}
+
 interface ThemeState {
   mode: ThemeMode
   resolved: ResolvedTheme
@@ -44,12 +60,16 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     try { localStorage.setItem(STORAGE_KEY, mode) } catch {}
     const resolved = resolve(mode)
     apply(resolved)
+    syncNativeFrame(mode)
     set({ mode, resolved })
   },
   init: () => {
     const { mode } = get()
     const resolved = resolve(mode)
     apply(resolved)
+    // Re-asserted on every boot, not just on change: this is what repairs a
+    // settings.json that never got one (upgrades) or drifted from localStorage.
+    syncNativeFrame(mode)
     set({ resolved })
     if (typeof window !== 'undefined' && window.matchMedia) {
       const mq = window.matchMedia('(prefers-color-scheme: dark)')

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -467,6 +467,8 @@ declare global {
       }>
       getSetting(key: string): Promise<unknown>
       setSetting(key: string, value: unknown): Promise<unknown>
+      /** Themes the OS-drawn window frame to match the app's theme. */
+      setThemeSource(mode: "light" | "dark" | "system"): Promise<unknown>
       getAllSettings(): Promise<Record<string, unknown>>
       exportSettings(): Promise<string>
       exportSettingsToFile(): Promise<{


### PR DESCRIPTION
Six fixes found while running 0.9.1 on Windows and macOS. Version bumped to **0.9.2** — nothing is tagged here, so no SignPath request is raised until someone pushes `launcher-v0.9.2`.

## 1. Windows tray icon

A white glyph on a light taskbar is invisible. The notification area follows the **Windows mode** setting independently of the app's own theme, so it can be light or dark and a monochrome glyph only ever works against one of them.

Colour does not rescue it either — the 1.0 mark's top-right arc and bottom-right dot are **black** and disappear on a dark taskbar. Rendered all three at 16px against both backgrounds before choosing:

| | light taskbar | dark taskbar |
|---|---|---|
| white glyph (before) | ❌ invisible | ✅ |
| transparent colour mark | ✅ | ❌ loses the black arc + dot |
| **opaque tile (`icon.ico`)** | ✅ | ✅ |

The tile carries its own background, and it is already what Windows shows for this app on the taskbar and in the Start menu. macOS keeps its inset white glyph, Linux keeps the white one (panels are conventionally dark).

`icon.ico` also had to be added to the `extraResources` filter — it only allowed `tray-icon*.png`, so dev looked fine while the packaged build would have fallen back to `createPlaceholderIcon()`.

## 2. Light Windows title bar on a dark app

The frame is drawn by the OS, so the OS has to be told how the app is themed. Nothing did — there was no `nativeTheme` anywhere; the theme lived entirely in the renderer's localStorage and CSS.

The renderer now hands its mode to `nativeTheme.themeSource` over IPC, and main mirrors it into `settings.json` so `whenReady` can apply it **before the first window exists**. That main-side copy is the point: the renderer reads localStorage synchronously so the page never flashes, but main cannot reach it at startup, and without a copy the frame would open in the system theme and correct itself once the renderer booted — a visible flicker on every launch for anyone not on the system default.

The mode is sent rather than the resolved theme: `system` is a value `themeSource` understands, and letting Electron follow the OS keeps the frame in step even while the window sleeps.

## 3. Sidebar follows the theme

Per the design mock. It was pinned near-black in both modes on the grounds that it frames the app like window chrome — but a light app with a near-black rail down one side reads as a rendering fault.

The surfaces that really are chrome and stay dark either way — the onboarding rail, the setup wizard's summary aside — move to their own `--panel-*` tokens. They had been borrowing the sidebar tokens, which worked only while those were pinned dark.

**Hover and selection are also split apart**, which stock shadcn cannot express (both land on `--sidebar-accent`). Three states, three token pairs:

```
--sidebar-accent   neutral fill      search field, status chip, icon-button hover
--sidebar-hover    accent, light     nav row under the pointer
--sidebar-active   accent, stronger  the selected nav row
```

Both nav states mix from `--accent`, so they **track the user's accent preset** rather than a hardcoded violet — the mock shows the default preset, not a fixed colour. `--accent` is the right base because it is defined with and without `data-accent` on the root, so even the first frame has something to mix.

| theme | state | background | label |
|---|---|---|---|
| light | rest | `#ffffff` | `#3a3a3c` |
| light | hover | `#f3f2fd` (accent 7%) | accent |
| light | selected | `#eae9fc` (accent 12%) | accent |
| dark | rest | `#0e1117` | `#a8aabb` |
| dark | hover | `#1e2237` (accent 14%) | `#ffffff` |
| dark | selected | `#30365a` (accent 30%) | `#ffffff` |

Dark labels stay white on purpose: the dark theme's accent is already a light violet, and putting it on a fill made of itself is the one pairing that does not read.

Also killed a dead rule — `[data-sidebar="dark"] :focus-visible` keyed off an attribute nothing ever set, so it had never applied; it is now `.panel-dark`, which the two dark surfaces carry.

## 4–5. Dashboard

- `messagesToday` had only singular/plural, so a quiet day read "0 new messages today". Added `messagesToday_zero` → "No new messages today." (verified i18next 25 matches `_zero` ahead of the plural rules — English's `Intl.PluralRules.select(0)` returns `other`, but i18next special-cases it).
- The stat columns centre label over value. `flex-col` left-aligns, and since the label carries an icon while the value is one or two glyphs, the number sat visibly off under its own heading.

## 6. Logs

**The correlated-failure tag no longer widens the panel.** A fixed `-translate-x-1/2` centres the label on the incident — right in the middle of the chart, wrong at either end. An incident near the last bucket hung half the label past the track, and since the track is `overflow-auto`, that overhang became real scroll width: a slab of white to the right and a scrollbar under the whole panel.

The anchor now slides with the position — left-aligned at 0%, centred at 50%, right-aligned at 100%, easing in between:

```
left:      calc(10rem + (100% - 10rem) * p)
transform: translateX(-p%)
```

No measuring, no overflow at any position, and the label still points at the right place.

**"Open in list" now scrolls to the entry.** It already switched views, paged to it and expanded it — but `highlightId` only ever added a background colour, and nothing moved the scroll container. An entry below the fold made the jump look like it had merely changed tabs. Confirmed the paging was already correct: `ordered` depends on `filtered` and `sort`, not on `view`, so both views index the same sequence.

## Verification

`npm run typecheck` (tsc -b, main + preload + renderer), 107 tests, and `npm run build` all clean. The build matters here — a CSS syntax error slipped past typecheck and vitest earlier in this work, since neither compiles the stylesheet.

Not run: the app itself. Needs a real launch on both platforms, particularly the Windows tray icon and title bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)