### PR TITLE
chore(launcher): v0.9.4

### DIFF
--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",


### PR DESCRIPTION
Version bump missed on today's push.

`0.9.3` → `0.9.4`, in the two files that carry it:

- `packages/launcher/package.json` — one occurrence
- `packages/launcher/package-lock.json` — two, the root version and `packages.""`

Patch rather than minor, matching how this package has always bumped — feature releases have gone out as patches before (`feat(launcher): connect Google & Linear; v0.8.21`).

Bounded the lockfile edit to the header: line 10240 is a dependency already sitting at `0.9.4`, and a blind find-and-replace would have caught it. Diff is 2 files / 3 lines, the same shape as the last bump (`6c7d21302`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)