### PR TITLE
feat(launcher): openagents.org skin behind an appearance switch

### DIFF
--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.3.0",
         "@openagents-org/agent-launcher": "0.2.149",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1428,6 +1429,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -32,6 +32,7 @@
     "dist": "npm run build && electron-builder --publish always"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.3.0",
     "@openagents-org/agent-launcher": "0.2.149",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1142,6 +1142,12 @@ const ACCENT_HEX = {
     orange: "#ea580c",
     rose: "#e11d48",
     slate: "#475569",
+    /* openagents.org's brand blue. Not a user-selectable preset — the skin
+       locks it — but it arrives here through the same door as the others,
+       because the appearance store mirrors the EFFECTIVE accent rather than
+       the stored one. Without an entry the lookup below would fall back to
+       indigo and the splash would come up violet in front of a blue app. */
+    oa: "#2f6bff",
   },
   dark: {
     indigo: "#818cf8",
@@ -1152,6 +1158,27 @@ const ACCENT_HEX = {
     orange: "#fb923c",
     rose: "#fb7185",
     slate: "#94a3b8",
+    oa: "#6b95ff",
+  },
+} as const
+
+/**
+ * Splash chrome per skin, mirroring the surface and text tokens each one sets
+ * in the renderer. Same duplication bargain as ACCENT_HEX above: the splash is
+ * painted before a renderer exists, so the stylesheet cannot be read.
+ *
+ * The dark pair is what makes this worth carrying — `#0f1115` and `#0b1121`
+ * are far enough apart that the window visibly changes colour under the splash
+ * on launch if the skin is on and this table is not consulted.
+ */
+const SPLASH_CHROME = {
+  default: {
+    light: { bg: "#f2f2f7", title: "#1c1c1e", msg: "#636366", detail: "#aeaeb2" },
+    dark: { bg: "#0f1115", title: "#f5f5f7", msg: "#a1a1aa", detail: "#6b6f7a" },
+  },
+  openagents: {
+    light: { bg: "#f9fafb", title: "#0a0a0a", msg: "#525252", detail: "#a3a3a3" },
+    dark: { bg: "#0b1121", title: "#f5f7fa", msg: "#9aa5bd", detail: "#66708a" },
   },
 } as const
 
@@ -1162,8 +1189,9 @@ const ACCENT_HEX = {
  * Both preferences live in the renderer's localStorage (they must be readable
  * synchronously, on the first paint) and are mirrored into settings.json
  * purely so this function can see them — `themeMode` by the `theme:set-source`
- * handler, `accent` by the appearance store. A missing or unrecognised value
- * falls back to the defaults, which is also what a fresh install gets.
+ * handler, `accent` and `skin` by the appearance store. A missing or
+ * unrecognised value falls back to the defaults, which is also what a fresh
+ * install gets.
  *
  * Call only after `applyThemeSource()`, so `shouldUseDarkColors` reflects the
  * app's own setting rather than the bare OS one.
@@ -1183,20 +1211,10 @@ function splashPalette(): {
     typeof stored === "string" && stored in accents
       ? accents[stored as keyof typeof accents]
       : accents.indigo
+  const storedSkin = store.get("skin")
+  const skin = storedSkin === "openagents" ? "openagents" : "default"
   return {
-    ...(scheme === "dark"
-      ? {
-          bg: "#0f1115",
-          title: "#f5f5f7",
-          msg: "#a1a1aa",
-          detail: "#6b6f7a",
-        }
-      : {
-          bg: "#f2f2f7",
-          title: "#1c1c1e",
-          msg: "#636366",
-          detail: "#aeaeb2",
-        }),
+    ...SPLASH_CHROME[skin][scheme],
     accent,
     // Same relationship the in-app <Progress> uses (`bg-primary/20` track under
     // a `bg-primary` bar), expressed as an 8-digit hex because there is no

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1142,12 +1142,13 @@ const ACCENT_HEX = {
     orange: "#ea580c",
     rose: "#e11d48",
     slate: "#475569",
-    /* openagents.org's brand blue. Not a user-selectable preset — the skin
-       locks it — but it arrives here through the same door as the others,
-       because the appearance store mirrors the EFFECTIVE accent rather than
-       the stored one. Without an entry the lookup below would fall back to
-       indigo and the splash would come up violet in front of a blue app. */
-    oa: "#2f6bff",
+    /* The skin's locked accent — teal, the colour this very progress bar
+       draws in. Not a user-selectable preset, but it arrives here through the
+       same door as the others, because the appearance store mirrors the
+       EFFECTIVE accent rather than the stored one. Without an entry the lookup
+       below would fall back to indigo and the splash would come up violet in
+       front of a teal app. Keep in step with `--accent-oa` in globals.css. */
+    oa: "#0d9488",
   },
   dark: {
     indigo: "#818cf8",
@@ -1158,7 +1159,7 @@ const ACCENT_HEX = {
     orange: "#fb923c",
     rose: "#fb7185",
     slate: "#94a3b8",
-    oa: "#6b95ff",
+    oa: "#2dd4bf",
   },
 } as const
 
@@ -1178,7 +1179,7 @@ const SPLASH_CHROME = {
   },
   openagents: {
     light: { bg: "#f9fafb", title: "#0a0a0a", msg: "#525252", detail: "#a3a3a3" },
-    dark: { bg: "#0b1121", title: "#f5f7fa", msg: "#9aa5bd", detail: "#66708a" },
+    dark: { bg: "#121a2c", title: "#f2f5fa", msg: "#9fabc4", detail: "#6b7791" },
   },
 } as const
 

--- a/packages/launcher/src/renderer/components/ui-kit/filter-chips.tsx
+++ b/packages/launcher/src/renderer/components/ui-kit/filter-chips.tsx
@@ -35,12 +35,17 @@ export function FilterChips<T extends string>({
   className,
 }: FilterChipsProps<T>): React.JSX.Element {
   return (
-    <div className={cn("flex flex-wrap items-center gap-1.5", className)}>
+    <div
+      data-slot="filter-chips"
+      className={cn("flex flex-wrap items-center gap-1.5", className)}
+    >
       {options.map((option) => {
         const active = option.value === value
         return (
           <button
             key={option.value}
+            data-slot="filter-chip"
+            data-active={active}
             type="button"
             aria-pressed={active}
             onClick={() => onChange(option.value)}

--- a/packages/launcher/src/renderer/components/ui-kit/icon-toggle.tsx
+++ b/packages/launcher/src/renderer/components/ui-kit/icon-toggle.tsx
@@ -35,6 +35,7 @@ export function IconToggle<T extends string>({
 }: IconToggleProps<T>): React.JSX.Element {
   return (
     <div
+      data-slot="icon-toggle"
       role="radiogroup"
       className={cn(
         "flex shrink-0 items-center gap-0.5 rounded-md border p-0.5",
@@ -46,6 +47,8 @@ export function IconToggle<T extends string>({
         return (
           <button
             key={option.value}
+            data-slot="icon-toggle-item"
+            data-active={active}
             type="button"
             role="radio"
             aria-checked={active}

--- a/packages/launcher/src/renderer/components/ui/sonner.tsx
+++ b/packages/launcher/src/renderer/components/ui/sonner.tsx
@@ -38,14 +38,21 @@ const Toaster = ({ ...props }: ToasterProps): React.JSX.Element => {
       // icon, which made success/warning/error read identically. Each type gets
       // the tint it already has elsewhere in the app; `!` is needed because
       // Sonner's own `[data-sonner-toast]` rule sets the background.
+      //
+      // The frame reads `--*-border` rather than a 25% cut of the text colour.
+      // Those two are the same colour in the default skin — the tokens were
+      // authored at 0.24–0.30 alpha of exactly these hues — so nothing moves
+      // here; what it buys is a border a skin can restate, which is how the
+      // openagents skin gets an inked frame on a toast without a second
+      // `!important` fighting this one.
       toastOptions={{
         classNames: {
           success:
-            "bg-(--success-bg)! text-(--success-text)! border-(--success-text)/25!",
+            "bg-(--success-bg)! text-(--success-text)! border-(--success-border)!",
           error:
-            "bg-(--danger-bg)! text-(--danger-text)! border-(--danger-text)/25!",
+            "bg-(--danger-bg)! text-(--danger-text)! border-(--danger-border)!",
           warning:
-            "bg-(--warning-bg)! text-(--warning-text)! border-(--warning-text)/25!",
+            "bg-(--warning-bg)! text-(--warning-text)! border-(--warning-border)!",
           info: "bg-(--bg-card)! text-(--text-primary)! border-(--border)!",
           // Sonner colours the title itself, which would keep it neutral on
           // top of a tinted surface — inherit so it follows the type.

--- a/packages/launcher/src/renderer/globals.css
+++ b/packages/launcher/src/renderer/globals.css
@@ -381,7 +381,11 @@
      `--accent` directly, so `--accent-hover`, `--accent-bg`, `--text-link`,
      `--primary`, `--ring` and the row states all derive from it exactly as
      they do for a user-chosen preset. */
-  --accent-oa: 223 100% 59%;  /* #2f6bff */
+  --accent-oa: 175 84% 32%;  /* #0d9488 — the teal the splash progress bar
+                                draws in; picked over the site's own #2F6BFF
+                                because that blue lands close enough to indigo
+                                on a dark surface to read as the violet the
+                                skin was meant to get away from. */
 }
 
 :root[data-theme="dark"] {
@@ -394,7 +398,7 @@
   --accent-rose: 351 94% 71%;    /* #fb7185 */
   --accent-slate: 215 20% 65%;   /* #94a3b8 */
   /* Lifted for the dark surface, same as every other preset's dark twin. */
-  --accent-oa: 223 100% 71%;  /* #6b95ff */
+  --accent-oa: 172 66% 50%;  /* #2dd4bf */
 }
 
 :root[data-accent="indigo"] { --accent-hsl-base: var(--accent-indigo); }

--- a/packages/launcher/src/renderer/globals.css
+++ b/packages/launcher/src/renderer/globals.css
@@ -5,6 +5,14 @@
    would pop in and out with no transition at all. */
 @import "tw-animate-css";
 
+/* The openagents.org skin — every rule inside is scoped to
+   `[data-skin="openagents"]` on <html>, so with the switch off (the default)
+   nothing in it matches and this import costs a stylesheet parse. Imported
+   here rather than appended because CSS requires `@import` before any rule;
+   the file is deliberately unlayered, which is what lets it outrank the
+   `@layer base` tokens below regardless of where it is pulled in. */
+@import "./styles/skin-openagents.css";
+
 /* shadcn components ship `dark:` variants that assume a `.dark` class. The
    launcher's theme store instead writes `<html data-theme="dark">` (see
    store/theme.ts), so point the variant at that attribute — otherwise every
@@ -366,6 +374,14 @@
   --accent-orange: 21 90% 48%;   /* #ea580c */
   --accent-rose: 347 77% 50%;    /* #e11d48 */
   --accent-slate: 215 19% 35%;   /* #475569 */
+  /* openagents.org's brand blue (#2F6BFF). Not in ACCENT_COLORS and so never
+     shown as a swatch: the skin owns it. Flipping the skin on writes
+     `data-accent="oa"` from the appearance store, which is what locks the
+     accent — going through the preset machinery rather than overriding
+     `--accent` directly, so `--accent-hover`, `--accent-bg`, `--text-link`,
+     `--primary`, `--ring` and the row states all derive from it exactly as
+     they do for a user-chosen preset. */
+  --accent-oa: 223 100% 59%;  /* #2f6bff */
 }
 
 :root[data-theme="dark"] {
@@ -377,6 +393,8 @@
   --accent-orange: 27 96% 61%;   /* #fb923c */
   --accent-rose: 351 94% 71%;    /* #fb7185 */
   --accent-slate: 215 20% 65%;   /* #94a3b8 */
+  /* Lifted for the dark surface, same as every other preset's dark twin. */
+  --accent-oa: 223 100% 71%;  /* #6b95ff */
 }
 
 :root[data-accent="indigo"] { --accent-hsl-base: var(--accent-indigo); }
@@ -387,6 +405,7 @@
 :root[data-accent="orange"] { --accent-hsl-base: var(--accent-orange); }
 :root[data-accent="rose"] { --accent-hsl-base: var(--accent-rose); }
 :root[data-accent="slate"] { --accent-hsl-base: var(--accent-slate); }
+:root[data-accent="oa"] { --accent-hsl-base: var(--accent-oa); }
 
 :root[data-accent] {
   --accent-base: hsl(var(--accent-hsl-base));

--- a/packages/launcher/src/renderer/i18n/locales/en/settings.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/settings.json
@@ -190,11 +190,14 @@
       "lg": "Large"
     },
     "theme": "Theme",
+    "skin": "Match openagents.org",
+    "skinDesc": "Uses the website’s look — bold frames, hard shadows and Inter",
     "behaviorGroup": "Interface behaviour",
     "animations": "Show animations",
     "animationsDesc": "Turning them off lowers resource use",
     "highContrast": "High contrast",
-    "highContrastDesc": "Makes text and controls easier to read"
+    "highContrastDesc": "Makes text and controls easier to read",
+    "accentLocked": "Locked to the OpenAgents blue while the website look is on"
   },
   "agents": {
     "startupGroup": "Startup",

--- a/packages/launcher/src/renderer/i18n/locales/zh/settings.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/settings.json
@@ -190,11 +190,14 @@
       "lg": "大"
     },
     "theme": "主题",
+    "skin": "对齐官网风格",
+    "skinDesc": "采用 openagents.org 的外观：粗描边、硬阴影与 Inter 字体",
     "behaviorGroup": "界面行为",
     "animations": "显示动画",
     "animationsDesc": "减少动画可降低资源占用",
     "highContrast": "高对比度",
-    "highContrastDesc": "提高文本和控件的可读性"
+    "highContrastDesc": "提高文本和控件的可读性",
+    "accentLocked": "官网风格开启时锁定为 OpenAgents 品牌蓝"
   },
   "agents": {
     "startupGroup": "启动设置",

--- a/packages/launcher/src/renderer/pages/install/components/marketplace-hero.tsx
+++ b/packages/launcher/src/renderer/pages/install/components/marketplace-hero.tsx
@@ -59,6 +59,11 @@ export function MarketplaceHero({
 
   return (
     <section
+      // Named so a skin can restyle the banner as one object. The frame here
+      // is `border-primary/25`, an explicit colour rather than `--border`, so
+      // it does not follow a skin that repaints the app's hairlines — this is
+      // the handle that lets the openagents skin ink it instead.
+      data-slot="hero"
       onMouseEnter={() => setPaused(true)}
       onMouseLeave={() => setPaused(false)}
       className="relative overflow-hidden rounded-xl border border-primary/25 bg-linear-to-r from-primary/12 via-primary/5 to-transparent px-7 py-6"
@@ -84,7 +89,10 @@ export function MarketplaceHero({
       >
         {/* The logo, full strength and framed — it anchors the left edge far
             better than the same mark faded into the background did. */}
-        <div className="flex size-24 shrink-0 items-center justify-center rounded-2xl border border-primary/20 bg-card/80 shadow-md backdrop-blur-sm">
+        <div
+          data-slot="hero-mark"
+          className="flex size-24 shrink-0 items-center justify-center rounded-2xl border border-primary/20 bg-card/80 shadow-md backdrop-blur-sm"
+        >
           <AgentIcon type={hero.name} size={52} />
         </div>
 
@@ -101,9 +109,23 @@ export function MarketplaceHero({
             {describeEntry(hero, t) || t("install.card.noDescription")}
           </p>
 
-          {/* Tags ride on the CTA row rather than claiming one of their own: at
-              these string lengths a dedicated row was mostly whitespace. */}
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pt-5">
+          {/* Tags sit ABOVE the CTA, on a row of their own. They used to ride
+              the CTA row to save the vertical space a short tag list wastes,
+              but that row wraps: four tags pushed them under the button, where
+              they read as something the button produced rather than as
+              metadata about the agent. A row that is occasionally sparse beats
+              one that occasionally reorders itself. */}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-4">
+              {tags.map((tag) => (
+                <Badge key={tag} variant="muted" size="sm" className="font-mono">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pt-4">
             <Button onClick={() => onOpen(hero.name)}>
               {hero.installed ? <ArrowUpRight /> : <Download />}
               {t(hero.installed ? "install.hero.viewDetail" : "install.hero.installNow")}
@@ -114,15 +136,6 @@ export function MarketplaceHero({
                 {current && latest && " · "}
                 {latest && t("install.hero.latest", { version: latest })}
               </span>
-            )}
-            {tags.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 lg:ml-2">
-                {tags.map((tag) => (
-                  <Badge key={tag} variant="muted" size="sm" className="font-mono">
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
             )}
           </div>
         </div>

--- a/packages/launcher/src/renderer/pages/install/detail/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/index.tsx
@@ -99,9 +99,16 @@ export default function AgentDetail({
       {/* Below `lg` there is no room for two columns, so the whole area
           becomes one scroller instead. */}
       <div className="mx-auto flex w-full min-h-0 max-w-7xl flex-1 flex-col gap-6 overflow-y-auto px-9 py-6 lg:flex-row lg:gap-8 lg:overflow-hidden">
+        {/* The padding is clearance for what a card draws OUTSIDE its own box:
+            the openagents skin lifts one 4px on hover and drops a 6px offset
+            shadow, and `overflow-y: auto` forces `overflow-x` to `auto` too,
+            so without room on all four sides the scroller clips both. The
+            negative top margin gives the lift its 4px back without moving the
+            content down. Harmless on the default skin, whose blurred shadow
+            was being clipped here as well, just less visibly. */}
         <div
           ref={documentRef}
-          className="flex min-w-0 flex-col gap-6 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1"
+          className="flex min-w-0 flex-col gap-6 lg:-mt-1 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pt-1 lg:pr-2 lg:pb-2"
         >
           <DetailSection title={t("agents.readme.overview")}>
             <DetailOverview entry={entry} />
@@ -165,8 +172,11 @@ export default function AgentDetail({
           </DetailSection>
         </div>
 
+        {/* Same clearance as the document column — this rail is where it shows
+            first, because its top card sits flush against the scroller's edge
+            and had its hover lift sliced off. */}
         <DetailRail
-          className="lg:min-h-0 lg:w-72 lg:shrink-0 lg:overflow-y-auto"
+          className="lg:-mt-1 lg:min-h-0 lg:w-72 lg:shrink-0 lg:overflow-y-auto lg:pt-1 lg:pr-2 lg:pb-2"
           entry={entry}
           installed={detail.installed}
           job={detail.job}

--- a/packages/launcher/src/renderer/pages/logs/components/log-table.tsx
+++ b/packages/launcher/src/renderer/pages/logs/components/log-table.tsx
@@ -137,7 +137,13 @@ export function LogTable({
               </TableRow>
               {expanded && (
                 <TableRow className="hover:bg-transparent">
-                  <TableCell colSpan={6} className="p-0">
+                  {/* Five, matching the header exactly. At six the browser
+                      added an anonymous column to hold the overflow, split the
+                      detail panel's intrinsic width across it, and pushed the
+                      table wider than its `overflow-x-auto` container — so
+                      opening any entry with a long message scrolled the whole
+                      log sideways and clipped the columns on the left. */}
+                  <TableCell colSpan={5} className="p-0">
                     <LogDetail
                       entry={entry}
                       onCopy={onCopyDetail}

--- a/packages/launcher/src/renderer/pages/settings/sections/appearance-section.tsx
+++ b/packages/launcher/src/renderer/pages/settings/sections/appearance-section.tsx
@@ -37,22 +37,32 @@ export function AppearanceSection(): React.JSX.Element {
     scale,
     animations,
     highContrast,
+    skin,
     setAccent,
     setScale,
     setAnimations,
     setHighContrast,
+    setSkin,
   } = useAppearanceStore(
     useShallow((s) => ({
       accent: s.accent,
       scale: s.scale,
       animations: s.animations,
       highContrast: s.highContrast,
+      skin: s.skin,
       setAccent: s.setAccent,
       setScale: s.setScale,
       setAnimations: s.setAnimations,
       setHighContrast: s.setHighContrast,
+      setSkin: s.setSkin,
     })),
   )
+
+  // The skin pins the accent to the brand blue, so the swatches below have
+  // nothing to change while it is on. Disabled rather than hidden: a row that
+  // vanishes reads as a bug, one that greys out reads as a consequence — and
+  // the description says which switch caused it.
+  const accentLocked = skin === "openagents"
 
   return (
     <>
@@ -66,14 +76,34 @@ export function AppearanceSection(): React.JSX.Element {
         </Row>
 
         <Row
-          label={t("settings.appearance.accent")}
-          desc={t("settings.appearance.accentDesc")}
+          label={t("settings.appearance.skin")}
+          desc={t("settings.appearance.skinDesc")}
         >
-          <div className="flex flex-wrap gap-2">
+          <Switch
+            checked={skin === "openagents"}
+            onCheckedChange={(on) => setSkin(on ? "openagents" : "default")}
+          />
+        </Row>
+
+        <Row
+          label={t("settings.appearance.accent")}
+          desc={
+            accentLocked
+              ? t("settings.appearance.accentLocked")
+              : t("settings.appearance.accentDesc")
+          }
+        >
+          <div
+            className={cn(
+              "flex flex-wrap gap-2",
+              accentLocked && "pointer-events-none opacity-40",
+            )}
+          >
             {ACCENT_COLORS.map((color) => (
               <button
                 key={color}
                 type="button"
+                disabled={accentLocked}
                 aria-label={t(`settings.appearance.accents.${color}`)}
                 title={t(`settings.appearance.accents.${color}`)}
                 onClick={() => setAccent(color)}

--- a/packages/launcher/src/renderer/store/appearance.ts
+++ b/packages/launcher/src/renderer/store/appearance.ts
@@ -22,6 +22,34 @@ export type AccentColor =
 
 export type UiScale = 'sm' | 'md' | 'lg'
 
+/**
+ * Visual skin. `openagents` aligns the launcher with openagents.org —
+ * neo-brutalism over Inter; see styles/skin-openagents.css for what it repaints
+ * and why. Orthogonal to the light/dark mode rather than a third mode: the skin
+ * ships both, so all four combinations are reachable.
+ */
+export type Skin = 'default' | 'openagents'
+
+export const SKINS: Skin[] = ['default', 'openagents']
+
+/**
+ * The accent the openagents skin pins itself to — the site's #2F6BFF, declared
+ * as `--accent-oa` in globals.css alongside the eight user-facing presets.
+ *
+ * Locking the accent is done by writing this as `data-accent` rather than by
+ * overriding `--accent` from the skin stylesheet. `:root[data-accent]` derives
+ * a dozen values from whichever preset is live — hover, tint, border, link,
+ * `--primary`, `--ring`, the sidebar and the row states — so going through the
+ * same door gets all of them for free and in the right order. Overriding
+ * `--accent` alone would leave every one of those still mixed from the user's
+ * old preset.
+ *
+ * Deliberately absent from ACCENT_COLORS: it is not a choice, so it is not a
+ * swatch. The user's own pick stays in the store untouched while the skin is
+ * on, and comes back the moment it is switched off.
+ */
+const BRAND_ACCENT = 'oa'
+
 export const ACCENT_COLORS: AccentColor[] = [
   'indigo',
   'blue',
@@ -39,6 +67,7 @@ const ACCENT_KEY = 'launcher:accent'
 const SCALE_KEY = 'launcher:ui-scale'
 const ANIMATIONS_KEY = 'launcher:animations'
 const CONTRAST_KEY = 'launcher:high-contrast'
+const SKIN_KEY = 'launcher:skin'
 
 function readStored<T extends string>(key: string, allowed: T[], fallback: T): T {
   try {
@@ -71,10 +100,17 @@ function writeFlag(key: string, on: boolean): void {
  * moment the colour is needed. Same arrangement `language` (i18n/index.ts) and
  * the theme mode (store/theme.ts) already use, and the only preference here
  * that main has any use for; scale, animations and contrast stay renderer-side.
+ *
+ * It is the EFFECTIVE accent that goes over, not the stored one — otherwise a
+ * user running the skin gets a splash in the preset they picked months ago,
+ * then a window in brand blue. The skin goes over for the same reason: it
+ * moves the splash's surface colour too (`SPLASH_CHROME` in main/index.ts),
+ * and dark default vs dark skin are far enough apart to see the seam.
  */
-function syncMain(accent: AccentColor): void {
+function syncMain(accent: string, skin: Skin): void {
   try {
     void window.api?.setSetting?.('accent', accent)
+    void window.api?.setSetting?.('skin', skin)
   } catch {
     /* Older preload, or no bridge in tests — the page still themes itself. */
   }
@@ -85,13 +121,29 @@ interface Applied {
   scale: UiScale
   animations: boolean
   highContrast: boolean
+  skin: Skin
 }
 
-function apply({ accent, scale, animations, highContrast }: Applied): void {
+/**
+ * The accent actually painted: the skin's brand blue while it is on, the
+ * user's own preset otherwise. Their stored choice is never overwritten, only
+ * shadowed, so turning the skin off restores it without having to remember it
+ * anywhere separate.
+ */
+function effectiveAccent({ accent, skin }: Pick<Applied, 'accent' | 'skin'>): string {
+  return skin === 'openagents' ? BRAND_ACCENT : accent
+}
+
+function apply(state: Applied): void {
   if (typeof document === 'undefined') return
+  const { scale, animations, highContrast, skin } = state
   const root = document.documentElement
-  root.dataset.accent = accent
+  root.dataset.accent = effectiveAccent(state)
   root.dataset.uiScale = scale
+  // Like `animations` below: the default skin carries no rules, so it leaves
+  // no attribute behind either.
+  if (skin === 'default') delete root.dataset.skin
+  else root.dataset.skin = skin
   // Only the off/high states carry a rule, so the default leaves no attribute
   // behind for a stylesheet to trip over.
   if (animations) delete root.dataset.animations
@@ -105,6 +157,7 @@ interface AppearanceState extends Applied {
   setScale: (s: UiScale) => void
   setAnimations: (on: boolean) => void
   setHighContrast: (on: boolean) => void
+  setSkin: (s: Skin) => void
   init: () => void
 }
 
@@ -113,13 +166,15 @@ export const useAppearanceStore = create<AppearanceState>((set, get) => ({
   scale: readStored<UiScale>(SCALE_KEY, UI_SCALES, 'md'),
   animations: readFlag(ANIMATIONS_KEY, true),
   highContrast: readFlag(CONTRAST_KEY, false),
+  skin: readStored<Skin>(SKIN_KEY, SKINS, 'default'),
 
   setAccent: (accent) => {
     try {
       localStorage.setItem(ACCENT_KEY, accent)
     } catch {}
-    apply({ ...get(), accent })
-    syncMain(accent)
+    const next = { ...get(), accent }
+    apply(next)
+    syncMain(effectiveAccent(next), next.skin)
     set({ accent })
   },
 
@@ -143,11 +198,23 @@ export const useAppearanceStore = create<AppearanceState>((set, get) => ({
     set({ highContrast })
   },
 
+  // Also re-syncs main: flipping the skin changes the effective accent, so the
+  // splash has to be told even though the user touched no swatch.
+  setSkin: (skin) => {
+    try {
+      localStorage.setItem(SKIN_KEY, skin)
+    } catch {}
+    const next = { ...get(), skin }
+    apply(next)
+    syncMain(effectiveAccent(next), next.skin)
+    set({ skin })
+  },
+
   // Re-asserted on every boot, not just on change: this is what gives main a
   // copy for users who picked their accent before it was ever mirrored, and
   // what repairs a settings.json that has drifted from localStorage.
   init: () => {
     apply(get())
-    syncMain(get().accent)
+    syncMain(effectiveAccent(get()), get().skin)
   },
 }))

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -128,18 +128,32 @@
   --destructive-foreground: 0 0% 100%;
   --border-hsl: 0 0% 0%;
   --input-hsl: 0 0% 0%;
-  /* Pushed to a true green, away from the site's own #16C79A. That teal was
-     the right pick while the accent was blue; with the accent now teal itself
-     the two sat within a few degrees of each other, and a status colour that
-     is indistinguishable from the brand colour cannot signal status. */
-  --success-hsl: 142 76% 36%;
-  --success-foreground: 142 72% 29%;
-  --success: #16a34a;
-  --success-bg: rgba(22, 163, 74, 0.1);
-  --success-border: rgba(22, 163, 74, 0.4);
-  --success-text: #15803d;
+  /* ONE green, and it is the skin's own — teal-700, a single step down from
+     the accent's teal-600 and the same hue (175°).
+
+     The default palette carries success at two lightnesses on purpose: a
+     bright fill for dots and icons, a dark one for text that has to clear 4.5:1
+     on white. That split is invisible until two components sitting side by side
+     land on different halves of it, which is what happened here — the same
+     "succeeded" state arriving as two different greens depending on which
+     token the component reached for.
+
+     Collapsed onto one value that satisfies both jobs: #0f766e is 5.4:1 on
+     white, so it works as body text, and white on it is the same 5.4:1, so it
+     works as a solid fill. `-bg` and `-border` still come off teal-600 —
+     a tint has to differ from the text sitting on it, which is the one
+     lightness split that earns its keep. */
+  --success-hsl: 175 77% 26%; /* #0f766e */
+  --success-foreground: 175 77% 26%;
+  --success: #0f766e;
+  --success-text: #0f766e;
+  --success-bg: rgba(13, 148, 136, 0.1);
+  --success-border: var(--skin-ink);
   --warning-hsl: 38 92% 47%;
   --warning-foreground: 33 90% 34%;
+  /* Status tints are chips, and every chip in this skin is inked. */
+  --warning-border: var(--skin-ink);
+  --danger-border: var(--skin-ink);
   --info: #2f6bff;
   --info-bg: rgba(47, 107, 255, 0.1);
   --info-text: #1d4ed8;
@@ -231,14 +245,19 @@
   --destructive-foreground: 222 42% 12%;
   --border-hsl: 220 56% 94%;
   --input-hsl: 220 56% 94%;
-  --success-hsl: 142 69% 58%;
-  --success-foreground: 142 69% 75%;
-  --success: #4ade80;
-  --success-bg: rgba(74, 222, 128, 0.14);
-  --success-border: rgba(74, 222, 128, 0.35);
-  --success-text: #86efac;
+  /* Same collapse as the light block, at the accent's own dark value — one
+     teal for every "succeeded" surface in the theme. It clears 8:1 on the page
+     here, so nothing is given up by using it for text as well as for fills. */
+  --success-hsl: 172 66% 50%; /* #2dd4bf */
+  --success-foreground: 172 66% 50%;
+  --success: #2dd4bf;
+  --success-text: #2dd4bf;
+  --success-bg: rgba(45, 212, 191, 0.14);
+  --success-border: var(--skin-ink);
   --warning-hsl: 43 96% 56%;
   --warning-foreground: 43 96% 76%;
+  --warning-border: var(--skin-ink);
+  --danger-border: var(--skin-ink);
   --info: #6b9bff;
   --info-bg: rgba(107, 155, 255, 0.16);
   --info-text: #a8c3ff;
@@ -466,6 +485,54 @@
 :root[data-skin='openagents'] [data-slot='button'][data-size='xs']:active:not(:disabled) {
   transform: none;
   box-shadow: none;
+}
+
+/* ===========================================================================
+   Status surfaces — toasts and banners
+   ===========================================================================
+   A toast is the most visible thing the app ever puts on screen and it was the
+   last surface still rendered in the default style: a soft 1px frame and a
+   blurred drop shadow floating over an interface that has neither.
+
+   It gets the container treatment, at control weight rather than shell weight
+   — it is a transient strip, not a panel, so 2px and a 4px block rather than
+   2.5px and 6px. The colour comes from Sonner's own per-type classes, which
+   now read `--*-border`; this skin points all three of those at the ink, so
+   the frame lands here without a second `!important` fighting the first.
+
+   Sonner sets `border-radius` from its own `--border-radius` custom property
+   (handed to it in components/ui/sonner.tsx), so the radius has to be restated
+   as a real declaration to win. */
+:root[data-skin='openagents'] [data-sonner-toast] {
+  border-width: var(--skin-border-w);
+  border-style: solid;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  /* The site sets every small label in bold; a four-second message is exactly
+     the case that benefits. */
+  font-weight: 600;
+}
+
+/* The close button and action button inside a toast are chrome on top of an
+   already-framed strip — they take the hairline, like everything else that
+   lives inside a container. */
+:root[data-skin='openagents'] [data-sonner-toast] [data-close-button],
+:root[data-skin='openagents'] [data-sonner-toast] [data-button] {
+  border-color: var(--skin-hairline);
+}
+
+/* The legacy `.banner` is the same object in page flow rather than floating.
+   Its warning variant hardcodes a 1px tinted border of its own, which is what
+   the second rule is for. */
+:root[data-skin='openagents'] .banner {
+  border: var(--skin-border-w) solid var(--skin-ink);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  font-weight: 600;
+}
+
+:root[data-skin='openagents'] .banner.warning {
+  border-color: var(--skin-ink);
 }
 
 /* ===========================================================================

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -306,7 +306,10 @@
    carries 2.5px of ink is exactly the inconsistency the skin exists to avoid.
 
    Tooltips are excluded on purpose. They are 11px transient labels; a 2.5px
-   frame and a 6px shadow on one is a billboard. */
+   frame and a 6px shadow on one is a billboard.
+
+   The frame is shared; the SHADOW is not, and that split is what the two rules
+   below are for. See the lift section further down. */
 :root[data-skin='openagents'] [data-slot='card'],
 :root[data-skin='openagents'] [data-slot='dialog-content'],
 :root[data-skin='openagents'] [data-slot='alert-dialog-content'],
@@ -322,6 +325,19 @@
   border-style: solid;
   border-color: var(--skin-ink);
   border-radius: var(--radius-xl);
+}
+
+/* Overlays are already off the page — that is what being an overlay means — so
+   they carry their shadow standing still and never move under the pointer. A
+   dialog that jumps 4px when the mouse crosses it is a bug, not a style. */
+:root[data-skin='openagents'] [data-slot='dialog-content'],
+:root[data-skin='openagents'] [data-slot='alert-dialog-content'],
+:root[data-skin='openagents'] [data-slot='popover-content'],
+:root[data-skin='openagents'] [data-slot='dropdown-menu-content'],
+:root[data-skin='openagents'] [data-slot='dropdown-menu-sub-content'],
+:root[data-skin='openagents'] [data-slot='select-content'],
+:root[data-skin='openagents'] [data-slot='command'],
+:root[data-skin='openagents'] .log-viewer {
   box-shadow: var(--shadow-md);
 }
 
@@ -362,21 +378,62 @@
   font-weight: 700;
 }
 
-/* Press-to-sink. The site lifts on hover (`hover:-translate-y-1` with the
-   shadow appearing underneath); a pointer-driven lift is right for a landing
-   page with eight cards and wrong for a tool where the pointer crosses fifty
-   rows on the way to one button — so the gesture is moved to the press, where
-   it answers an actual click.
+/* ===========================================================================
+   Lift — the site's hover gesture
+   ===========================================================================
+   `transition-all duration-100 hover:-translate-y-1 hover:shadow-[6px_6px_0_0_#000]`,
+   on a surface that is flat (`border-2 border-black bg-white`, no shadow at
+   rest). Every animated element on the site's homepage is one of these four,
+   and they are the only motion it has — so this is the whole interaction,
+   ported at its own numbers: 4px of travel, a 6px block appearing underneath,
+   100ms.
 
-   Translating by exactly `--skin-lift` while removing a shadow of the same
-   offset is what makes the control look like it is being pushed down onto the
-   page rather than sliding across it. */
+   Cards start flat and earn their shadow on hover; controls carry a smaller
+   one standing still, because a button has to look pressable before the
+   pointer arrives. That split is the site's too — its cards are shadowless at
+   rest while its solid CTA ships `shadow-sm`.
+
+   Two shared numbers, so the whole gesture is retuned from one place. */
+:root[data-skin='openagents'] {
+  --skin-hover-shadow: 6px;
+  --skin-lift-duration: 0.1s;
+}
+
+/* Cards. `.card-legacy` had a blur-and-tighten hover of its own from the
+   default skin; this replaces it outright rather than stacking on top. */
+:root[data-skin='openagents'] [data-slot='card'],
+:root[data-skin='openagents'] .card-legacy {
+  box-shadow: none;
+  transition:
+    transform var(--skin-lift-duration) var(--ease),
+    box-shadow var(--skin-lift-duration) var(--ease),
+    border-color var(--skin-lift-duration) var(--ease);
+}
+
+:root[data-skin='openagents'] [data-slot='card']:hover,
+:root[data-skin='openagents'] .card-legacy:hover {
+  transform: translateY(calc(var(--skin-lift) * -1));
+  box-shadow: var(--skin-hover-shadow) var(--skin-hover-shadow) 0 0
+    var(--skin-ink-shadow);
+}
+
+/* Controls: shadowed at rest, lifted on hover, and driven into the page on
+   press. The press value is the one place this leaves the site behind, because
+   the site has no pressed state to copy — a link navigates away. Landing at
+   exactly `--skin-lift` with the shadow removed puts the control where its own
+   shadow was, which is what reads as "pushed down" rather than "slid across". */
 :root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']) {
   box-shadow: var(--skin-lift) var(--skin-lift) 0 0 var(--skin-ink-shadow);
   transition:
-    transform 0.1s var(--ease),
-    box-shadow 0.1s var(--ease),
-    background-color 0.1s var(--ease);
+    transform var(--skin-lift-duration) var(--ease),
+    box-shadow var(--skin-lift-duration) var(--ease),
+    background-color var(--skin-lift-duration) var(--ease);
+}
+
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']):hover:not(:disabled) {
+  transform: translateY(calc(var(--skin-lift) * -1));
+  box-shadow: var(--skin-hover-shadow) var(--skin-hover-shadow) 0 0
+    var(--skin-ink-shadow);
 }
 
 :root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']):active:not(:disabled) {
@@ -384,24 +441,31 @@
   box-shadow: 0 0 0 0 var(--skin-ink-shadow);
 }
 
-/* Disabled controls have nothing to sink into. */
+/* Disabled controls have nothing to lift or sink. */
 :root[data-skin='openagents'] [data-slot='button']:disabled {
   box-shadow: none;
+  transform: none;
 }
 
 /* Icon-only buttons in toolbars and the title bar are chrome, not CTAs. At the
    xs/sm sizes a 4px offset block is bigger than the gap to the next control,
-   so they keep the frame and drop the shadow. */
+   so they keep the frame and drop both the shadow and the travel — a row of
+   24px icons bobbing one at a time as the pointer sweeps it is noise, and
+   these sit in exactly the places the pointer sweeps. */
 :root[data-skin='openagents'] [data-slot='button'][data-size='icon-xs'],
 :root[data-skin='openagents'] [data-slot='button'][data-size='icon-sm'],
 :root[data-skin='openagents'] [data-slot='button'][data-size='xs'] {
   box-shadow: none;
 }
 
+:root[data-skin='openagents'] [data-slot='button'][data-size='icon-xs']:hover:not(:disabled),
+:root[data-skin='openagents'] [data-slot='button'][data-size='icon-sm']:hover:not(:disabled),
+:root[data-skin='openagents'] [data-slot='button'][data-size='xs']:hover:not(:disabled),
 :root[data-skin='openagents'] [data-slot='button'][data-size='icon-xs']:active:not(:disabled),
 :root[data-skin='openagents'] [data-slot='button'][data-size='icon-sm']:active:not(:disabled),
 :root[data-skin='openagents'] [data-slot='button'][data-size='xs']:active:not(:disabled) {
   transform: none;
+  box-shadow: none;
 }
 
 /* ===========================================================================
@@ -463,6 +527,18 @@
   border-color: var(--skin-hairline);
   box-shadow: none;
   border-radius: var(--radius-lg);
+}
+
+/* …and they do not lift either. An interior section rising out of the panel it
+   is part of separates from its own frame; worse, an outer card and the card
+   inside it both match `:hover`, so the pointer would move them 8px together.
+   Higher specificity than the lift rule, so this is what wins on a nested
+   card, while a top-level one is untouched. */
+:root[data-skin='openagents'] [data-slot='card'] [data-slot='card']:hover,
+:root[data-skin='openagents'] [data-slot='dialog-content'] [data-slot='card']:hover,
+:root[data-skin='openagents'] [data-slot='sheet-content'] [data-slot='card']:hover {
+  transform: none;
+  box-shadow: none;
 }
 
 /* The active tab is the site's `border-b-2 border-blue-600` — a brand-coloured

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -494,23 +494,45 @@
    last surface still rendered in the default style: a soft 1px frame and a
    blurred drop shadow floating over an interface that has neither.
 
-   It gets the container treatment, at control weight rather than shell weight
-   — it is a transient strip, not a panel, so 2px and a 4px block rather than
-   2.5px and 6px. The colour comes from Sonner's own per-type classes, which
-   now read `--*-border`; this skin points all three of those at the ink, so
-   the frame lands here without a second `!important` fighting the first.
+   It gets the FULL shell treatment — 2.5px of ink and a 6px block, the same
+   numbers as a card — not the lighter control weight it carried first. A toast
+   is the one surface that appears unannounced over whatever the user was
+   reading, so it is the last place to be timid about the frame; at control
+   weight it still read as the default skin's soft strip sitting on top of a
+   hard-edged interface.
 
-   Sonner sets `border-radius` from its own `--border-radius` custom property
-   (handed to it in components/ui/sonner.tsx), so the radius has to be restated
-   as a real declaration to win. */
+   Sonner's own rule is `[data-sonner-toast][data-styled='true']` (0,2,0) and
+   it sets `border` and `box-shadow` as shorthands; this selector is (0,3,0),
+   so the longhands below win on the cascade without `!important`. The border
+   COLOUR comes from Sonner's per-type classes, which read `--*-border` — this
+   skin points all three of those at the ink.
+
+   `border-radius` has to be restated as a real declaration because Sonner
+   drives it from its own `--border-radius` custom property, handed over in
+   components/ui/sonner.tsx. */
 :root[data-skin='openagents'] [data-sonner-toast] {
-  border-width: var(--skin-border-w);
+  border-width: var(--skin-border-w-lg);
   border-style: solid;
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--skin-hover-shadow) var(--skin-hover-shadow) 0 0
+    var(--skin-ink-shadow);
   /* The site sets every small label in bold; a four-second message is exactly
      the case that benefits. */
-  font-weight: 600;
+  font-weight: 700;
+}
+
+/* Sonner animates `box-shadow` over 200ms as part of its lift-on-hover, which
+   on a hard shadow reads as the block sliding out from under the toast. The
+   frame is not a state here — it just is. */
+:root[data-skin='openagents'] [data-sonner-toast]:hover {
+  box-shadow: var(--skin-hover-shadow) var(--skin-hover-shadow) 0 0
+    var(--skin-ink-shadow);
+}
+
+/* The type icon is a filled glyph on a tinted ground; at the skin's weight it
+   should carry the same presence as the text beside it. */
+:root[data-skin='openagents'] [data-sonner-toast] [data-icon] svg {
+  stroke-width: 2.5;
 }
 
 /* The close button and action button inside a toast are chrome on top of an

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -1,0 +1,485 @@
+/* ===========================================================================
+   OpenAgents skin — activated by [data-skin="openagents"] on <html>
+   ===========================================================================
+   Aligns the launcher with openagents.org: neo-brutalism over Inter. The site
+   is a marketing page and this is a dense tool, so what is ported is the
+   STRUCTURE the site actually uses, not its 17px/40px type scale.
+
+   The site is itself layered, and this file follows that layering exactly:
+
+     shell     rounded-2xl border-[2.5px] border-black shadow-[6px_6px_0_0_#000]
+     controls  rounded-full border-2 border-black
+     inside    border-r border-neutral-200        ← hairlines, NOT black
+
+   Its own product mock has a 2.5px black frame with a `border-neutral-200`
+   sidebar inside it. Painting all 370 `border` call sites black would be
+   louder than the site itself, so containers and controls take the ink and
+   everything inside them keeps a hairline (see the hairline section below).
+
+   Layering: this file is UNLAYERED. The tokens it overrides live in
+   `@layer base` in globals.css, and unlayered rules outrank every layer, so
+   the skin wins without an `!important` or a specificity contest. The one
+   thing it deliberately does NOT set is the accent: locking the brand blue is
+   done by writing `data-accent="oa"` from the store, so it flows through the
+   existing preset machinery instead of fighting `:root[data-accent]` — which
+   is unlayered too and declared after this file.
+
+   Everything here keys off `[data-skin="openagents"]`, so the default skin is
+   untouched: with the switch off, not one rule in this file matches. */
+
+/* Inter, self-hosted — the site's typeface. Pulled straight from the package's
+   files rather than importing its stylesheet: that would ship the Cyrillic,
+   Greek and Vietnamese subsets too, and the launcher's UI text is latin plus
+   CJK (which falls through to the system stack below either way). */
+@font-face {
+  font-family: 'Inter Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url('../../../node_modules/@fontsource-variable/inter/files/inter-latin-wght-normal.woff2')
+    format('woff2-variations');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Inter Variable';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url('../../../node_modules/@fontsource-variable/inter/files/inter-latin-ext-wght-normal.woff2')
+    format('woff2-variations');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+    U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+    U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* ===========================================================================
+   Tokens — light
+   ===========================================================================
+   `--skin-ink` is the single colour the whole skin is drawn with: borders take
+   it at full strength, hard shadows take `--skin-ink-shadow`. Holding both as
+   one pair is what lets the dark block below flip the entire look by
+   redefining two values.
+
+   `--skin-hairline` is the other half of the contract: every rule that pushes
+   ink onto a surface has a matching rule further down that pulls the interior
+   back to this. */
+:root[data-skin='openagents'] {
+  --skin-ink: #000000;
+  --skin-ink-shadow: #000000;
+  --skin-hairline: #e5e5e5; /* neutral-200 — what the site's mock uses inside */
+  --skin-border-w: 2px;
+  --skin-border-w-lg: 2.5px;
+  /* Offset of the hard shadow, and the distance a control travels when
+     pressed. They are one number on purpose: a button that sinks by exactly
+     its own shadow lands flush with the surface instead of drifting. */
+  --skin-lift: 4px;
+
+  /* Surfaces — the site is bg-gray-50 with white cards throughout. */
+  --bg-primary: #f9fafb;
+  --bg-secondary: #ffffff;
+  --bg-card: #ffffff;
+  --bg-card-hover: #ffffff;
+  --bg-input: #ffffff;
+  --bg-sidebar: #ffffff;
+
+  --skeleton-base: #ededf0;
+  --skeleton-highlight: #f9fafb;
+
+  /* Text — neutral-950/600/400, the site's three steps. */
+  --text-primary: #0a0a0a;
+  --text-secondary: #525252;
+  --text-tertiary: #a3a3a3;
+
+  --border: var(--skin-ink);
+  --border-hover: var(--skin-ink);
+
+  /* Hard shadows: zero blur, zero spread, offset only. This is the single
+     change that carries most of the style — `shadow-sm/md/lg` are already
+     wired to these variables in globals.css, so every existing call site
+     switches over without touching a component. */
+  --shadow-sm: 2px 2px 0 0 var(--skin-ink-shadow);
+  --shadow-md: var(--skin-lift) var(--skin-lift) 0 0 var(--skin-ink-shadow);
+  --shadow-lg: 8px 8px 0 0 var(--skin-ink-shadow);
+
+  /* The site rounds harder than the launcher: lg=12, 2xl=16 on its cards. */
+  --radius: 16px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* shadcn HSL aliases. `--border-hsl` goes to full ink for the same reason
+     `--border` does; the hairline section below is what keeps that from
+     reaching table rows and separators. */
+  --background: 220 20% 98%; /* #f9fafb */
+  --foreground: 0 0% 4%;
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 4%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 4%;
+  --secondary: 220 14% 96%;
+  --secondary-foreground: 0 0% 32%;
+  --muted: 220 14% 96%;
+  --muted-foreground: 0 0% 64%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --border-hsl: 0 0% 0%;
+  --input-hsl: 0 0% 0%;
+  /* #16C79A — the site's teal, its only semantic colour besides the blue. */
+  --success-hsl: 165 80% 43%;
+  --success-foreground: 165 84% 26%;
+  --success: #16c79a;
+  --success-bg: rgba(22, 199, 154, 0.1);
+  --success-border: rgba(22, 199, 154, 0.4);
+  --success-text: #0b7a5e;
+  --warning-hsl: 38 92% 47%;
+  --warning-foreground: 33 90% 34%;
+  --info: #2f6bff;
+  --info-bg: rgba(47, 107, 255, 0.1);
+  --info-text: #1d4ed8;
+
+  /* Rail. `--sidebar-border` is the hairline, not the ink: it draws the lines
+     BETWEEN rows inside the rail. The rail's own outer edge is inked further
+     down, where it can be targeted as one border rather than four. */
+  --sidebar: #ffffff;
+  --sidebar-foreground: #404040;
+  --sidebar-accent: #f3f4f6;
+  --sidebar-accent-foreground: #0a0a0a;
+  --sidebar-border: var(--skin-hairline);
+  --sidebar-muted: #a3a3a3;
+
+  /* The always-dark panels take the site's dark surface, so onboarding matches
+     the dark theme's pages instead of sitting a shade off them. */
+  --panel: #0b1121;
+  --panel-foreground: #9aa5bd;
+  --panel-muted: #66708a;
+}
+
+/* ===========================================================================
+   Tokens — dark
+   ===========================================================================
+   The site has no dark mode (`<html class="light">` is hardcoded), so this is
+   a translation rather than a port. Two rules carry it:
+
+     border  mirrors — black on white becomes near-white on near-black
+     shadow  does NOT — it stays black
+
+   The shadow staying black is the part that is easy to get wrong. The page
+   underneath is #0B1121, which is the site's OWN dark card colour and is not
+   actually black, so a black offset block still reads against it. Mirroring
+   the shadow to white as well would light up a halo behind every card and lose
+   the "solid object sitting on a surface" that the style is entirely about. */
+:root[data-skin='openagents'][data-theme='dark'] {
+  --skin-ink: #e8edf7;
+  --skin-ink-shadow: rgba(0, 0, 0, 0.8);
+  --skin-hairline: rgba(255, 255, 255, 0.1);
+
+  --bg-primary: #0b1121; /* the site's own dark surface */
+  --bg-secondary: #131b30;
+  --bg-card: #131b30;
+  --bg-card-hover: #18213a;
+  --bg-input: #0b1121;
+  --bg-sidebar: #0b1121;
+
+  --skeleton-base: #1b2440;
+  --skeleton-highlight: #253052;
+
+  --text-primary: #f5f7fa;
+  --text-secondary: #9aa5bd;
+  --text-tertiary: #66708a;
+
+  --background: 224 50% 9%;
+  --foreground: 220 25% 97%;
+  --card: 222 43% 13%;
+  --card-foreground: 220 25% 97%;
+  --popover: 222 43% 13%;
+  --popover-foreground: 220 25% 97%;
+  --secondary: 222 35% 18%;
+  --secondary-foreground: 220 18% 78%;
+  --muted: 222 35% 18%;
+  --muted-foreground: 220 12% 60%;
+  --destructive: 0 84% 66%;
+  --destructive-foreground: 224 50% 9%;
+  --border-hsl: 220 33% 94%;
+  --input-hsl: 220 33% 94%;
+  --success-hsl: 165 70% 52%;
+  --success-foreground: 165 70% 72%;
+  --success: #2ee0b0;
+  --success-bg: rgba(46, 224, 176, 0.14);
+  --success-border: rgba(46, 224, 176, 0.35);
+  --success-text: #6ff0d0;
+  --warning-hsl: 43 96% 56%;
+  --warning-foreground: 43 96% 76%;
+  --info: #6b9bff;
+  --info-bg: rgba(107, 155, 255, 0.16);
+  --info-text: #a8c3ff;
+
+  --sidebar: #0b1121;
+  --sidebar-foreground: #9aa5bd;
+  --sidebar-accent: #1b2440;
+  --sidebar-accent-foreground: #f5f7fa;
+  --sidebar-border: var(--skin-hairline);
+  --sidebar-muted: #66708a;
+}
+
+/* ===========================================================================
+   Typography
+   ===========================================================================
+   Inter first, then the platform stack — which still carries the CJK the latin
+   subsets above deliberately leave out. `tracking-tight` is on the site's
+   <body>; the launcher already sits at -0.01em, so this only sharpens it. */
+:root[data-skin='openagents'] body {
+  font-family:
+    'Inter Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
+    sans-serif;
+  letter-spacing: -0.02em;
+}
+
+/* The site's headings are font-black/extrabold. Applied to headings and to the
+   title slots only — pushing every `font-semibold` in the app to 800 would
+   make list rows shout as loudly as page titles. */
+:root[data-skin='openagents'] h1,
+:root[data-skin='openagents'] h2,
+:root[data-skin='openagents'] [data-slot='card-title'],
+:root[data-skin='openagents'] [data-slot='dialog-title'],
+:root[data-skin='openagents'] [data-slot='alert-dialog-title'],
+:root[data-skin='openagents'] [data-slot='sheet-title'] {
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+/* `text-[10px] font-semibold uppercase tracking-wider text-neutral-400` — the
+   site's section eyebrow, used verbatim above each of its column lists. The
+   launcher's equivalents are the sidebar group headings and the settings card
+   titles. */
+:root[data-skin='openagents'] [data-slot='sidebar-group-label'],
+:root[data-skin='openagents'] [data-slot='select-label'],
+:root[data-skin='openagents'] [data-slot='dropdown-menu-label'],
+:root[data-skin='openagents'] [data-slot='command-group'] [cmdk-group-heading] {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+/* ===========================================================================
+   Containers — the shell treatment
+   ===========================================================================
+   `rounded-2xl border-[2.5px] border-black shadow-[6px_6px_0_0_#000]`.
+
+   Overlays (dialog, popover, menu, select, sheet, command) get it as well as
+   cards: they are the same thing — a solid panel sitting above the page —
+   and leaving them on the default 1px hairline while every card behind them
+   carries 2.5px of ink is exactly the inconsistency the skin exists to avoid.
+
+   Tooltips are excluded on purpose. They are 11px transient labels; a 2.5px
+   frame and a 6px shadow on one is a billboard. */
+:root[data-skin='openagents'] [data-slot='card'],
+:root[data-skin='openagents'] [data-slot='dialog-content'],
+:root[data-skin='openagents'] [data-slot='alert-dialog-content'],
+:root[data-skin='openagents'] [data-slot='sheet-content'],
+:root[data-skin='openagents'] [data-slot='popover-content'],
+:root[data-skin='openagents'] [data-slot='dropdown-menu-content'],
+:root[data-skin='openagents'] [data-slot='dropdown-menu-sub-content'],
+:root[data-skin='openagents'] [data-slot='select-content'],
+:root[data-skin='openagents'] [data-slot='command'],
+:root[data-skin='openagents'] .card-legacy,
+:root[data-skin='openagents'] .log-viewer {
+  border-width: var(--skin-border-w-lg);
+  border-style: solid;
+  border-color: var(--skin-ink);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+}
+
+/* The sheet is anchored to an edge, so it has no room for an offset shadow on
+   the side it is attached to — and a 16px radius on a full-height panel reads
+   as a mistake. Frame only. */
+:root[data-skin='openagents'] [data-slot='sheet-content'] {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* ===========================================================================
+   Controls
+   ===========================================================================
+   `rounded-full border-2 border-black px-3 py-1 text-[12px] font-extrabold` is
+   the site's pill; its solid CTA is `rounded-lg bg-blue-600`. Both are framed,
+   so every control here takes the ink at the standard 2px.
+
+   Ghost and link buttons are excluded — they are text, and framing them would
+   turn every toolbar into a grid of boxes. The site does the same: its nav
+   items are bare `font-bold text-neutral-700`. */
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']),
+:root[data-skin='openagents'] [data-slot='input'],
+:root[data-skin='openagents'] [data-slot='textarea'],
+:root[data-skin='openagents'] [data-slot='select-trigger'],
+:root[data-skin='openagents'] [data-slot='checkbox'],
+:root[data-skin='openagents'] [data-slot='sidebar-input'] {
+  border-width: var(--skin-border-w);
+  border-style: solid;
+  border-color: var(--skin-ink);
+}
+
+/* Badges are the site's pill, near enough exactly. */
+:root[data-skin='openagents'] [data-slot='badge'] {
+  border-width: var(--skin-border-w);
+  border-style: solid;
+  border-color: var(--skin-ink);
+  font-weight: 700;
+}
+
+/* Press-to-sink. The site lifts on hover (`hover:-translate-y-1` with the
+   shadow appearing underneath); a pointer-driven lift is right for a landing
+   page with eight cards and wrong for a tool where the pointer crosses fifty
+   rows on the way to one button — so the gesture is moved to the press, where
+   it answers an actual click.
+
+   Translating by exactly `--skin-lift` while removing a shadow of the same
+   offset is what makes the control look like it is being pushed down onto the
+   page rather than sliding across it. */
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']) {
+  box-shadow: var(--skin-lift) var(--skin-lift) 0 0 var(--skin-ink-shadow);
+  transition:
+    transform 0.1s var(--ease),
+    box-shadow 0.1s var(--ease),
+    background-color 0.1s var(--ease);
+}
+
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']):active:not(:disabled) {
+  transform: translate(var(--skin-lift), var(--skin-lift));
+  box-shadow: 0 0 0 0 var(--skin-ink-shadow);
+}
+
+/* Disabled controls have nothing to sink into. */
+:root[data-skin='openagents'] [data-slot='button']:disabled {
+  box-shadow: none;
+}
+
+/* Icon-only buttons in toolbars and the title bar are chrome, not CTAs. At the
+   xs/sm sizes a 4px offset block is bigger than the gap to the next control,
+   so they keep the frame and drop the shadow. */
+:root[data-skin='openagents'] [data-slot='button'][data-size='icon-xs'],
+:root[data-skin='openagents'] [data-slot='button'][data-size='icon-sm'],
+:root[data-skin='openagents'] [data-slot='button'][data-size='xs'] {
+  box-shadow: none;
+}
+
+:root[data-skin='openagents'] [data-slot='button'][data-size='icon-xs']:active:not(:disabled),
+:root[data-skin='openagents'] [data-slot='button'][data-size='icon-sm']:active:not(:disabled),
+:root[data-skin='openagents'] [data-slot='button'][data-size='xs']:active:not(:disabled) {
+  transform: none;
+}
+
+/* ===========================================================================
+   Hairlines — the other half of the contract
+   ===========================================================================
+   `--border` and `--border-hsl` are full ink now, and they are what the global
+   `*, ::before, ::after { border-color: var(--border) }` reset in globals.css
+   feeds to all 370 `border` call sites. That is right for the containers and
+   controls above and wrong for everything living inside them.
+
+   These rules pull the interior back to a hairline, matching what the site's
+   own mock does inside its 2.5px frame. Anything not listed here that sits
+   inside a card and draws a line should be added rather than left to inherit
+   the ink. */
+:root[data-skin='openagents'] [data-slot='separator'],
+:root[data-skin='openagents'] [data-slot='dropdown-menu-separator'],
+:root[data-skin='openagents'] [data-slot='select-separator'],
+:root[data-skin='openagents'] [data-slot='command-separator'],
+:root[data-skin='openagents'] [data-slot='sidebar-separator'] {
+  background-color: var(--skin-hairline);
+}
+
+:root[data-skin='openagents'] [data-slot='card-header'],
+:root[data-skin='openagents'] [data-slot='card-footer'],
+:root[data-skin='openagents'] [data-slot='card-content'],
+:root[data-skin='openagents'] [data-slot='dialog-header'],
+:root[data-skin='openagents'] [data-slot='dialog-footer'],
+:root[data-skin='openagents'] [data-slot='dialog-body'],
+:root[data-skin='openagents'] [data-slot='alert-dialog-header'],
+:root[data-skin='openagents'] [data-slot='alert-dialog-footer'],
+:root[data-skin='openagents'] [data-slot='sheet-header'],
+:root[data-skin='openagents'] [data-slot='sheet-footer'],
+:root[data-skin='openagents'] [data-slot='table'],
+:root[data-skin='openagents'] [data-slot='table-row'],
+:root[data-skin='openagents'] [data-slot='table-head'],
+:root[data-skin='openagents'] [data-slot='table-cell'],
+:root[data-skin='openagents'] [data-slot='table-header'],
+:root[data-skin='openagents'] [data-slot='table-footer'],
+:root[data-skin='openagents'] [data-slot='tabs-list'],
+:root[data-skin='openagents'] [data-slot='tabs-trigger'],
+:root[data-skin='openagents'] [data-slot='command-input-wrapper'],
+:root[data-skin='openagents'] [data-slot='sidebar-container'],
+:root[data-skin='openagents'] [data-slot='sidebar-inner'],
+:root[data-skin='openagents'] [data-slot='sidebar-header'],
+:root[data-skin='openagents'] [data-slot='sidebar-footer'],
+:root[data-skin='openagents'] [data-slot='sidebar-group'],
+:root[data-skin='openagents'] [data-slot='sidebar-menu-button'],
+:root[data-skin='openagents'] [data-slot='sidebar-menu-sub'] {
+  border-color: var(--skin-hairline);
+}
+
+/* The nested surfaces: a card inside a card, a section inside a dialog body.
+   They are interior, so they get the hairline and no offset shadow — the frame
+   they sit in already carries both. */
+:root[data-skin='openagents'] [data-slot='card'] [data-slot='card'],
+:root[data-skin='openagents'] [data-slot='dialog-content'] [data-slot='card'],
+:root[data-skin='openagents'] [data-slot='sheet-content'] [data-slot='card'] {
+  border-width: 1px;
+  border-color: var(--skin-hairline);
+  box-shadow: none;
+  border-radius: var(--radius-lg);
+}
+
+/* The active tab is the site's `border-b-2 border-blue-600` — a brand-coloured
+   underline, not an inked box. */
+:root[data-skin='openagents'] [data-slot='tabs-trigger'][data-state='active'] {
+  border-bottom-color: var(--accent);
+}
+
+/* ===========================================================================
+   Chrome
+   ===========================================================================
+   The rail is a full-height edge, so it takes the ink as a single dividing
+   line rather than a frame — the same way the site's mock separates its
+   sidebar from its content pane, just at the skin's weight. */
+:root[data-skin='openagents'] [data-slot='sidebar-container'] {
+  border-right-width: var(--skin-border-w);
+  border-right-color: var(--skin-ink);
+}
+
+/* The always-dark panels (onboarding rail, setup summary) keep their surface
+   but need the skin's frame colour, since the light-mode ink is black and
+   these are near-black already. */
+:root[data-skin='openagents'] .panel-dark {
+  --panel-border: rgba(255, 255, 255, 0.16);
+}
+
+/* Scrollbars — square and inked, like everything else. */
+:root[data-skin='openagents'] ::-webkit-scrollbar-thumb {
+  background: var(--skin-hairline);
+  border-radius: 0;
+}
+
+/* ===========================================================================
+   High contrast
+   ===========================================================================
+   `data-contrast="high"` lifts `--border` for the default skin. Here the
+   border is already full ink and cannot go further, so the setting is left to
+   do what it still can — the text steps — and the hairline is what tightens.
+   Without this the two settings fight: high contrast would push interior lines
+   back toward the ink the skin just pulled them away from. */
+:root[data-skin='openagents'][data-contrast='high'] {
+  --skin-hairline: #9a9a9a;
+  --border: var(--skin-ink);
+  --border-hover: var(--skin-ink);
+}
+
+:root[data-skin='openagents'][data-theme='dark'][data-contrast='high'] {
+  --skin-hairline: rgba(255, 255, 255, 0.32);
+  --border: var(--skin-ink);
+  --border-hover: var(--skin-ink);
+}

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -19,7 +19,7 @@
    Layering: this file is UNLAYERED. The tokens it overrides live in
    `@layer base` in globals.css, and unlayered rules outrank every layer, so
    the skin wins without an `!important` or a specificity contest. The one
-   thing it deliberately does NOT set is the accent: locking the brand blue is
+   thing it deliberately does NOT set is the accent: pinning it to the teal is
    done by writing `data-accent="oa"` from the store, so it flows through the
    existing preset machinery instead of fighting `:root[data-accent]` — which
    is unlayered too and declared after this file.
@@ -128,13 +128,16 @@
   --destructive-foreground: 0 0% 100%;
   --border-hsl: 0 0% 0%;
   --input-hsl: 0 0% 0%;
-  /* #16C79A — the site's teal, its only semantic colour besides the blue. */
-  --success-hsl: 165 80% 43%;
-  --success-foreground: 165 84% 26%;
-  --success: #16c79a;
-  --success-bg: rgba(22, 199, 154, 0.1);
-  --success-border: rgba(22, 199, 154, 0.4);
-  --success-text: #0b7a5e;
+  /* Pushed to a true green, away from the site's own #16C79A. That teal was
+     the right pick while the accent was blue; with the accent now teal itself
+     the two sat within a few degrees of each other, and a status colour that
+     is indistinguishable from the brand colour cannot signal status. */
+  --success-hsl: 142 76% 36%;
+  --success-foreground: 142 72% 29%;
+  --success: #16a34a;
+  --success-bg: rgba(22, 163, 74, 0.1);
+  --success-border: rgba(22, 163, 74, 0.4);
+  --success-text: #15803d;
   --warning-hsl: 38 92% 47%;
   --warning-foreground: 33 90% 34%;
   --info: #2f6bff;
@@ -150,6 +153,17 @@
   --sidebar-accent-foreground: #0a0a0a;
   --sidebar-border: var(--skin-hairline);
   --sidebar-muted: #a3a3a3;
+  /* The selected nav row goes SOLID — the site's `bg-blue-600 text-white` tab,
+     not the 12% tint the default skin uses. A wash is the right weight when
+     hover and selected have to be told apart by strength alone; here they are
+     told apart by kind, which is what lets the current page be findable in the
+     rail at a glance. Hover stays a tint: it is the pointer's position, not a
+     state, and promoting it to solid too would make the rail flicker between
+     two filled rows as the mouse crosses it. */
+  --sidebar-active: var(--accent);
+  --sidebar-active-foreground: #ffffff;
+  --sidebar-hover: color-mix(in srgb, var(--accent) 12%, transparent);
+  --sidebar-hover-foreground: var(--accent);
 
   /* The always-dark panels take the site's dark surface, so onboarding matches
      the dark theme's pages instead of sitting a shade off them. */
@@ -167,62 +181,79 @@
      border  mirrors — black on white becomes near-white on near-black
      shadow  does NOT — it stays black
 
-   The shadow staying black is the part that is easy to get wrong. The page
-   underneath is #0B1121, which is the site's OWN dark card colour and is not
-   actually black, so a black offset block still reads against it. Mirroring
-   the shadow to white as well would light up a halo behind every card and lose
-   the "solid object sitting on a surface" that the style is entirely about. */
+   The shadow staying black is the part that is easy to get wrong, and it comes
+   with a condition: a black offset block only exists if the surface behind it
+   is light enough to lose to. That condition is met by the page value below,
+   not by the near-black the first pass used — see the note on `--bg-primary`.
+   Mirroring the shadow to white instead would light a halo behind every card
+   and lose the "solid object on a surface" the whole style is built on. */
 :root[data-skin='openagents'][data-theme='dark'] {
-  --skin-ink: #e8edf7;
-  --skin-ink-shadow: rgba(0, 0, 0, 0.8);
-  --skin-hairline: rgba(255, 255, 255, 0.1);
+  --skin-ink: #e6ecf8;
+  /* Nearly opaque: at 0.8 the page tint bled through and the block read as a
+     smudge rather than as a second object. */
+  --skin-ink-shadow: rgba(0, 0, 0, 0.92);
+  --skin-hairline: rgba(255, 255, 255, 0.12);
 
-  --bg-primary: #0b1121; /* the site's own dark surface */
-  --bg-secondary: #131b30;
-  --bg-card: #131b30;
-  --bg-card-hover: #18213a;
+  /* The page is deliberately NOT the site's #0B1121. At 8% lightness a black
+     shadow has nothing to fall on: every card kept its white frame and lost
+     the offset block entirely, which is the half of the style that carries the
+     weight — the dark theme ended up as outlines on a void. Lifting the page
+     to 12% is what buys the shadow somewhere to land while staying firmly
+     dark. #0B1121 is still here; it moved to the rail and the input wells,
+     where being the darkest thing on screen is the point. */
+  --bg-primary: #121a2c;
+  --bg-secondary: #1b2440;
+  --bg-card: #1b2440;
+  --bg-card-hover: #223055;
+  /* Below the page, not above it: an inked field on a lighter card reads as a
+     well cut into the surface, which is how the style treats inputs. */
   --bg-input: #0b1121;
-  --bg-sidebar: #0b1121;
+  --bg-sidebar: #0d1424;
 
-  --skeleton-base: #1b2440;
-  --skeleton-highlight: #253052;
+  --skeleton-base: #223055;
+  --skeleton-highlight: #2c3c68;
 
-  --text-primary: #f5f7fa;
-  --text-secondary: #9aa5bd;
-  --text-tertiary: #66708a;
+  --text-primary: #f2f5fa;
+  --text-secondary: #9fabc4;
+  --text-tertiary: #6b7791;
 
-  --background: 224 50% 9%;
-  --foreground: 220 25% 97%;
-  --card: 222 43% 13%;
-  --card-foreground: 220 25% 97%;
-  --popover: 222 43% 13%;
-  --popover-foreground: 220 25% 97%;
-  --secondary: 222 35% 18%;
-  --secondary-foreground: 220 18% 78%;
-  --muted: 222 35% 18%;
-  --muted-foreground: 220 12% 60%;
+  --background: 222 42% 12%;
+  --foreground: 218 45% 96%;
+  --card: 225 23% 18%;
+  --card-foreground: 218 45% 96%;
+  --popover: 225 23% 18%;
+  --popover-foreground: 218 45% 96%;
+  --secondary: 224 38% 23%;
+  --secondary-foreground: 220 18% 80%;
+  --muted: 224 38% 23%;
+  --muted-foreground: 221 15% 49%;
   --destructive: 0 84% 66%;
-  --destructive-foreground: 224 50% 9%;
-  --border-hsl: 220 33% 94%;
-  --input-hsl: 220 33% 94%;
-  --success-hsl: 165 70% 52%;
-  --success-foreground: 165 70% 72%;
-  --success: #2ee0b0;
-  --success-bg: rgba(46, 224, 176, 0.14);
-  --success-border: rgba(46, 224, 176, 0.35);
-  --success-text: #6ff0d0;
+  --destructive-foreground: 222 42% 12%;
+  --border-hsl: 220 56% 94%;
+  --input-hsl: 220 56% 94%;
+  --success-hsl: 142 69% 58%;
+  --success-foreground: 142 69% 75%;
+  --success: #4ade80;
+  --success-bg: rgba(74, 222, 128, 0.14);
+  --success-border: rgba(74, 222, 128, 0.35);
+  --success-text: #86efac;
   --warning-hsl: 43 96% 56%;
   --warning-foreground: 43 96% 76%;
   --info: #6b9bff;
   --info-bg: rgba(107, 155, 255, 0.16);
   --info-text: #a8c3ff;
 
-  --sidebar: #0b1121;
-  --sidebar-foreground: #9aa5bd;
-  --sidebar-accent: #1b2440;
-  --sidebar-accent-foreground: #f5f7fa;
+  /* The rail takes the site's darkest value, so it reads as chrome the page
+     sits on rather than as another panel floating at the same depth. */
+  --sidebar: #0d1424;
+  --sidebar-foreground: #9fabc4;
+  --sidebar-accent: #223055;
+  --sidebar-accent-foreground: #f2f5fa;
   --sidebar-border: var(--skin-hairline);
-  --sidebar-muted: #66708a;
+  --sidebar-muted: #6b7791;
+  /* The accent is already a bright teal here, so a label painted in it on a
+     fill made of the same colour is the one pairing that does not read. */
+  --sidebar-hover-foreground: #ffffff;
 }
 
 /* ===========================================================================
@@ -445,10 +476,46 @@
    ===========================================================================
    The rail is a full-height edge, so it takes the ink as a single dividing
    line rather than a frame — the same way the site's mock separates its
-   sidebar from its content pane, just at the skin's weight. */
-:root[data-skin='openagents'] [data-slot='sidebar-container'] {
+   sidebar from its content pane, just at the skin's weight.
+
+   `AppSidebar` writes its own `border-r border-sidebar-border` on top of the
+   container, and that utility is a 1px hairline. Both properties have to be
+   restated here to beat it. */
+:root[data-skin='openagents'] [data-slot='sidebar-container'],
+:root[data-skin='openagents'] [data-slot='sidebar-inner'] {
   border-right-width: var(--skin-border-w);
   border-right-color: var(--skin-ink);
+}
+
+/* The selected nav row. The fill arrives through `--sidebar-active` above; what
+   is left is making it look struck rather than tinted — the site sets its
+   active tab in `font-semibold`, and a solid block wants a squarer corner than
+   the 8px `rounded-md` the row ships with.
+
+   No border: the row is `h-8 p-2`, and 2px of frame inside that would either
+   reflow the label or shave the icon. The fill is already the loudest thing in
+   the rail. */
+:root[data-skin='openagents'] [data-slot='sidebar-menu-button'] {
+  border-radius: var(--radius-sm);
+}
+
+:root[data-skin='openagents'] [data-slot='sidebar-menu-button'][data-active='true'] {
+  font-weight: 700;
+}
+
+/* The update-count pill rides on the selected row, where the fill is now the
+   accent it paints itself with. Ink it so the number stays a separate object
+   instead of dissolving into the row underneath. */
+:root[data-skin='openagents'] [data-slot='sidebar-menu-badge'] {
+  border: 1px solid var(--skin-ink);
+}
+
+/* The search affordance reads as a field, so it is inked like one — it carries
+   `border-sidebar-border` (the hairline) of its own, which this overrides. */
+:root[data-skin='openagents'] [data-testid='sidebar-search'] {
+  border-width: var(--skin-border-w);
+  border-color: var(--skin-ink);
+  border-radius: var(--radius-sm);
 }
 
 /* The always-dark panels (onboarding rail, setup summary) keep their surface

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -360,6 +360,31 @@
   box-shadow: var(--shadow-md);
 }
 
+/* The marketplace banner. Its frame is `border-primary/25` and its fill is a
+   brand gradient — an explicit colour, so unlike every `border` in the app it
+   does not follow `--border` and stayed soft while the spec cards inside it
+   went black. The gradient stays: the site's own hero is
+   `linear-gradient(160deg,#eaf2ff,#f4f8ff,#fff)`, so a tinted wash under a
+   hard frame is exactly its vocabulary. Only the frame changes.
+
+   No hover lift — it is a billboard, not a card, and nothing about it is
+   clickable as a whole. */
+:root[data-skin='openagents'] [data-slot='hero'] {
+  border-width: var(--skin-border-w-lg);
+  border-color: var(--skin-ink);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+}
+
+/* The agent mark inside it is a framed tile in its own right — same treatment
+   one step down, so it reads as sitting on the banner rather than in it. */
+:root[data-skin='openagents'] [data-slot='hero-mark'] {
+  border-width: var(--skin-border-w);
+  border-color: var(--skin-ink);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
 /* The sheet is anchored to an edge, so it has no room for an offset shadow on
    the side it is attached to — and a 16px radius on a full-height panel reads
    as a mistake. Frame only. */
@@ -383,7 +408,18 @@
 :root[data-skin='openagents'] [data-slot='textarea'],
 :root[data-skin='openagents'] [data-slot='select-trigger'],
 :root[data-skin='openagents'] [data-slot='checkbox'],
-:root[data-skin='openagents'] [data-slot='sidebar-input'] {
+:root[data-skin='openagents'] [data-slot='sidebar-input'],
+/* The search fields are `InputGroup`, not `Input` — a wrapper that draws the
+   frame around a borderless control plus its icon addons. Matching only
+   `[data-slot=input]` left every search box in the app on the default 1px
+   hairline while the sort dropdown beside it was inked. */
+:root[data-skin='openagents'] [data-slot='input-group'],
+/* Filter chips and the grid/list switch are ui-kit, not shadcn, and had no
+   slot to aim at until now. They already inherited the ink through `border`
+   + `--border`, but only at 1px — half the weight of every control beside
+   them. */
+:root[data-skin='openagents'] [data-slot='filter-chip'],
+:root[data-skin='openagents'] [data-slot='icon-toggle'] {
   border-width: var(--skin-border-w);
   border-style: solid;
   border-color: var(--skin-ink);
@@ -394,6 +430,19 @@
   border-width: var(--skin-border-w);
   border-style: solid;
   border-color: var(--skin-ink);
+  font-weight: 700;
+}
+
+/* The ⌘K legend in the rail's search field. It paints itself from
+   `--sidebar-border` at 60% behind `--sidebar-muted` text — both of which this
+   skin resolves to hairline weight, so the shortcut came out grey on grey and
+   was effectively unreadable. The site's own key cap is
+   `bg-white ring-1 ring-neutral-200`: a solid tile with a frame around it, and
+   that is what this restores at the skin's weight. */
+:root[data-skin='openagents'] [data-slot='kbd'] {
+  border: 1px solid var(--skin-ink);
+  background-color: var(--bg-card);
+  color: var(--text-secondary);
   font-weight: 700;
 }
 


### PR DESCRIPTION
Settings → Appearance gains a **Match openagents.org** switch that repaints the launcher in the site's neo-brutalism: inked frames, hard offset shadows, Inter, and a locked brand accent.

## How it is built

A fifth orthogonal appearance dimension (`data-skin` on `<html>`), alongside accent / scale / animations / contrast — not a third theme mode. The skin ships its own light **and** dark palettes, so all four combinations are reachable.

**No component was restyled.** Every rule keys off the `data-slot` attributes the primitives already carry, and the tokens the skin overrides (`--shadow-*`, `--radius-*`, `--border`, the sidebar set) were already variables. With the switch off, not one rule in `skin-openagents.css` matches.

The accent locks to the theme's teal by writing `data-accent="oa"` from the store, routing through the existing preset machinery so hover, tint, ring, links and the row states all derive correctly. The user's own preset is shadowed, never overwritten, and comes back when the switch goes off.

## Design decisions worth reviewing

**Layering follows the site's own.** openagents.org frames its product mock at `border-[2.5px] border-black` but uses `border-neutral-200` hairlines *inside* it. So containers and controls take the ink; everything within them is pulled back to a hairline. Painting all 370 `border` call sites black would have been louder than the site is.

**Dark is a translation, not a port** — the site hardcodes `class="light"`. The border mirrors to near-white; the shadow stays black. The page had to lift to `#121a2c` for that to work: at the site's own `#0B1121` (8% lightness) a black offset block has nothing to fall on, and the first pass shipped a dark theme that was outlines on a void.

**Hover-lift is the site's only motion** — `duration-100 hover:-translate-y-1 hover:shadow-[6px_6px_0_0_#000]` on a surface flat at rest. Ported at those numbers. Overlays, xs/icon buttons and nested cards are excluded, each for a concrete failure (a dialog jumping under the pointer; a row of 24px icons bobbing; an inner card rising 8px out of its own frame).

## Fixes found along the way

Three are **not skin-specific** and stand on their own:

- **Expanded log detail scrolled the table sideways.** The detail row spanned six columns against a five-column header; the browser answers an out-of-range colspan with an anonymous extra column, pushing the table past its `overflow-x-auto` container.
- **Detail-page scrollers clipped card shadows.** Both columns lacked padding, and `overflow-y: auto` computes `overflow-x` to `auto` too. The default skin's blurred shadow was being clipped in the same place, just less visibly.
- **One "succeeded" state rendered in two greens.** `--success` (bright, for icons) and `--success-text` (dark, for text) is a deliberate contrast split, invisible until two components side by side reach for different halves of it. Collapsed to one value under the skin.

Sonner's per-type classes move from a 25% cut of the text colour to `--*-border`. Visually identical in the default skin — those tokens were authored at 0.24–0.30 alpha of exactly those hues.

## Verification

`tsc -b`, `electron-vite build` and 136 unit tests pass. Inter's latin + latin-ext subsets are bundled (133KB) and self-hosted, so the skin works offline. Bundle CSS was inspected to confirm the skin block lands unlayered (outranking Tailwind utilities) and that `[data-accent="oa"]` is ordered after it.

**Not verified visually** — the four skin × theme combinations need a real run, particularly the dark palette's shadow contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)