### PR TITLE
Add Pi CLI agent with Launcher-managed provider configuration

### DIFF
--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -1,0 +1,447 @@
+# Pi
+
+OpenAgents supports **Pi**, Earendil's coding agent for the terminal —
+executable `pi`, distributed as the npm package
+[`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent).
+
+- **Internal agent id:** `pi`
+- **User-facing name:** Pi
+- **Adapter:** `packages/agent-connector/src/adapters/pi.js`
+- **Stream parser:** `packages/agent-connector/src/adapters/pi-stream.js`
+- **Registry source:** `sdk/src/openagents/registry/pi.yaml`
+  (hand-synced into `packages/agent-connector/registry.json`)
+- **Verified against:** `pi 0.83.0`
+
+---
+
+## Architecture: one long-lived RPC subprocess per channel
+
+Pi is integrated the same way every other coding agent in this repo is — as a
+**CLI subprocess**. Nothing in OpenAgents imports Pi's SDK, `AgentSession`, or
+any `@earendil-works/*` module, and no Pi source is vendored in. A test
+statically asserts this (`test/pi.test.js` → "never imports a Pi SDK or
+internal Pi module").
+
+The adapter reuses the **persistent-process model already proven by
+`claude.js`**, structure for structure:
+
+| Concern | `claude.js` | `pi.js` |
+|---|---|---|
+| per-channel process record | `_persistentProcs[channel]` | same |
+| process handle the daemon/stop path reads | `_channelProcesses[channel]` | same |
+| release an idle channel | `_resetIdleTimer` (1 h) | same (1 h) |
+| kill a wedged process | `_startWatchdog` / `_stopWatchdog` (15 s × 20) | same |
+| cross-platform tree kill | `_stopProcess` (SIGTERM→SIGKILL / `taskkill /F /T`) | same |
+| stop only one channel | `_onControlAction('stop', {channel})` | same |
+| dedup the stop notice | `_stopNoticeSent` | same |
+| teardown on daemon shutdown | `stop()` → `_stopAllProcesses` | same |
+
+What differs is the **wire protocol**. Claude Code takes one user message per
+stdin line and answers with a `result` event; Pi speaks a request/response RPC:
+
+```
+pi --mode rpc --session-dir <oa dir> --session-id <uuid> --no-approve \
+   [--provider …] [--model …] [--thinking …] --append-system-prompt <text> --name <agent/channel>
+```
+
+- Commands go to **stdin** as JSONL, each with a unique `id`.
+- **stdout** carries both `{"type":"response","id":…}` correlations and a live
+  event stream.
+- **stderr is diagnostics only** and is never parsed as JSONL.
+
+A turn is: send `prompt` → receive `response{success:true}` (this only means
+*accepted*) → consume events → the turn is over at **`agent_settled`**.
+Provider failures do **not** arrive as a failed response; they arrive as an
+assistant message with `stopReason: "error"` and an `errorMessage`. The adapter
+handles both paths.
+
+### JSONL framing
+
+Pi's RPC framing is strict and the docs are explicit that **Node's `readline`
+is not protocol-compliant** (it also splits on U+2028/U+2029, which are legal
+inside JSON strings). `pi-stream.js` therefore implements framing by hand:
+
+- a `StringDecoder('utf8')` does the byte→string step, so a multi-byte UTF-8
+  sequence split across two chunks (CJK, emoji) is reassembled rather than
+  decoded into `�` — most other adapters in this repo call `chunk.toString()`
+  directly, which has exactly that bug
+- records split on `\n` and **only** `\n`; a trailing `\r` is stripped
+- one record may span many chunks; one chunk may carry many records
+- a single un-terminated record over 16 MB is dropped and the framer
+  resynchronizes on the next `\n`
+- a corrupt line degrades to a redacted `unknown` event — never a throw
+
+### Event mapping
+
+`EVENT_KIND_BY_TYPE` in `pi-stream.js` is the **single** place Pi's type
+strings appear; a Pi upgrade is a one-table edit.
+
+| Pi event | OpenAgents |
+|---|---|
+| `agent_start` | status "Pi is working..." |
+| `message_update` (`thinking_end`) | streamed `thinking` message |
+| `message_update` (`text_end`) | held until `message_end` decides its role |
+| `message_end` (`stopReason: toolUse`) | the text was narration → posted as `thinking` |
+| `message_end` (any other stop reason) | the text is the answer candidate |
+| `tool_execution_start` | status `<tool> › <redacted, truncated args>` |
+| `tool_execution_update` | progress only (keeps the watchdog quiet) |
+| `tool_execution_end` | completion status (`<tool> ✓`) or a failure status |
+| `bash_execution_update` | treated as tool activity |
+| `compaction_start` / `compaction_end` | context-compaction status |
+| `auto_retry_start` / `auto_retry_end` | retry status; a failed retry becomes the turn error |
+| `extension_error` | redacted, diagnosable status + log |
+| `agent_end` | one low-level run done (`willRetry` may follow) |
+| `agent_settled` | turn complete → post the final answer |
+
+**Streaming vs. final, deduplicated — twice over.** Pi emits every assistant
+content block twice: incrementally via `message_update` and again in the
+`message_end` payload. Two mechanisms keep the workspace from ever seeing the
+same text more than once:
+
+1. `PiAssistantAccumulator` releases each block **once**, keyed by its
+   `contentIndex`, so a block that streamed is not re-released at
+   `message_end`, and a block whose streaming `*_end` never arrived is still
+   emitted. Blocks are scoped per message; a missing `message_start` reopens
+   the accumulator implicitly rather than swallowing the next message.
+2. Released **text** blocks are *held*, not posted, until `message_end` says
+   what they are. `stopReason: "toolUse"` means the model is about to call a
+   tool and will speak again, so that text is narration → posted as `thinking`.
+   Any other stop reason means the message stands on its own → it becomes the
+   answer candidate and is posted **once**, as a chat message, at settlement.
+   A candidate superseded by a later message is flushed as `thinking` rather
+   than dropped, so nothing the model said is lost.
+
+The trade-off is deliberate: the final answer arrives whole rather than
+streaming, because posting it progressively *and* as the reply is exactly the
+duplication this avoids. Tool statuses carry the live progress instead.
+
+**Hidden reasoning is never an answer.** `thinking` content blocks go out
+through `sendThinking()` only and can never reach `sendResponse()`.
+
+---
+
+## Installation
+
+```bash
+agn install pi
+```
+
+Pi installs into the **isolated runtime prefix**
+`~/.openagents/runtimes/pi/` — you never need a global `pi` on your PATH, and a
+global one can never shadow the launcher-managed copy (the isolated prefix is
+resolution tier 0).
+
+### Node.js requirement — a hard gate
+
+`@earendil-works/pi-coding-agent` declares `engines.node >= 22.19.0`. Because
+`pi`'s bin is a **Node entry point**, the adapter resolves it to
+`[node, dist/cli.js]` and runs it under the **launcher's bundled portable Node
+(v22.22.3)**, not whatever `node` happens to be first on PATH. If the only
+available interpreter is older than 22.19.0, `preflight()` returns
+`REASON.VERSION_INCOMPATIBLE` with the detected version and the agent refuses
+to start rather than failing every message.
+
+### Binary resolution order
+
+1. `~/.openagents/runtimes/pi/node_modules/.bin/pi` (`pi.cmd` on Windows)
+2. legacy shared prefix `~/.openagents/nodejs/node_modules/.bin/pi`
+3. the package's own entry point
+   `…/node_modules/@earendil-works/pi-coding-agent/dist/cli.js`
+   (covers an install that left no `.bin` shim)
+4. codepage-safe PATH lookup (`whereBinary`) — survives a non-ASCII username
+5. next to the running Node interpreter
+6. common install locations
+7. deep scan of every known bin dir (nvm / fnm / volta / Homebrew / …)
+
+On Windows a `.cmd` shim is **parsed** into `[node, entry.js]` rather than
+wrapped in `cmd.exe /c`: `cmd.exe`'s 8191-character command-line cap would
+truncate the long `--append-system-prompt` argument and hang the agent. Both
+npm shim dialects are handled — the modern `SET dp0=%~dp0` … `"%dp0%\…"` form
+and the older/hand-written `"%~dp0\…"` form. (The sibling Claude and Cline
+adapters recognise only the first; `parseWindowsCmdShim` in `pi-stream.js` is
+pure and covered by tests that run on every OS, not just Windows.)
+
+---
+
+## Configuration
+
+The Launcher exposes these values directly on Pi's **Configure** dialog; no
+manual Pi file is required. Common profiles are:
+
+| Target | Provider | API format | Base URL | Key |
+|---|---|---|---|---|
+| Native Claude API | `anthropic` | `auto` | blank | Anthropic key |
+| Claude relay (Anthropic protocol) | `anthropic` | `anthropic-messages` | relay base | relay key |
+| Claude/Codex relay (OpenAI chat protocol) | `openai` | `openai-completions` | relay base | relay key |
+| Codex relay (Responses protocol) | `openai` | `openai-responses` | relay base | relay key |
+| Native DeepSeek API | `deepseek` | `auto` | blank | DeepSeek key |
+| Native OpenAI API | `openai` | `auto` | blank | OpenAI key |
+| Codex subscription login already stored by Pi | `openai-codex` | `auto` | blank | blank |
+
+Set `PI_MODEL` to the exact model id exposed by the selected service. For a
+relay, use the relay's documented id rather than guessing from the upstream
+model name.
+
+```bash
+agn env pi --set PI_PROVIDER=anthropic
+agn env pi --set PI_MODEL=claude-sonnet-4-6
+agn env pi --set PI_THINKING=medium
+agn env pi --set PI_API_KEY=sk-ant-…
+```
+
+| Variable | Read by | Effect |
+|---|---|---|
+| `PI_PROVIDER` | the OpenAgents adapter | `--provider <name>` |
+| `PI_MODEL` | the OpenAgents adapter | `--model <pattern>` |
+| `PI_API_FORMAT` | the OpenAgents adapter | native auto-detection or a relay protocol |
+| `PI_BASE_URL` | the OpenAgents adapter | process-local provider extension for a relay/proxy |
+| `PI_API_KEY` | the OpenAgents adapter | mapped to the selected native provider or relay |
+| `PI_THINKING` | the OpenAgents adapter | `--thinking <level>` (invalid values are dropped) |
+| `PI_TRUST_PROJECT` | the OpenAgents adapter | `--approve` when `1/true/yes/on`, else `--no-approve` |
+| provider-specific legacy key variables | **Pi itself** | still accepted for backwards compatibility |
+
+Pi itself has no generic base-URL environment variable. OpenAgents supplies the
+missing layer: native providers receive their conventional key environment, and
+a custom `PI_BASE_URL` loads the bundled `pi-launcher-provider.mjs` extension
+for that child process. It does not modify `~/.pi/agent/models.json`.
+
+> **Naming note.** Pi *injects* resolved session values into commands run by its
+> own `bash` tool. OpenAgents also uses the `PI_*` names as launcher inputs and
+> translates them before Pi starts; the names remain consistent with
+> `CODEX_MODEL` / `CLINE_MODEL` / `GOOSE_MODEL`.
+
+### Authentication: your existing Pi login is reused
+
+OpenAgents does **not** maintain a separate Pi credential store. Pi resolves
+credentials from `~/.pi/agent/auth.json` first, then the environment, and the
+adapter leaves that file completely alone. So both work:
+
+- run `pi` once and use `/login` — the launcher's readiness check verifies that
+  `~/.pi/agent/auth.json` contains at least one top-level provider entry (values
+  are never logged or returned; an auto-created empty `{}` stays signed out), **or**
+- set a provider API key in the launcher — it is injected as an environment
+  variable.
+
+**API keys are never passed as command-line arguments.** `--api-key` is never
+emitted, so a key cannot appear in `ps`, a crash dump, a log line, the registry
+or a session file. A test asserts the key is absent from argv and present in
+the child's environment.
+
+### Custom endpoints
+
+Set `PI_BASE_URL` and select `PI_API_FORMAT`. The adapter explicitly loads a
+bundled extension that calls `pi.registerProvider()` using the form values. The
+extension reads the key from the child environment, is scoped to that process,
+and never writes the secret or overwrites the user's global Pi configuration.
+
+---
+
+## Project trust policy — deny by default
+
+**OpenAgents runs Pi with `--no-approve` unless you explicitly opt in.**
+
+Pi's project trust controls whether it loads project-local resources from the
+working directory: `.pi/settings.json`, `.pi/extensions`, `.pi/skills`,
+`.pi/prompts`, `.pi/themes`, `.pi/SYSTEM.md`, `.pi/APPEND_SYSTEM.md`, and
+project `.agents/skills`. Extensions in particular are **TypeScript modules
+that execute with the full permissions of the Pi process**.
+
+The workspace points Pi at an arbitrary user repository, which may be a clone
+of code the user has not audited. Treating those files as trusted by default
+would mean a repository could silently change Pi's settings and run its own
+code the first time an agent opens it. So the default is deny:
+
+- `--no-approve` is passed on **every** spawn unless `PI_TRUST_PROJECT` opts in
+- OpenAgents **never writes or modifies** `~/.pi/agent/trust.json`; a saved
+  decision the user made themselves in interactive Pi is not consulted, because
+  the per-run flag overrides it
+- to opt in per agent: `agn env pi --set PI_TRUST_PROJECT=1`
+
+**What this does not protect against.** Pi has no sandbox: with trust denied it
+still reads, writes and runs shell commands in the working directory with your
+user's permissions. Project trust is an *input-loading* guard, not a security
+boundary, and it does not stop prompt injection from repository content. For
+untrusted repositories, run the launcher inside a container or VM.
+
+`AGENTS.md` / `CLAUDE.md` context files load **regardless** of trust (Pi's
+documented behavior). OpenAgents keeps that on. Note this means Pi may see
+project instructions that partly overlap the injected workspace system context;
+they coexist rather than conflict, but a project file with contradictory
+instructions will compete with the workspace prompt. Disable it per agent by
+adding `-nc` only if that becomes a problem — the adapter does not pass it today.
+
+### Headless interaction is never blocking
+
+If a user- or CLI-level Pi extension calls a blocking UI method (`select`,
+`confirm`, `input`, `editor`), Pi emits an `extension_ui_request` and **waits**.
+There is no terminal to answer it. The adapter immediately replies
+`{"type":"extension_ui_response","id":…,"cancelled":true}` and posts a status
+line saying an extension asked for input and was dismissed. Without this, one
+such extension would hang the channel forever.
+
+---
+
+## Sessions
+
+Each channel gets its own Pi session, addressed by a UUID **OpenAgents mints**:
+
+```
+--session-dir  ~/.openagents/pi-sessions/<workspaceId>_<agentName>/
+--session-id   <uuid minted per channel>
+```
+
+`--session-id` **creates the session when it does not exist and resumes it when
+it does** (verified against 0.83.0), so there is no session-id correlation
+heuristic anywhere — the mapping is deterministic and survives process
+restarts, daemon restarts and launcher restarts.
+
+The channel → UUID map is persisted at
+`~/.openagents/sessions/<workspaceId>_<agentName>_pi.json`.
+
+Isolation is threefold:
+
+- **Per workspace + agent** — a separate session file *and* a separate session
+  directory, so two agents can never read each other's transcripts.
+- **Per channel** — a separate UUID and a separate `pi` process.
+- **Away from the user's project** — sessions never land in the working
+  directory, and never in the shared `~/.pi/agent/sessions/`.
+
+A missing, corrupt, or non-UUID stored id is discarded and a fresh one minted
+(logged, redacted). A session bound to a different working directory is not
+reused. `/restart` in a channel kills its process and clears its session id.
+
+---
+
+## Using it in a workspace
+
+```bash
+agn install pi
+agn create my-pi --type pi --path /path/to/project
+agn env pi --set PI_PROVIDER=anthropic
+agn env pi --set ANTHROPIC_API_KEY=sk-ant-…
+agn up
+agn connect my-pi <workspace-token>
+```
+
+- The child's **cwd is the agent's configured `workingDir`**, always. A missing
+  directory is reported as an error instead of silently falling back.
+- Spawning uses an **argument array** — never a composed shell string — so a
+  path or prompt containing spaces, quotes or shell metacharacters cannot be
+  interpreted as a command.
+- The workspace system context is injected with **`--append-system-prompt`**,
+  never `--system-prompt` (which would *replace* Pi's own coding prompt and
+  strip its tool instructions). It is built by `buildPiSystemPrompt()` in
+  `workspace-prompt.js` with `toolMode: 'skills'` — Pi reaches the workspace
+  REST API through its built-in `bash` tool and curl, exactly like the OpenCode
+  and Amp adapters. **Pi is not wired to MCP**; only the Claude adapter uses
+  `--mcp-config`.
+- Plan mode (`this._mode === 'plan'`) is expressed in the system prompt. Because
+  the prompt is fixed at spawn time, switching modes respawns the process — the
+  session id is unchanged, so the conversation is preserved.
+
+### Attachments
+
+Image attachments are downloaded from the workspace and passed **inline** on the
+RPC `prompt` command as `images: [{type:"image", data:<base64>, mimeType}]` —
+Pi's documented image format. Non-image attachments (and images whose download
+failed, with a visible notice) are described in the prompt with curl
+instructions so Pi can fetch them with its `bash` + `read` tools.
+
+---
+
+## Interrupting & cleanup
+
+**Stop** on a channel:
+
+1. mark that channel's process `userStopped`
+2. send the RPC `abort` command (with a unique id)
+3. wait a 3 s grace period for `agent_settled` — a clean abort **keeps the
+   process alive**, so the next message reuses its context
+4. otherwise terminate the process tree (`SIGTERM` → `SIGKILL`, or
+   `taskkill /F /T` on Windows)
+5. reject every pending RPC with `PiCancelledError`, clear the queue, buffers,
+   idle timer, watchdog and stream listeners
+
+Other channels and other agents are untouched. "Execution stopped by user." is
+posted exactly once (`_stopNoticeSent`).
+
+Also handled explicitly: a CLI that exits immediately, stdin/stdout closing
+early, a non-zero exit mid-turn (reported with redacted stderr tail), an RPC
+response timeout, a response with an unknown id (logged, ignored), corrupt
+JSONL, and daemon shutdown (`stop()` tears down every `pi` child so nothing
+outlives the launcher).
+
+**Asynchronous stdin failures.** A `Writable` reports `EPIPE` and a premature
+pipe close through an `error` *event*, which the `try/catch` around
+`stdin.write()` cannot see — an unhandled one would take the whole daemon down.
+`proc.stdin` therefore carries its own error listener; a broken pipe is
+remembered on the process record so later RPCs fail fast with a clear
+cancellation instead of writing into the void.
+
+---
+
+## Security & privacy
+
+- **No new dependencies.** Only Node built-ins (`string_decoder`,
+  `child_process`, `crypto`, `fs`, `os`, `path`). A test asserts the package's
+  dependency list is unchanged.
+- **Redaction at one boundary.** `pi-stream.js` is pure and cannot know this
+  agent's concrete credential values, so it only applies *pattern* redaction —
+  which misses a key like Google's `AIza…` that matches no known shape. Every
+  event therefore passes through `_redactEvent()` in the adapter, one choke
+  point that re-masks the diagnostic fields (`preview`, `message`, `error`,
+  `finalError`, `raw`, `title`) with the agent's exact secrets folded in, so a
+  newly added event kind cannot forget it. Assistant message text is
+  deliberately left intact — it is the model's reply to the user, and rewriting
+  it would corrupt code and command output. Logged argv elides the system
+  prompt (which embeds the workspace token) as `<N chars>`.
+- **`PI_SKIP_VERSION_CHECK=1`** is set for the child so a launcher-managed
+  install does not phone home for update checks mid-session.
+- Pi has **no sandbox** and the built-in tools run with your user's permissions.
+  This is the same posture as every other CLI agent in the catalog.
+
+---
+
+## Launcher visibility
+
+Pi is implemented, runnable, and included in `CORE_AGENTS`. It is installable
+from the Launcher marketplace and available during onboarding. The Configure
+dialog owns native-provider and relay setup end to end.
+
+---
+
+## Known limitations
+
+- **The remote catalog may not list `pi` yet.** The launcher reads
+  remote API → 24 h local cache → bundled `registry.json`. Until the remote
+  catalog is updated, users on a fresh cache see Pi only via the bundled
+  fallback; a user whose cache was populated from a remote catalog *without*
+  `pi` will not see the row until the cache expires or the remote catalog adds
+  it. `agn install pi` works regardless, because the CLI reads the same bundled
+  registry.
+- **`npm run build:registry` cannot run in this repo.** Its `REGISTRY_DIR`
+  resolves to `<repo>/src/openagents/registry`, but the sources live in
+  `sdk/src/openagents/registry`, so it exits 1 before reading anything (a
+  pre-existing condition, unrelated to Pi). `pi.yaml` and the `pi` entry in
+  `packages/agent-connector/registry.json` are therefore maintained **by hand
+  in two places**. A test (`test/pi.test.js` → "keeps the registry.json entry
+  identical to the pi.yaml source") cross-checks the fields that matter, but a
+  new field added to only one of the files will not be caught automatically.
+  The adapter reads the npm package name and the version floor **from** the
+  registry entry (and the entry-point path from the installed package's own
+  manifest), so a catalog bump cannot leave the runtime probing a stale path
+  or enforcing a stale minimum.
+- **Pi event-schema drift.** The `EVENT_KIND_BY_TYPE` table was verified against
+  0.83.0. A future Pi release that renames or restructures an event degrades
+  that event to a logged `unknown` — fidelity drops (a status line goes
+  missing), the turn does not crash. The one event that would actually break a
+  turn if renamed is `agent_settled`; the watchdog is the backstop (it kills a
+  process silent for ~5 minutes and tells the user). Re-verify the table on
+  every Pi upgrade.
+- **No MCP.** Workspace tools go through bash + curl, so Pi cannot use the
+  native `workspace_*` MCP tools.
+- **Model/provider are fixed per process.** Changing `PI_MODEL` takes effect on
+  the next spawn (after an idle release, a `/restart`, or a mode switch), not
+  mid-conversation. The RPC `set_model` command exists but is not wired.
+- **No end-to-end run against a real provider** has been performed — every test
+  uses a mock CLI. See the delivery notes for the manual acceptance steps.

--- a/packages/agent-connector/icons/pi.svg
+++ b/packages/agent-connector/icons/pi.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Pi</title><rect x="2.8" y="5.2" width="18.4" height="3.1" rx="1.55"></rect><rect x="6.1" y="7.6" width="3.1" height="11.4" rx="1.55"></rect><rect x="14.8" y="7.6" width="3.1" height="11.4" rx="1.55"></rect></svg>

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -930,5 +930,149 @@
       ],
       "not_ready_message": "mini-SWE-agent CLI detected. Configure a model through environment variables (MSWEA_MODEL_NAME + a provider key), a full config file (MSWEA_MINI_CONFIG_PATH), or the Model field before running a task."
     }
+  },
+  {
+    "name": "pi",
+    "label": "Pi",
+    "description": "Earendil's Pi coding agent for the terminal — headless RPC mode, many providers",
+    "homepage": "https://pi.dev",
+    "tags": [
+      "coding",
+      "cli",
+      "open-source",
+      "rpc"
+    ],
+    "builtin": true,
+    "support": {
+      "install": true,
+      "workspace": true,
+      "collaboration": true
+    },
+    "install": {
+      "binary": "pi",
+      "npm_package": "@earendil-works/pi-coding-agent",
+      "requires": [
+        "nodejs"
+      ],
+      "min_version": "0.83.0",
+      "verify": "pi --version >/dev/null 2>&1",
+      "verify_win": "pi --version >nul 2>nul",
+      "macos": "npm install -g @earendil-works/pi-coding-agent@0.83.0",
+      "linux": "npm install -g @earendil-works/pi-coding-agent@0.83.0",
+      "windows": "npm install -g @earendil-works/pi-coding-agent@0.83.0"
+    },
+    "adapter": {
+      "module": "openagents.adapters.pi",
+      "class": "PiAdapter"
+    },
+    "launch": {
+      "args": []
+    },
+    "env_config": [
+      {
+        "name": "PI_PROVIDER",
+        "description": "Provider: anthropic/openai for native APIs or compatible relays, deepseek for the native DeepSeek API, openai-codex for an existing Pi subscription login, or custom.",
+        "required": false,
+        "placeholder": "anthropic",
+        "default": "anthropic",
+        "options": [
+          "anthropic",
+          "openai",
+          "deepseek",
+          "openai-codex",
+          "openrouter",
+          "google",
+          "custom"
+        ]
+      },
+      {
+        "name": "PI_MODEL",
+        "description": "Exact model id exposed by the provider or relay (for example claude-sonnet-4-6, gpt-5-codex, or deepseek-v4-flash).",
+        "required": false,
+        "placeholder": "claude-sonnet-4-6"
+      },
+      {
+        "name": "PI_API_FORMAT",
+        "description": "API protocol. Keep auto for native providers; choose anthropic-messages, openai-completions, or openai-responses for a relay.",
+        "required": false,
+        "default": "auto",
+        "options": [
+          "auto",
+          "anthropic-messages",
+          "openai-completions",
+          "openai-responses"
+        ]
+      },
+      {
+        "name": "PI_BASE_URL",
+        "description": "Optional relay/proxy base URL. Leave blank for the provider's native API. OpenAgents configures Pi automatically when this is set.",
+        "required": false,
+        "placeholder": "https://relay.example.com/v1"
+      },
+      {
+        "name": "PI_API_KEY",
+        "description": "API key for the selected provider or relay. Leave blank to reuse an existing Pi /login session.",
+        "required": false,
+        "password": true
+      },
+      {
+        "name": "PI_THINKING",
+        "description": "Reasoning effort: off, minimal, low, medium, high, xhigh, max. Leave blank for the model default.",
+        "required": false,
+        "default": "off",
+        "options": [
+          "off",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      },
+      {
+        "name": "PI_TRUST_PROJECT",
+        "description": "Set to 1 to let Pi load project-local .pi/settings.json, extensions and skills from the working directory. OFF by default — project files are executable surface.",
+        "required": false,
+        "default": "0",
+        "options": [
+          "0",
+          "1"
+        ]
+      }
+    ],
+    "check_ready": {
+      "creds_file": "~/.pi/agent/auth.json",
+      "creds_no_parse": true,
+      "creds_json_has_entries": true,
+      "env_vars": [
+        "PI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENROUTER_API_KEY"
+      ],
+      "saved_env_key": "PI_API_KEY",
+      "login_command": "pi",
+      "not_ready_message": "Not configured — set a provider API key (press e), or run `pi` and use /login once.",
+      "unreadable_message": "Pi credentials were found but could not be read. Check permissions on ~/.pi/agent, or run `pi` and sign in again."
+    },
+    "resolve_env": {
+      "rules": [
+        {
+          "from": "LLM_API_KEY",
+          "to": "PI_API_KEY"
+        },
+        {
+          "from": "LLM_BASE_URL",
+          "to": "PI_BASE_URL"
+        },
+        {
+          "from": "LLM_MODEL",
+          "to": "PI_MODEL"
+        }
+      ]
+    }
   }
 ]

--- a/packages/agent-connector/src/adapters/index.js
+++ b/packages/agent-connector/src/adapters/index.js
@@ -20,6 +20,7 @@ const CopilotAdapter = require('./copilot');
 const ClineAdapter = require('./cline');
 const AmpAdapter = require('./amp');
 const MiniSweAgentAdapter = require('./mini');
+const PiAdapter = require('./pi');
 
 const ADAPTER_MAP = {
   openclaw: OpenClawAdapter,
@@ -37,11 +38,12 @@ const ADAPTER_MAP = {
   cline: ClineAdapter,
   amp: AmpAdapter,
   'mini-swe-agent': MiniSweAgentAdapter,
+  pi: PiAdapter,
 };
 
 /**
  * Create an adapter instance for the given agent type.
- * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, aider, goose, copilot, cline, amp, mini-swe-agent)
+ * @param {string} type - Agent type (openclaw, claude, codex, opencode, nanoclaw, cursor, hermes, gemini, kimi, aider, goose, copilot, cline, amp, mini-swe-agent, pi)
  * @param {object} opts - Adapter constructor options
  * @returns {BaseAdapter}
  */
@@ -70,6 +72,7 @@ module.exports = {
   ClineAdapter,
   AmpAdapter,
   MiniSweAgentAdapter,
+  PiAdapter,
   createAdapter,
   ADAPTER_MAP,
 };

--- a/packages/agent-connector/src/adapters/pi-launcher-provider.mjs
+++ b/packages/agent-connector/src/adapters/pi-launcher-provider.mjs
@@ -1,0 +1,116 @@
+/**
+ * Process-local Pi provider configured entirely by Launcher environment fields.
+ *
+ * This extension is loaded explicitly when PI_BASE_URL or the Launcher's
+ * provider-neutral PI_API_KEY is set. It never persists settings or
+ * credentials: the key is read from the child environment at runtime. That
+ * keeps separate OpenAgents Pi instances isolated and leaves the user's
+ * ~/.pi/agent/models.json and auth.json untouched.
+ */
+
+const value = (name) => String(process.env[name] || '').trim()
+
+const PROVIDER_DEFAULTS = {
+  anthropic: {
+    baseUrl: 'https://api.anthropic.com',
+    api: 'anthropic-messages',
+  },
+  openai: {
+    baseUrl: 'https://api.openai.com/v1',
+    api: 'openai-responses',
+  },
+  deepseek: {
+    baseUrl: 'https://api.deepseek.com/v1',
+    api: 'openai-completions',
+  },
+  google: {
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+    api: 'google-generative-ai',
+  },
+  openrouter: {
+    baseUrl: 'https://openrouter.ai/api/v1',
+    api: 'openai-completions',
+  },
+}
+
+function providerKey(provider) {
+  return value('PI_API_KEY') || {
+    anthropic: value('ANTHROPIC_API_KEY'),
+    openai: value('OPENAI_API_KEY'),
+    deepseek: value('DEEPSEEK_API_KEY'),
+    google: value('GEMINI_API_KEY'),
+    openrouter: value('OPENROUTER_API_KEY'),
+  }[provider] || ''
+}
+
+function apiFormat(provider) {
+  const configured = value('PI_API_FORMAT').toLowerCase()
+  if (configured && configured !== 'auto') return configured
+  return PROVIDER_DEFAULTS[provider]?.api || 'openai-completions'
+}
+
+function isOfficialAnthropic(url) {
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+    return host === 'anthropic.com' || host.endsWith('.anthropic.com')
+  } catch {
+    return false
+  }
+}
+
+export default function configureLauncherProvider(pi) {
+  const provider = value('PI_PROVIDER').toLowerCase()
+  const model = value('PI_MODEL')
+  const key = providerKey(provider)
+  const configuredBaseUrl = value('PI_BASE_URL')
+  let baseUrl = (
+    configuredBaseUrl || PROVIDER_DEFAULTS[provider]?.baseUrl || ''
+  ).replace(/\/+$/, '')
+  if (!baseUrl || !provider || !model || (!configuredBaseUrl && !key)) return
+
+  const api = apiFormat(provider)
+  // Anthropic's SDK appends /v1/messages itself. Accept either the service
+  // root or the commonly copied .../v1 URL from a relay dashboard.
+  if (api === 'anthropic-messages') baseUrl = baseUrl.replace(/\/v1$/i, '')
+  const thinking = value('PI_THINKING').toLowerCase()
+  const compat = {}
+  if (provider === 'deepseek' || baseUrl.toLowerCase().includes('deepseek.com')) {
+    compat.supportsDeveloperRole = false
+  }
+
+  pi.registerProvider(provider, {
+    baseUrl,
+    api,
+    // Pass the resolved secret directly to the process-local provider. This is
+    // deliberately not an argv flag or a persisted models.json/auth.json value.
+    // It also avoids relying on Pi's built-in credential resolver, which has
+    // failed to observe a present DEEPSEEK_API_KEY in some RPC launches.
+    apiKey: key || undefined,
+    // Anthropic's native endpoint uses x-api-key. The common relay convention
+    // is Bearer auth; enabling it for non-official endpoints mirrors the
+    // Launcher's Claude-agent behavior while leaving direct Anthropic untouched.
+    authHeader: api === 'anthropic-messages' && !isOfficialAnthropic(baseUrl),
+    ...(Object.keys(compat).length ? { compat } : {}),
+    models: [
+      {
+        id: model,
+        name: model,
+        reasoning: !!thinking && thinking !== 'off',
+        input: ['text', 'image'],
+        // Pi's runtime cost calculator treats `cost` as required and reads its
+        // tier list after every provider response. Launcher-managed relays can
+        // have arbitrary pricing, so use an explicit zero-cost placeholder
+        // instead of inventing charges. The provider still bills normally.
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          tiers: [],
+        },
+        contextWindow: 200000,
+        maxTokens: 16384,
+      },
+    ],
+  })
+}

--- a/packages/agent-connector/src/adapters/pi-stream.js
+++ b/packages/agent-connector/src/adapters/pi-stream.js
@@ -1,0 +1,922 @@
+/**
+ * Pi CLI — RPC (JSONL) framing, event classification and helpers (pure, no I/O).
+ *
+ * This module turns the raw byte stream produced by
+ *   `pi --mode rpc [...]`
+ * into normalized events the PiAdapter maps onto OpenAgents workspace
+ * messages. Like copilot-stream-parser.js it is split into layers so a Pi
+ * upgrade only ever touches one table:
+ *
+ *   1. FRAMING (schema-agnostic) — `PiJsonlFramer`
+ *      Reassembles complete records from arbitrary chunk boundaries. Pi's RPC
+ *      protocol is *strict* JSONL: LF (`\n`) is the ONLY record delimiter, a
+ *      trailing `\r` may be stripped, and U+2028/U+2029 MUST NOT be treated as
+ *      newlines (they are legal inside JSON strings). Node's `readline` splits
+ *      on those separators and is therefore not protocol-compliant — hence the
+ *      hand-rolled framer here. A `StringDecoder` does the byte→string step so
+ *      a multi-byte UTF-8 sequence (CJK, emoji) split across two chunks is
+ *      reassembled instead of being decoded into replacement characters.
+ *
+ *   2. CLASSIFICATION (schema-aware) — `classifyPiEvent()` + EVENT_KIND_BY_TYPE
+ *      Maps one parsed JSON object onto `{ kind, ... }`. All Pi type strings
+ *      live in ONE table so a schema drift is a single-point edit. Anything
+ *      unrecognized degrades to a redacted `unknown` event — never a throw.
+ *
+ *   3. TURN ACCUMULATION — `PiAssistantAccumulator`
+ *      Pi emits each assistant content block TWICE: incrementally through
+ *      `message_update` (`text_delta` … `text_end`) and again in full on
+ *      `message_end`. The accumulator hands each block to the caller exactly
+ *      once, keyed by its `contentIndex`, so streaming output and the final
+ *      message can never be posted twice.
+ *
+ * ── Verification status ──────────────────────────────────────────────────
+ * Verified against @earendil-works/pi-coding-agent v0.83.0 (bin `pi`,
+ * engines.node >= 22.19.0) using the RPC protocol spec shipped in the package
+ * (docs/rpc.md) plus live `pi --mode rpc` captures. Confirmed by capture:
+ *   • command responses: {"id","type":"response","command","success",[data|error]}
+ *   • event order for a turn: agent_start → turn_start → message_start/…_end
+ *     (user) → message_start/…_end (assistant) → turn_end → agent_end →
+ *     agent_settled
+ *   • a provider/auth failure is NOT a failed `response`: the prompt is
+ *     accepted (success:true) and the failure arrives as an assistant message
+ *     with stopReason "error" + `errorMessage`
+ *   • `--session-id <uuid>` creates the session when missing and resumes it on
+ *     the next process, so no session-id correlation heuristics are needed
+ * Never infer an event's meaning from a field name alone.
+ *
+ * Normalized event kinds (the adapter's stable contract):
+ *   { kind:'response',        id, command, success, data, error }
+ *   { kind:'agent_start' }
+ *   { kind:'agent_end',       willRetry }
+ *   { kind:'agent_settled' }
+ *   { kind:'message_start',   role }
+ *   { kind:'message_update',  delta }        raw assistantMessageEvent
+ *   { kind:'message_end',     message }      full AgentMessage
+ *   { kind:'tool_start',      toolCallId, toolName, preview }
+ *   { kind:'tool_update',     toolCallId, toolName }
+ *   { kind:'tool_end',        toolCallId, toolName, isError, preview }
+ *   { kind:'bash_output',     id, delta }
+ *   { kind:'queue_update',    steering, followUp }
+ *   { kind:'compaction_start',reason }
+ *   { kind:'compaction_end',  reason, aborted, willRetry, error }
+ *   { kind:'retry_start',     attempt, maxAttempts, delayMs, message }
+ *   { kind:'retry_end',       success, attempt, finalError }
+ *   { kind:'extension_error', message }
+ *   { kind:'ui_request',      id, method, needsResponse, title }
+ *   { kind:'oversize',        bytes }        a single record blew the line cap
+ *   { kind:'unknown',         raw }          unrecognized / unparseable (redacted)
+ */
+
+'use strict';
+
+const path = require('path');
+const { StringDecoder } = require('string_decoder');
+
+// ────────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * FALLBACK floor only. The authoritative minimum lives in the registry
+ * (`install.min_version` in pi.yaml / registry.json) so the catalog and the
+ * runtime gate cannot drift; the adapter reads it from there and passes it to
+ * `classifyPiVersion`. This constant is used only when the registry entry
+ * cannot be read at all.
+ */
+const MIN_PI_VERSION = '0.83.0';
+
+/** Pi's own hard engine floor (package.json engines.node). */
+const MIN_NODE_VERSION = '22.19.0';
+
+/**
+ * Hard cap on a single un-terminated record we will buffer. Pi can emit very
+ * large single lines (an `agent_end` carries every message of the run), so this
+ * is generous — but unbounded buffering on a wedged stream is how a daemon
+ * OOMs. Mirrors goose-stream.js's MAX_LINE_BYTES rationale.
+ */
+const MAX_LINE_BYTES = 16 * 1024 * 1024;
+
+/** How much of a tool argument we surface as a workspace status line. */
+const TOOL_PREVIEW_LIMIT = 160;
+
+/**
+ * Extension UI methods that BLOCK the Pi process until the client answers.
+ * A headless run has no one to answer them, so the adapter must reply
+ * `{cancelled:true}` immediately or the turn hangs forever.
+ */
+const BLOCKING_UI_METHODS = new Set(['select', 'confirm', 'input', 'editor']);
+
+// ────────────────────────────────────────────────────────────────────────
+// Redaction
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mask credentials in arbitrary text before it reaches a log, a status file or
+ * the workspace. `secrets` are exact values (e.g. the configured API key) that
+ * must be masked even when they don't match any known shape. Never throws.
+ *
+ * @param {string} text
+ * @param {string[]} [secrets]
+ * @returns {string}
+ */
+function redactSecrets(text, secrets) {
+  if (text == null) return '';
+  let out = typeof text === 'string' ? text : String(text);
+  for (const secret of secrets || []) {
+    if (secret && typeof secret === 'string' && secret.length >= 8) {
+      out = out.split(secret).join('***');
+    }
+  }
+  out = out.replace(
+    /\b(api[_-]?key|secret|token|authorization|auth|bearer|password)\b\s*[:=]?\s*['"]?([A-Za-z0-9._-]{8,})['"]?/gi,
+    (_m, label) => `${label}=***`,
+  );
+  out = out.replace(/\b(?:sk|pk|rk)-[A-Za-z0-9._-]{6,}\b/g, '***');
+  out = out.replace(/\bgh[pousr]_[A-Za-z0-9]{16,}\b/g, '***');
+  out = out.replace(/\bAKIA[0-9A-Z]{12,}\b/g, '***');
+  // scheme://user:pass@host
+  out = out.replace(/(\b[a-z][a-z0-9+.-]*:\/\/)[^/@\s:]+:[^/@\s]+@/gi, '$1***@');
+  return out;
+}
+
+/**
+ * Short, redacted, single-line diagnostic for an unrecognized record so a
+ * schema drift is observable in logs without dumping a transcript or a secret.
+ */
+function diagnosticFor(value, maxLen = 300) {
+  let s;
+  if (typeof value === 'string') s = value;
+  else {
+    try { s = JSON.stringify(value); } catch { s = String(value); }
+  }
+  s = redactSecrets(s == null ? '' : s).replace(/\s+/g, ' ').trim();
+  return s.length > maxLen ? s.slice(0, maxLen) + '…' : s;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Framing — strict JSONL, LF only, UTF-8 safe across chunk boundaries
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Incremental JSONL framer for Pi's RPC stdout.
+ *
+ * Contract (from the Pi RPC spec):
+ *   - split on `\n` and ONLY on `\n`
+ *   - tolerate (strip) a single trailing `\r`
+ *   - never treat U+2028 / U+2029 as a record separator
+ *   - a record may span many chunks; a chunk may carry many records
+ */
+class PiJsonlFramer {
+  constructor({ maxLineBytes = MAX_LINE_BYTES } = {}) {
+    this._decoder = new StringDecoder('utf8');
+    this._buf = '';
+    this._maxLineBytes = maxLineBytes;
+    /** Records dropped because they exceeded the cap (diagnostics only). */
+    this.dropped = 0;
+    /** Byte length of the last dropped record, for a redacted log line. */
+    this.lastDroppedBytes = 0;
+    this._skippingOversize = false;
+  }
+
+  /**
+   * Feed a stdout chunk. Returns the complete records it completed, in order.
+   * A record that exceeds the cap is dropped (and counted) rather than
+   * buffered forever; the framer then resynchronizes on the next `\n`.
+   *
+   * @param {Buffer|string} chunk
+   * @returns {string[]}
+   */
+  push(chunk) {
+    if (chunk == null) return [];
+    this._buf += typeof chunk === 'string' ? chunk : this._decoder.write(chunk);
+    return this._drain();
+  }
+
+  /**
+   * Flush at EOF: decodes any dangling multi-byte remainder and emits the
+   * trailing record when the stream ended without a final `\n`. Idempotent.
+   * @returns {string[]}
+   */
+  flush() {
+    this._buf += this._decoder.end();
+    const lines = this._drain();
+    const tail = this._buf;
+    this._buf = '';
+    if (this._skippingOversize) {
+      // The stream ended mid-oversize record — it was already counted.
+      this._skippingOversize = false;
+      return lines;
+    }
+    if (tail) lines.push(PiJsonlFramer._strip(tail));
+    return lines;
+  }
+
+  _drain() {
+    const lines = [];
+    while (true) {
+      const idx = this._buf.indexOf('\n');
+      if (idx === -1) break;
+      const raw = this._buf.slice(0, idx);
+      this._buf = this._buf.slice(idx + 1);
+      if (this._skippingOversize) {
+        // Tail of a record we already gave up on — resynchronized now.
+        this._skippingOversize = false;
+        continue;
+      }
+      lines.push(PiJsonlFramer._strip(raw));
+    }
+    if (this._buf.length > this._maxLineBytes) {
+      this.dropped++;
+      this.lastDroppedBytes = this._buf.length;
+      this._buf = '';
+      this._skippingOversize = true;
+    }
+    return lines;
+  }
+
+  /** Strip a single trailing CR, per the RPC spec's `\r\n` tolerance. */
+  static _strip(line) {
+    return line.endsWith('\r') ? line.slice(0, -1) : line;
+  }
+}
+
+/**
+ * Parse one JSONL record. Returns null for a blank line or anything that isn't
+ * a JSON object — a corrupt record must degrade, never abort the turn.
+ * @param {string} line
+ * @returns {object|null}
+ */
+function parseLine(line) {
+  if (line == null) return null;
+  const trimmed = String(line).trim();
+  if (!trimmed) return null;
+  if (trimmed[0] !== '{') return null; // Pi only ever emits objects
+  try {
+    const v = JSON.parse(trimmed);
+    return v && typeof v === 'object' && !Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Classification — the SINGLE place that knows Pi's type strings
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pi RPC record `type` → normalized kind. Verified against v0.83.0 docs/rpc.md.
+ * Extend ONLY this table when Pi adds events; unlisted types become `unknown`.
+ */
+const EVENT_KIND_BY_TYPE = {
+  // command responses
+  response: 'response',
+  // agent lifecycle
+  agent_start: 'agent_start',
+  agent_end: 'agent_end',
+  agent_settled: 'agent_settled',
+  turn_start: 'turn_start',
+  turn_end: 'turn_end',
+  // messages
+  message_start: 'message_start',
+  message_update: 'message_update',
+  message_end: 'message_end',
+  // tools
+  tool_execution_start: 'tool_start',
+  tool_execution_update: 'tool_update',
+  tool_execution_end: 'tool_end',
+  bash_execution_update: 'bash_output',
+  // queue / context management
+  queue_update: 'queue_update',
+  compaction_start: 'compaction_start',
+  compaction_end: 'compaction_end',
+  // retries
+  auto_retry_start: 'retry_start',
+  auto_retry_end: 'retry_end',
+  summarization_retry_scheduled: 'retry_start',
+  summarization_retry_attempt_start: 'turn_start',
+  summarization_retry_finished: 'retry_end',
+  // diagnostics + extension UI
+  extension_error: 'extension_error',
+  extension_ui_request: 'ui_request',
+};
+
+function _str(v) {
+  return typeof v === 'string' && v.length ? v : undefined;
+}
+
+/**
+ * Condense a tool's arguments into one short, redacted status preview.
+ * @param {string} toolName
+ * @param {*} args
+ * @returns {string}
+ */
+function summarizeToolArgs(toolName, args) {
+  if (!args || typeof args !== 'object') return '';
+  const PREFERRED = [
+    'command', 'file_path', 'path', 'filePath', 'file',
+    'pattern', 'query', 'url', 'glob', 'old_string',
+  ];
+  let preview = '';
+  for (const key of PREFERRED) {
+    const val = args[key];
+    if (typeof val === 'string' && val) { preview = val; break; }
+  }
+  if (!preview) {
+    const keys = Object.keys(args).filter((k) => typeof k === 'string');
+    if (!keys.length) return '';
+    preview = keys.slice(0, 6).join(', ');
+  }
+  preview = redactSecrets(preview).replace(/\s+/g, ' ').trim();
+  if (preview.length > TOOL_PREVIEW_LIMIT) preview = preview.slice(0, TOOL_PREVIEW_LIMIT) + '…';
+  return preview;
+}
+
+/** Condense a tool result's content blocks into a short redacted preview. */
+function summarizeToolResult(result) {
+  if (!result || typeof result !== 'object') return '';
+  const content = Array.isArray(result.content) ? result.content : [];
+  const text = content
+    .map((b) => (b && typeof b === 'object' && typeof b.text === 'string' ? b.text : ''))
+    .join(' ')
+    .trim();
+  if (!text) return '';
+  const preview = redactSecrets(text).replace(/\s+/g, ' ').trim();
+  return preview.length > TOOL_PREVIEW_LIMIT ? preview.slice(0, TOOL_PREVIEW_LIMIT) + '…' : preview;
+}
+
+/**
+ * Classify one parsed Pi RPC record. Never throws; an unrecognized shape
+ * becomes `{ kind:'unknown', raw }` carrying a redacted diagnostic.
+ * @param {object} obj
+ * @returns {{kind: string} & object}
+ */
+function classifyPiEvent(obj) {
+  if (!obj || typeof obj !== 'object') return { kind: 'unknown', raw: diagnosticFor(obj) };
+  const type = _str(obj.type);
+  const kind = type ? EVENT_KIND_BY_TYPE[type] : undefined;
+
+  switch (kind) {
+    case 'response':
+      return {
+        kind: 'response',
+        id: obj.id == null ? null : String(obj.id),
+        command: _str(obj.command) || null,
+        success: obj.success === true,
+        data: obj.data == null ? null : obj.data,
+        error: _str(obj.error) || null,
+      };
+    case 'agent_start':
+      return { kind: 'agent_start' };
+    case 'agent_end':
+      return { kind: 'agent_end', willRetry: obj.willRetry === true };
+    case 'agent_settled':
+      return { kind: 'agent_settled' };
+    case 'turn_start':
+      return { kind: 'turn_start' };
+    case 'turn_end':
+      return { kind: 'turn_end' };
+    case 'message_start':
+      return {
+        kind: 'message_start',
+        role: (obj.message && _str(obj.message.role)) || null,
+      };
+    case 'message_update':
+      return {
+        kind: 'message_update',
+        delta: (obj.assistantMessageEvent && typeof obj.assistantMessageEvent === 'object')
+          ? obj.assistantMessageEvent
+          : null,
+      };
+    case 'message_end':
+      return {
+        kind: 'message_end',
+        message: (obj.message && typeof obj.message === 'object') ? obj.message : null,
+      };
+    case 'tool_start': {
+      const toolName = _str(obj.toolName) || 'tool';
+      return {
+        kind: 'tool_start',
+        toolCallId: _str(obj.toolCallId) || null,
+        toolName,
+        preview: summarizeToolArgs(toolName, obj.args),
+      };
+    }
+    case 'tool_update':
+      return {
+        kind: 'tool_update',
+        toolCallId: _str(obj.toolCallId) || null,
+        toolName: _str(obj.toolName) || 'tool',
+      };
+    case 'tool_end': {
+      const toolName = _str(obj.toolName) || 'tool';
+      return {
+        kind: 'tool_end',
+        toolCallId: _str(obj.toolCallId) || null,
+        toolName,
+        isError: obj.isError === true,
+        preview: summarizeToolResult(obj.result),
+      };
+    }
+    case 'bash_output':
+      return {
+        kind: 'bash_output',
+        id: obj.id == null ? null : String(obj.id),
+        delta: typeof obj.delta === 'string' ? obj.delta : '',
+      };
+    case 'queue_update':
+      return {
+        kind: 'queue_update',
+        steering: Array.isArray(obj.steering) ? obj.steering.length : 0,
+        followUp: Array.isArray(obj.followUp) ? obj.followUp.length : 0,
+      };
+    case 'compaction_start':
+      return { kind: 'compaction_start', reason: _str(obj.reason) || 'manual' };
+    case 'compaction_end':
+      return {
+        kind: 'compaction_end',
+        reason: _str(obj.reason) || 'manual',
+        aborted: obj.aborted === true,
+        willRetry: obj.willRetry === true,
+        error: _str(obj.errorMessage) ? redactSecrets(obj.errorMessage) : null,
+      };
+    case 'retry_start':
+      return {
+        kind: 'retry_start',
+        attempt: Number.isFinite(obj.attempt) ? obj.attempt : null,
+        maxAttempts: Number.isFinite(obj.maxAttempts) ? obj.maxAttempts : null,
+        delayMs: Number.isFinite(obj.delayMs) ? obj.delayMs : null,
+        message: _str(obj.errorMessage) ? redactSecrets(obj.errorMessage) : null,
+      };
+    case 'retry_end':
+      return {
+        kind: 'retry_end',
+        // `summarization_retry_finished` carries no outcome — treat as success.
+        success: obj.success !== false,
+        attempt: Number.isFinite(obj.attempt) ? obj.attempt : null,
+        finalError: _str(obj.finalError) ? redactSecrets(obj.finalError) : null,
+      };
+    case 'extension_error':
+      return {
+        kind: 'extension_error',
+        message: redactSecrets(_str(obj.error) || 'Pi extension reported an error'),
+      };
+    case 'ui_request': {
+      const method = _str(obj.method) || '';
+      return {
+        kind: 'ui_request',
+        id: obj.id == null ? null : String(obj.id),
+        method,
+        needsResponse: BLOCKING_UI_METHODS.has(method),
+        title: redactSecrets(_str(obj.title) || _str(obj.message) || ''),
+      };
+    }
+    default:
+      return { kind: 'unknown', raw: diagnosticFor(obj) };
+  }
+}
+
+/**
+ * Stateful parser: bytes in, normalized events out. Thin wrapper over the
+ * framer + classifier so the adapter never touches either directly.
+ */
+class PiStreamParser {
+  constructor(opts) {
+    this._framer = new PiJsonlFramer(opts);
+  }
+
+  /** @param {Buffer|string} chunk @returns {Array<object>} */
+  push(chunk) {
+    return this._classify(this._framer.push(chunk));
+  }
+
+  /** Flush at EOF. @returns {Array<object>} */
+  flush() {
+    return this._classify(this._framer.flush());
+  }
+
+  _classify(lines) {
+    const before = this._reportedDrops || 0;
+    const events = [];
+    for (const line of lines) {
+      const obj = parseLine(line);
+      if (obj === null) {
+        // Blank lines are silent; anything else is a corrupt/foreign record we
+        // surface as `unknown` so a schema drift shows up in the logs.
+        if (String(line).trim()) events.push({ kind: 'unknown', raw: diagnosticFor(line) });
+        continue;
+      }
+      events.push(classifyPiEvent(obj));
+    }
+    if (this._framer.dropped > before) {
+      this._reportedDrops = this._framer.dropped;
+      events.push({ kind: 'oversize', bytes: this._framer.lastDroppedBytes });
+    }
+    return events;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Turn accumulation — deduplicates message_update against message_end
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pi delivers each assistant content block twice: incrementally via
+ * `message_update` (…`text_end` / `thinking_end` carry the COMPLETE block) and
+ * again inside the `message_end` payload. This accumulator releases each block
+ * exactly once, keyed by its `contentIndex`, so the adapter can stream blocks
+ * as they finish AND still finalize from `message_end` without duplicating a
+ * single character.
+ *
+ * Usage per assistant message:
+ *   acc.startMessage()                    // on message_start (role 'assistant')
+ *   acc.pushDelta(ev.delta) -> blocks[]   // on message_update
+ *   acc.endMessage(ev.message) -> {...}   // on message_end
+ */
+class PiAssistantAccumulator {
+  constructor() {
+    this.reset();
+  }
+
+  reset() {
+    this._released = new Set();   // contentIndex values already handed out
+    this._texts = [];             // released text blocks, in order
+    this._thinking = [];          // released thinking blocks, in order
+    this._active = false;
+    this._closed = false;
+  }
+
+  /**
+   * Begin a new assistant message. Block indices AND the released-block lists
+   * are per-message: in a tool loop Pi emits several assistant messages per
+   * turn, and only the LAST one's text is the user-facing answer (the earlier
+   * ones are narration around tool calls). Keeping the lists per-message is
+   * what lets the adapter take "the final message's text" as the reply.
+   */
+  startMessage() {
+    this._released = new Set();
+    this._texts = [];
+    this._thinking = [];
+    this._active = true;
+    this._closed = false;
+  }
+
+  /**
+   * Begin a new message implicitly when the previous one already ended.
+   * Pi always emits `message_start` first, but relying on that alone means a
+   * dropped or reordered start event would make the NEXT message's block look
+   * like a duplicate of the previous message's same-index block and silently
+   * swallow it — losing an answer. Reopening here removes that failure mode.
+   */
+  _ensureOpen() {
+    if (this._closed) this.startMessage();
+  }
+
+  /**
+   * Feed one `assistantMessageEvent`. Returns the blocks it completed —
+   * `[{ type:'text'|'thinking', text }]` — or [] for a partial delta.
+   * @param {object|null} delta
+   */
+  pushDelta(delta) {
+    if (!delta || typeof delta !== 'object') return [];
+    this._ensureOpen();
+    const out = [];
+    const idx = Number.isFinite(delta.contentIndex) ? delta.contentIndex : null;
+    if (delta.type === 'text_end') {
+      const text = typeof delta.content === 'string' ? delta.content : '';
+      if (this._release(idx, 'text', text)) out.push({ type: 'text', text });
+    } else if (delta.type === 'thinking_end') {
+      const text = typeof delta.content === 'string'
+        ? delta.content
+        : (typeof delta.thinking === 'string' ? delta.thinking : '');
+      if (this._release(idx, 'thinking', text)) out.push({ type: 'thinking', text });
+    }
+    return out;
+  }
+
+  /**
+   * Finalize from the `message_end` payload. Emits any block the streaming
+   * path never released (a non-streaming provider, or a block whose `*_end`
+   * delta was lost), and reports the message-level error.
+   *
+   * @param {object|null} message  the AgentMessage from message_end
+   * @returns {{blocks: Array<{type:string,text:string}>, texts: string[],
+   *           thinking: string[], errorMessage: string|null, stopReason: string|null}}
+   */
+  endMessage(message) {
+    this._ensureOpen();
+    const blocks = [];
+    const content = message && Array.isArray(message.content) ? message.content : [];
+    for (let i = 0; i < content.length; i++) {
+      const block = content[i];
+      if (!block || typeof block !== 'object') continue;
+      if (block.type === 'text') {
+        const text = typeof block.text === 'string' ? block.text : '';
+        if (this._release(i, 'text', text)) blocks.push({ type: 'text', text });
+      } else if (block.type === 'thinking') {
+        const text = typeof block.thinking === 'string' ? block.thinking : '';
+        if (this._release(i, 'thinking', text)) blocks.push({ type: 'thinking', text });
+      }
+      // toolCall blocks are surfaced through tool_execution_* events instead.
+    }
+    this._active = false;
+    this._closed = true;
+    const stopReason = message && _str(message.stopReason) ? message.stopReason : null;
+    const rawError = message && _str(message.errorMessage) ? message.errorMessage : null;
+    return {
+      blocks,
+      texts: this._texts.slice(),
+      thinking: this._thinking.slice(),
+      errorMessage: rawError ? redactSecrets(rawError) : null,
+      stopReason,
+    };
+  }
+
+  /** Text of the whole message, in block order, once it has ended. */
+  get text() {
+    return this._texts.join('\n').trim();
+  }
+
+  _release(idx, type, text) {
+    // A block with no usable index can't be deduped by index; fall back to
+    // value-identity so a repeated payload still can't be posted twice.
+    const key = idx == null ? `${type}:${text}` : `${idx}`;
+    if (this._released.has(key)) return false;
+    this._released.add(key);
+    if (!text || !text.trim()) return false;
+    if (type === 'text') this._texts.push(text);
+    else this._thinking.push(text);
+    return true;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Error classification → the SHARED health-status vocabulary
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Map a raw Pi failure string (an assistant `errorMessage`, a failed RPC
+ * `error`, or stderr) to `{ kind, userMessage }`. `kind` is one of
+ * 'auth' | 'rate_limit' | 'model' | 'provider' | 'network' | 'context' |
+ * 'filesystem' | null, and the caller decides which REASON (if any) it maps
+ * to. Always pass the result through redactSecrets before display.
+ *
+ * @param {string} text
+ * @returns {{kind: string|null, userMessage: string}}
+ */
+function classifyPiError(text) {
+  const raw = redactSecrets(String(text == null ? '' : text)).trim();
+  if (!raw) return { kind: null, userMessage: 'Pi reported an error.' };
+  const low = raw.toLowerCase();
+  const has = (...needles) => needles.some((n) => low.includes(n));
+
+  if (has('401', '403', 'unauthorized', 'authentication_error', 'authentication failed',
+    'invalid api key', 'invalid x-api-key', 'invalid_api_key', 'no api key',
+    'missing api key', 'no credentials', 'not authenticated')) {
+    return {
+      kind: 'auth',
+      userMessage:
+        `Pi authentication failed: ${raw}\n\n` +
+        "Check this agent's PI_API_KEY in the launcher (OpenAgents maps it to the provider's " +
+        'native env var, including DEEPSEEK_API_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY / ' +
+        'GEMINI_API_KEY), or sign in once ' +
+        'with `pi` → `/login` so the credential lands in ~/.pi/agent/auth.json.',
+    };
+  }
+  if (has('429', 'rate limit', 'rate_limit', 'too many requests', 'quota', 'overloaded',
+    'insufficient_quota')) {
+    return {
+      kind: 'rate_limit',
+      userMessage: `Pi hit the provider's rate limit or quota: ${raw}\n\nWait and retry, or switch provider/model.`,
+    };
+  }
+  if (has('context', 'too long', 'maximum context', 'context_length_exceeded')) {
+    return {
+      kind: 'context',
+      userMessage: `Pi exceeded the model's context window: ${raw}\n\nUse /restart in this channel to start a fresh Pi session.`,
+    };
+  }
+  if (has('model not found', 'unknown model', 'no such model', 'no model matching',
+    'model_not_found', 'does not support')) {
+    return {
+      kind: 'model',
+      userMessage: `Pi could not use the configured model: ${raw}\n\nCheck PI_MODEL (and PI_PROVIDER) for this agent.`,
+    };
+  }
+  if (has('unknown provider', 'no provider', 'provider not found', 'unsupported provider')) {
+    return {
+      kind: 'provider',
+      userMessage: `Pi could not use the configured provider: ${raw}\n\nCheck PI_PROVIDER for this agent (run \`pi --list-models\` to see what is configured).`,
+    };
+  }
+  if (has('econnrefused', 'enotfound', 'etimedout', 'network', 'socket hang up',
+    'fetch failed', 'timed out', 'getaddrinfo', 'certificate')) {
+    return {
+      kind: 'network',
+      userMessage: `Pi could not reach the provider: ${raw}\n\nCheck network access and any HTTP_PROXY/HTTPS_PROXY setting.`,
+    };
+  }
+  if (has('enoent', 'eacces', 'eperm', 'no such file', 'permission denied', 'not a directory')) {
+    return {
+      kind: 'filesystem',
+      userMessage: `Pi hit a filesystem error: ${raw}\n\nCheck that the agent's working directory exists and is writable.`,
+    };
+  }
+  return { kind: null, userMessage: `Pi error: ${raw}` };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Version helpers + argv construction
+// ────────────────────────────────────────────────────────────────────────
+
+/** Extract a dotted version from arbitrary CLI output, or null. */
+function parseVersion(raw) {
+  if (!raw) return null;
+  const m = String(raw).match(/(\d+)\.(\d+)\.(\d+)/);
+  return m ? `${m[1]}.${m[2]}.${m[3]}` : null;
+}
+
+/** -1 / 0 / 1 for semver-ish triples. Missing components count as 0. */
+function compareVersions(a, b) {
+  const pa = String(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+/**
+ * Classify a `pi --version` output against the minimum supported version.
+ * @param {string} raw
+ * @param {string} [minVersion] the registry's `install.min_version`; falls back
+ *   to MIN_PI_VERSION only when the registry entry is unreadable.
+ * @returns {{version: string|null, supported: boolean|null}}
+ *   supported true → >= min; false → CONFIRMED older; null → undetermined.
+ */
+function classifyPiVersion(raw, minVersion = MIN_PI_VERSION) {
+  const version = parseVersion(raw);
+  if (!version) return { version: null, supported: null };
+  const floor = parseVersion(minVersion) || MIN_PI_VERSION;
+  return { version, supported: compareVersions(version, floor) >= 0 };
+}
+
+/**
+ * Classify a Node runtime version against Pi's engine floor (>= 22.19.0).
+ * @returns {{version: string|null, supported: boolean|null}}
+ */
+function classifyNodeVersion(raw) {
+  const version = parseVersion(raw);
+  if (!version) return { version: null, supported: null };
+  return { version, supported: compareVersions(version, MIN_NODE_VERSION) >= 0 };
+}
+
+/**
+ * Extract the real target out of a Windows `.cmd` shim's text.
+ *
+ * npm has shipped two shim dialects and both are in the wild:
+ *   - modern cmd-shim: `SET dp0=%~dp0` … `"%dp0%\..\pkg\dist\cli.js"`
+ *   - older / hand-written: `node "%~dp0\cli.js" %*` (or `"%~dp0cli.js"`,
+ *     since `%~dp0` already ends in a backslash)
+ * Matching only `%dp0%` — as the older sibling adapters do — silently fails on
+ * the second dialect and falls back to `cmd.exe /c`, where the ~14 KB
+ * `--append-system-prompt` argument blows past cmd.exe's 8191-character command
+ * line and the agent hangs. So both dialects are accepted here.
+ *
+ * A `.js`/`.mjs` target wins over a `.exe` target: the modern shim names
+ * `node.exe` on the same line as the script, and the script is what we want to
+ * run under a Node WE choose.
+ *
+ * Pure (string + path math only) and resolved with win32 path semantics —
+ * `.cmd` shims are a Windows-only construct — so it is unit-testable on any OS.
+ *
+ * @param {string} content  the .cmd file's text
+ * @param {string} cmdDir   the directory the .cmd lives in
+ * @returns {{kind:'script'|'exe', target:string}|null}
+ */
+function parseWindowsCmdShim(content, cmdDir) {
+  if (!content) return null;
+  // `%dp0%` | `%~dp0` | `%~dp0%`, then an OPTIONAL separator, then the path.
+  const jsMatch = String(content).match(/%~?dp0%?[\\/]?([^\s"*?]+\.m?js)/i);
+  if (jsMatch) return { kind: 'script', target: path.win32.resolve(cmdDir, jsMatch[1]) };
+  const exeMatch = String(content).match(/%~?dp0%?[\\/]?([^\s"*?]+\.exe)/i);
+  if (exeMatch) return { kind: 'exe', target: path.win32.resolve(cmdDir, exeMatch[1]) };
+  return null;
+}
+
+/** A canonical v4/v7 UUID, the only shape we accept for a stored session id. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidSessionId(id) {
+  return typeof id === 'string' && UUID_RE.test(id);
+}
+
+/**
+ * Build the argv (WITHOUT the executable) for one `pi --mode rpc` process.
+ *
+ * Secrets never appear here: Pi reads provider credentials from the
+ * environment (or ~/.pi/agent/auth.json), and `--api-key` is deliberately
+ * never emitted so a key cannot leak into `ps`, a crash dump or a log line.
+ *
+ * @param {object} o
+ * @param {string} o.sessionDir        OpenAgents-managed session storage
+ * @param {string} o.sessionId         stable per-channel session UUID
+ * @param {string} [o.appendSystemPrompt]
+ * @param {string} [o.provider]
+ * @param {string} [o.model]
+ * @param {string} [o.thinking]        off|minimal|low|medium|high|xhigh|max
+ * @param {string} [o.sessionName]
+ * @param {string[]} [o.extensions]     explicit OpenAgents-managed extensions
+ * @param {boolean} [o.trustProject=false]  true → --approve, false → --no-approve
+ * @returns {string[]}
+ */
+function buildPiArgs({
+  sessionDir,
+  sessionId,
+  appendSystemPrompt,
+  provider,
+  model,
+  thinking,
+  sessionName,
+  extensions = [],
+  trustProject = false,
+} = {}) {
+  const args = ['--mode', 'rpc'];
+  if (sessionDir) args.push('--session-dir', sessionDir);
+  if (sessionId) args.push('--session-id', sessionId);
+  if (sessionName) args.push('--name', sessionName);
+  // Project trust: default DENY. `workingDir` is an arbitrary user repo, and a
+  // trusted project may load .pi/settings.json and project-local extensions —
+  // executable surface we must not opt into implicitly. See docs/agents/pi.md.
+  args.push(trustProject ? '--approve' : '--no-approve');
+  if (provider) args.push('--provider', provider);
+  if (model) args.push('--model', model);
+  if (thinking) args.push('--thinking', thinking);
+  for (const extension of extensions || []) {
+    if (extension) args.push('--extension', extension);
+  }
+  if (appendSystemPrompt) args.push('--append-system-prompt', appendSystemPrompt);
+  return args;
+}
+
+/** Valid `--thinking` levels (Pi v0.83.0). Anything else is dropped. */
+const THINKING_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+
+/** Normalize a user-supplied thinking level, or null when unusable. */
+function normalizeThinking(value) {
+  const v = String(value == null ? '' : value).trim().toLowerCase();
+  return THINKING_LEVELS.has(v) ? v : null;
+}
+
+/**
+ * Interpret the PI_TRUST_PROJECT env value. Default (unset/anything else) is
+ * FALSE — the safe, non-executing choice.
+ */
+function parseTrustProject(value) {
+  const v = String(value == null ? '' : value).trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+/** Redact an argv for logging (no secret is ever passed as an arg, but the
+ *  system prompt embeds the workspace token, so the value is elided). */
+function redactArgs(argv) {
+  const out = [];
+  const ELIDE = new Set(['--append-system-prompt', '--system-prompt']);
+  for (let i = 0; i < argv.length; i++) {
+    out.push(argv[i]);
+    if (ELIDE.has(argv[i]) && i + 1 < argv.length) {
+      out.push(`<${argv[i + 1].length} chars>`);
+      i++;
+    }
+  }
+  return out.map((a) => redactSecrets(a));
+}
+
+module.exports = {
+  MIN_PI_VERSION,
+  MIN_NODE_VERSION,
+  MAX_LINE_BYTES,
+  BLOCKING_UI_METHODS,
+  EVENT_KIND_BY_TYPE,
+  PiJsonlFramer,
+  PiStreamParser,
+  PiAssistantAccumulator,
+  parseLine,
+  classifyPiEvent,
+  summarizeToolArgs,
+  summarizeToolResult,
+  redactSecrets,
+  diagnosticFor,
+  classifyPiError,
+  parseVersion,
+  compareVersions,
+  classifyPiVersion,
+  classifyNodeVersion,
+  parseWindowsCmdShim,
+  isValidSessionId,
+  buildPiArgs,
+  normalizeThinking,
+  parseTrustProject,
+  redactArgs,
+  THINKING_LEVELS,
+};

--- a/packages/agent-connector/src/adapters/pi.js
+++ b/packages/agent-connector/src/adapters/pi.js
@@ -1,0 +1,1492 @@
+/**
+ * Pi CLI adapter for OpenAgents workspace.
+ *
+ * Bridges the Pi coding agent (https://pi.dev, npm `@earendil-works/pi-coding-agent`,
+ * executable `pi`) to an OpenAgents workspace:
+ *   - polling loop + per-channel task dispatch (inherited from BaseAdapter)
+ *   - ONE long-lived `pi --mode rpc` subprocess per active channel, driven over
+ *     stdin/stdout JSONL — the same persistent-process model claude.js uses
+ *     (_persistentProcs / _channelProcesses / idle timer / watchdog /
+ *     _stopProcess), so process lifecycle behaviour is identical across the two
+ *   - the RPC stream is framed + classified by pi-stream.js (pure, unit-tested)
+ *     and mapped onto the standard OpenAgents events (thinking / status /
+ *     response / error)
+ *   - real session continuity via Pi's `--session-id <uuid>`, which CREATES the
+ *     session when missing and RESUMES it when present, so a channel keeps its
+ *     context across messages, process restarts and launcher restarts without
+ *     any session-correlation guesswork
+ *
+ * Deliberately NOT used: `@earendil-works/pi-coding-agent`'s in-process
+ * `AgentSession` / Agent Core API. OpenAgents integrates every coding agent as
+ * a CLI subprocess (see the sibling adapters); embedding Pi's SDK would put a
+ * third-party agent runtime, its provider stack and its extension loader inside
+ * the daemon process. Nothing here imports any Pi module.
+ *
+ * Verified against pi 0.83.0 (engines.node >= 22.19.0). Because that engine
+ * floor is above what a user's ambient Node may satisfy, a resolved JS entry
+ * point is launched with the launcher's own portable Node (v22.22.3) and
+ * preflight refuses to start on anything older.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, execSync, spawn } = require('child_process');
+
+const BaseAdapter = require('./base');
+const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');
+const { buildPiSystemPrompt } = require('./workspace-prompt');
+const { REASON, classifySpawnError } = require('./health-status');
+const { defaultAgentWorkdir, whichBinary, whereBinary } = require('../paths');
+const {
+  PiStreamParser,
+  PiAssistantAccumulator,
+  buildPiArgs,
+  classifyNodeVersion,
+  classifyPiError,
+  classifyPiVersion,
+  isValidSessionId,
+  normalizeThinking,
+  parseTrustProject,
+  parseWindowsCmdShim,
+  redactArgs,
+  redactSecrets,
+  MIN_NODE_VERSION,
+  MIN_PI_VERSION,
+} = require('./pi-stream');
+
+const IS_WINDOWS = process.platform === 'win32';
+const LAUNCHER_PROVIDER_EXTENSION = path.join(__dirname, 'pi-launcher-provider.mjs');
+
+// ---------------------------------------------------------------------------
+// Package identity — read from the registry, never hard-coded here
+// ---------------------------------------------------------------------------
+
+/**
+ * The bundled registry's `pi` entry, memoized. The npm package name and the
+ * minimum supported version are CONFIGURATION: they live in
+ * sdk/src/openagents/registry/pi.yaml → packages/agent-connector/registry.json
+ * and are read from there, so bumping the catalog cannot leave this adapter
+ * probing a stale path or enforcing a stale version floor.
+ */
+let _piRegistryEntry;
+function piRegistryEntry() {
+  if (_piRegistryEntry !== undefined) return _piRegistryEntry;
+  _piRegistryEntry = null;
+  try {
+    const catalog = require('../../registry.json');
+    if (Array.isArray(catalog)) {
+      _piRegistryEntry = catalog.find((e) => e && e.name === 'pi') || null;
+    }
+  } catch { /* bundle unreadable — fall back to the module defaults */ }
+  return _piRegistryEntry;
+}
+
+/** The npm package Pi installs as, per the registry. Null when undeclared. */
+function piNpmPackage() {
+  const entry = piRegistryEntry();
+  return (entry && entry.install && entry.install.npm_package) || null;
+}
+
+/** The registry's version floor, falling back to the module default. */
+function piMinVersion() {
+  const entry = piRegistryEntry();
+  return (entry && entry.install && entry.install.min_version) || MIN_PI_VERSION;
+}
+
+/** Release an idle channel's Pi process after this long (matches claude.js). */
+const IDLE_TIMEOUT_MS = 60 * 60 * 1000;
+
+/** Watchdog cadence + how many consecutive silences kill a wedged process. */
+const WATCHDOG_INTERVAL_MS = 15_000;
+const WATCHDOG_MAX_TIMEOUTS = 20; // 20 × 15s = 5 min of silence
+
+/** How long a control RPC (abort / get_state) may wait for its response. */
+const RPC_TIMEOUT_MS = 30_000;
+
+/** Grace given to an in-flight turn to settle after an `abort` before the kill. */
+const ABORT_GRACE_MS = 3_000;
+
+/** Version probes are cached per resolved binary so we never spawn per message. */
+const VERSION_CACHE_TTL_MS = 5 * 60 * 1000;
+const _piVersionCache = new Map(); // binPath -> { version, supported, at }
+const _nodeVersionCache = new Map(); // nodeBin -> { version, supported, at }
+
+/** Thrown into pending RPCs when a channel is torn down. */
+class PiCancelledError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PiCancelledError';
+  }
+}
+
+class PiAdapter extends BaseAdapter {
+  /**
+   * @param {object} opts - BaseAdapter opts plus:
+   * @param {Set} [opts.disabledModules]
+   * @param {string} [opts.workingDir]
+   */
+  constructor(opts) {
+    super(opts);
+    this.disabledModules = opts.disabledModules || new Set();
+    /** Pi reaches workspace APIs via bash + curl; there is no MCP wiring. */
+    this.toolMode = 'skills';
+
+    // channel → { sessionId, workingDir } (Pi session UUIDs we own)
+    this._channelSessions = {};
+    // channel → persistent-process record
+    this._persistentProcs = {};
+    // channel → child process (BaseAdapter/stop paths read this)
+    this._channelProcesses = {};
+    this._stoppingChannels = new Set();
+    // Dedup for "Execution stopped by user." — the control handler and the
+    // in-flight message handler both race to announce it (see claude.js).
+    this._stopNoticeSent = new Set();
+
+    this._sessionsFile = path.join(
+      os.homedir(), '.openagents', 'sessions',
+      `${this.workspaceId}_${this.agentName}_pi.json`,
+    );
+    // Pi sessions live under OpenAgents' own data tree, NOT in the user's
+    // project and NOT in the shared ~/.pi/agent/sessions — one directory per
+    // (workspace, agent) so two agents can never read each other's transcripts.
+    this._sessionDir = path.join(
+      os.homedir(), '.openagents', 'pi-sessions',
+      `${PiAdapter._safe(this.workspaceId)}_${PiAdapter._safe(this.agentName)}`,
+    );
+    this._piBin = null;
+    this._loadSessions();
+  }
+
+  static _safe(value) {
+    return String(value || 'default').replace(/[^A-Za-z0-9._-]/g, '_') || 'default';
+  }
+
+  /** Exact secret values that must never reach a log, status or chat message. */
+  _secrets() {
+    const env = this.agentEnv || process.env;
+    const out = [];
+    if (this.token) out.push(this.token);
+    for (const [k, v] of Object.entries(env)) {
+      if (!v || typeof v !== 'string' || v.length < 8) continue;
+      if (/(_API_KEY|_AUTH_TOKEN|_OAUTH_TOKEN|_TOKEN|_SECRET|_ACCESS_KEY)$/.test(k)) out.push(v);
+    }
+    return out;
+  }
+
+  /** Redact with this agent's concrete secrets folded in. */
+  _redact(text) {
+    return redactSecrets(text, this._secrets());
+  }
+
+  // ------------------------------------------------------------------
+  // Session persistence (Pi session UUIDs, bound to the working dir)
+  // ------------------------------------------------------------------
+
+  _loadSessions() {
+    try {
+      if (!fs.existsSync(this._sessionsFile)) return;
+      const data = JSON.parse(fs.readFileSync(this._sessionsFile, 'utf-8'));
+      if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        this._log('Pi sessions file has an unexpected shape — starting fresh');
+        return;
+      }
+      let kept = 0;
+      for (const [channel, entry] of Object.entries(data)) {
+        if (entry && typeof entry === 'object' && isValidSessionId(entry.sessionId)) {
+          this._channelSessions[channel] = { sessionId: entry.sessionId, workingDir: entry.workingDir || null };
+          kept++;
+        }
+      }
+      this._log(`Loaded ${kept} Pi session(s)`);
+    } catch {
+      // A truncated/corrupt file must never wedge the agent: drop it and let
+      // each channel mint a fresh session id on its next message.
+      this._log('Could not read Pi sessions file (corrupt or unreadable) — starting fresh');
+    }
+  }
+
+  _saveSessions() {
+    try {
+      fs.mkdirSync(path.dirname(this._sessionsFile), { recursive: true });
+      fs.writeFileSync(this._sessionsFile, JSON.stringify(this._channelSessions));
+    } catch {}
+  }
+
+  /**
+   * The Pi session id for a channel, minting (and persisting) one when absent,
+   * corrupt, or bound to a different working directory. Pi's `--session-id`
+   * creates the session when it does not exist, so a lost/deleted session file
+   * degrades to "fresh context", never to an error.
+   */
+  _sessionIdFor(channel, workingDir) {
+    const entry = this._channelSessions[channel];
+    if (entry && isValidSessionId(entry.sessionId)
+      && (!entry.workingDir || !workingDir || entry.workingDir === workingDir)) {
+      return entry.sessionId;
+    }
+    const sessionId = crypto.randomUUID();
+    this._channelSessions[channel] = { sessionId, workingDir: workingDir || null };
+    this._saveSessions();
+    this._log(`Minted Pi session ${sessionId} for channel=${channel}`);
+    return sessionId;
+  }
+
+  _clearSession(channel) {
+    if (this._channelSessions[channel]) {
+      delete this._channelSessions[channel];
+      this._saveSessions();
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Binary resolution (mirrors the Claude/Cline adapters tier-for-tier)
+  // ------------------------------------------------------------------
+
+  /**
+   * The portable Node the launcher installs, else the Node running this daemon.
+   * Bare 'node' is never used: a packaged daemon's PATH may not have one.
+   */
+  _findNodeBin() {
+    const home = os.homedir();
+    const candidates = IS_WINDOWS
+      ? [path.join(home, '.openagents', 'nodejs', 'node.exe')]
+      : [path.join(home, '.openagents', 'nodejs', 'node'),
+        path.join(home, '.openagents', 'nodejs', 'bin', 'node')];
+    for (const c of candidates) if (fs.existsSync(c)) return c;
+    return process.execPath;
+  }
+
+  /**
+   * Resolve a shim/symlink to [nodeBin, jsEntry] so we spawn the JS entry point
+   * under a Node we control. On Windows this also avoids wrapping a `.cmd` in
+   * `cmd.exe /c`, whose 8191-char command-line cap would truncate the long
+   * --append-system-prompt. Returns null when the target is a native binary.
+   */
+  _resolveToNodeCmd(binPath) {
+    const nodeBin = this._findNodeBin();
+    if (IS_WINDOWS && binPath.toLowerCase().endsWith('.cmd')) {
+      try {
+        const cmdDir = path.dirname(path.resolve(binPath));
+        // Both npm shim dialects (`%dp0%` and `%~dp0`) are parsed — see
+        // parseWindowsCmdShim. A shim we fail to parse falls back to
+        // `cmd.exe /c`, where the ~14 KB --append-system-prompt exceeds
+        // cmd.exe's 8191-character command line and the agent hangs.
+        const shim = parseWindowsCmdShim(fs.readFileSync(binPath, 'utf-8'), cmdDir);
+        if (shim && shim.kind === 'script') return [nodeBin, shim.target];
+        if (shim && shim.kind === 'exe') return [shim.target];
+      } catch {}
+    } else {
+      try {
+        let target = binPath;
+        if (fs.lstatSync(binPath).isSymbolicLink()) {
+          target = path.resolve(path.dirname(binPath), fs.readlinkSync(binPath));
+        }
+        if (target.endsWith('.js') || target.endsWith('.mjs')) return [nodeBin, target];
+        if (this._isNodeShebangScript(target)) return [nodeBin, target];
+      } catch {}
+    }
+    return null;
+  }
+
+  /** True when a file begins with a `#!...node` shebang. */
+  _isNodeShebangScript(filePath) {
+    try {
+      const fd = fs.openSync(filePath, 'r');
+      try {
+        const buf = Buffer.alloc(64);
+        const n = fs.readSync(fd, buf, 0, 64, 0);
+        const head = buf.slice(0, n).toString('utf-8');
+        return head.startsWith('#!') && /\bnode\b/.test(head.split('\n')[0]);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Locate the `pi` executable. The isolated runtime prefix installed by
+   * `openagents install pi` wins over anything on the user's PATH, so a global
+   * Pi can never shadow the version OpenAgents manages.
+   */
+  _findPiBinary() {
+    const home = os.homedir();
+    const ext = IS_WINDOWS ? '.cmd' : '';
+
+    // Tier 0: isolated runtime prefix (~/.openagents/runtimes/pi/)
+    const runtimeCandidate = path.join(home, '.openagents', 'runtimes', 'pi', 'node_modules', '.bin', `pi${ext}`);
+    if (fs.existsSync(runtimeCandidate)) return runtimeCandidate;
+
+    // Tier 0b: legacy shared portable prefix
+    const portable = path.join(home, '.openagents', 'nodejs', 'node_modules', '.bin', `pi${ext}`);
+    if (fs.existsSync(portable)) return portable;
+
+    // Tier 0c: the package's own entry point. npm normally creates the .bin
+    // shim above, but a partially-completed install can leave the package
+    // present without it — and the entry point is a Node script we can run.
+    // The package NAME comes from the registry and the entry path from the
+    // installed package's own `bin` field, so neither is written here.
+    const pkgBin = this._findPackageEntryPoint(home);
+    if (pkgBin) return pkgBin;
+
+    // Tier 1: PATH search via the codepage-safe lookup (forces UTF-8 output and
+    // verifies existence, so a non-ASCII username isn't mangled into ENOENT).
+    const viaWhere = whereBinary('pi');
+    if (viaWhere) return viaWhere;
+
+    // Tier 2: next to the Node interpreter running this daemon (npm global)
+    const nearNode = path.join(path.dirname(process.execPath), `pi${ext}`);
+    if (fs.existsSync(nearNode)) return nearNode;
+
+    // Tier 3: common install locations
+    const candidates = IS_WINDOWS ? [
+      path.join(process.env.APPDATA || '', 'npm', 'pi.cmd'),
+    ] : [
+      path.join(home, '.local', 'bin', 'pi'),
+      path.join(home, '.npm-global', 'bin', 'pi'),
+      '/opt/homebrew/bin/pi',
+      '/usr/local/bin/pi',
+    ];
+    for (const c of candidates) if (fs.existsSync(c)) return c;
+
+    // Tier 4: deep scan of every known bin dir (nvm/fnm/volta/homebrew/…)
+    return whichBinary('pi') || null;
+  }
+
+  /**
+   * Locate the installed Pi package's own executable entry point, without
+   * naming either the package or its bin path in this file: the package name
+   * comes from the registry (`install.npm_package`) and the entry path from
+   * that package's `bin` field on disk. Returns null when it can't be resolved.
+   */
+  _findPackageEntryPoint(home) {
+    const pkgName = piNpmPackage();
+    const binName = (piRegistryEntry() || {}).install?.binary || 'pi';
+    if (!pkgName) return null;
+    for (const root of [
+      path.join(home, '.openagents', 'runtimes', 'pi', 'node_modules'),
+      path.join(home, '.openagents', 'nodejs', 'node_modules'),
+    ]) {
+      const pkgDir = path.join(root, ...pkgName.split('/'));
+      try {
+        const meta = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf-8'));
+        const bin = meta && meta.bin;
+        const rel = typeof bin === 'string' ? bin : (bin && (bin[binName] || bin[pkgName]));
+        if (!rel) continue;
+        const entry = path.join(pkgDir, rel);
+        if (fs.existsSync(entry)) return entry;
+      } catch { /* not installed here, or unreadable manifest */ }
+    }
+    return null;
+  }
+
+  /** Resolve [cmd, ...args] for spawning, preferring the portable-Node path. */
+  _spawnableCmd(binPath, args) {
+    const resolved = this._resolveToNodeCmd(binPath);
+    if (resolved) return [...resolved, ...args];
+    if (IS_WINDOWS && binPath.toLowerCase().endsWith('.cmd')) return ['cmd.exe', '/c', binPath, ...args];
+    return [binPath, ...args];
+  }
+
+  // ------------------------------------------------------------------
+  // Version gates
+  // ------------------------------------------------------------------
+
+  /**
+   * Run `pi --version`. Uses execFileSync (argument array, no shell) so a
+   * resolved path containing spaces or shell metacharacters can never be
+   * re-interpreted as a command. Isolated so tests can stub it.
+   */
+  _readPiVersionRaw(piBin) {
+    const [cmd, ...args] = this._spawnableCmd(piBin, ['--version']);
+    return execFileSync(cmd, args, {
+      encoding: 'utf-8', timeout: 15000, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  }
+
+  /** Run `node --version` for the interpreter we would launch Pi with. */
+  _readNodeVersionRaw(nodeBin) {
+    if (nodeBin === process.execPath) return process.version;
+    return execFileSync(nodeBin, ['--version'], {
+      encoding: 'utf-8', timeout: 8000, windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  }
+
+  /**
+   * @returns {{version: string|null, compatible: boolean|null}}
+   *   compatible true → >= MIN_PI_VERSION; false → CONFIRMED older;
+   *   null → undetermined (we proceed leniently, like the Cline adapter).
+   */
+  _checkPiVersion(piBin) {
+    const now = Date.now();
+    const cached = _piVersionCache.get(piBin);
+    if (cached && (now - cached.at) < VERSION_CACHE_TTL_MS) {
+      return { version: cached.version, compatible: cached.supported };
+    }
+    let version = null;
+    let supported = null;
+    try {
+      ({ version, supported } = classifyPiVersion(this._readPiVersionRaw(piBin), piMinVersion()));
+    } catch {
+      version = null;
+      supported = null;
+    }
+    _piVersionCache.set(piBin, { version, supported, at: now });
+    return { version, compatible: supported };
+  }
+
+  /** Same shape for the Node that will host Pi (hard floor: 22.19.0). */
+  _checkNodeVersion(nodeBin) {
+    const now = Date.now();
+    const cached = _nodeVersionCache.get(nodeBin);
+    if (cached && (now - cached.at) < VERSION_CACHE_TTL_MS) {
+      return { version: cached.version, compatible: cached.supported };
+    }
+    let version = null;
+    let supported = null;
+    try {
+      ({ version, supported } = classifyNodeVersion(this._readNodeVersionRaw(nodeBin)));
+    } catch {
+      version = null;
+      supported = null;
+    }
+    _nodeVersionCache.set(nodeBin, { version, supported, at: now });
+    return { version, compatible: supported };
+  }
+
+  /** Clear both version caches (test hook; also correct after an install). */
+  static _clearVersionCache() {
+    _piVersionCache.clear();
+    _nodeVersionCache.clear();
+  }
+
+  /**
+   * Preflight gate, run by the daemon BEFORE the workspace join. Pi cannot do
+   * anything without a resolvable CLI and a Node new enough to run it, so both
+   * are checked here and reported with a precise REASON instead of failing
+   * every message after a pointless join.
+   */
+  preflight() {
+    const piBin = this._piBin || this._findPiBinary();
+    if (!piBin) {
+      return {
+        ok: false,
+        reason: REASON.RUNTIME_MISSING,
+        message: 'Pi CLI not found — install it with: openagents install pi',
+      };
+    }
+    this._piBin = piBin;
+
+    // Only a JS entry point runs under a Node we choose; a native binary
+    // carries its own runtime and the engine floor does not apply.
+    const resolved = this._resolveToNodeCmd(piBin);
+    if (resolved && resolved.length === 2) {
+      const node = this._checkNodeVersion(resolved[0]);
+      if (node.compatible === false) {
+        return {
+          ok: false,
+          reason: REASON.VERSION_INCOMPATIBLE,
+          message:
+            `Pi requires Node.js >= ${MIN_NODE_VERSION} but the available runtime is ` +
+            `${node.version} (${resolved[0]}). Install the launcher's bundled Node ` +
+            '(reinstall Pi from the Install page) or upgrade the system Node.',
+        };
+      }
+    }
+
+    const ver = this._checkPiVersion(piBin);
+    if (ver.compatible === false) {
+      return {
+        ok: false,
+        reason: REASON.VERSION_INCOMPATIBLE,
+        message:
+          `Pi CLI ${ver.version} is below the minimum supported version ${piMinVersion()}. ` +
+          'Update it from the Install page.',
+      };
+    }
+
+    this._log(`Pi CLI resolved: ${piBin}${ver.version ? ` (v${ver.version})` : ''}`);
+    return { ok: true };
+  }
+
+  // ------------------------------------------------------------------
+  // Control actions (stop / restart) + shutdown
+  // ------------------------------------------------------------------
+
+  async _onControlAction(action, payload) {
+    if (action === 'stop') {
+      const channel = (payload && typeof payload === 'object') ? payload.channel : null;
+      if (channel) {
+        const pp = this._persistentProcs[channel];
+        if (pp) pp.userStopped = true;
+        if (this._channelProcesses[channel]) {
+          this._log(`Stopping Pi for channel=${channel}`);
+          this._stoppingChannels.add(channel);
+          await this._abortChannel(channel);
+          delete this._channelQueues[channel];
+          await this._postStopNotice(channel);
+        }
+      } else {
+        for (const pp of Object.values(this._persistentProcs)) pp.userStopped = true;
+        await this._stopAllProcesses('Execution stopped by user.');
+      }
+      return;
+    }
+    if (action === 'restart') {
+      const channel = (payload && typeof payload === 'object') ? payload.channel : null;
+      if (channel) {
+        await this._killPersistentProc(channel, 'restart requested');
+        this._clearSession(channel);
+        try {
+          await this.client.sendMessage(this.workspaceId, channel, this.token,
+            'Session restarted — the next message starts a fresh Pi session.',
+            {
+              senderType: 'agent',
+              senderName: this.agentName,
+              messageType: 'status',
+              metadata: { agent_mode: this._mode },
+              sessionId: this._sessionId,
+            });
+        } catch (e) {
+          this._log(`Restart: failed to post status: ${this._redact(e && e.message)}`);
+        }
+      } else {
+        this._channelSessions = {};
+        this._saveSessions();
+        await this._stopAllProcesses('Execution stopped.');
+      }
+      return;
+    }
+    await super._onControlAction(action, payload);
+  }
+
+  /**
+   * Daemon shutdown — tear down every Pi child so no orphan survives the
+   * launcher and no channel is left showing a stale "running" status.
+   * Fire-and-forget: daemon._killAgent allows a short grace period.
+   */
+  stop() {
+    this._stopAllProcesses(
+      'Task interrupted — daemon restarting. Send another message to continue.',
+    ).catch(() => {});
+    super.stop();
+  }
+
+  async _stopAllProcesses(message = 'Execution stopped.') {
+    const channels = Object.keys(this._persistentProcs);
+    if (!channels.length) return;
+    this._log(`Stopping ${channels.length} Pi process(es)...`);
+    for (const channel of channels) {
+      this._stoppingChannels.add(channel);
+      await this._killPersistentProc(channel, 'adapter stopping');
+      delete this._channelQueues[channel];
+      try { await this.sendResponse(channel, message); } catch {}
+    }
+  }
+
+  /** Post "Execution stopped by user." at most once per stop, per channel. */
+  async _postStopNotice(channel) {
+    if (!channel || this._stopNoticeSent.has(channel)) return;
+    this._stopNoticeSent.add(channel);
+    try { await this.sendResponse(channel, 'Execution stopped by user.'); } catch {}
+  }
+
+  /**
+   * Stop ONE channel: ask Pi to `abort` over RPC first (so it can unwind its
+   * tool work), give the turn a short grace period to settle, then terminate
+   * the process tree. Other channels and other agents are untouched.
+   */
+  async _abortChannel(channel) {
+    const pp = this._persistentProcs[channel];
+    if (!pp) return;
+    try {
+      await this._sendRpc(pp, { type: 'abort' }, { timeoutMs: ABORT_GRACE_MS });
+    } catch (e) {
+      this._log(`Abort RPC did not complete for ${channel}: ${this._redact(e && e.message)}`);
+    }
+    // Give the in-flight turn a moment to settle on its own after the abort.
+    // Capture the record first: the exit/teardown path can null pp.turn between
+    // the check and the await.
+    const turn = pp.turn;
+    if (turn) {
+      const settled = await Promise.race([
+        turn.promise.then(() => true, () => true),
+        this._sleep(ABORT_GRACE_MS).then(() => false),
+      ]);
+      if (settled && !pp.turnInFlight) {
+        // Clean abort: keep the process so the next message reuses its context.
+        this._log(`Pi aborted cleanly for ${channel} — process kept alive`);
+        return;
+      }
+    }
+    await this._killPersistentProc(channel, 'stop requested');
+  }
+
+  /**
+   * Cross-platform process-tree termination. Same shape as claude.js: SIGINT/
+   * SIGTERM on the process GROUP first (Pi spawns bash tool children that must
+   * die with it), escalating to SIGKILL / `taskkill /F /T`.
+   */
+  async _stopProcess(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (IS_WINDOWS) {
+        try { proc.kill('SIGINT'); } catch {}
+        const exited = await this._waitExit(proc, 1500);
+        if (!exited) {
+          try { execSync(`taskkill /F /T /PID ${proc.pid}`, { timeout: 5000, windowsHide: true }); } catch {}
+        }
+      } else {
+        try { process.kill(-proc.pid, 'SIGTERM'); } catch { try { proc.kill('SIGTERM'); } catch {} }
+        const exited = await this._waitExit(proc, 1500);
+        if (!exited) {
+          try { process.kill(-proc.pid, 'SIGKILL'); } catch { try { proc.kill('SIGKILL'); } catch {} }
+          await this._waitExit(proc, 1000);
+        }
+      }
+    } catch {}
+  }
+
+  _waitExit(proc, ms) {
+    return new Promise((resolve) => {
+      if (proc.exitCode !== null) { resolve(true); return; }
+      const t = setTimeout(() => resolve(false), ms);
+      proc.once('exit', () => { clearTimeout(t); resolve(true); });
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Persistent process lifecycle
+  // ------------------------------------------------------------------
+
+  /**
+   * Kill a channel's Pi process and clear every resource it owns: timers,
+   * pending RPCs (rejected with a clear cancellation), stream listeners and
+   * both channel registrations. Returns once the process has actually exited,
+   * so a replacement spawn can never race the old exit handler.
+   */
+  _killPersistentProc(channel, why = 'released') {
+    const pp = this._persistentProcs[channel];
+    if (!pp) return Promise.resolve();
+    this._teardownProcState(pp, `Pi process ${why}`);
+    delete this._persistentProcs[channel];
+    if (this._channelProcesses[channel] === pp.proc) delete this._channelProcesses[channel];
+    return this._stopProcess(pp.proc).catch(() => {});
+  }
+
+  /** Clear timers/listeners and fail everything still waiting on this process. */
+  _teardownProcState(pp, reason) {
+    if (pp.idleTimer) { clearTimeout(pp.idleTimer); pp.idleTimer = null; }
+    this._stopWatchdog(pp);
+    pp.alive = false;
+    const err = new PiCancelledError(reason);
+    for (const [, entry] of pp.pending) {
+      if (entry.timer) clearTimeout(entry.timer);
+      try { entry.reject(err); } catch {}
+    }
+    pp.pending.clear();
+    if (pp.turn) {
+      const turn = pp.turn;
+      pp.turn = null;
+      pp.turnInFlight = false;
+      try { turn.resolve({ ended: true, reason }); } catch {}
+    }
+    for (const stream of [pp.proc && pp.proc.stdout, pp.proc && pp.proc.stderr]) {
+      if (!stream) continue;
+      stream.removeAllListeners('data');
+      stream.removeAllListeners('end');
+      // Keep an error guard: a SIGKILL'd child's pipe can still emit 'error'
+      // after teardown, and an unhandled stream error would crash the daemon.
+      stream.on('error', () => {});
+    }
+  }
+
+  /** Drop registrations only if they still point at THIS process. */
+  _unregisterProc(channel, pp, proc) {
+    if (this._persistentProcs[channel] === pp) delete this._persistentProcs[channel];
+    if (this._channelProcesses[channel] === proc) delete this._channelProcesses[channel];
+  }
+
+  _resetIdleTimer(channel) {
+    const pp = this._persistentProcs[channel];
+    if (!pp) return;
+    if (pp.idleTimer) clearTimeout(pp.idleTimer);
+    pp.idleTimer = setTimeout(() => {
+      this._log(`Pi process idle for ${IDLE_TIMEOUT_MS / 60000}min, releasing ${channel}`);
+      this._killPersistentProc(channel, 'idle timeout');
+    }, IDLE_TIMEOUT_MS);
+    // An idle timer must not hold the event loop open on shutdown.
+    if (typeof pp.idleTimer.unref === 'function') pp.idleTimer.unref();
+  }
+
+  /**
+   * Kill the process when stdout falls silent while a turn is in flight.
+   * Paused during tool execution: a long build or test run legitimately
+   * produces no RPC events for minutes.
+   */
+  _startWatchdog(pp) {
+    this._stopWatchdog(pp);
+    pp.lastStdoutTime = Date.now();
+    let consecutive = 0;
+    pp.watchdogTimer = setInterval(async () => {
+      if (!pp.turnInFlight) { consecutive = 0; return; }
+      if (pp.awaitingToolResult) { consecutive = 0; return; }
+      if (Date.now() - pp.lastStdoutTime < WATCHDOG_INTERVAL_MS) { consecutive = 0; return; }
+      consecutive++;
+      pp.lastStdoutTime = Date.now();
+      if (consecutive === 2) {
+        try { await this.sendStatus(pp.msgChannel, 'Still working...'); } catch {}
+      }
+      if (consecutive >= WATCHDOG_MAX_TIMEOUTS) {
+        this._log(`Watchdog: Pi silent ${consecutive * (WATCHDOG_INTERVAL_MS / 1000)}s on ${pp.msgChannel} — killing`);
+        pp.watchdogKilled = true;
+        try { await this.sendError(pp.msgChannel, 'The Pi process became unresponsive and was restarted.'); } catch {}
+        await this._killPersistentProc(pp.msgChannel, 'watchdog timeout');
+      }
+    }, WATCHDOG_INTERVAL_MS);
+    if (typeof pp.watchdogTimer.unref === 'function') pp.watchdogTimer.unref();
+  }
+
+  _stopWatchdog(pp) {
+    if (pp.watchdogTimer) { clearInterval(pp.watchdogTimer); pp.watchdogTimer = null; }
+  }
+
+  /**
+   * Spawn one `pi --mode rpc` process for a channel and wire its streams.
+   * @returns {object} the persistent-process record
+   */
+  _spawnPersistentProc(channel, { piBin, args, workingDir, env, sessionId }) {
+    const [cmd, ...spawnArgs] = this._spawnableCmd(piBin, args);
+    this._log(`Spawning pi in ${workingDir}: ${redactArgs([cmd, ...spawnArgs]).join(' ')}`);
+
+    const proc = spawn(cmd, spawnArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+      cwd: workingDir,
+      detached: !IS_WINDOWS,
+      windowsHide: true,
+    });
+
+    const pp = {
+      proc,
+      parser: new PiStreamParser(),
+      pending: new Map(),        // rpc id → { resolve, reject, timer, command }
+      queue: Promise.resolve(),  // serializes async event handling
+      turn: null,                // { promise, resolve } for the in-flight prompt
+      turnInFlight: false,
+      acc: new PiAssistantAccumulator(),
+      msgChannel: channel,
+      sessionId,
+      spawnMode: this._mode,
+      workingDir,
+      idleTimer: null,
+      watchdogTimer: null,
+      watchdogKilled: false,
+      awaitingToolResult: false,
+      lastStdoutTime: Date.now(),
+      alive: true,
+      stdinBroken: false,
+      userStopped: false,
+      rpcSeq: 0,
+      // per-turn accounting
+      turnTexts: [],      // the answer candidate (last non-toolUse message)
+      heldTexts: [],      // text blocks of the message currently streaming
+      turnError: null,
+      everPosted: false,
+      stderrBuf: '',
+    };
+
+    proc.stdout.on('data', (chunk) => {
+      pp.lastStdoutTime = Date.now();
+      let events;
+      try {
+        events = pp.parser.push(chunk);
+      } catch (e) {
+        // Framing must never take the adapter down.
+        this._log(`Pi stream framing error: ${this._redact(e && e.message)}`);
+        return;
+      }
+      for (const ev of events) {
+        pp.queue = pp.queue.then(() => this._handleEvent(pp, ev)).catch(() => {});
+      }
+    });
+
+    // stderr is diagnostics ONLY — Pi's RPC protocol lives entirely on stdout,
+    // so a stderr line is never parsed as JSONL.
+    proc.stderr.on('data', (chunk) => {
+      const text = chunk.toString('utf-8');
+      pp.stderrBuf = (pp.stderrBuf + text).slice(-8192);
+      const line = text.trim();
+      if (line) this._log(`pi stderr [${channel}]: ${this._redact(line).slice(0, 500)}`);
+    });
+
+    proc.stdout.on('error', () => {});
+    proc.stderr.on('error', () => {});
+    // stdin errors arrive ASYNCHRONOUSLY: a Writable reports EPIPE / premature
+    // pipe close through an 'error' event, which the try/catch around
+    // stdin.write() cannot see. Without this listener a Pi process that exits
+    // mid-write raises an unhandled stream error and takes the daemon down.
+    if (proc.stdin) {
+      proc.stdin.on('error', (err) => {
+        pp.stdinBroken = true;
+        this._log(`pi stdin [${channel}] closed: ${this._redact(err && err.message)}`);
+      });
+    }
+
+    proc.stdout.on('end', () => {
+      let events = [];
+      try { events = pp.parser.flush(); } catch {}
+      for (const ev of events) {
+        pp.queue = pp.queue.then(() => this._handleEvent(pp, ev)).catch(() => {});
+      }
+    });
+
+    proc.on('exit', (code, signal) => {
+      this._log(`Pi process exited: channel=${channel} code=${code} signal=${signal || 'none'}`);
+      const why = signal
+        ? `Pi process terminated by ${signal}`
+        : `Pi process exited with code ${code}`;
+      // A crash / non-zero exit mid-turn is a real failure the user must see.
+      // A user stop, a watchdog kill and a clean code-0 exit all have their own
+      // messaging, so none of them set a turn error here.
+      const abnormal = code !== 0 || (signal && !pp.userStopped);
+      if (pp.turnInFlight && abnormal && !pp.userStopped && !pp.watchdogKilled
+        && !this._stoppingChannels.has(channel) && !pp.turnError) {
+        const stderr = this._redact((pp.stderrBuf || '').trim()).slice(-400);
+        pp.turnError = stderr ? `${why}. Last diagnostics: ${stderr}` : why;
+      }
+      pp.exitCode = code;
+      this._teardownProcState(pp, why);
+      this._unregisterProc(channel, pp, proc);
+    });
+
+    proc.on('error', (err) => {
+      const { message } = classifySpawnError(err, { label: 'Pi', bin: cmd });
+      this._log(message);
+      pp.spawnError = message;
+      this._reportStatus(REASON.SPAWN_FAILED, message);
+      this._teardownProcState(pp, message);
+      this._unregisterProc(channel, pp, proc);
+    });
+
+    this._persistentProcs[channel] = pp;
+    this._channelProcesses[channel] = proc;
+    this._resetIdleTimer(channel);
+    return pp;
+  }
+
+  // ------------------------------------------------------------------
+  // RPC plumbing
+  // ------------------------------------------------------------------
+
+  /** Write one JSONL command. Strict LF framing, exactly as Pi requires. */
+  _writeRpc(pp, payload) {
+    pp.proc.stdin.write(JSON.stringify(payload) + '\n');
+  }
+
+  /**
+   * Send an RPC command and await its `response`. Every command carries a
+   * unique id so responses can be correlated; a timeout rejects rather than
+   * leaking a pending entry forever.
+   */
+  _sendRpc(pp, command, { timeoutMs = RPC_TIMEOUT_MS } = {}) {
+    if (!pp.alive || pp.stdinBroken || !pp.proc.stdin || pp.proc.stdin.destroyed) {
+      return Promise.reject(new PiCancelledError('Pi process is not accepting commands'));
+    }
+    const id = `oa-${++pp.rpcSeq}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pp.pending.delete(id);
+        reject(new Error(`Pi RPC "${command.type}" timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      if (typeof timer.unref === 'function') timer.unref();
+      pp.pending.set(id, { resolve, reject, timer, command: command.type });
+      try {
+        this._writeRpc(pp, { ...command, id });
+      } catch (e) {
+        clearTimeout(timer);
+        pp.pending.delete(id);
+        reject(new Error(`Pi stdin write failed: ${this._redact(e && e.message)}`));
+      }
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Event → workspace mapping
+  // ------------------------------------------------------------------
+
+  /**
+   * Re-redact a classified event's DIAGNOSTIC strings with this agent's
+   * concrete credential values before anything is logged or posted.
+   *
+   * pi-stream.js is pure and dependency-free, so it can only apply PATTERN
+   * redaction — it has no way to know that this agent's GEMINI_API_KEY is
+   * `AIza…`, a shape no generic rule matches. Doing the pass HERE, once, at the
+   * single boundary every event crosses, means a newly-added event kind cannot
+   * forget it: only fields listed below are ever surfaced.
+   *
+   * Assistant message text (`delta` / `message`) is deliberately NOT rewritten:
+   * it is the model's answer to the user, and mangling it would corrupt code
+   * and command output. That matches every other adapter in this package.
+   */
+  _redactEvent(ev) {
+    const DIAGNOSTIC_FIELDS = ['preview', 'message', 'error', 'finalError', 'raw', 'title'];
+    let copy = null;
+    for (const field of DIAGNOSTIC_FIELDS) {
+      const value = ev[field];
+      if (typeof value !== 'string' || !value) continue;
+      const masked = this._redact(value);
+      if (masked === value) continue;
+      if (!copy) copy = { ...ev };
+      copy[field] = masked;
+    }
+    return copy || ev;
+  }
+
+  async _handleEvent(pp, rawEvent) {
+    const ev = this._redactEvent(rawEvent);
+    const channel = pp.msgChannel;
+    switch (ev.kind) {
+      case 'response': {
+        const entry = ev.id ? pp.pending.get(ev.id) : null;
+        if (!entry) {
+          // Unknown/absent id: log and ignore. Pi answers `parse` errors with
+          // no id, and a late response after a timeout lands here too.
+          if (!ev.success) {
+            this._log(`Pi RPC failed (${ev.command || 'unknown'}, unmatched id): ${this._redact(ev.error)}`);
+          }
+          return;
+        }
+        pp.pending.delete(ev.id);
+        if (entry.timer) clearTimeout(entry.timer);
+        entry.resolve(ev);
+        return;
+      }
+
+      case 'agent_start':
+        pp.awaitingToolResult = false;
+        await this._status(pp, 'Pi is working...');
+        return;
+
+      case 'message_start':
+        if (ev.role === 'assistant') pp.acc.startMessage();
+        return;
+
+      case 'message_update': {
+        // Each COMPLETED content block, released exactly once by the
+        // accumulator, so the matching message_end can never re-post it.
+        //
+        // `thinking` goes out immediately — hidden reasoning is never the
+        // answer, so it cannot collide with the final reply. `text` is HELD
+        // until message_end, where stopReason says whether this message is
+        // interim narration (post it as thinking) or the turn's answer (post
+        // it once, as a chat message, at settlement). Posting text here as
+        // well would make the final answer appear twice: once as thinking and
+        // once as the reply.
+        for (const block of pp.acc.pushDelta(ev.delta)) {
+          if (block.type === 'thinking') await this._emitThinking(pp, block.text);
+          else pp.heldTexts.push(block.text);
+        }
+        // A streaming error delta is the provider aborting mid-message.
+        if (ev.delta && ev.delta.type === 'error' && ev.delta.reason === 'error') {
+          pp.turnError = pp.turnError || 'The model stream ended with an error.';
+        }
+        return;
+      }
+
+      case 'message_end': {
+        const msg = ev.message;
+        if (!msg || msg.role !== 'assistant') return;
+        const result = pp.acc.endMessage(msg);
+        // Blocks whose streaming *_end never arrived (a non-streaming provider,
+        // or a lost delta) surface here for the first time.
+        for (const block of result.blocks) {
+          if (block.type === 'thinking') await this._emitThinking(pp, block.text);
+          else pp.heldTexts.push(block.text);
+        }
+        if (result.errorMessage) {
+          pp.turnError = result.errorMessage;
+        } else if (result.stopReason === 'error') {
+          pp.turnError = pp.turnError || 'Pi ended the turn with an error.';
+        }
+        // stopReason 'toolUse' means the model is calling a tool and will speak
+        // again — this message's text is narration around the call, so it goes
+        // out now as `thinking`. Any other stop reason means the message stands
+        // on its own: hold it as the answer candidate. The LAST such candidate
+        // of the turn is what _postTurnOutcome posts, exactly once.
+        const held = pp.heldTexts;
+        pp.heldTexts = [];
+        if (!held.length) return;
+        if (result.stopReason === 'toolUse') {
+          for (const text of held) await this._emitThinking(pp, text);
+        } else {
+          // A previous candidate is superseded — flush it as thinking rather
+          // than dropping it, so nothing the model said is ever lost.
+          for (const text of pp.turnTexts) await this._emitThinking(pp, text);
+          pp.turnTexts = held;
+          pp.everPosted = true;
+        }
+        return;
+      }
+
+      case 'tool_start':
+        pp.awaitingToolResult = true;
+        pp.everPosted = true;
+        await this._status(pp, ev.preview ? `${ev.toolName} › ${ev.preview}` : `${ev.toolName} running`);
+        return;
+
+      case 'tool_update':
+        // Progress only — keeps the watchdog quiet without spamming the channel.
+        pp.lastStdoutTime = Date.now();
+        return;
+
+      case 'tool_end':
+        // Always report completion, not just failure: without a terminal status
+        // the thread stays visually parked on the tool's "running" line.
+        pp.awaitingToolResult = false;
+        await this._status(pp, ev.isError
+          ? `${ev.toolName} failed${ev.preview ? `: ${ev.preview}` : ''}`
+          : `${ev.toolName} ✓${ev.preview ? ` ${ev.preview}` : ''}`);
+        return;
+
+      case 'bash_output':
+        // Direct RPC bash output. We never issue `bash` commands ourselves, so
+        // this only appears if an extension does; treat it as tool activity.
+        pp.awaitingToolResult = true;
+        return;
+
+      case 'queue_update':
+        return;
+
+      case 'compaction_start':
+        await this._status(pp, `Compacting conversation context (${ev.reason})...`);
+        return;
+
+      case 'compaction_end':
+        if (ev.error) {
+          await this._status(pp, `Context compaction failed: ${ev.error}`);
+        } else if (!ev.aborted) {
+          await this._status(pp, 'Context compaction complete.');
+        }
+        return;
+
+      case 'retry_start':
+        await this._status(
+          pp,
+          `Transient provider error — retrying (attempt ${ev.attempt ?? '?'}` +
+          `${ev.maxAttempts ? `/${ev.maxAttempts}` : ''})...`,
+        );
+        return;
+
+      case 'retry_end':
+        if (!ev.success) {
+          pp.turnError = pp.turnError || (ev.finalError || 'Pi exhausted its automatic retries.');
+        }
+        return;
+
+      case 'extension_error':
+        // The pure classifier can only apply PATTERN redaction — it does not
+        // know this agent's concrete credential values. Re-redact here, at the
+        // boundary, or a key that matches no known shape (e.g. a Google
+        // AIza... key) reaches the log and the workspace verbatim.
+        this._log(`Pi extension error on ${channel}: ${ev.message}`);
+        await this._status(pp, `A Pi extension reported an error: ${ev.message}`);
+        return;
+
+      case 'ui_request':
+        await this._handleUiRequest(pp, ev);
+        return;
+
+      case 'agent_end':
+        // A low-level run finished. `willRetry` means Pi continues on its own —
+        // the turn is only over at agent_settled.
+        pp.awaitingToolResult = false;
+        return;
+
+      case 'agent_settled':
+        pp.awaitingToolResult = false;
+        if (pp.turn) {
+          const turn = pp.turn;
+          pp.turn = null;
+          pp.turnInFlight = false;
+          this._stopWatchdog(pp);
+          turn.resolve({ settled: true });
+        }
+        return;
+
+      case 'oversize':
+        this._log(`Pi emitted a record over the ${ev.bytes}-byte line cap — dropped`);
+        return;
+
+      case 'unknown':
+        this._log(`Unrecognized Pi RPC record: ${ev.raw}`);
+        return;
+
+      default:
+        return;
+    }
+  }
+
+  /**
+   * Answer an extension UI request. Headless runs must NEVER block on terminal
+   * interaction, so every dialog method is immediately cancelled — the
+   * extension sees "user dismissed" and Pi keeps going. Fire-and-forget
+   * methods (notify/setStatus/…) expect no reply.
+   */
+  async _handleUiRequest(pp, ev) {
+    if (!ev.needsResponse) {
+      if (ev.method === 'notify' && ev.title) await this._status(pp, ev.title);
+      return;
+    }
+    this._log(`Pi extension asked for "${ev.method}" input — auto-cancelling (headless)`);
+    try {
+      this._writeRpc(pp, { type: 'extension_ui_response', id: ev.id, cancelled: true });
+    } catch (e) {
+      this._log(`Could not answer extension UI request: ${this._redact(e && e.message)}`);
+    }
+    await this._status(
+      pp,
+      `A Pi extension requested interactive input (${ev.method}) and was dismissed — ` +
+      'the workspace runs Pi headless.',
+    );
+  }
+
+  /**
+   * Post interim content as a `thinking` event: hidden model reasoning (which
+   * must never become an assistant reply) and narration around tool calls.
+   * The turn's ANSWER never comes through here — it is posted exactly once by
+   * _postTurnOutcome, so no text can appear both as thinking and as the reply.
+   */
+  async _emitThinking(pp, text) {
+    if (!text || !text.trim()) return;
+    pp.everPosted = true;
+    try { await this.sendThinking(pp.msgChannel, text); } catch {}
+  }
+
+  /**
+   * Post a status line. Deliberately does NOT set `everPosted`: that flag
+   * gates the "Pi finished without producing a response" diagnostic, and a
+   * generic progress line must not suppress it.
+   */
+  async _status(pp, text) {
+    try { await this.sendStatus(pp.msgChannel, text); } catch {}
+  }
+
+  // ------------------------------------------------------------------
+  // Message handling
+  // ------------------------------------------------------------------
+
+  /** Environment for the Pi child: agent env plus Pi's own hygiene settings. */
+  _buildEnv() {
+    const env = { ...(this.agentEnv || process.env) };
+    // The Launcher exposes one provider-agnostic secret field. Pi's native
+    // providers still expect their conventional env var, so mirror the value
+    // in memory for the child only. Existing provider-specific env remains
+    // authoritative for backwards compatibility.
+    const provider = String(env.PI_PROVIDER || '').trim().toLowerCase();
+    const key = String(env.PI_API_KEY || '').trim();
+    if (key) {
+      const target = {
+        anthropic: 'ANTHROPIC_API_KEY',
+        openai: 'OPENAI_API_KEY',
+        deepseek: 'DEEPSEEK_API_KEY',
+        google: 'GEMINI_API_KEY',
+        openrouter: 'OPENROUTER_API_KEY',
+      }[provider];
+      if (target && !String(env[target] || '').trim()) env[target] = key;
+    }
+    // Keep the child off the network at startup for update/telemetry checks:
+    // a launcher-managed install must not silently self-update mid-session.
+    env.PI_SKIP_VERSION_CHECK = env.PI_SKIP_VERSION_CHECK || '1';
+    // Pi writes config/auth under this dir; leave the user's own ~/.pi/agent in
+    // place so an existing `pi` login is reused, but never write trust.json.
+    return env;
+  }
+
+  /** Provider/model/thinking/trust configuration, read from the agent env. */
+  _config() {
+    const env = this.agentEnv || process.env;
+    const val = (k) => String(env[k] == null ? '' : env[k]).trim();
+    return {
+      provider: val('PI_PROVIDER') || null,
+      model: val('PI_MODEL') || null,
+      baseUrl: val('PI_BASE_URL') || null,
+      apiFormat: val('PI_API_FORMAT') || 'auto',
+      thinking: normalizeThinking(val('PI_THINKING')),
+      trustProject: parseTrustProject(val('PI_TRUST_PROJECT')),
+    };
+  }
+
+  _dirExists(p) {
+    try { return fs.statSync(p).isDirectory(); } catch { return false; }
+  }
+
+  /**
+   * Split attachments into images Pi can take inline over RPC and everything
+   * else, which is described in the prompt (Pi fetches those with bash+curl).
+   * A download failure demotes the image to the curl path rather than failing
+   * the message.
+   */
+  async _prepareAttachments(channel, attachments) {
+    const images = [];
+    const rest = [];
+    for (const att of attachments || []) {
+      const contentType = String((att && att.contentType) || '');
+      const fileId = att && att.fileId;
+      if (!contentType.startsWith('image/') || !fileId) { rest.push(att); continue; }
+      try {
+        const buffer = await this.client.readFile(this.workspaceId, this.token, fileId);
+        if (!buffer || !buffer.length) throw new Error('empty file');
+        images.push({ type: 'image', data: Buffer.from(buffer).toString('base64'), mimeType: contentType });
+      } catch (e) {
+        this._log(`Could not inline image ${att.filename || fileId}: ${this._redact(e && e.message)}`);
+        try {
+          await this.sendStatus(
+            channel,
+            `Could not attach "${att.filename || 'image'}" directly — Pi will download it from the workspace instead.`,
+          );
+        } catch {}
+        rest.push(att);
+      }
+    }
+    return { images, rest };
+  }
+
+  /**
+   * Reuse the channel's live Pi process when it is still valid, otherwise spawn
+   * a fresh one. The mode (execute/plan) is baked into the system prompt at
+   * spawn time, so a mode switch always forces a respawn — the resumed session
+   * keeps the conversation, exactly like claude.js's --resume respawn.
+   */
+  async _ensureProc(channel, workingDir, systemPrompt) {
+    const existing = this._persistentProcs[channel];
+    if (existing && existing.alive) {
+      if (existing.spawnMode === this._mode && existing.workingDir === workingDir) {
+        this._resetIdleTimer(channel);
+        return existing;
+      }
+      this._log(`Pi process for ${channel} is stale (mode/workdir changed) — respawning`);
+      await this._killPersistentProc(channel, 'configuration changed');
+    }
+
+    const piBin = this._piBin || this._findPiBinary();
+    if (!piBin) {
+      const message = 'Pi CLI not found — install it with: openagents install pi';
+      this._reportStatus(REASON.RUNTIME_MISSING, message);
+      throw new Error(message);
+    }
+    this._piBin = piBin;
+
+    const cfg = this._config();
+    const launcherKey = String((this.agentEnv || process.env).PI_API_KEY || '').trim();
+    if (cfg.baseUrl && (!cfg.provider || !cfg.model)) {
+      throw new Error('PI_PROVIDER and PI_MODEL are required when PI_BASE_URL is set.');
+    }
+    const sessionId = this._sessionIdFor(channel, workingDir);
+    try { fs.mkdirSync(this._sessionDir, { recursive: true }); } catch {}
+
+    const args = buildPiArgs({
+      sessionDir: this._sessionDir,
+      sessionId,
+      appendSystemPrompt: systemPrompt,
+      provider: cfg.provider,
+      model: cfg.model,
+      thinking: cfg.thinking,
+      sessionName: `${this.agentName}/${channel}`,
+      // A Launcher-managed key is supplied through the same process-local
+      // provider extension as relays. Besides keeping credentials out of argv
+      // and ~/.pi, this bypasses Pi's native auth resolver on installations
+      // where it incorrectly reports a present provider env key as missing.
+      extensions: cfg.baseUrl || launcherKey ? [LAUNCHER_PROVIDER_EXTENSION] : [],
+      trustProject: cfg.trustProject,
+    });
+
+    const pp = this._spawnPersistentProc(channel, {
+      piBin,
+      args,
+      workingDir,
+      env: this._buildEnv(),
+      sessionId,
+    });
+    if (pp.spawnError) throw new Error(pp.spawnError);
+    return pp;
+  }
+
+  async _handleMessage(msg) {
+    let content = (msg.content || '').trim();
+    const attachments = msg.attachments || [];
+    const channel = msg.sessionId || this.channelName || 'general';
+
+    this._stoppingChannels.delete(channel);
+    this._stopNoticeSent.delete(channel);
+
+    if (!content && !attachments.length) return;
+
+    // Validate the working directory BEFORE any expensive work (attachment
+    // downloads, prompt assembly) — never silently fall back to another dir.
+    const workingDir = this.workingDir || defaultAgentWorkdir(this.agentName);
+    if (this.workingDir && !this._dirExists(this.workingDir)) {
+      await this.sendError(channel, `Working directory does not exist: ${this.workingDir}`);
+      return;
+    }
+
+    const { images, rest } = await this._prepareAttachments(channel, attachments);
+    const attText = formatAttachmentsForPrompt(rest, 'skills');
+    if (attText) content = content ? content + attText : attText.trim();
+    if (!content && !images.length) return;
+    if (!content) content = 'Please look at the attached image(s).';
+
+    const sender = msg.senderName || msg.senderType || 'user';
+    this._log(`Processing message from ${sender} in ${channel}: ${this._redact(content.slice(0, 80))}...`);
+
+    // Auto-title + resume-from on first encounter (parity with other adapters).
+    if (!this._titledSessions.has(channel)) {
+      this._titledSessions.add(channel);
+      try {
+        const info = await this.client.getSession(this.workspaceId, channel, this.token);
+        const resumeFrom = info.resumeFrom;
+        if (resumeFrom && !this._channelSessions[channel] && this._channelSessions[resumeFrom]) {
+          this._channelSessions[channel] = { ...this._channelSessions[resumeFrom] };
+          this._saveSessions();
+        }
+        const title = generateSessionTitle(content);
+        if (title && !info.titleManuallySet && SESSION_DEFAULT_RE.test(info.title || '')) {
+          await this.client.updateSession(this.workspaceId, channel, this.token, { title, autoTitle: true });
+        }
+      } catch {}
+    }
+
+    await this.sendStatus(channel, 'thinking...');
+
+    let browserEnabled = false;
+    try { browserEnabled = await this.getBrowserEnabled(); } catch {}
+    const systemPrompt = '\n' + buildPiSystemPrompt({
+      agentName: this.agentName,
+      workspaceId: this.workspaceId,
+      channelName: channel,
+      endpoint: this.endpoint,
+      token: this.token,
+      mode: this._mode,
+      disabledModules: this.disabledModules,
+      browserEnabled,
+    });
+
+    let pp;
+    try {
+      pp = await this._ensureProc(channel, workingDir, systemPrompt);
+    } catch (e) {
+      await this.sendError(channel, this._redact(e && e.message) || 'Could not start the Pi CLI.');
+      return;
+    }
+
+    // Fresh per-turn accounting.
+    pp.msgChannel = channel;
+    pp.turnTexts = [];
+    pp.heldTexts = [];
+    pp.turnError = null;
+    pp.everPosted = false;
+    pp.awaitingToolResult = false;
+    pp.acc.reset();
+
+    const turn = {};
+    turn.promise = new Promise((resolve) => { turn.resolve = resolve; });
+    pp.turn = turn;
+    pp.turnInFlight = true;
+    this._startWatchdog(pp);
+
+    const command = { type: 'prompt', message: content };
+    if (images.length) command.images = images;
+
+    let accepted;
+    try {
+      accepted = await this._sendRpc(pp, command);
+    } catch (e) {
+      pp.turnInFlight = false;
+      pp.turn = null;
+      this._stopWatchdog(pp);
+      await this._reportTurnFailure(pp, channel, e);
+      return;
+    }
+
+    if (!accepted.success) {
+      pp.turnInFlight = false;
+      pp.turn = null;
+      this._stopWatchdog(pp);
+      const { userMessage } = classifyPiError(accepted.error || 'Pi rejected the prompt.');
+      await this.sendError(channel, this._redact(userMessage));
+      return;
+    }
+
+    // Pi acknowledges acceptance immediately; the turn ends at `agent_settled`
+    // (or when the process dies / the user stops it).
+    await turn.promise;
+    this._stopWatchdog(pp);
+    pp.turnInFlight = false;
+
+    if (pp.userStopped || this._stoppingChannels.has(channel)) {
+      if (!pp.everPosted) await this._postStopNotice(channel);
+      pp.userStopped = false;
+      return;
+    }
+    if (pp.watchdogKilled) {
+      pp.watchdogKilled = false;
+      return; // the watchdog already told the user
+    }
+
+    await this._postTurnOutcome(pp, channel);
+    if (this._persistentProcs[channel] === pp) this._resetIdleTimer(channel);
+  }
+
+  /** Classify + surface a failure that happened before the turn even started. */
+  async _reportTurnFailure(pp, channel, error) {
+    const raw = (error && error.message) || String(error);
+    if (error instanceof PiCancelledError && (pp.userStopped || this._stoppingChannels.has(channel))) {
+      await this._postStopNotice(channel);
+      return;
+    }
+    const { kind, userMessage } = classifyPiError(raw);
+    if (kind === 'auth') this._reportStatus(REASON.LOGIN_REQUIRED, 'Pi is not authenticated');
+    await this.sendError(channel, this._redact(userMessage));
+  }
+
+  /**
+   * Post the outcome of a settled turn: the final answer, or a classified
+   * error, or — when Pi produced neither — an explicit notice so the thread
+   * never hangs on "thinking…".
+   */
+  async _postTurnOutcome(pp, channel) {
+    const finalText = (pp.turnTexts || []).join('\n').trim();
+    if (pp.turnError) {
+      const { kind, userMessage } = classifyPiError(pp.turnError);
+      if (kind === 'auth') {
+        this._reportStatus(REASON.LOGIN_REQUIRED, 'Pi provider credentials were rejected');
+      } else {
+        this._reportStatus(null);
+      }
+      try { await this.sendError(channel, this._redact(userMessage)); } catch {}
+      return;
+    }
+    this._reportStatus(null);
+    if (finalText) {
+      try { await this.sendResponse(channel, finalText); } catch {}
+      return;
+    }
+    if (!pp.everPosted) {
+      const stderr = this._redact((pp.stderrBuf || '').trim()).slice(-400);
+      try {
+        await this.sendError(
+          channel,
+          'Pi finished without producing a response.' + (stderr ? `\n\nLast diagnostics:\n${stderr}` : ''),
+        );
+      } catch {}
+    }
+  }
+}
+
+module.exports = PiAdapter;
+module.exports.PiCancelledError = PiCancelledError;

--- a/packages/agent-connector/src/adapters/workspace-prompt.js
+++ b/packages/agent-connector/src/adapters/workspace-prompt.js
@@ -870,6 +870,26 @@ function buildOpenCodeSystemPrompt({ agentName, workspaceId, channelName, endpoi
 }
 
 /**
+ * Build the system prompt appended to Pi's own prompt (`--append-system-prompt`).
+ *
+ * Shape mirrors buildOpenCodeSystemPrompt: identity + browser directive +
+ * collaboration + mode + the REST "skills" block, because Pi is NOT wired to an
+ * MCP server (only the Claude adapter uses --mcp-config). Pi reaches workspace
+ * APIs through its built-in `bash` tool + curl, exactly like OpenCode/Amp.
+ *
+ * NOTE: this is APPENDED, never passed via `--system-prompt` — that flag would
+ * REPLACE Pi's own coding-assistant prompt and strip its tool instructions.
+ */
+function buildPiSystemPrompt({ agentName, workspaceId, channelName, endpoint, token, mode = 'execute', disabledModules, browserEnabled = false }) {
+  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, mode, 'skills');
+  const directive = buildBrowserDirective(browserEnabled);
+  const collab = buildCollaborationPrompt('skills', workspaceSkillName(agentName));
+  const modePrompt = buildModePrompt(mode);
+  const api = buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channelName, disabledModules, mode });
+  return identity + directive + '\n' + collab + '\n' + modePrompt + '\n' + api + '\n' + buildGuardrails();
+}
+
+/**
  * Build workspace skill markdown for OpenCode (written to .opencode/skills/).
  */
 function buildOpenCodeSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules }) {
@@ -972,6 +992,7 @@ module.exports = {
   buildOpenclawSkillMd,
   buildOpenCodeSystemPrompt,
   buildOpenCodeSkillMd,
+  buildPiSystemPrompt,
   buildClaudeSkillMd,
   buildCursorSkillMd,
 };

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -626,7 +626,12 @@ class Installer {
     const directReady = directEnv || directSaved;
     const envAnyReady = this._hasAnyValue(process.env, checkReady.env_vars);
     const savedAnyReady = !!(checkReady.saved_env_key && savedEnv[checkReady.saved_env_key]);
-    const credsReady = this._checkCredsReady(checkReady);
+    // A registry entry may require a non-empty JSON object rather than mere
+    // parseability. In that mode the stricter _evaluateCredsFile path below is
+    // authoritative; the legacy parser treats an empty {} as ready.
+    const credsReady = checkReady.creds_json_has_entries
+      ? false
+      : this._checkCredsReady(checkReady);
     // Content-free credential probes (opt-in via check_ready). Detect agents
     // whose sign-in is a local OAuth/credential FILE (e.g. Gemini's
     // ~/.gemini/oauth_creds.json) or a service-account file path, WITHOUT
@@ -753,9 +758,12 @@ class Installer {
   }
 
   /**
-   * Existence/readability of a credential file WITHOUT reading its contents —
-   * never loads a token/key into memory. Returns 'present' | 'unreadable' |
-   * 'absent'. A non-empty readable file (or a non-empty directory) is 'present';
+   * Existence/readability of a credential file. Returns 'present' |
+   * 'unreadable' | 'absent'. A non-empty readable file (or a non-empty
+   * directory) is normally 'present'. Entries with creds_json_has_entries
+   * additionally require at least one top-level JSON entry, allowing an empty
+   * auto-created {} file to remain signed out. Credential values are never
+   * logged or returned.
    * a path that exists but cannot be statted/read is 'unreadable'. Resolves "~"
    * against the running user's home (the daemon/launcher user), not the
    * renderer/browser user.
@@ -770,6 +778,14 @@ class Installer {
       const st = fs.statSync(p);
       if (st.isDirectory()) return fs.readdirSync(p).length > 0 ? 'present' : 'absent';
       fs.accessSync(p, fs.constants.R_OK);
+      if (checkReady.creds_json_has_entries) {
+        const parsed = JSON.parse(fs.readFileSync(p, 'utf-8'));
+        if (Array.isArray(parsed)) return parsed.length > 0 ? 'present' : 'absent';
+        if (parsed && typeof parsed === 'object') {
+          return Object.keys(parsed).length > 0 ? 'present' : 'absent';
+        }
+        return 'absent';
+      }
       return st.size > 0 ? 'present' : 'absent';
     } catch {
       return 'unreadable';

--- a/packages/agent-connector/test/fixtures/mock-pi.js
+++ b/packages/agent-connector/test/fixtures/mock-pi.js
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * A fake `pi` CLI for the PiAdapter tests.
+ *
+ * Speaks the real Pi RPC protocol (strict JSONL over stdin/stdout, LF only)
+ * as captured from @earendil-works/pi-coding-agent v0.83.0, so the adapter's
+ * spawn → frame → classify → post path can be exercised with no real CLI, no
+ * provider, no API key and no network.
+ *
+ * Driven entirely by environment variables so a single script covers every
+ * scenario:
+ *   FAKE_SCENARIO    which event script to play (see below)
+ *   FAKE_PI_VERSION  what `--version` prints (default 0.83.0)
+ *   FAKE_ARGV_LOG    file to write { argv, cwd, env, stdinCommands } to
+ *   FAKE_EXIT_CODE   exit code for the `exit_immediately` scenario
+ *
+ * Scenarios:
+ *   complete       a two-turn tool loop ending in a final answer
+ *   unicode        a single assistant message of multi-byte text
+ *   auth_error     the prompt is ACCEPTED, then the assistant message carries
+ *                  stopReason "error" + a 401 errorMessage (real Pi behavior)
+ *   hang           accepts the prompt, never settles; `abort` settles it
+ *   ignore_abort   accepts the prompt and `abort`, but NEVER settles
+ *   crash_mid_turn accepts the prompt, emits agent_start, then dies non-zero
+ *   exit_immediately  dies before reading any command
+ *   ui_prompt      an extension asks a blocking question, then settles only
+ *                  after the client answers it
+ */
+
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+
+if (args.includes('--version') || args.includes('-v')) {
+  process.stdout.write((process.env.FAKE_PI_VERSION || '0.83.0') + '\n');
+  process.exit(0);
+}
+
+const scenario = process.env.FAKE_SCENARIO || 'complete';
+const stdinCommands = [];
+
+if (process.env.FAKE_ARGV_LOG) {
+  const snapshot = () => {
+    try {
+      fs.writeFileSync(process.env.FAKE_ARGV_LOG, JSON.stringify({
+        argv: args,
+        cwd: process.cwd(),
+        env: {
+          ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || null,
+          OPENAI_API_KEY: process.env.OPENAI_API_KEY || null,
+          DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY || null,
+          PI_API_KEY: process.env.PI_API_KEY || null,
+          PI_BASE_URL: process.env.PI_BASE_URL || null,
+          PI_PROVIDER: process.env.PI_PROVIDER || null,
+          PI_MODEL: process.env.PI_MODEL || null,
+          PI_SKIP_VERSION_CHECK: process.env.PI_SKIP_VERSION_CHECK || null,
+        },
+        stdinCommands,
+      }));
+    } catch {}
+  };
+  snapshot();
+  process.on('exit', snapshot);
+}
+
+if (scenario === 'exit_immediately') {
+  process.exit(parseInt(process.env.FAKE_EXIT_CODE || '3', 10));
+}
+
+const w = (o) => { try { process.stdout.write(JSON.stringify(o) + '\n'); } catch {} };
+const ok = (cmd) => w({ id: cmd.id, type: 'response', command: cmd.type, success: true });
+
+const userMsg = (text) => ({ role: 'user', content: [{ type: 'text', text }], timestamp: 1 });
+const asstMsg = (content, extra) => Object.assign({
+  role: 'assistant',
+  content,
+  api: 'anthropic-messages',
+  provider: 'anthropic',
+  model: 'fake-model',
+  usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+  stopReason: 'stop',
+  timestamp: 2,
+}, extra || {});
+
+let promptCount = 0;
+let settled = false;
+
+function settle() {
+  if (settled) return;
+  settled = true;
+  w({ type: 'agent_end', messages: [], willRetry: false });
+  w({ type: 'agent_settled' });
+}
+
+function runComplete(prompt) {
+  promptCount++;
+  w({ type: 'agent_start' });
+  w({ type: 'turn_start' });
+  w({ type: 'message_start', message: userMsg(prompt) });
+  w({ type: 'message_end', message: userMsg(prompt) });
+
+  // Turn 1: narration, then a tool call.
+  const narration = 'Let me look at the file.';
+  w({ type: 'message_start', message: asstMsg([]) });
+  w({
+    type: 'message_update',
+    message: asstMsg([{ type: 'text', text: narration }]),
+    assistantMessageEvent: { type: 'text_start', contentIndex: 0 },
+  });
+  w({
+    type: 'message_update',
+    message: asstMsg([{ type: 'text', text: narration }]),
+    assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Let me look ' },
+  });
+  w({
+    type: 'message_update',
+    message: asstMsg([{ type: 'text', text: narration }]),
+    assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: narration },
+  });
+  w({
+    type: 'message_end',
+    message: asstMsg(
+      [{ type: 'text', text: narration },
+        { type: 'toolCall', id: 'call_1', name: 'read', arguments: { file_path: 'src/x.js' } }],
+      { stopReason: 'toolUse' },
+    ),
+  });
+  w({ type: 'tool_execution_start', toolCallId: 'call_1', toolName: 'read', args: { file_path: 'src/x.js' } });
+  w({
+    type: 'tool_execution_end',
+    toolCallId: 'call_1',
+    toolName: 'read',
+    result: { content: [{ type: 'text', text: 'file contents' }], details: {} },
+    isError: false,
+  });
+  w({ type: 'turn_end', message: asstMsg([]), toolResults: [] });
+
+  // Turn 2: the final answer. It echoes the prompt and the prompt counter so
+  // the test can prove the SAME process handled a follow-up with context.
+  const answer = `Done (prompt #${promptCount}): ${prompt}`;
+  w({ type: 'turn_start' });
+  w({ type: 'message_start', message: asstMsg([]) });
+  w({
+    type: 'message_update',
+    message: asstMsg([{ type: 'text', text: answer }]),
+    assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: answer },
+  });
+  w({ type: 'message_end', message: asstMsg([{ type: 'text', text: answer }]) });
+  w({ type: 'turn_end', message: asstMsg([]), toolResults: [] });
+  settled = false;
+  settle();
+}
+
+function runUnicode(prompt) {
+  const answer = `完成了：${prompt} 🚀`;
+  w({ type: 'agent_start' });
+  w({ type: 'message_start', message: asstMsg([]) });
+  w({
+    type: 'message_update',
+    message: asstMsg([{ type: 'text', text: answer }]),
+    assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: answer },
+  });
+  w({ type: 'message_end', message: asstMsg([{ type: 'text', text: answer }]) });
+  settled = false;
+  settle();
+}
+
+function runAuthError() {
+  const errorMessage =
+    '401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}';
+  w({ type: 'agent_start' });
+  w({ type: 'message_start', message: asstMsg([]) });
+  w({ type: 'message_end', message: asstMsg([], { stopReason: 'error', errorMessage }) });
+  settled = false;
+  settle();
+}
+
+function handle(cmd) {
+  stdinCommands.push({ type: cmd.type, id: cmd.id || null, hasImages: Array.isArray(cmd.images) });
+
+  if (cmd.type === 'extension_ui_response') {
+    if (scenario === 'ui_prompt') { settled = false; settle(); }
+    return;
+  }
+
+  if (cmd.type === 'abort') {
+    ok(cmd);
+    if (scenario === 'ignore_abort') return; // deliberately never settles
+    settle();
+    return;
+  }
+
+  if (cmd.type !== 'prompt') { ok(cmd); return; }
+
+  ok(cmd); // Pi answers `prompt` as soon as it is ACCEPTED
+  const prompt = String(cmd.message == null ? '' : cmd.message);
+
+  switch (scenario) {
+    case 'unicode':
+      runUnicode(prompt);
+      break;
+    case 'auth_error':
+      runAuthError();
+      break;
+    case 'hang':
+    case 'ignore_abort':
+      w({ type: 'agent_start' });
+      break;
+    case 'crash_mid_turn':
+      w({ type: 'agent_start' });
+      setTimeout(() => process.exit(parseInt(process.env.FAKE_EXIT_CODE || '7', 10)), 20);
+      break;
+    case 'ui_prompt':
+      w({ type: 'agent_start' });
+      w({
+        type: 'extension_ui_request',
+        id: 'ui-1',
+        method: 'confirm',
+        title: 'Allow dangerous command?',
+        message: 'rm -rf /',
+      });
+      break;
+    default:
+      runComplete(prompt);
+      break;
+  }
+}
+
+let buf = '';
+process.stdin.on('data', (chunk) => {
+  buf += chunk.toString('utf-8');
+  let i;
+  while ((i = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, i);
+    buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    try { handle(JSON.parse(line)); } catch { /* mirror Pi: ignore junk */ }
+  }
+});
+process.stdin.on('end', () => {
+  if (scenario !== 'hang' && scenario !== 'ignore_abort') process.exit(0);
+});

--- a/packages/agent-connector/test/pi-stream.test.js
+++ b/packages/agent-connector/test/pi-stream.test.js
@@ -1,0 +1,613 @@
+'use strict';
+
+/**
+ * Unit tests for the pure Pi RPC framing / classification module.
+ *
+ * Everything here runs without a Pi CLI, an API key or a network: the module
+ * under test has no I/O at all. The wire shapes asserted below are the ones
+ * documented in @earendil-works/pi-coding-agent v0.83.0's docs/rpc.md and
+ * captured from a live `pi --mode rpc` session.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PiJsonlFramer,
+  PiStreamParser,
+  PiAssistantAccumulator,
+  classifyPiEvent,
+  parseLine,
+  buildPiArgs,
+  classifyPiError,
+  classifyPiVersion,
+  classifyNodeVersion,
+  compareVersions,
+  isValidSessionId,
+  normalizeThinking,
+  parseTrustProject,
+  parseWindowsCmdShim,
+  redactSecrets,
+  redactArgs,
+  summarizeToolArgs,
+  MIN_PI_VERSION,
+  MIN_NODE_VERSION,
+} = require('../src/adapters/pi-stream');
+
+const enc = (s) => Buffer.from(s, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// 1–7: framing
+// ---------------------------------------------------------------------------
+
+describe('PiJsonlFramer / PiStreamParser framing', () => {
+  it('reassembles one JSON record split across many chunks', () => {
+    const parser = new PiStreamParser();
+    const record = JSON.stringify({ type: 'agent_start' }) + '\n';
+    let events = [];
+    for (const byte of record.split('')) events = events.concat(parser.push(enc(byte)));
+    assert.deepEqual(events, [{ kind: 'agent_start' }]);
+  });
+
+  it('splits many JSON records carried by a single chunk', () => {
+    const parser = new PiStreamParser();
+    const chunk =
+      JSON.stringify({ type: 'agent_start' }) + '\n' +
+      JSON.stringify({ type: 'turn_start' }) + '\n' +
+      JSON.stringify({ type: 'agent_settled' }) + '\n';
+    const events = parser.push(enc(chunk));
+    assert.deepEqual(events.map((e) => e.kind), ['agent_start', 'turn_start', 'agent_settled']);
+  });
+
+  it('reassembles multi-byte UTF-8 split mid-character (CJK + emoji)', () => {
+    const parser = new PiStreamParser();
+    const text = '你好，世界 — 修复这个 bug 🚀🇯🇵';
+    const buf = enc(JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: text },
+    }) + '\n');
+
+    // Feed one byte at a time: every multi-byte sequence is split.
+    let events = [];
+    for (let i = 0; i < buf.length; i++) events = events.concat(parser.push(buf.subarray(i, i + 1)));
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].kind, 'message_update');
+    assert.equal(events[0].delta.content, text);
+    assert.ok(!events[0].delta.content.includes('�'), 'no replacement characters');
+  });
+
+  it('never treats U+2028 / U+2029 as a record separator', () => {
+    const parser = new PiStreamParser();
+    // Both separators live INSIDE a JSON string, exactly the case that makes
+    // Node's readline non-compliant for this protocol.
+    const text = 'line one\u2028line two\u2029line three';
+    const events = parser.push(enc(JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_end', contentIndex: 0, content: text },
+    }) + '\n'));
+    assert.equal(events.length, 1, 'one record, not three');
+    assert.equal(events[0].delta.content, text);
+  });
+
+  it('strips a trailing CR from \\r\\n line endings', () => {
+    const framer = new PiJsonlFramer();
+    const lines = framer.push(enc('{"type":"agent_start"}\r\n{"type":"agent_settled"}\r\n'));
+    assert.deepEqual(lines, ['{"type":"agent_start"}', '{"type":"agent_settled"}']);
+  });
+
+  it('degrades a single invalid JSON line to `unknown` without throwing', () => {
+    const parser = new PiStreamParser();
+    const events = parser.push(enc(
+      'not json at all\n' +
+      '{"type":"agent_start"}\n' +
+      '{"type": broken\n' +
+      '{"type":"agent_settled"}\n',
+    ));
+    assert.deepEqual(events.map((e) => e.kind), ['unknown', 'agent_start', 'unknown', 'agent_settled']);
+    assert.match(events[0].raw, /not json at all/);
+  });
+
+  it('drops an over-long unterminated record and resynchronizes on the next LF', () => {
+    const parser = new PiStreamParser({ maxLineBytes: 64 });
+    // A record far beyond the cap, never terminated within this chunk.
+    const huge = parser.push(enc('{"type":"agent_start","pad":"' + 'x'.repeat(500)));
+    assert.deepEqual(huge.map((e) => e.kind), ['oversize']);
+    assert.ok(huge[0].bytes > 64);
+
+    // The tail of the dropped record plus a good record after it.
+    const after = parser.push(enc('"}\n{"type":"agent_settled"}\n'));
+    assert.deepEqual(after.map((e) => e.kind), ['agent_settled']);
+  });
+
+  it('flushes a trailing record that arrived without a final newline', () => {
+    const parser = new PiStreamParser();
+    assert.deepEqual(parser.push(enc('{"type":"agent_settled"}')), []);
+    assert.deepEqual(parser.flush().map((e) => e.kind), ['agent_settled']);
+  });
+
+  it('ignores blank lines entirely', () => {
+    const parser = new PiStreamParser();
+    assert.deepEqual(parser.push(enc('\n\n   \n')), []);
+  });
+
+  it('parseLine rejects non-objects and blank input', () => {
+    assert.equal(parseLine(''), null);
+    assert.equal(parseLine('   '), null);
+    assert.equal(parseLine('[1,2]'), null);
+    assert.equal(parseLine('"a string"'), null);
+    assert.deepEqual(parseLine('{"a":1}'), { a: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8: RPC response correlation
+// ---------------------------------------------------------------------------
+
+describe('RPC response correlation', () => {
+  it('carries the request id, command and success flag through', () => {
+    const ev = classifyPiEvent({
+      id: 'oa-7', type: 'response', command: 'prompt', success: true,
+    });
+    assert.deepEqual(ev, {
+      kind: 'response', id: 'oa-7', command: 'prompt', success: true, data: null, error: null,
+    });
+  });
+
+  it('surfaces a failed response with its error string', () => {
+    const ev = classifyPiEvent({
+      id: 'oa-8', type: 'response', command: 'set_model', success: false,
+      error: 'Model not found: invalid/model',
+    });
+    assert.equal(ev.success, false);
+    assert.equal(ev.error, 'Model not found: invalid/model');
+  });
+
+  it('classifies an id-less response (Pi parse errors) without throwing', () => {
+    const ev = classifyPiEvent({ type: 'response', command: 'parse', success: false, error: 'bad' });
+    assert.equal(ev.kind, 'response');
+    assert.equal(ev.id, null);
+  });
+
+  it('an unknown id is still a well-formed response the caller can ignore', () => {
+    // The adapter drops responses whose id is not in its pending map; the
+    // parser's job is only to never throw and to preserve the id verbatim.
+    const ev = classifyPiEvent({ id: 'someone-elses-id', type: 'response', command: 'abort', success: true });
+    assert.equal(ev.id, 'someone-elses-id');
+    assert.equal(ev.success, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9: message_update / message_end deduplication
+// ---------------------------------------------------------------------------
+
+describe('PiAssistantAccumulator (message_update vs message_end dedup)', () => {
+  it('releases a streamed block once and does not repeat it at message_end', () => {
+    const acc = new PiAssistantAccumulator();
+    acc.startMessage();
+    assert.deepEqual(acc.pushDelta({ type: 'text_start', contentIndex: 0 }), []);
+    assert.deepEqual(acc.pushDelta({ type: 'text_delta', contentIndex: 0, delta: 'Hello' }), []);
+    assert.deepEqual(acc.pushDelta({ type: 'text_delta', contentIndex: 0, delta: ' world' }), []);
+    const streamed = acc.pushDelta({ type: 'text_end', contentIndex: 0, content: 'Hello world' });
+    assert.deepEqual(streamed, [{ type: 'text', text: 'Hello world' }]);
+
+    const end = acc.endMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Hello world' }],
+      stopReason: 'stop',
+    });
+    assert.deepEqual(end.blocks, [], 'message_end must not re-emit an already streamed block');
+    assert.deepEqual(end.texts, ['Hello world'], 'but it is still part of the final answer');
+  });
+
+  it('emits a block at message_end when its streaming *_end never arrived', () => {
+    const acc = new PiAssistantAccumulator();
+    acc.startMessage();
+    const end = acc.endMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Non-streaming answer' }],
+      stopReason: 'stop',
+    });
+    assert.deepEqual(end.blocks, [{ type: 'text', text: 'Non-streaming answer' }]);
+    assert.deepEqual(end.texts, ['Non-streaming answer']);
+  });
+
+  it('keeps thinking blocks out of the answer text', () => {
+    const acc = new PiAssistantAccumulator();
+    acc.startMessage();
+    acc.pushDelta({ type: 'thinking_end', contentIndex: 0, content: 'internal reasoning' });
+    acc.pushDelta({ type: 'text_end', contentIndex: 1, content: 'The answer.' });
+    const end = acc.endMessage({
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'internal reasoning' },
+        { type: 'text', text: 'The answer.' },
+      ],
+      stopReason: 'stop',
+    });
+    assert.deepEqual(end.blocks, []);
+    assert.deepEqual(end.texts, ['The answer.']);
+    assert.deepEqual(end.thinking, ['internal reasoning']);
+  });
+
+  it('scopes released blocks per message so a tool loop keeps only the last answer', () => {
+    const acc = new PiAssistantAccumulator();
+    // First assistant message: narration before a tool call, same contentIndex.
+    acc.startMessage();
+    acc.pushDelta({ type: 'text_end', contentIndex: 0, content: 'Let me look at the file.' });
+    const first = acc.endMessage({ role: 'assistant', content: [{ type: 'text', text: 'Let me look at the file.' }] });
+    assert.deepEqual(first.texts, ['Let me look at the file.']);
+
+    // Second assistant message reuses contentIndex 0 — it must NOT be deduped
+    // against the previous message's block.
+    acc.startMessage();
+    const streamed = acc.pushDelta({ type: 'text_end', contentIndex: 0, content: 'Done — fixed it.' });
+    assert.deepEqual(streamed, [{ type: 'text', text: 'Done — fixed it.' }]);
+    const second = acc.endMessage({ role: 'assistant', content: [{ type: 'text', text: 'Done — fixed it.' }] });
+    assert.deepEqual(second.texts, ['Done — fixed it.'], 'the final message alone is the answer');
+  });
+
+  it('reports a message-level provider error, redacted', () => {
+    const acc = new PiAssistantAccumulator();
+    acc.startMessage();
+    const end = acc.endMessage({
+      role: 'assistant',
+      content: [],
+      stopReason: 'error',
+      errorMessage: '401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+    });
+    assert.equal(end.stopReason, 'error');
+    assert.match(end.errorMessage, /authentication_error/);
+  });
+
+  it('drops empty and whitespace-only blocks', () => {
+    const acc = new PiAssistantAccumulator();
+    acc.startMessage();
+    assert.deepEqual(acc.pushDelta({ type: 'text_end', contentIndex: 0, content: '   ' }), []);
+    const end = acc.endMessage({ role: 'assistant', content: [{ type: 'text', text: '   ' }] });
+    assert.deepEqual(end.blocks, []);
+    assert.deepEqual(end.texts, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10: Pi event → OpenAgents mapping, asserted event by event
+// ---------------------------------------------------------------------------
+
+describe('classifyPiEvent — Pi event → normalized kind', () => {
+  const CASES = [
+    [{ type: 'agent_start' }, 'agent_start'],
+    [{ type: 'agent_end', messages: [], willRetry: false }, 'agent_end'],
+    [{ type: 'agent_settled' }, 'agent_settled'],
+    [{ type: 'turn_start' }, 'turn_start'],
+    [{ type: 'turn_end', message: {}, toolResults: [] }, 'turn_end'],
+    [{ type: 'message_start', message: { role: 'assistant' } }, 'message_start'],
+    [{ type: 'message_update', assistantMessageEvent: { type: 'text_delta' } }, 'message_update'],
+    [{ type: 'message_end', message: { role: 'assistant' } }, 'message_end'],
+    [{ type: 'tool_execution_start', toolCallId: 'c1', toolName: 'bash', args: {} }, 'tool_start'],
+    [{ type: 'tool_execution_update', toolCallId: 'c1', toolName: 'bash' }, 'tool_update'],
+    [{ type: 'tool_execution_end', toolCallId: 'c1', toolName: 'bash', result: {}, isError: false }, 'tool_end'],
+    [{ type: 'bash_execution_update', id: 'r1', delta: 'out' }, 'bash_output'],
+    [{ type: 'queue_update', steering: [], followUp: [] }, 'queue_update'],
+    [{ type: 'compaction_start', reason: 'threshold' }, 'compaction_start'],
+    [{ type: 'compaction_end', reason: 'threshold', aborted: false }, 'compaction_end'],
+    [{ type: 'auto_retry_start', attempt: 1, maxAttempts: 3 }, 'retry_start'],
+    [{ type: 'auto_retry_end', success: true, attempt: 2 }, 'retry_end'],
+    [{ type: 'summarization_retry_scheduled', attempt: 1 }, 'retry_start'],
+    [{ type: 'summarization_retry_finished' }, 'retry_end'],
+    [{ type: 'extension_error', extensionPath: '/x.ts', error: 'boom' }, 'extension_error'],
+    [{ type: 'extension_ui_request', id: 'u1', method: 'confirm' }, 'ui_request'],
+    [{ type: 'response', command: 'prompt', success: true }, 'response'],
+    [{ type: 'a_type_pi_has_not_invented_yet' }, 'unknown'],
+    [{ noTypeAtAll: 1 }, 'unknown'],
+  ];
+
+  for (const [raw, kind] of CASES) {
+    it(`maps ${raw.type || '(untyped)'} → ${kind}`, () => {
+      assert.equal(classifyPiEvent(raw).kind, kind);
+    });
+  }
+
+  it('extracts a redacted tool preview from tool_execution_start', () => {
+    const ev = classifyPiEvent({
+      type: 'tool_execution_start', toolCallId: 'c1', toolName: 'bash',
+      args: { command: 'curl -H "authorization: Bearer sk-live-abcdefghijklmnop" https://x' },
+    });
+    assert.equal(ev.toolName, 'bash');
+    assert.ok(!ev.preview.includes('sk-live-abcdefghijklmnop'), 'the bearer token must be masked');
+  });
+
+  it('truncates a very long tool preview', () => {
+    const ev = classifyPiEvent({
+      type: 'tool_execution_start', toolName: 'bash', args: { command: 'a'.repeat(1000) },
+    });
+    assert.ok(ev.preview.length <= 161, `preview was ${ev.preview.length} chars`);
+    assert.ok(ev.preview.endsWith('…'));
+  });
+
+  it('flags a tool failure', () => {
+    const ev = classifyPiEvent({
+      type: 'tool_execution_end', toolName: 'edit', isError: true,
+      result: { content: [{ type: 'text', text: 'file not found' }] },
+    });
+    assert.equal(ev.isError, true);
+    assert.equal(ev.preview, 'file not found');
+  });
+
+  it('marks only the four blocking extension UI methods as needing a reply', () => {
+    for (const method of ['select', 'confirm', 'input', 'editor']) {
+      assert.equal(classifyPiEvent({ type: 'extension_ui_request', id: 'u', method }).needsResponse, true, method);
+    }
+    for (const method of ['notify', 'setStatus', 'setWidget', 'setTitle', 'set_editor_text']) {
+      assert.equal(classifyPiEvent({ type: 'extension_ui_request', id: 'u', method }).needsResponse, false, method);
+    }
+  });
+
+  it('summarizeToolArgs falls back to key names when no known field is present', () => {
+    assert.equal(summarizeToolArgs('mystery', { alpha: 1, beta: 2 }), 'alpha, beta');
+    assert.equal(summarizeToolArgs('mystery', null), '');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11: redaction on the log / error paths
+// ---------------------------------------------------------------------------
+
+describe('redaction', () => {
+  it('masks an exact known secret anywhere it appears', () => {
+    const key = 'sk-ant-api03-SUPERSECRETVALUE01234';
+    const out = redactSecrets(`failed with ${key} in header`, [key]);
+    assert.ok(!out.includes(key));
+    assert.match(out, /\*\*\*/);
+  });
+
+  it('masks key=value, bearer tokens, provider key shapes and URL credentials', () => {
+    const samples = [
+      ['api_key=abcdefghijklmnop', 'abcdefghijklmnop'],
+      ['Authorization: Bearer abcdefghijklmnopqrst', 'abcdefghijklmnopqrst'],
+      ['token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345', 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345'],
+      ['using sk-proj-abcdefghijkl now', 'sk-proj-abcdefghijkl'],
+      ['https://user:hunter2@relay.example.com/v1', 'hunter2'],
+    ];
+    for (const [input, secret] of samples) {
+      const out = redactSecrets(input);
+      assert.ok(!out.includes(secret), `${input} → ${out}`);
+    }
+  });
+
+  it('leaves ordinary prose untouched', () => {
+    assert.equal(redactSecrets('Edited src/index.js and ran the tests.'),
+      'Edited src/index.js and ran the tests.');
+  });
+
+  it('never throws on non-strings', () => {
+    assert.equal(redactSecrets(null), '');
+    assert.equal(redactSecrets(undefined), '');
+    assert.equal(redactSecrets(42), '42');
+  });
+
+  it('redactArgs elides the system prompt instead of printing it', () => {
+    const argv = ['pi', '--mode', 'rpc', '--append-system-prompt', 'x'.repeat(5000), '--no-approve'];
+    const out = redactArgs(argv);
+    assert.deepEqual(out, ['pi', '--mode', 'rpc', '--append-system-prompt', '<5000 chars>', '--no-approve']);
+  });
+
+  it('a message-level provider error keeps its meaning but not its credential', () => {
+    const key = 'sk-ant-REALKEYVALUE0123456789';
+    const { userMessage } = classifyPiError(`401 invalid x-api-key (${key})`);
+    const masked = redactSecrets(userMessage, [key]);
+    assert.ok(!masked.includes(key));
+    assert.match(masked, /authentication failed/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error classification → the shared vocabulary
+// ---------------------------------------------------------------------------
+
+describe('classifyPiError', () => {
+  const CASES = [
+    ['401 {"type":"error","error":{"type":"authentication_error"}}', 'auth'],
+    ['Error: 429 rate limit exceeded', 'rate_limit'],
+    ['prompt is too long: maximum context length is 200000 tokens', 'context'],
+    ['No model matching "gpt-9000"', 'model'],
+    ['unknown provider: notaprovider', 'provider'],
+    ['fetch failed: getaddrinfo ENOTFOUND api.anthropic.com', 'network'],
+    ['EACCES: permission denied, open \'/root/x\'', 'filesystem'],
+    ['something entirely novel', null],
+  ];
+  for (const [raw, kind] of CASES) {
+    it(`classifies "${raw.slice(0, 40)}" as ${kind}`, () => {
+      assert.equal(classifyPiError(raw).kind, kind);
+    });
+  }
+
+  it('always returns a non-empty user message', () => {
+    for (const input of ['', null, undefined, 'x']) {
+      assert.ok(classifyPiError(input).userMessage.length > 0);
+    }
+  });
+
+  it('points a missing DeepSeek key at the unified Launcher field', () => {
+    const message = classifyPiError('No API key found for deepseek').userMessage;
+    assert.match(message, /PI_API_KEY/);
+    assert.match(message, /DEEPSEEK_API_KEY/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version gates + argv construction
+// ---------------------------------------------------------------------------
+
+describe('version helpers', () => {
+  it('compares dotted versions', () => {
+    assert.equal(compareVersions('0.83.0', '0.83.0'), 0);
+    assert.equal(compareVersions('0.84.0', '0.83.0'), 1);
+    assert.equal(compareVersions('0.82.9', '0.83.0'), -1);
+    assert.equal(compareVersions('22.22.3', '22.19.0'), 1);
+    assert.equal(compareVersions('22.9.0', '22.19.0'), -1, 'numeric, not lexical');
+  });
+
+  it('takes its floor from the caller (the registry), not only the module default', () => {
+    // The registry's install.min_version is authoritative; the module constant
+    // is a fallback. A registry bump must move the runtime gate with it.
+    assert.deepEqual(classifyPiVersion('0.83.0', '0.90.0'), { version: '0.83.0', supported: false });
+    assert.deepEqual(classifyPiVersion('0.91.0', '0.90.0'), { version: '0.91.0', supported: true });
+    // An unusable floor degrades to the module default rather than throwing.
+    assert.equal(classifyPiVersion('0.83.0', undefined).supported, true);
+    assert.equal(classifyPiVersion('0.83.0', 'not-a-version').supported, true);
+  });
+
+  it('classifies `pi --version` output', () => {
+    assert.deepEqual(classifyPiVersion('0.83.0'), { version: '0.83.0', supported: true });
+    assert.deepEqual(classifyPiVersion('pi 0.90.1\n'), { version: '0.90.1', supported: true });
+    assert.deepEqual(classifyPiVersion('0.50.0'), { version: '0.50.0', supported: false });
+    assert.deepEqual(classifyPiVersion('command not found'), { version: null, supported: null });
+    assert.equal(MIN_PI_VERSION, '0.83.0');
+  });
+
+  it("classifies a Node runtime against Pi's engine floor", () => {
+    assert.equal(MIN_NODE_VERSION, '22.19.0');
+    assert.deepEqual(classifyNodeVersion('v22.22.3'), { version: '22.22.3', supported: true });
+    assert.deepEqual(classifyNodeVersion('v22.19.0'), { version: '22.19.0', supported: true });
+    assert.deepEqual(classifyNodeVersion('v20.11.1'), { version: '20.11.1', supported: false });
+    assert.deepEqual(classifyNodeVersion('v22.18.9'), { version: '22.18.9', supported: false });
+    assert.deepEqual(classifyNodeVersion(''), { version: null, supported: null });
+  });
+
+  it('validates session ids', () => {
+    assert.equal(isValidSessionId('019fd680-2c4c-7093-a69e-a71e5b407cce'), true);
+    assert.equal(isValidSessionId('not-a-uuid'), false);
+    assert.equal(isValidSessionId(''), false);
+    assert.equal(isValidSessionId(null), false);
+    assert.equal(isValidSessionId({ sessionId: 'x' }), false);
+  });
+
+  it('normalizes the thinking level and drops junk', () => {
+    assert.equal(normalizeThinking('HIGH'), 'high');
+    assert.equal(normalizeThinking('  max '), 'max');
+    assert.equal(normalizeThinking('turbo'), null);
+    assert.equal(normalizeThinking(''), null);
+    assert.equal(normalizeThinking(undefined), null);
+  });
+
+  it('defaults project trust to false for anything but an explicit opt-in', () => {
+    for (const on of ['1', 'true', 'TRUE', 'yes', 'on']) assert.equal(parseTrustProject(on), true, on);
+    for (const off of ['0', 'false', '', 'maybe', undefined, null]) {
+      assert.equal(parseTrustProject(off), false, String(off));
+    }
+  });
+});
+
+describe('parseWindowsCmdShim', () => {
+  // .cmd shims are Windows-only, but the parser is pure and resolved with
+  // win32 path semantics, so every dialect is covered on every OS. Matching
+  // only `%dp0%` (as the older sibling adapters do) silently drops the
+  // `%~dp0` dialect into the `cmd.exe /c` fallback, where the ~14 KB
+  // --append-system-prompt exceeds cmd.exe's 8191-character command line.
+  const MODERN_NPM = [
+    '@ECHO off', 'GOTO start', ':find_dp0', 'SET dp0=%~dp0', 'EXIT /b',
+    ':start', 'SETLOCAL', 'CALL :find_dp0', '',
+    'IF EXIST "%dp0%\\node.exe" (',
+    '  "%dp0%\\node.exe"  "%dp0%\\..\\@earendil-works\\pi-coding-agent\\dist\\cli.js" %*',
+    ') ELSE (',
+    '  node  "%dp0%\\..\\@earendil-works\\pi-coding-agent\\dist\\cli.js" %*',
+    ')',
+  ].join('\r\n');
+
+  it('parses the modern npm dialect (SET dp0=%~dp0 … "%dp0%\\…")', () => {
+    assert.deepEqual(parseWindowsCmdShim(MODERN_NPM, 'C:\\bin'), {
+      kind: 'script',
+      target: 'C:\\@earendil-works\\pi-coding-agent\\dist\\cli.js',
+    });
+  });
+
+  it('parses the %~dp0 dialect with a separator', () => {
+    assert.deepEqual(parseWindowsCmdShim('@echo off\r\nnode "%~dp0\\cli.js" %*\r\n', 'C:\\bin'), {
+      kind: 'script', target: 'C:\\bin\\cli.js',
+    });
+  });
+
+  it('parses %~dp0 with no separator (it already ends in a backslash)', () => {
+    assert.deepEqual(parseWindowsCmdShim('@echo off\r\nnode "%~dp0cli.js" %*\r\n', 'C:\\bin'), {
+      kind: 'script', target: 'C:\\bin\\cli.js',
+    });
+  });
+
+  it('prefers the script over node.exe on the same line', () => {
+    const shim = 'SET dp0=%~dp0\r\n"%dp0%\\node.exe" "%dp0%\\cli.mjs" %*\r\n';
+    assert.deepEqual(parseWindowsCmdShim(shim, 'C:\\bin'), {
+      kind: 'script', target: 'C:\\bin\\cli.mjs',
+    });
+  });
+
+  it('falls back to a native .exe target when there is no script', () => {
+    assert.deepEqual(parseWindowsCmdShim('SET dp0=%~dp0\r\n"%dp0%\\pi.exe" %*\r\n', 'C:\\bin'), {
+      kind: 'exe', target: 'C:\\bin\\pi.exe',
+    });
+  });
+
+  it('returns null for an unrecognizable or empty shim', () => {
+    assert.equal(parseWindowsCmdShim('@echo off\r\nrem nothing here\r\n', 'C:\\bin'), null);
+    assert.equal(parseWindowsCmdShim('', 'C:\\bin'), null);
+    assert.equal(parseWindowsCmdShim(null, 'C:\\bin'), null);
+  });
+});
+
+describe('buildPiArgs', () => {
+  const base = { sessionDir: '/data/sess', sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' };
+
+  it('always requests RPC mode with an OpenAgents-managed session directory', () => {
+    const args = buildPiArgs(base);
+    assert.deepEqual(args.slice(0, 6), [
+      '--mode', 'rpc', '--session-dir', '/data/sess',
+      '--session-id', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+  });
+
+  it('defaults to --no-approve and never emits --approve implicitly', () => {
+    const args = buildPiArgs(base);
+    assert.ok(args.includes('--no-approve'));
+    assert.ok(!args.includes('--approve'));
+  });
+
+  it('emits --approve only on an explicit opt-in', () => {
+    const args = buildPiArgs({ ...base, trustProject: true });
+    assert.ok(args.includes('--approve'));
+    assert.ok(!args.includes('--no-approve'));
+  });
+
+  it('appends the system prompt and never replaces Pi\'s own', () => {
+    const args = buildPiArgs({ ...base, appendSystemPrompt: 'workspace context' });
+    assert.ok(args.includes('--append-system-prompt'));
+    assert.equal(args[args.indexOf('--append-system-prompt') + 1], 'workspace context');
+    assert.ok(!args.includes('--system-prompt'), '--system-prompt would drop Pi\'s coding prompt');
+  });
+
+  it('passes provider / model / thinking through as separate argv entries', () => {
+    const args = buildPiArgs({ ...base, provider: 'anthropic', model: 'claude-sonnet-4-6', thinking: 'high' });
+    assert.equal(args[args.indexOf('--provider') + 1], 'anthropic');
+    assert.equal(args[args.indexOf('--model') + 1], 'claude-sonnet-4-6');
+    assert.equal(args[args.indexOf('--thinking') + 1], 'high');
+  });
+
+  it('loads explicit managed extensions without putting credentials in argv', () => {
+    const args = buildPiArgs({ ...base, extensions: ['/managed/pi-provider.mjs'] });
+    assert.equal(args[args.indexOf('--extension') + 1], '/managed/pi-provider.mjs');
+    assert.ok(!args.includes('--api-key'));
+  });
+
+  it('omits every optional flag when nothing is configured', () => {
+    const args = buildPiArgs(base);
+    for (const flag of ['--provider', '--model', '--thinking', '--extension', '--name', '--append-system-prompt']) {
+      assert.ok(!args.includes(flag), `${flag} must not appear`);
+    }
+  });
+
+  it('NEVER emits --api-key — credentials go through the environment only', () => {
+    const args = buildPiArgs({ ...base, provider: 'anthropic', model: 'm', apiKey: 'sk-should-be-ignored' });
+    assert.ok(!args.includes('--api-key'));
+    assert.ok(!args.some((a) => String(a).includes('sk-should-be-ignored')));
+  });
+});

--- a/packages/agent-connector/test/pi.test.js
+++ b/packages/agent-connector/test/pi.test.js
@@ -1,0 +1,1058 @@
+'use strict';
+
+/**
+ * PiAdapter tests.
+ *
+ * Everything runs against test/fixtures/mock-pi.js — a Node script that speaks
+ * the real Pi RPC protocol — so no Pi CLI, provider, API key or network is
+ * needed. The mock's wire format was captured from
+ * @earendil-works/pi-coding-agent v0.83.0.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const PiAdapter = require('../src/adapters/pi');
+const { ADAPTER_MAP, createAdapter } = require('../src/adapters');
+const { Installer } = require('../src/installer');
+const { MIN_NODE_VERSION } = require('../src/adapters/pi-stream');
+const { REASON } = require('../src/adapters/health-status');
+
+const IS_WINDOWS = process.platform === 'win32';
+const MOCK_PI_SRC = path.join(__dirname, 'fixtures', 'mock-pi.js');
+
+let tmpRoot;
+let fakeBin;      // what _findPiBinary returns
+let workDir;      // the agent's working directory
+let adapterSeq = 0;
+
+before(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-test-'));
+  workDir = path.join(tmpRoot, 'project');
+  fs.mkdirSync(workDir, { recursive: true });
+
+  const script = fs.readFileSync(MOCK_PI_SRC, 'utf-8');
+  if (IS_WINDOWS) {
+    // Mirror a REAL npm cmd-shim (`SET dp0=%~dp0` … `"%dp0%\…"`), not a
+    // simplified one: the adapter must parse it into [node, entry.js] so the
+    // long --append-system-prompt never goes through cmd.exe's 8191-char cap.
+    fs.writeFileSync(path.join(tmpRoot, 'fake-pi.js'), script);
+    fakeBin = path.join(tmpRoot, 'fake-pi.cmd');
+    fs.writeFileSync(
+      fakeBin,
+      '@ECHO off\r\nSET dp0=%~dp0\r\nnode "%dp0%\\fake-pi.js" %*\r\n',
+    );
+  } else {
+    fakeBin = path.join(tmpRoot, 'fake-pi');
+    fs.writeFileSync(fakeBin, script, { mode: 0o755 });
+  }
+});
+
+after(() => {
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+/**
+ * Build an adapter wired to the mock CLI, with every network-touching helper
+ * captured and all on-disk state redirected into the test temp dir.
+ */
+function makeAdapter(extra = {}) {
+  const id = ++adapterSeq;
+  const a = new PiAdapter({
+    workspaceId: extra.workspaceId || `ws-${id}`,
+    channelName: 'general',
+    token: 'workspace-token-value',
+    agentName: extra.agentName || `pi-bot-${id}`,
+    agentEnv: extra.agentEnv || {},
+    workingDir: 'workingDir' in extra ? extra.workingDir : workDir,
+  });
+
+  // Redirect all persisted state into the temp dir (the constructor computes
+  // real ~/.openagents paths, which the isolation test asserts on directly).
+  a._sessionsFile = path.join(tmpRoot, `sessions-${a.workspaceId}-${a.agentName}.json`);
+  a._sessionDir = path.join(tmpRoot, `pi-sessions-${a.workspaceId}-${a.agentName}`);
+
+  a._captured = { thinking: [], status: [], response: [], error: [] };
+  a.sendThinking = async (_c, t) => { a._captured.thinking.push(t); };
+  a.sendStatus = async (_c, t) => { a._captured.status.push(t); };
+  a.sendResponse = async (_c, t) => { a._captured.response.push(t); };
+  a.sendError = async (_c, t) => { a._captured.error.push(t); };
+  a._statuses = [];
+  a._reportStatus = (reason, message) => { a._statuses.push({ reason, message }); };
+  a._log = () => {};
+
+  a.client = {
+    getSession: async () => ({ title: 'Session 1', titleManuallySet: false, resumeFrom: null }),
+    updateSession: async () => ({}),
+    getWorkspaceMetadata: async () => ({ browserEnabled: false }),
+    sendMessage: async () => ({}),
+    readFile: async () => Buffer.from('fake-image-bytes'),
+  };
+
+  a._findPiBinary = () => fakeBin;
+  a._piBin = fakeBin;
+  return a;
+}
+
+function msg(content, channel = 'thread-a', extra = {}) {
+  return Object.assign({ content, sessionId: channel, senderName: 'user' }, extra);
+}
+
+/** Read the argv/cwd/env snapshot the mock wrote. */
+function readArgvLog(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf-8'));
+}
+
+async function shutdown(a) {
+  for (const channel of Object.keys(a._persistentProcs)) {
+    await a._killPersistentProc(channel, 'test teardown');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 12: registration
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — registration', () => {
+  it('is registered under the `pi` agent type', () => {
+    assert.equal(ADAPTER_MAP.pi, PiAdapter);
+    const inst = createAdapter('pi', {
+      workspaceId: 'ws', channelName: 't', token: 'tok', agentName: 'p', agentEnv: {},
+    });
+    assert.ok(inst instanceof PiAdapter);
+  });
+
+  it('is listed in the registry catalog with an npm install spec', () => {
+    const catalog = require('../registry.json');
+    const entry = catalog.find((e) => e.name === 'pi');
+    assert.ok(entry, 'registry.json must contain a `pi` entry');
+    assert.equal(entry.install.binary, 'pi');
+    assert.equal(entry.install.npm_package, '@earendil-works/pi-coding-agent');
+    assert.deepEqual(entry.install.requires, ['nodejs']);
+    for (const key of ['macos', 'linux', 'windows']) {
+      assert.match(entry.install[key], /^npm install -g @earendil-works\/pi-coding-agent@\d+\.\d+\.\d+$/, key);
+    }
+    assert.equal(entry.adapter.class, 'PiAdapter');
+    assert.ok(entry.install.min_version);
+    assert.ok(entry.install.verify && entry.install.verify_win);
+    assert.equal(entry.check_ready.creds_json_has_entries, true);
+  });
+
+  it('does not treat an auto-created empty auth.json as a CLI login', () => {
+    const authFile = path.join(tmpRoot, 'pi-auth.json');
+    const checkReady = {
+      creds_file: authFile,
+      creds_no_parse: true,
+      creds_json_has_entries: true,
+      not_ready_message: 'Pi login required',
+    };
+    const entry = { name: 'pi', check_ready: checkReady };
+    const installer = new Installer({ getEntry: () => entry, getResolveRules: () => [] }, tmpRoot);
+    installer.env.getEffective = () => ({});
+
+    fs.writeFileSync(authFile, '{}');
+    assert.equal(installer._evaluateReadiness('pi', entry, '/fake/pi').ready, false);
+
+    fs.writeFileSync(authFile, JSON.stringify({ 'openai-codex': { type: 'oauth', access: 'redacted' } }));
+    const loggedIn = installer._evaluateReadiness('pi', entry, '/fake/pi');
+    assert.equal(loggedIn.ready, true);
+    assert.equal(loggedIn.auth_mode, 'cli_login');
+  });
+
+  it('keeps the registry.json entry identical to the pi.yaml source', () => {
+    // build:registry cannot run (its REGISTRY_DIR points at a path that does
+    // not exist in this repo), so the bundle is hand-synced — this guards it.
+    const yaml = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'sdk', 'src', 'openagents', 'registry', 'pi.yaml'),
+      'utf-8',
+    );
+    const entry = require('../registry.json').find((e) => e.name === 'pi');
+    for (const value of [
+      entry.install.npm_package,
+      entry.install.min_version,
+      entry.install.linux,
+      entry.check_ready.creds_file,
+      entry.adapter.class,
+    ]) {
+      assert.ok(yaml.includes(value), `pi.yaml is missing "${value}"`);
+    }
+    for (const field of entry.env_config) {
+      assert.ok(yaml.includes(`name: ${field.name}`), `pi.yaml is missing env ${field.name}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13 / 14: binary + CLI entry-point resolution
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — binary resolution', () => {
+  it('prefers the isolated runtime prefix over anything on PATH', () => {
+    const home = fs.mkdtempSync(path.join(tmpRoot, 'home-'));
+    const binDir = path.join(home, '.openagents', 'runtimes', 'pi', 'node_modules', '.bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const expected = path.join(binDir, IS_WINDOWS ? 'pi.cmd' : 'pi');
+    fs.writeFileSync(expected, '#!/usr/bin/env node\n');
+
+    const a = makeAdapter();
+    delete a._findPiBinary; // use the real resolver
+    const realHomedir = os.homedir;
+    os.homedir = () => home;
+    try {
+      assert.equal(a._findPiBinary(), expected);
+    } finally {
+      os.homedir = realHomedir;
+    }
+  });
+
+  it('falls back to the package entry point when npm left no .bin shim', () => {
+    const home = fs.mkdtempSync(path.join(tmpRoot, 'home-nobin-'));
+    const pkgName = require('../registry.json').find((e) => e.name === 'pi').install.npm_package;
+    const pkgRoot = path.join(
+      home, '.openagents', 'runtimes', 'pi', 'node_modules', ...pkgName.split('/'),
+    );
+    const pkgDir = path.join(pkgRoot, 'dist');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    const entry = path.join(pkgDir, 'cli.js');
+    fs.writeFileSync(entry, '#!/usr/bin/env node\n');
+    // The entry path comes from the package's own manifest, so the adapter
+    // never has to know it — a real install always ships this file.
+    fs.writeFileSync(path.join(pkgRoot, 'package.json'),
+      JSON.stringify({ name: pkgName, bin: { pi: 'dist/cli.js' } }));
+
+    const a = makeAdapter();
+    delete a._findPiBinary;
+    const realHomedir = os.homedir;
+    os.homedir = () => home;
+    try {
+      assert.equal(a._findPiBinary(), entry);
+    } finally {
+      os.homedir = realHomedir;
+    }
+  });
+
+  it('resolves the npm .bin symlink to [node, dist/cli.js] on macOS/Linux',
+    { skip: IS_WINDOWS ? 'POSIX symlink shim' : false }, () => {
+      const root = fs.mkdtempSync(path.join(tmpRoot, 'shim-'));
+      const distDir = path.join(root, 'node_modules', '@earendil-works', 'pi-coding-agent', 'dist');
+      const binDir = path.join(root, 'node_modules', '.bin');
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.mkdirSync(binDir, { recursive: true });
+      const entry = path.join(distDir, 'cli.js');
+      fs.writeFileSync(entry, '#!/usr/bin/env node\n');
+      const shim = path.join(binDir, 'pi');
+      fs.symlinkSync(path.relative(binDir, entry), shim);
+
+      const a = makeAdapter();
+      const resolved = a._resolveToNodeCmd(shim);
+      assert.ok(resolved, 'the shim must resolve to a node + entry pair');
+      assert.equal(resolved.length, 2);
+      assert.equal(resolved[1], entry);
+      assert.ok(fs.existsSync(resolved[0]), 'the resolved node interpreter must exist');
+    });
+
+  it('parses a real Windows .cmd shim into [node, entry.js] on Windows',
+    { skip: IS_WINDOWS ? false : 'Windows-only: _resolveToNodeCmd gates on the platform' }, () => {
+      const root = fs.mkdtempSync(path.join(tmpRoot, 'wincmd-'));
+      fs.writeFileSync(path.join(root, 'entry.js'), '// entry\n');
+      const cmd = path.join(root, 'pi.cmd');
+      // The modern npm cmd-shim dialect.
+      fs.writeFileSync(cmd,
+        '@ECHO off\r\nGOTO start\r\n:find_dp0\r\nSET dp0=%~dp0\r\nEXIT /b\r\n:start\r\n' +
+        'SETLOCAL\r\nCALL :find_dp0\r\n"%dp0%\\node.exe"  "%dp0%\\entry.js" %*\r\n');
+
+      const a = makeAdapter();
+      const resolved = a._resolveToNodeCmd(cmd);
+      assert.ok(resolved, 'the shim must parse, or the long system prompt hits cmd.exe\'s 8191-char cap');
+      assert.equal(resolved.length, 2);
+      assert.equal(resolved[1], path.join(root, 'entry.js'));
+    });
+
+  it('parses the bundled fixture shim on Windows',
+    { skip: IS_WINDOWS ? false : 'Windows-only shim format' }, () => {
+      const a = makeAdapter();
+      const resolved = a._resolveToNodeCmd(fakeBin);
+      assert.ok(resolved, 'the test fixture must exercise the parsed path, not cmd.exe /c');
+      assert.equal(resolved.length, 2);
+      assert.equal(resolved[1], path.join(tmpRoot, 'fake-pi.js'));
+    });
+
+  it('runs a shebang script under a Node we choose rather than the shebang', () => {
+    const a = makeAdapter();
+    const resolved = a._resolveToNodeCmd(fakeBin);
+    if (IS_WINDOWS) {
+      assert.ok(resolved, 'the .cmd shim resolves to node + js');
+      assert.ok(resolved[1].endsWith('.js'));
+    } else {
+      assert.deepEqual(resolved, [a._findNodeBin(), fakeBin]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15 / 16 / 17: preflight
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — preflight', () => {
+  it('reports RUNTIME_MISSING with an install hint when the CLI is absent', () => {
+    const a = makeAdapter();
+    a._piBin = null;
+    a._findPiBinary = () => null;
+    const pf = a.preflight();
+    assert.equal(pf.ok, false);
+    assert.equal(pf.reason, REASON.RUNTIME_MISSING);
+    assert.match(pf.message, /openagents install pi/);
+  });
+
+  it(`reports VERSION_INCOMPATIBLE when Node is below ${MIN_NODE_VERSION}`, () => {
+    const a = makeAdapter();
+    PiAdapter._clearVersionCache();
+    a._findNodeBin = () => '/fake/old/node';
+    a._readNodeVersionRaw = () => 'v20.11.1';
+    const pf = a.preflight();
+    assert.equal(pf.ok, false);
+    assert.equal(pf.reason, REASON.VERSION_INCOMPATIBLE);
+    assert.match(pf.message, /Node\.js >= 22\.19\.0/);
+    assert.match(pf.message, /20\.11\.1/);
+    PiAdapter._clearVersionCache();
+  });
+
+  it('accepts a Node at or above the floor', () => {
+    const a = makeAdapter();
+    PiAdapter._clearVersionCache();
+    a._findNodeBin = () => '/fake/new/node';
+    a._readNodeVersionRaw = () => 'v22.22.3';
+    assert.equal(a.preflight().ok, true);
+    PiAdapter._clearVersionCache();
+  });
+
+  it('reports VERSION_INCOMPATIBLE for a confirmed-old Pi', () => {
+    const a = makeAdapter();
+    PiAdapter._clearVersionCache();
+    a._readNodeVersionRaw = () => 'v22.22.3';
+    a._readPiVersionRaw = () => '0.50.0';
+    const pf = a.preflight();
+    assert.equal(pf.ok, false);
+    assert.equal(pf.reason, REASON.VERSION_INCOMPATIBLE);
+    assert.match(pf.message, /0\.50\.0/);
+    PiAdapter._clearVersionCache();
+  });
+
+  it('detects the Pi version from the real mock CLI and passes', () => {
+    const a = makeAdapter({ agentEnv: { FAKE_PI_VERSION: '0.83.0' } });
+    PiAdapter._clearVersionCache();
+    // Pin the Node probe: preflight would otherwise read the version of the
+    // runtime executing the tests, so this case failed on the CI matrix's
+    // Node 20 legs even though it is about detecting the PI version.
+    a._readNodeVersionRaw = () => 'v22.22.3';
+    const probe = a._checkPiVersion(fakeBin);
+    assert.equal(probe.version, '0.83.0');
+    assert.equal(probe.compatible, true);
+    assert.equal(a.preflight().ok, true);
+    PiAdapter._clearVersionCache();
+  });
+
+  it('proceeds leniently when the version cannot be determined', () => {
+    const a = makeAdapter();
+    PiAdapter._clearVersionCache();
+    a._readPiVersionRaw = () => { throw new Error('boom'); };
+    a._readNodeVersionRaw = () => 'v22.22.3';
+    assert.equal(a._checkPiVersion(fakeBin).compatible, null);
+    assert.equal(a.preflight().ok, true);
+    PiAdapter._clearVersionCache();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 18 / 28 / 29: launch command, argv, cwd, env
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — launch command', () => {
+  it('spawns RPC mode in workingDir with the configured provider/model and NO key in argv', async () => {
+    const log = path.join(tmpRoot, `argv-${Date.now()}.json`);
+    const a = makeAdapter({
+      agentEnv: {
+        FAKE_SCENARIO: 'complete',
+        FAKE_ARGV_LOG: log,
+        PI_PROVIDER: 'anthropic',
+        PI_MODEL: 'claude-sonnet-4-6',
+        PI_THINKING: 'high',
+        ANTHROPIC_API_KEY: 'sk-ant-SECRETVALUE0123456789',
+      },
+    });
+    await a._handleMessage(msg('fix the bug'));
+    const snap = readArgvLog(log);
+
+    // RPC mode, in the agent's working directory
+    assert.equal(snap.argv[0], '--mode');
+    assert.equal(snap.argv[1], 'rpc');
+    assert.equal(fs.realpathSync(snap.cwd), fs.realpathSync(workDir));
+
+    // Session storage is OpenAgents-managed, never the user's project.
+    const sessionDir = snap.argv[snap.argv.indexOf('--session-dir') + 1];
+    assert.equal(sessionDir, a._sessionDir);
+    assert.ok(!sessionDir.startsWith(workDir), 'sessions must not land in the project');
+    assert.ok(!sessionDir.includes(path.join('.pi', 'agent')), 'must not reuse ~/.pi/agent/sessions');
+
+    // Configuration reaches Pi as separate argv entries (no shell string).
+    assert.equal(snap.argv[snap.argv.indexOf('--provider') + 1], 'anthropic');
+    assert.equal(snap.argv[snap.argv.indexOf('--model') + 1], 'claude-sonnet-4-6');
+    assert.equal(snap.argv[snap.argv.indexOf('--thinking') + 1], 'high');
+
+    // The API key is injected ONLY through the environment.
+    assert.ok(!snap.argv.includes('--api-key'));
+    assert.ok(!snap.argv.some((x) => x.includes('sk-ant-SECRETVALUE0123456789')),
+      'the API key must never appear in argv');
+    assert.equal(snap.env.ANTHROPIC_API_KEY, 'sk-ant-SECRETVALUE0123456789');
+
+    await shutdown(a);
+  });
+
+  it('maps the unified Launcher key and loads the process-local provider extension', async () => {
+    const log = path.join(tmpRoot, `argv-relay-${Date.now()}.json`);
+    const secret = 'relay-secret-DO-NOT-LOG-12345';
+    const a = makeAdapter({
+      agentEnv: {
+        FAKE_SCENARIO: 'complete',
+        FAKE_ARGV_LOG: log,
+        PI_PROVIDER: 'deepseek',
+        PI_MODEL: 'deepseek-v4-flash',
+        PI_BASE_URL: 'https://relay.example/v1',
+        PI_API_FORMAT: 'openai-completions',
+        PI_API_KEY: secret,
+      },
+    });
+    await a._handleMessage(msg('hello'));
+    const snap = readArgvLog(log);
+
+    assert.equal(snap.env.PI_API_KEY, secret);
+    assert.equal(snap.env.DEEPSEEK_API_KEY, secret);
+    assert.equal(snap.env.PI_BASE_URL, 'https://relay.example/v1');
+    const extension = snap.argv[snap.argv.indexOf('--extension') + 1];
+    assert.match(extension, /pi-launcher-provider\.mjs$/);
+    assert.ok(!snap.argv.some((arg) => String(arg).includes(secret)));
+    await shutdown(a);
+  });
+
+  it('loads the process-local provider extension for a native Launcher key', async () => {
+    const log = path.join(tmpRoot, `argv-native-key-${Date.now()}.json`);
+    const secret = 'native-secret-DO-NOT-LOG-12345';
+    const a = makeAdapter({
+      agentEnv: {
+        FAKE_SCENARIO: 'complete',
+        FAKE_ARGV_LOG: log,
+        PI_PROVIDER: 'deepseek',
+        PI_MODEL: 'deepseek-v4-flash',
+        PI_API_KEY: secret,
+      },
+    });
+    await a._handleMessage(msg('hello'));
+    const snap = readArgvLog(log);
+
+    assert.equal(snap.env.PI_API_KEY, secret);
+    assert.equal(snap.env.DEEPSEEK_API_KEY, secret);
+    const extension = snap.argv[snap.argv.indexOf('--extension') + 1];
+    assert.match(extension, /pi-launcher-provider\.mjs$/);
+    assert.ok(!snap.argv.some((arg) => String(arg).includes(secret)));
+    await shutdown(a);
+  });
+
+  it('requires provider and model before launching a custom base URL', async () => {
+    const a = makeAdapter({
+      agentEnv: { FAKE_SCENARIO: 'complete', PI_BASE_URL: 'https://relay.example/v1' },
+    });
+    await a._handleMessage(msg('hello'));
+    assert.equal(a._captured.error.length, 1);
+    assert.match(a._captured.error[0], /PI_PROVIDER and PI_MODEL are required/);
+    await shutdown(a);
+  });
+
+  it('registers a Launcher relay entirely from the child environment', async () => {
+    const names = ['PI_PROVIDER', 'PI_MODEL', 'PI_BASE_URL', 'PI_API_FORMAT', 'PI_API_KEY', 'PI_THINKING'];
+    const before = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+    Object.assign(process.env, {
+      PI_PROVIDER: 'anthropic',
+      PI_MODEL: 'relay-claude',
+      PI_BASE_URL: 'https://relay.example/v1',
+      PI_API_FORMAT: 'anthropic-messages',
+      PI_API_KEY: 'relay-key-in-memory-only',
+      PI_THINKING: 'high',
+    });
+    try {
+      const extensionUrl = pathToFileURL(
+        path.join(__dirname, '..', 'src', 'adapters', 'pi-launcher-provider.mjs'),
+      );
+      extensionUrl.searchParams.set('test', String(Date.now()));
+      const configure = (await import(extensionUrl.href)).default;
+      let registered;
+      configure({ registerProvider: (provider, config) => { registered = { provider, config }; } });
+
+      assert.equal(registered.provider, 'anthropic');
+      assert.equal(registered.config.baseUrl, 'https://relay.example');
+      assert.equal(registered.config.api, 'anthropic-messages');
+      assert.equal(registered.config.apiKey, 'relay-key-in-memory-only');
+      assert.equal(registered.config.authHeader, true);
+      assert.equal(registered.config.models[0].id, 'relay-claude');
+      assert.equal(registered.config.models[0].reasoning, true);
+      assert.deepEqual(registered.config.models[0].cost, {
+        input: 0, output: 0, cacheRead: 0, cacheWrite: 0, tiers: [],
+      });
+    } finally {
+      for (const name of names) {
+        if (before[name] === undefined) delete process.env[name];
+        else process.env[name] = before[name];
+      }
+    }
+  });
+
+  it('registers native DeepSeek with an explicit process-local key', async () => {
+    const names = ['PI_PROVIDER', 'PI_MODEL', 'PI_BASE_URL', 'PI_API_FORMAT', 'PI_API_KEY'];
+    const before = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+    Object.assign(process.env, {
+      PI_PROVIDER: 'deepseek',
+      PI_MODEL: 'deepseek-v4-flash',
+      PI_API_KEY: 'native-key-in-memory-only',
+    });
+    delete process.env.PI_BASE_URL;
+    delete process.env.PI_API_FORMAT;
+    try {
+      const extensionUrl = pathToFileURL(
+        path.join(__dirname, '..', 'src', 'adapters', 'pi-launcher-provider.mjs'),
+      );
+      extensionUrl.searchParams.set('test', String(Date.now()));
+      const configure = (await import(extensionUrl.href)).default;
+      let registered;
+      configure({ registerProvider: (provider, config) => { registered = { provider, config }; } });
+
+      assert.equal(registered.provider, 'deepseek');
+      assert.equal(registered.config.baseUrl, 'https://api.deepseek.com/v1');
+      assert.equal(registered.config.api, 'openai-completions');
+      assert.equal(registered.config.apiKey, 'native-key-in-memory-only');
+      assert.equal(registered.config.models[0].id, 'deepseek-v4-flash');
+      assert.deepEqual(registered.config.models[0].cost, {
+        input: 0, output: 0, cacheRead: 0, cacheWrite: 0, tiers: [],
+      });
+    } finally {
+      for (const name of names) {
+        if (before[name] === undefined) delete process.env[name];
+        else process.env[name] = before[name];
+      }
+    }
+  });
+
+  it('registers a custom relay without forcing a Launcher key', async () => {
+    const names = ['PI_PROVIDER', 'PI_MODEL', 'PI_BASE_URL', 'PI_API_FORMAT', 'PI_API_KEY'];
+    const before = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+    Object.assign(process.env, {
+      PI_PROVIDER: 'custom',
+      PI_MODEL: 'relay-model',
+      PI_BASE_URL: 'https://relay.example/v1',
+      PI_API_FORMAT: 'openai-completions',
+    });
+    delete process.env.PI_API_KEY;
+    try {
+      const extensionUrl = pathToFileURL(
+        path.join(__dirname, '..', 'src', 'adapters', 'pi-launcher-provider.mjs'),
+      );
+      extensionUrl.searchParams.set('test', String(Date.now()));
+      const configure = (await import(extensionUrl.href)).default;
+      let registered;
+      configure({ registerProvider: (provider, config) => { registered = { provider, config }; } });
+
+      assert.equal(registered.provider, 'custom');
+      assert.equal(registered.config.baseUrl, 'https://relay.example/v1');
+      assert.equal(registered.config.apiKey, undefined);
+    } finally {
+      for (const name of names) {
+        if (before[name] === undefined) delete process.env[name];
+        else process.env[name] = before[name];
+      }
+    }
+  });
+
+  it('defaults to --no-approve and never blocks on a trust prompt', async () => {
+    const log = path.join(tmpRoot, `argv-trust-${Date.now()}.json`);
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete', FAKE_ARGV_LOG: log } });
+    await a._handleMessage(msg('hello'));
+    const snap = readArgvLog(log);
+    assert.ok(snap.argv.includes('--no-approve'));
+    assert.ok(!snap.argv.includes('--approve'));
+    // The turn completed, i.e. nothing waited on terminal interaction.
+    assert.equal(a._captured.response.length, 1);
+    await shutdown(a);
+  });
+
+  it('switches to --approve only when PI_TRUST_PROJECT opts in', async () => {
+    const log = path.join(tmpRoot, `argv-trust2-${Date.now()}.json`);
+    const a = makeAdapter({
+      agentEnv: { FAKE_SCENARIO: 'complete', FAKE_ARGV_LOG: log, PI_TRUST_PROJECT: '1' },
+    });
+    await a._handleMessage(msg('hello'));
+    const snap = readArgvLog(log);
+    assert.ok(snap.argv.includes('--approve'));
+    assert.ok(!snap.argv.includes('--no-approve'));
+    await shutdown(a);
+  });
+
+  it('appends the workspace system prompt without replacing Pi\'s own', async () => {
+    const log = path.join(tmpRoot, `argv-sys-${Date.now()}.json`);
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete', FAKE_ARGV_LOG: log } });
+    await a._handleMessage(msg('hello'));
+    const snap = readArgvLog(log);
+    const idx = snap.argv.indexOf('--append-system-prompt');
+    assert.ok(idx >= 0);
+    assert.ok(!snap.argv.includes('--system-prompt'));
+    const prompt = snap.argv[idx + 1];
+    assert.match(prompt, /OpenAgents workspace/);
+    assert.match(prompt, new RegExp(a.agentName));
+    await shutdown(a);
+  });
+
+  it('reports a missing working directory instead of spawning', async () => {
+    const a = makeAdapter({ workingDir: path.join(tmpRoot, 'nope') });
+    await a._handleMessage(msg('hello'));
+    assert.equal(a._captured.error.length, 1);
+    assert.match(a._captured.error[0], /Working directory does not exist/);
+    assert.equal(Object.keys(a._persistentProcs).length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 19: no Pi SDK anywhere in the source
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — CLI-only integration', () => {
+  it('never imports a Pi SDK or internal Pi module', () => {
+    const files = ['pi.js', 'pi-stream.js'].map((f) =>
+      fs.readFileSync(path.join(__dirname, '..', 'src', 'adapters', f), 'utf-8'));
+    const BANNED = [
+      /require\(\s*['"]@earendil-works\//,
+      /require\(\s*['"]pi-coding-agent/,
+      /from\s+['"]@earendil-works\//,
+      /import\(\s*['"]@earendil-works\//,
+      /\bAgentSession\b\s*\(/,
+    ];
+    for (const src of files) {
+      for (const re of BANNED) {
+        assert.ok(!re.test(src), `source must not match ${re}`);
+      }
+    }
+  });
+
+  it('declares no new runtime dependency for Pi', () => {
+    const pkg = require('../package.json');
+    assert.deepEqual(Object.keys(pkg.dependencies).sort(), ['blessed', 'ws']);
+  });
+
+  it('keeps the npm package name and version floor out of adapter code', () => {
+    // The contract: package identity lives in registry configuration only.
+    const src = fs.readFileSync(path.join(__dirname, '..', 'src', 'adapters', 'pi.js'), 'utf-8');
+    const entry = require('../registry.json').find((e) => e.name === 'pi');
+    // The literal package name appears only inside comments, never in code.
+    const code = src.split('\n')
+      .filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l))
+      .join('\n');
+    assert.ok(!code.includes(entry.install.npm_package),
+      'the npm package name must be read from the registry, not written in pi.js');
+    assert.ok(!code.includes(entry.install.min_version),
+      'the version floor must be read from the registry, not written in pi.js');
+  });
+
+  it('resolves the package entry point from the registry + the installed manifest', () => {
+    const entry = require('../registry.json').find((e) => e.name === 'pi');
+    const home = fs.mkdtempSync(path.join(tmpRoot, 'pkgentry-'));
+    const pkgDir = path.join(
+      home, '.openagents', 'runtimes', 'pi', 'node_modules',
+      ...entry.install.npm_package.split('/'),
+    );
+    fs.mkdirSync(path.join(pkgDir, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'dist', 'cli.js'), '#!/usr/bin/env node\n');
+    fs.writeFileSync(path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: entry.install.npm_package, bin: { pi: 'dist/cli.js' } }));
+
+    const a = makeAdapter();
+    assert.equal(a._findPackageEntryPoint(home), path.join(pkgDir, 'dist', 'cli.js'));
+  });
+
+  it('takes the version floor from the registry entry', () => {
+    const entry = require('../registry.json').find((e) => e.name === 'pi');
+    const a = makeAdapter();
+    PiAdapter._clearVersionCache();
+    a._readNodeVersionRaw = () => 'v22.22.3';
+    // One patch below the registry's declared floor must be refused.
+    const [maj, min] = entry.install.min_version.split('.').map(Number);
+    a._readPiVersionRaw = () => `${maj}.${Math.max(0, min - 1)}.0`;
+    const pf = a.preflight();
+    assert.equal(pf.reason, REASON.VERSION_INCOMPATIBLE);
+    assert.match(pf.message, new RegExp(entry.install.min_version.replace(/\./g, '\\.')));
+    PiAdapter._clearVersionCache();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 20 / 21 / 22 / 23: sessions, process reuse and isolation
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — session + process isolation', () => {
+  it('reuses one process for consecutive messages in the same channel', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('first', 'thread-a'));
+    const pid1 = a._persistentProcs['thread-a'].proc.pid;
+    const session1 = a._persistentProcs['thread-a'].sessionId;
+
+    await a._handleMessage(msg('second', 'thread-a'));
+    const pp = a._persistentProcs['thread-a'];
+    assert.equal(pp.proc.pid, pid1, 'the same process must serve the follow-up');
+    assert.equal(pp.sessionId, session1);
+    // The mock echoes its per-process prompt counter — proof the SAME process
+    // (and therefore the same Pi conversation) handled both turns.
+    assert.match(a._captured.response[0], /^Done \(prompt #1\): first$/);
+    assert.match(a._captured.response[1], /^Done \(prompt #2\): second$/);
+    await shutdown(a);
+  });
+
+  it('gives each channel its own process and its own Pi session', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('a', 'thread-a'));
+    await a._handleMessage(msg('b', 'thread-b'));
+
+    const ppA = a._persistentProcs['thread-a'];
+    const ppB = a._persistentProcs['thread-b'];
+    assert.notEqual(ppA.proc.pid, ppB.proc.pid);
+    assert.notEqual(ppA.sessionId, ppB.sessionId);
+    // Each channel's Pi process counted its own prompts → separate contexts.
+    assert.match(a._captured.response[1], /^Done \(prompt #1\): b$/);
+    await shutdown(a);
+  });
+
+  it('isolates session state per workspace and per agent on disk', () => {
+    const one = new PiAdapter({ workspaceId: 'ws-1', channelName: 'g', token: 't', agentName: 'alpha', agentEnv: {} });
+    const two = new PiAdapter({ workspaceId: 'ws-1', channelName: 'g', token: 't', agentName: 'beta', agentEnv: {} });
+    const three = new PiAdapter({ workspaceId: 'ws-2', channelName: 'g', token: 't', agentName: 'alpha', agentEnv: {} });
+
+    const files = [one._sessionsFile, two._sessionsFile, three._sessionsFile];
+    assert.equal(new Set(files).size, 3, 'no two agents may share a session file');
+    for (const f of files) assert.match(f, /[/\\]\.openagents[/\\]sessions[/\\]/);
+    assert.match(one._sessionsFile, /ws-1_alpha_pi\.json$/);
+
+    const dirs = [one._sessionDir, two._sessionDir, three._sessionDir];
+    assert.equal(new Set(dirs).size, 3, 'no two agents may share a Pi session directory');
+    for (const d of dirs) {
+      assert.match(d, /[/\\]\.openagents[/\\]pi-sessions[/\\]/);
+      assert.ok(!d.includes(path.join('.pi', 'agent')), 'never write into the user-global Pi session store');
+    }
+  });
+
+  it('persists a channel session and resumes the same id after a restart', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('hello', 'thread-a'));
+    const sessionId = a._channelSessions['thread-a'].sessionId;
+    assert.match(sessionId, /^[0-9a-f-]{36}$/);
+    await shutdown(a);
+
+    // A "restarted launcher": a brand-new adapter reading the same file.
+    const b = makeAdapter({ workspaceId: a.workspaceId, agentName: a.agentName });
+    b._sessionsFile = a._sessionsFile;
+    b._loadSessions();
+    assert.equal(b._sessionIdFor('thread-a', workDir), sessionId);
+  });
+
+  it('mints a fresh session when the sessions file is corrupt', () => {
+    const a = makeAdapter();
+    fs.writeFileSync(a._sessionsFile, '{ this is not json');
+    a._channelSessions = {};
+    a._loadSessions();
+    assert.deepEqual(a._channelSessions, {});
+    const id = a._sessionIdFor('thread-a', workDir);
+    assert.match(id, /^[0-9a-f-]{36}$/);
+  });
+
+  it('discards a stored session id that is not a valid UUID', () => {
+    const a = makeAdapter();
+    fs.writeFileSync(a._sessionsFile, JSON.stringify({ 'thread-a': { sessionId: 'garbage' } }));
+    a._channelSessions = {};
+    a._loadSessions();
+    assert.equal(a._channelSessions['thread-a'], undefined);
+    assert.notEqual(a._sessionIdFor('thread-a', workDir), 'garbage');
+  });
+
+  it('does not resume a session bound to a different working directory', () => {
+    const a = makeAdapter();
+    a._channelSessions['thread-a'] = { sessionId: '11111111-2222-3333-4444-555555555555', workingDir: '/other/project' };
+    const id = a._sessionIdFor('thread-a', workDir);
+    assert.notEqual(id, '11111111-2222-3333-4444-555555555555');
+    assert.equal(a._channelSessions['thread-a'].workingDir, workDir);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event → workspace mapping
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — event mapping', () => {
+  it('streams interim text + tool status and posts the final answer once', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('fix it'));
+
+    assert.deepEqual(a._captured.response, ['Done (prompt #1): fix it']);
+    assert.ok(a._captured.thinking.includes('Let me look at the file.'));
+    assert.ok(a._captured.status.some((s) => s.startsWith('read › src/x.js')),
+      `tool status missing: ${JSON.stringify(a._captured.status)}`);
+    // The streamed block and the message_end payload must not both be posted.
+    const narrations = a._captured.thinking.filter((t) => t === 'Let me look at the file.');
+    assert.equal(narrations.length, 1, 'interim text posted exactly once');
+    assert.equal(a._captured.error.length, 0);
+    await shutdown(a);
+  });
+
+  it('posts the final answer EXACTLY once — never as thinking and as a reply', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('fix it'));
+
+    const answer = 'Done (prompt #1): fix it';
+    assert.deepEqual(a._captured.response, [answer]);
+    assert.ok(!a._captured.thinking.includes(answer),
+      `the answer must not also be posted as thinking: ${JSON.stringify(a._captured.thinking)}`);
+    // Narration before the tool call still streams — only the answer is held.
+    assert.deepEqual(a._captured.thinking, ['Let me look at the file.']);
+    await shutdown(a);
+  });
+
+  it('does not drop a superseded answer candidate — it becomes thinking', async () => {
+    // Two consecutive assistant messages that both end with stopReason 'stop':
+    // the first is superseded and must resurface as thinking, not vanish.
+    const a = makeAdapter();
+    const pp = {
+      msgChannel: 'thread-a', pending: new Map(), heldTexts: [], turnTexts: [],
+      acc: new (require('../src/adapters/pi-stream').PiAssistantAccumulator)(),
+    };
+    const send = (message) => a._handleEvent(pp, {
+      kind: 'message_end', message: { role: 'assistant', ...message },
+    });
+    await send({ content: [{ type: 'text', text: 'first pass' }], stopReason: 'stop' });
+    await send({ content: [{ type: 'text', text: 'second pass' }], stopReason: 'stop' });
+
+    assert.deepEqual(pp.turnTexts, ['second pass'], 'the last message is the answer');
+    assert.deepEqual(a._captured.thinking, ['first pass'], 'the superseded one is not lost');
+  });
+
+  it('reports a successful tool completion, not just failures', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('fix it'));
+    assert.ok(a._captured.status.some((s) => s.startsWith('read ✓')),
+      `expected a tool-completed status: ${JSON.stringify(a._captured.status)}`);
+    await shutdown(a);
+  });
+
+  it('redacts this agent\'s exact credentials in every diagnostic path', async () => {
+    // A Google key matches NO generic secret pattern, so only the instance's
+    // concrete secret list can mask it. The pure classifier cannot know it.
+    const key = 'AIzaSyD-1234567890abcdefghijklmnop';
+    const a = makeAdapter({ agentEnv: { GEMINI_API_KEY: key } });
+    const logged = [];
+    a._log = (m) => logged.push(m);
+    const pp = { msgChannel: 'thread-a', pending: new Map(), heldTexts: [], turnTexts: [] };
+
+    await a._handleEvent(pp, { kind: 'extension_error', message: `boom: GEMINI_API_KEY=${key}` });
+    await a._handleEvent(pp, { kind: 'unknown', raw: `{"payload":"${key}"}` });
+    await a._handleEvent(pp, { kind: 'tool_start', toolName: 'bash', preview: `echo ${key}` });
+    await a._handleEvent(pp, { kind: 'tool_end', toolName: 'bash', isError: true, preview: key });
+    await a._handleEvent(pp, {
+      kind: 'compaction_end', reason: 'threshold', aborted: false, error: `upstream ${key}`,
+    });
+
+    for (const line of [...a._captured.status, ...logged]) {
+      assert.ok(!line.includes(key), `credential leaked: ${line}`);
+    }
+    assert.ok(a._captured.status.length > 0, 'the statuses were actually exercised');
+    // The workspace token is masked the same way.
+    await a._handleEvent(pp, { kind: 'extension_error', message: `token ${a.token}` });
+    assert.ok(!a._captured.status.at(-1).includes(a.token));
+  });
+
+  it('carries multi-byte text through the stream unmangled', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'unicode' } });
+    await a._handleMessage(msg('修复这个 bug'));
+    assert.deepEqual(a._captured.response, ['完成了：修复这个 bug 🚀']);
+    await shutdown(a);
+  });
+
+  it('surfaces a provider auth failure as a redacted, actionable error', async () => {
+    const a = makeAdapter({
+      agentEnv: { FAKE_SCENARIO: 'auth_error', ANTHROPIC_API_KEY: 'sk-ant-SECRETVALUE0123456789' },
+    });
+    await a._handleMessage(msg('hello'));
+
+    assert.equal(a._captured.response.length, 0, 'a failed turn must not post an answer');
+    assert.equal(a._captured.error.length, 1);
+    const err = a._captured.error[0];
+    assert.match(err, /authentication failed/i);
+    assert.ok(!err.includes('sk-ant-SECRETVALUE0123456789'), 'the key must be redacted');
+    assert.ok(a._statuses.some((s) => s.reason === REASON.LOGIN_REQUIRED));
+    await shutdown(a);
+  });
+
+  it('auto-cancels a blocking extension UI request instead of hanging', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'ui_prompt' } });
+    // Without the auto-cancel the mock never settles and this would time out.
+    await a._handleMessage(msg('do something risky'));
+    assert.ok(a._captured.status.some((s) => /requested interactive input/.test(s)),
+      `expected a dismissal notice: ${JSON.stringify(a._captured.status)}`);
+    await shutdown(a);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 24 / 25 / 26 / 27: stop, abort escalation, crashes, teardown
+// ---------------------------------------------------------------------------
+
+describe('PiAdapter — stop and failure handling', () => {
+  it('stops only the targeted channel and leaves the others running', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('a', 'thread-a'));
+    await a._handleMessage(msg('b', 'thread-b'));
+    const otherProc = a._persistentProcs['thread-b'].proc;
+
+    await a._onControlAction('stop', { channel: 'thread-a' });
+
+    assert.equal(a._persistentProcs['thread-a'], undefined, 'the target process is gone');
+    assert.ok(a._persistentProcs['thread-b'], 'the sibling channel is untouched');
+    assert.equal(a._persistentProcs['thread-b'].proc.pid, otherProc.pid);
+    assert.equal(otherProc.exitCode, null, 'the sibling process is still alive');
+    await shutdown(a);
+  });
+
+  it('sends `abort` first and keeps the process when Pi settles cleanly', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'hang' } });
+    const turn = a._handleMessage(msg('long task', 'thread-a'));
+    await waitFor(() => a._persistentProcs['thread-a'] && a._persistentProcs['thread-a'].turnInFlight);
+
+    a._persistentProcs['thread-a'].userStopped = true;
+    await a._abortChannel('thread-a');
+    await turn;
+
+    const pp = a._persistentProcs['thread-a'];
+    assert.ok(pp, 'a clean abort keeps the session process alive for the next message');
+    assert.equal(pp.proc.exitCode, null);
+    await shutdown(a);
+  });
+
+  it('escalates to a process-tree kill when abort is ignored', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'ignore_abort' } });
+    const turn = a._handleMessage(msg('wedged task', 'thread-a'));
+    await waitFor(() => a._persistentProcs['thread-a'] && a._persistentProcs['thread-a'].turnInFlight);
+    const proc = a._persistentProcs['thread-a'].proc;
+
+    await a._onControlAction('stop', { channel: 'thread-a' });
+    await turn;
+
+    assert.equal(a._persistentProcs['thread-a'], undefined);
+    assert.ok(proc.exitCode !== null || proc.signalCode !== null,
+      'the wedged process must have been terminated');
+    assert.deepEqual(a._captured.response, ['Execution stopped by user.']);
+  });
+
+  it('posts the stop notice exactly once', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'ignore_abort' } });
+    const turn = a._handleMessage(msg('wedged', 'thread-a'));
+    await waitFor(() => a._persistentProcs['thread-a'] && a._persistentProcs['thread-a'].turnInFlight);
+    await a._onControlAction('stop', { channel: 'thread-a' });
+    await a._onControlAction('stop', { channel: 'thread-a' });
+    await turn;
+    assert.equal(a._captured.response.filter((r) => r === 'Execution stopped by user.').length, 1);
+  });
+
+  it('rejects pending RPCs with a clear cancellation when the CLI dies', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'hang' } });
+    const turn = a._handleMessage(msg('x', 'thread-a'));
+    await waitFor(() => a._persistentProcs['thread-a'] && a._persistentProcs['thread-a'].turnInFlight);
+    const pp = a._persistentProcs['thread-a'];
+
+    // A control RPC that will never be answered, then the process dies.
+    const pending = pp._testPending = a._sendRpc(pp, { type: 'get_state' }, { timeoutMs: 60000 });
+    let rejection = null;
+    pending.catch((e) => { rejection = e; });
+    await a._killPersistentProc('thread-a', 'simulated crash');
+    await turn;
+    await new Promise((r) => setImmediate(r));
+
+    assert.ok(rejection, 'the pending RPC must reject, not leak');
+    assert.equal(rejection.name, 'PiCancelledError');
+    assert.equal(pp.pending.size, 0);
+  });
+
+  it('survives an asynchronous stdin EPIPE instead of crashing the daemon', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'hang' } });
+    const turn = a._handleMessage(msg('x', 'thread-a'));
+    await waitFor(() => a._persistentProcs['thread-a'] && a._persistentProcs['thread-a'].turnInFlight);
+    const pp = a._persistentProcs['thread-a'];
+
+    // A Writable reports EPIPE through an 'error' EVENT, which the try/catch
+    // around stdin.write() cannot see. Without a listener this is an
+    // unhandled 'error' and Node tears the process down.
+    assert.ok(pp.proc.stdin.listenerCount('error') > 0, 'stdin needs an error guard');
+    pp.proc.stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+    assert.equal(pp.stdinBroken, true, 'a broken pipe is remembered');
+
+    // Further RPCs fail fast and cleanly rather than writing into the void.
+    await assert.rejects(
+      () => a._sendRpc(pp, { type: 'get_state' }, { timeoutMs: 500 }),
+      (e) => e.name === 'PiCancelledError',
+    );
+
+    await a._killPersistentProc('thread-a', 'test');
+    await turn;
+  });
+
+  it('reports an abnormal CLI exit mid-turn instead of hanging on "thinking"', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'crash_mid_turn', FAKE_EXIT_CODE: '7' } });
+    await a._handleMessage(msg('boom', 'thread-a'));
+    assert.equal(a._captured.response.length, 0);
+    assert.equal(a._captured.error.length, 1);
+    assert.match(a._captured.error[0], /exited with code 7/);
+  });
+
+  it('surfaces a CLI that dies before accepting the prompt', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'exit_immediately', FAKE_EXIT_CODE: '3' } });
+    await a._handleMessage(msg('hello', 'thread-a'));
+    assert.equal(a._captured.error.length, 1, JSON.stringify(a._captured));
+    assert.equal(a._captured.response.length, 0);
+  });
+
+  it('leaves no child process, timer or listener behind after stop()', async () => {
+    const a = makeAdapter({ agentEnv: { FAKE_SCENARIO: 'complete' } });
+    await a._handleMessage(msg('a', 'thread-a'));
+    await a._handleMessage(msg('b', 'thread-b'));
+    const procs = Object.values(a._persistentProcs).map((pp) => pp.proc);
+    const records = Object.values(a._persistentProcs);
+    assert.equal(procs.length, 2);
+
+    a.stop();
+    await waitFor(() => procs.every((p) => p.exitCode !== null || p.signalCode !== null), 8000);
+
+    assert.deepEqual(Object.keys(a._persistentProcs), []);
+    assert.deepEqual(Object.keys(a._channelProcesses), []);
+    for (const pp of records) {
+      assert.equal(pp.idleTimer, null, 'idle timer cleared');
+      assert.equal(pp.watchdogTimer, null, 'watchdog cleared');
+      assert.equal(pp.pending.size, 0, 'no pending RPC left');
+      assert.equal(pp.alive, false);
+      assert.equal(pp.proc.stdout.listenerCount('data'), 0, 'stdout data listeners removed');
+      assert.equal(pp.proc.stderr.listenerCount('data'), 0, 'stderr data listeners removed');
+    }
+  });
+});
+
+/** Poll until `fn()` is truthy, or fail after `timeoutMs`. */
+async function waitFor(fn, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fn()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error('waitFor timed out');
+}

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -7,6 +7,7 @@ import { net } from "electron"
 import { spawn, spawnSync } from "child_process"
 import { withPathEnv, readPathEnv } from "./env"
 import { npmRegistryBase } from "./mirror"
+import { mirrorPiProviderApiKey } from "./pi-env"
 import {
   extractHostedWorkspaceToken,
   hostedWorkspaceSlug,
@@ -78,7 +79,9 @@ export interface OnboardingAgent {
  * terminal login (`claude login`, `gemini`, `codex login`), but the launcher
  * prefers to collect the key/base-URL directly in onboarding and inject it into
  * the agent's env — no external terminal. We apply this purely in launcher code
- * so the bundled registry.json (and its source SDK YAML) stays untouched.
+ * so agent-specific Launcher behavior does not have to depend on the installed
+ * core version. Pi mirrors the same fields in the shared registry as well,
+ * because its adapter also consumes them directly.
  *
  * When an entry exists for an agent we: use these fields as the onboarding
  * inputs, force "env" auth mode, and drop the login command so the terminal
@@ -161,6 +164,74 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       required: true,
       default: "gpt-5-codex",
       placeholder: "gpt-5-codex",
+    },
+  ],
+  pi: [
+    {
+      name: "PI_PROVIDER",
+      description:
+        "Provider: anthropic/openai for native APIs or compatible relays, deepseek for the native DeepSeek API, openai-codex for an existing Pi subscription login, or custom.",
+      required: false,
+      default: "anthropic",
+      options: [
+        "anthropic",
+        "openai",
+        "deepseek",
+        "openai-codex",
+        "openrouter",
+        "google",
+        "custom",
+      ],
+    },
+    {
+      name: "PI_MODEL",
+      description:
+        "Exact model id exposed by the provider or relay (for example claude-sonnet-4-6, gpt-5-codex, or deepseek-v4-flash).",
+      required: false,
+      placeholder: "claude-sonnet-4-6",
+    },
+    {
+      name: "PI_API_FORMAT",
+      description:
+        "API protocol. Keep auto for native providers; choose the relay's protocol when a Base URL is set.",
+      required: false,
+      default: "auto",
+      options: [
+        "auto",
+        "anthropic-messages",
+        "openai-completions",
+        "openai-responses",
+      ],
+    },
+    {
+      name: "PI_BASE_URL",
+      description:
+        "Optional relay/proxy base URL. Leave blank for the provider's native API.",
+      required: false,
+      placeholder: "https://relay.example.com/v1",
+    },
+    {
+      name: "PI_API_KEY",
+      description:
+        "API key for the selected provider or relay. Leave blank to reuse an existing Pi /login session.",
+      required: false,
+      password: true,
+    },
+    {
+      name: "PI_THINKING",
+      description:
+        "Reasoning effort: off, minimal, low, medium, high, xhigh, max.",
+      required: false,
+      default: "off",
+      options: ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
+    },
+    {
+      name: "PI_TRUST_PROJECT",
+      description:
+        "Set to 1 to load project-local executable Pi settings, extensions and skills.",
+      required: false,
+      default: "0",
+      options: ["0", "1"],
     },
   ],
   kimi: [
@@ -488,6 +559,10 @@ const CORE_AGENTS: readonly string[] = [
   // "coming soon" (visible but not installable) so the supported download list
   // is the core agents + amp.
   "amp",
+  // Pi is temporarily kept off the Launcher release surface while its
+  // provider integration is still being validated. Leave the implementation
+  // and catalog entry intact so enabling it later is a one-line change.
+  // "pi",
   // NanoClaw is intentionally NOT in this set: it's a BETA external
   // containerized runtime bridged via a native NanoClaw `openagents` channel,
   // so it stays "coming soon" (visible but not installable) and out of
@@ -579,6 +654,7 @@ async function testLLMConnection(
 ): Promise<LLMTestResult> {
   const pick = (...names: string[]): string => {
     for (const n of names) {
+      if (!n) continue
       const v = (env[n] || "").trim()
       if (v) return v
     }
@@ -587,6 +663,143 @@ async function testLLMConnection(
   const trimSlash = (u: string): string => u.replace(/\/+$/, "")
 
   try {
+    // ── Pi: provider-agnostic key/base/model fields from the Launcher. ──
+    // Keep this ahead of the generic branches: PI_API_KEY is mirrored to the
+    // provider's native env variable only when the Pi child is spawned, while
+    // this probe runs directly from the current (possibly unsaved) form.
+    const piProvider = pick("PI_PROVIDER").toLowerCase()
+    const piBaseInput = pick("PI_BASE_URL")
+    const piKey = pick(
+      "PI_API_KEY",
+      piProvider === "anthropic" ? "ANTHROPIC_API_KEY" : "",
+      piProvider === "deepseek" ? "DEEPSEEK_API_KEY" : "",
+      piProvider === "google" ? "GEMINI_API_KEY" : "",
+      piProvider === "openrouter" ? "OPENROUTER_API_KEY" : "",
+      piProvider === "openai" || piProvider === "openai-codex"
+        ? "OPENAI_API_KEY"
+        : "",
+    )
+    if (piProvider || piBaseInput || pick("PI_API_KEY")) {
+      if (!piKey) {
+        return {
+          success: false,
+          error:
+            piProvider === "openai-codex"
+              ? "OpenAI Codex subscription login is checked by Pi itself. Save, launch Pi and use /login if needed."
+              : "Enter PI_API_KEY, or save and launch Pi to reuse an existing /login session.",
+        }
+      }
+
+      const defaults: Record<
+        string,
+        { base: string; api: string; model: string }
+      > = {
+        anthropic: {
+          base: "https://api.anthropic.com",
+          api: "anthropic-messages",
+          model: "claude-sonnet-4-6",
+        },
+        openai: {
+          base: "https://api.openai.com/v1",
+          api: "openai-responses",
+          model: "gpt-5-codex",
+        },
+        deepseek: {
+          base: "https://api.deepseek.com/v1",
+          api: "openai-completions",
+          model: "deepseek-v4-flash",
+        },
+        openrouter: {
+          base: "https://openrouter.ai/api/v1",
+          api: "openai-completions",
+          model: "openai/gpt-4o-mini",
+        },
+      }
+      const fallback = defaults[piProvider]
+      if (!piBaseInput && !fallback) {
+        return {
+          success: false,
+          error: `PI_PROVIDER=${piProvider || "custom"} requires PI_BASE_URL.`,
+        }
+      }
+
+      const base = trimSlash(piBaseInput || fallback?.base || "")
+      const configuredApi = pick("PI_API_FORMAT").toLowerCase()
+      const api =
+        configuredApi && configuredApi !== "auto"
+          ? configuredApi
+          : fallback?.api ||
+            (piProvider === "anthropic"
+              ? "anthropic-messages"
+              : "openai-completions")
+      const model = pick("PI_MODEL") || fallback?.model
+      if (!model) {
+        return { success: false, error: "PI_MODEL is required for this provider." }
+      }
+
+      if (api === "anthropic-messages") {
+        const url = /\/v1$/i.test(base)
+          ? `${base}/messages`
+          : `${base}/v1/messages`
+        const official = isOfficialAnthropicBase(base)
+        const { status, text } = await httpRequestJson(
+          url,
+          "POST",
+          {
+            "x-api-key": piKey,
+            ...(official ? {} : { Authorization: `Bearer ${piKey}` }),
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+          },
+          JSON.stringify({
+            model,
+            max_tokens: 16,
+            messages: [{ role: "user", content: "Say hi in 5 words." }],
+          }),
+        )
+        if (status >= 400)
+          return { success: false, error: `HTTP ${status}: ${text.slice(0, 200)}` }
+        let reply = ""
+        try {
+          reply = JSON.parse(text)?.content?.[0]?.text || ""
+        } catch {}
+        return { success: true, model, response: reply.slice(0, 80) }
+      }
+
+      if (api !== "openai-completions" && api !== "openai-responses") {
+        return {
+          success: false,
+          error: `Unsupported PI_API_FORMAT '${api}' for Launcher testing.`,
+        }
+      }
+      const apiBase = /\/v\d+$/i.test(base) ? base : `${base}/v1`
+      const responsesApi = api === "openai-responses"
+      const { status, text } = await httpRequestJson(
+        `${apiBase}/${responsesApi ? "responses" : "chat/completions"}`,
+        "POST",
+        { Authorization: `Bearer ${piKey}`, "Content-Type": "application/json" },
+        JSON.stringify(
+          responsesApi
+            ? { model, input: "Say hi in 5 words.", max_output_tokens: 16 }
+            : {
+                model,
+                max_tokens: 16,
+                messages: [{ role: "user", content: "Say hi in 5 words." }],
+              },
+        ),
+      )
+      if (status >= 400)
+        return { success: false, error: `HTTP ${status}: ${text.slice(0, 200)}` }
+      let reply = ""
+      try {
+        const parsed = JSON.parse(text)
+        reply = responsesApi
+          ? parsed?.output_text || parsed?.output?.[0]?.content?.[0]?.text || ""
+          : parsed?.choices?.[0]?.message?.content || ""
+      } catch {}
+      return { success: true, model, response: String(reply).slice(0, 80) }
+    }
+
     // ── Aider: routes through LiteLLM, so the provider (and therefore the
     // endpoint to probe) is decided by AIDER_PROVIDER / the model at run time.
     // There is no single key endpoint to test here, and we must NOT report a
@@ -893,7 +1106,7 @@ function isOfficialAnthropicBase(base: string): boolean {
 function normalizeEnvForSave(
   env: Record<string, string>,
 ): Record<string, string> {
-  const out = { ...env }
+  const out = mirrorPiProviderApiKey(env)
   const anthropicBase = out.ANTHROPIC_BASE_URL
   if (typeof anthropicBase === "string" && anthropicBase.trim()) {
     out.ANTHROPIC_BASE_URL = anthropicBase

--- a/packages/launcher/src/main/pi-env.test.ts
+++ b/packages/launcher/src/main/pi-env.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { mirrorPiProviderApiKey } from "./pi-env"
+
+describe("mirrorPiProviderApiKey", () => {
+  it("mirrors the unified key for native DeepSeek", () => {
+    expect(
+      mirrorPiProviderApiKey({
+        PI_PROVIDER: "deepseek",
+        PI_API_KEY: "test-secret",
+      }),
+    ).toMatchObject({
+      PI_API_KEY: "test-secret",
+      DEEPSEEK_API_KEY: "test-secret",
+    })
+  })
+
+  it("does not overwrite an explicitly supplied provider key", () => {
+    expect(
+      mirrorPiProviderApiKey({
+        PI_PROVIDER: "deepseek",
+        PI_API_KEY: "unified",
+        DEEPSEEK_API_KEY: "explicit",
+      }).DEEPSEEK_API_KEY,
+    ).toBe("explicit")
+  })
+
+  it("does nothing when the form has no unified Pi key", () => {
+    expect(mirrorPiProviderApiKey({ PI_PROVIDER: "deepseek" })).toEqual({
+      PI_PROVIDER: "deepseek",
+    })
+  })
+})

--- a/packages/launcher/src/main/pi-env.ts
+++ b/packages/launcher/src/main/pi-env.ts
@@ -1,0 +1,25 @@
+/**
+ * Mirror Launcher's provider-neutral Pi key to the conventional variable that
+ * Pi's native provider reads. Keeping PI_API_KEY as the source of truth lets
+ * the UI stay simple; persisting the mirror also supports daemon processes
+ * that were started with an older connector build.
+ */
+export function mirrorPiProviderApiKey(
+  env: Record<string, string>,
+): Record<string, string> {
+  const out = { ...env }
+  if (!Object.prototype.hasOwnProperty.call(out, "PI_API_KEY")) return out
+
+  const provider = (out.PI_PROVIDER || "").trim().toLowerCase()
+  const target = {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    deepseek: "DEEPSEEK_API_KEY",
+    google: "GEMINI_API_KEY",
+    openrouter: "OPENROUTER_API_KEY",
+  }[provider]
+  if (target && !(out[target] || "").trim()) {
+    out[target] = (out.PI_API_KEY || "").trim()
+  }
+  return out
+}

--- a/packages/launcher/src/renderer/components/AgentIcon.tsx
+++ b/packages/launcher/src/renderer/components/AgentIcon.tsx
@@ -18,6 +18,7 @@ const BUNDLED_SLUGS = new Set([
   "openai",
   "openclaw",
   "opencode",
+  "pi",
   "yaml-agent",
 ])
 

--- a/packages/launcher/src/renderer/components/agent-env-fields.tsx
+++ b/packages/launcher/src/renderer/components/agent-env-fields.tsx
@@ -7,6 +7,13 @@ import {
   FieldLabel,
 } from "@renderer/components/ui/field"
 import { Input } from "@renderer/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select"
 import { PasswordInput } from "@renderer/components/ui-kit"
 import { envFieldHint } from "@renderer/lib/agent-meta"
 import { cn } from "@renderer/lib/utils"
@@ -50,6 +57,7 @@ export function AgentEnvFields({
     <div className={cn("flex flex-col gap-4", className)}>
       {fields.map((f) => {
         const id = `${idPrefix}-${f.name}`
+        const value = values[f.name] ?? f.default ?? ""
         const FieldInput = f.password ? PasswordInput : Input
         return (
           <Field key={f.name}>
@@ -59,14 +67,36 @@ export function AgentEnvFields({
                   distinct element rather than folding it into the label text. */}
               {f.required && <span className="required"> *</span>}
             </FieldLabel>
-            <FieldInput
-              id={id}
-              value={values[f.name] ?? f.default ?? ""}
-              onChange={(e) => onChange(f.name, e.target.value)}
-              placeholder={
-                f.placeholder || t("agents.envFields.enterField", { name: f.name })
-              }
-            />
+            {f.options?.length ? (
+              <Select
+                value={value}
+                onValueChange={(next: string) => onChange(f.name, next)}
+              >
+                <SelectTrigger id={id} className="w-full">
+                  <SelectValue
+                    placeholder={
+                      f.placeholder || t("agents.envFields.enterField", { name: f.name })
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {f.options.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <FieldInput
+                id={id}
+                value={value}
+                onChange={(e) => onChange(f.name, e.target.value)}
+                placeholder={
+                  f.placeholder || t("agents.envFields.enterField", { name: f.name })
+                }
+              />
+            )}
             {/* Translated where we have a catalog entry, the registry's own
                 English wording otherwise. See lib/agent-meta. */}
             {envFieldHint(f, t) && (

--- a/packages/launcher/src/renderer/i18n/locales/en/agentMeta.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agentMeta.json
@@ -14,7 +14,8 @@
     "opencode": "Open-source terminal-native AI coding agent.",
     "kimi": "Powered by Moonshot AI over an OpenAI-compatible API, strong on long context.",
     "hermes": "Nous Hermes — self-improving AI with tools, profiles, memory and messaging.",
-    "mini-swe-agent": "A minimal shell-based coding agent for fixing issues and modifying code in a workspace."
+    "mini-swe-agent": "A minimal shell-based coding agent for fixing issues and modifying code in a workspace.",
+    "pi": "Earendil's Pi coding agent for the terminal — headless RPC mode, many providers."
   },
   "genericLabels": {
     "apiKey": "API key",
@@ -182,6 +183,34 @@
     "OPENAI_BASE_URL": {
       "label": "Base URL",
       "hint": "OpenAI-compatible base URL. The default works for the OpenAI API; change it for a proxy or relay."
+    },
+    "PI_MODEL": {
+      "label": "Model",
+      "hint": "Exact model id exposed by the provider or relay, such as claude-sonnet-4-6, gpt-5-codex, or deepseek-v4-flash."
+    },
+    "PI_PROVIDER": {
+      "label": "Provider",
+      "hint": "Choose anthropic for native/relay Claude, openai for native/relay OpenAI, deepseek for DeepSeek, or openai-codex for a ChatGPT subscription login."
+    },
+    "PI_API_FORMAT": {
+      "label": "API protocol",
+      "hint": "Keep auto for native providers. For a relay choose anthropic-messages, openai-completions, or openai-responses as documented by the relay."
+    },
+    "PI_BASE_URL": {
+      "label": "Relay base URL",
+      "hint": "Leave blank for native APIs; set this for a relay, proxy, or self-hosted endpoint. OpenAgents configures Pi without models.json."
+    },
+    "PI_API_KEY": {
+      "label": "API key",
+      "hint": "API key for the selected provider or relay. Leave blank to reuse an existing Pi /login session."
+    },
+    "PI_THINKING": {
+      "label": "Reasoning effort",
+      "hint": "One of off, minimal, low, medium, high, xhigh, max. Leave blank for the model default."
+    },
+    "PI_TRUST_PROJECT": {
+      "label": "Trust project files",
+      "hint": "Off by default. When set to 1, Pi loads .pi/settings.json, extensions and skills from the working directory — that is executable code from the repository, so only enable it for projects you trust."
     }
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/agentMeta.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agentMeta.json
@@ -14,7 +14,8 @@
     "opencode": "开源、终端原生的 AI 编程智能体，可接任意模型。",
     "kimi": "Moonshot AI 驱动，OpenAI 兼容接口，长上下文见长。",
     "hermes": "Nous Hermes —— 带工具、画像、记忆与消息能力的自进化智能体。",
-    "mini-swe-agent": "极简的 shell 编程智能体，用于在工作区中修复问题、改写代码。"
+    "mini-swe-agent": "极简的 shell 编程智能体，用于在工作区中修复问题、改写代码。",
+    "pi": "Earendil 出品的终端编程智能体 Pi —— 无头 RPC 模式，支持众多服务商。"
   },
   "genericLabels": {
     "apiKey": "API 密钥",
@@ -182,6 +183,34 @@
     "OPENAI_BASE_URL": {
       "label": "接口地址",
       "hint": "OpenAI 兼容的接口地址。默认值直连 OpenAI 官方 API；使用中转或代理时改这里。"
+    },
+    "PI_MODEL": {
+      "label": "模型名称",
+      "hint": "服务商或中转站提供的精确模型 id，例如 claude-sonnet-4-6、gpt-5-codex、deepseek-v4-flash。"
+    },
+    "PI_PROVIDER": {
+      "label": "服务商",
+      "hint": "原生 Claude/中转 Claude 选 anthropic；原生 OpenAI/Codex 中转选 openai；DeepSeek 选 deepseek；ChatGPT 订阅登录选 openai-codex。"
+    },
+    "PI_API_FORMAT": {
+      "label": "接口协议",
+      "hint": "原生服务保持 auto。中转站按其文档选择 anthropic-messages、openai-completions 或 openai-responses。"
+    },
+    "PI_BASE_URL": {
+      "label": "中转接口地址",
+      "hint": "原生服务留空；中转、代理或自建端点填写 Base URL。OpenAgents 会自动配置 Pi，无需 models.json。"
+    },
+    "PI_API_KEY": {
+      "label": "API 密钥",
+      "hint": "所选服务商或中转站的 API 密钥。若要复用 Pi 的 /login 登录，可留空。"
+    },
+    "PI_THINKING": {
+      "label": "推理强度",
+      "hint": "可选 off、minimal、low、medium、high、xhigh、max。留空则用模型默认值。"
+    },
+    "PI_TRUST_PROJECT": {
+      "label": "信任项目文件",
+      "hint": "默认关闭。设为 1 后，Pi 会加载工作目录下的 .pi/settings.json、扩展与技能 —— 这些是来自仓库的可执行代码，只在信任该项目时开启。"
     }
   }
 }

--- a/packages/launcher/src/renderer/lib/agent-auth.test.ts
+++ b/packages/launcher/src/renderer/lib/agent-auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { isCliLoginDetected } from "./agent-auth"
+
+describe("isCliLoginDetected", () => {
+  it("does not label API-key readiness as a CLI login", () => {
+    expect(
+      isCliLoginDetected(
+        { ready: true, auth_mode: "api_key" },
+        true,
+      ),
+    ).toBe(false)
+  })
+
+  it("accepts an explicit CLI-login health result", () => {
+    expect(
+      isCliLoginDetected(
+        { ready: true, auth_mode: "cli_login" },
+        true,
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps the ready fallback only for legacy login-only agents", () => {
+    expect(isCliLoginDetected({ ready: true }, false)).toBe(true)
+    expect(isCliLoginDetected({ ready: true }, true)).toBe(false)
+  })
+
+  it("prefers an explicit logged_in result", () => {
+    expect(
+      isCliLoginDetected(
+        { ready: true, auth_mode: "api_key", logged_in: true },
+        true,
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/launcher/src/renderer/lib/agent-auth.ts
+++ b/packages/launcher/src/renderer/lib/agent-auth.ts
@@ -23,3 +23,24 @@ export function isLoginOnlyAgent(
 ): boolean {
   return !!entry.check_ready?.login_command && (envFields?.length ?? 0) === 0
 }
+
+/**
+ * Decide whether the CLI-login tab may say "signed in". `ready` alone is not
+ * enough for dual-auth agents: an API key also makes them ready. Newer health
+ * results identify the auth mode; older login-only agents may only expose the
+ * aggregate ready bit, so retain that fallback only when no key fields exist.
+ */
+export function isCliLoginDetected(
+  health:
+    | { logged_in?: unknown; auth_mode?: unknown; ready?: unknown }
+    | null
+    | undefined,
+  hasEnvFields: boolean,
+): boolean {
+  if (!health) return false
+  if (typeof health.logged_in === "boolean") return health.logged_in
+  if (typeof health.auth_mode === "string") {
+    return health.ready === true && health.auth_mode === "cli_login"
+  }
+  return !hasEnvFields && health.ready === true
+}

--- a/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
@@ -23,6 +23,7 @@ import {
 } from "@renderer/components/agent-auth/auth-status"
 import { ConfigureWorkDir } from "./configure-workdir"
 import { AgentEnvFields } from "@renderer/components/agent-env-fields"
+import { isCliLoginDetected } from "@renderer/lib/agent-auth"
 import { capture } from "@renderer/lib/analytics"
 import type { EnvField } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
@@ -147,7 +148,10 @@ export function ConfigureDialog({
                 // For dual-auth agents `logged_in` reflects the CLI sign-in
                 // specifically (`ready` can be true from an API key alone), so
                 // prefer it; fall back to `ready` for pure login agents.
-                const ok = h?.logged_in ?? h?.ready ?? false
+                const ok = isCliLoginDetected(
+                  h,
+                  hasFields,
+                )
                 setLoggedIn(ok)
                 setAuthInfo({
                   ready: !!h?.ready,
@@ -186,7 +190,10 @@ export function ConfigureDialog({
     try {
       await window.api.clearLoginKey(agentType, agentName || undefined)
       const h = await window.api.refreshLogin(agentType)
-      const ok = !!h?.ready
+      const ok = isCliLoginDetected(
+        h,
+        fields.length > 0,
+      )
       setLoggedIn(ok)
       setAuthInfo({
         ready: ok,

--- a/packages/launcher/src/renderer/pages/install/pi-entry.test.ts
+++ b/packages/launcher/src/renderer/pages/install/pi-entry.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest"
+
+import BUNDLED_REGISTRY from "../../../../../agent-connector/registry.json"
+import EN_AGENT_META from "../../i18n/locales/en/agentMeta.json"
+import ZH_AGENT_META from "../../i18n/locales/zh/agentMeta.json"
+import { entryStatus, platformsOf, runtimeOf, STATUS_VARIANT } from "./entry-meta"
+import {
+  parseNpmInstallCommand,
+  resolveNpmPackage,
+  globalUninstallCommand,
+} from "../../../shared/npm-install-spec"
+import type { CatalogEntry } from "../../types"
+
+/**
+ * The Pi catalog entry, read from the registry the launcher actually bundles.
+ * These assertions are what stand between a hand-synced registry.json (the
+ * build:registry script cannot run in this repo) and a broken Install page.
+ */
+const PI = (BUNDLED_REGISTRY as unknown as Array<Record<string, unknown>>).find(
+  (e) => e.name === "pi",
+) as unknown as CatalogEntry & {
+  install: Record<string, string | string[]>
+  check_ready: Record<string, unknown>
+  env_config: Array<Record<string, unknown>>
+}
+
+describe("Pi registry entry", () => {
+  it("is present in the bundled registry", () => {
+    expect(PI).toBeTruthy()
+    expect(PI.label).toBe("Pi")
+  })
+
+  it("declares an npm install spec the launcher can parse on every platform", () => {
+    for (const key of ["macos", "linux", "windows"] as const) {
+      const cmd = PI.install[key] as string
+      expect(parseNpmInstallCommand(cmd)).toEqual({
+        pkg: "@earendil-works/pi-coding-agent",
+        spec: expect.stringMatching(/^\d+\.\d+\.\d+$/),
+      })
+    }
+  })
+
+  it("resolves to the real npm package (never to the `pi` binary name)", () => {
+    for (const platformKey of ["macos", "linux", "windows"]) {
+      expect(resolveNpmPackage(PI.install, platformKey)).toBe(
+        "@earendil-works/pi-coding-agent",
+      )
+    }
+    expect(globalUninstallCommand(PI.install.linux as string)).toBe(
+      "npm uninstall -g @earendil-works/pi-coding-agent",
+    )
+  })
+
+  it("requires the Node runtime and supports all three platforms", () => {
+    expect(runtimeOf(PI as CatalogEntry)).toBe("nodejs")
+    expect(platformsOf(PI as CatalogEntry).sort()).toEqual([
+      "Linux",
+      "Windows",
+      "macOS",
+    ])
+  })
+
+  it("keeps every credential field marked as a password", () => {
+    const secretish = PI.env_config.filter((f) =>
+      /_API_KEY$/.test(String(f.name)),
+    )
+    expect(secretish.length).toBeGreaterThan(0)
+    for (const field of secretish) expect(field.password).toBe(true)
+    // The adapter-read configuration fields are plain text, not secrets.
+    const provider = PI.env_config.find((f) => f.name === "PI_PROVIDER")
+    expect(provider?.password).toBeUndefined()
+  })
+
+  it("never ships a literal credential in the catalog", () => {
+    const json = JSON.stringify(PI)
+    expect(json).not.toMatch(/sk-[A-Za-z0-9-]{10,}/)
+    expect(json).not.toMatch(/--api-key/)
+  })
+
+  it("points readiness at Pi's own auth file without parsing it", () => {
+    expect(PI.check_ready.creds_file).toBe("~/.pi/agent/auth.json")
+    expect(PI.check_ready.creds_no_parse).toBe(true)
+  })
+})
+
+describe("Pi in the Install marketplace", () => {
+  /** How getCatalog stamps a non-core agent (CORE_AGENTS in agent-manager). */
+  const asComingSoon = (): CatalogEntry =>
+    ({ ...(PI as CatalogEntry), comingSoon: true, installed: false })
+  const asCore = (installed: boolean): CatalogEntry =>
+    ({ ...(PI as CatalogEntry), comingSoon: false, installed })
+
+  it("renders as a disabled 'coming soon' row while it is not a core agent", () => {
+    const status = entryStatus(asComingSoon(), false)
+    expect(status).toBe("comingSoon")
+    expect(STATUS_VARIANT[status]).toBe("muted")
+  })
+
+  it("becomes installable the moment it joins CORE_AGENTS", () => {
+    expect(entryStatus(asCore(false), false)).toBe("available")
+    expect(entryStatus(asCore(true), false)).toBe("installed")
+    expect(entryStatus(asCore(true), true)).toBe("update")
+  })
+
+  it("has a translated description and env labels in both locales", () => {
+    for (const meta of [EN_AGENT_META, ZH_AGENT_META] as Array<{
+      descriptions: Record<string, string>
+      env: Record<string, { label: string; hint: string }>
+    }>) {
+      expect(meta.descriptions.pi).toBeTruthy()
+      for (const key of [
+        "PI_PROVIDER",
+        "PI_MODEL",
+        "PI_API_FORMAT",
+        "PI_BASE_URL",
+        "PI_API_KEY",
+        "PI_THINKING",
+        "PI_TRUST_PROJECT",
+      ]) {
+        expect(meta.env[key]?.label, key).toBeTruthy()
+        expect(meta.env[key]?.hint, key).toBeTruthy()
+      }
+    }
+  })
+
+  it("offers one Launcher-managed key plus provider/API dropdowns", () => {
+    const fields = new Map(PI.env_config.map((field) => [field.name, field]))
+    expect(fields.get("PI_API_KEY")?.password).toBe(true)
+    expect(fields.get("PI_PROVIDER")?.options).toContain("deepseek")
+    expect(fields.get("PI_API_FORMAT")?.options).toContain("anthropic-messages")
+    expect(fields.get("PI_BASE_URL")).toBeTruthy()
+  })
+
+  it("warns about executable project files in the trust toggle's help text", () => {
+    expect(EN_AGENT_META.env.PI_TRUST_PROJECT.hint).toMatch(/executable/i)
+    expect(ZH_AGENT_META.env.PI_TRUST_PROJECT.hint).toMatch(/可执行/)
+  })
+})

--- a/packages/launcher/src/renderer/public/icons/pi.svg
+++ b/packages/launcher/src/renderer/public/icons/pi.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Pi</title><rect x="2.8" y="5.2" width="18.4" height="3.1" rx="1.55"></rect><rect x="6.1" y="7.6" width="3.1" height="11.4" rx="1.55"></rect><rect x="14.8" y="7.6" width="3.1" height="11.4" rx="1.55"></rect></svg>

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -47,6 +47,8 @@ export interface EnvField {
   password?: boolean
   placeholder?: string
   default?: string
+  /** Optional fixed choices. Fields without options remain free-form inputs. */
+  options?: string[]
 }
 
 /**

--- a/sdk/src/openagents/registry/pi.yaml
+++ b/sdk/src/openagents/registry/pi.yaml
@@ -1,0 +1,104 @@
+name: pi
+label: Pi
+description: Earendil's Pi coding agent for the terminal — headless RPC mode, many providers
+homepage: https://pi.dev
+tags: [coding, cli, open-source, rpc]
+builtin: true
+support:
+  install: true
+  workspace: true
+  collaboration: true
+
+# Pi ships as an npm package whose bin is a Node entry point. `engines.node` is
+# ">=22.19.0" — ABOVE what many systems provide — so the adapter launches the
+# entry point with the launcher's bundled portable Node (v22.22.3) and refuses
+# to start on anything older (REASON.VERSION_INCOMPATIBLE).
+#
+# The package name and version live HERE only; no adapter or installer code
+# hard-codes them.
+install:
+  binary: pi
+  npm_package: "@earendil-works/pi-coding-agent"
+  requires: [nodejs]
+  min_version: "0.83.0"
+  verify: "pi --version >/dev/null 2>&1"
+  verify_win: "pi --version >nul 2>nul"
+  macos: "npm install -g @earendil-works/pi-coding-agent@0.83.0"
+  linux: "npm install -g @earendil-works/pi-coding-agent@0.83.0"
+  windows: "npm install -g @earendil-works/pi-coding-agent@0.83.0"
+
+adapter:
+  module: openagents.adapters.pi
+  class: PiAdapter
+
+launch:
+  args: []
+
+# OpenAgents converts the fields below into Pi flags/environment. When a custom
+# base URL is supplied, the adapter explicitly loads its bundled provider
+# extension for that Pi process; users never need to edit ~/.pi/agent/models.json.
+# API keys stay in the child environment and are never put in argv or files.
+env_config:
+  - name: PI_PROVIDER
+    description: "Provider: anthropic/openai for native APIs or compatible relays, deepseek for the native DeepSeek API, openai-codex for an existing Pi subscription login, or custom."
+    required: false
+    placeholder: anthropic
+    default: anthropic
+    options: [anthropic, openai, deepseek, openai-codex, openrouter, google, custom]
+  - name: PI_MODEL
+    description: "Exact model id exposed by the provider or relay (for example claude-sonnet-4-6, gpt-5-codex, or deepseek-v4-flash)."
+    required: false
+    placeholder: claude-sonnet-4-6
+  - name: PI_API_FORMAT
+    description: "API protocol. Keep auto for native providers; choose anthropic-messages, openai-completions, or openai-responses for a relay."
+    required: false
+    default: auto
+    options: [auto, anthropic-messages, openai-completions, openai-responses]
+  - name: PI_BASE_URL
+    description: "Optional relay/proxy base URL. Leave blank for the provider's native API. OpenAgents configures Pi automatically when this is set."
+    required: false
+    placeholder: https://relay.example.com/v1
+  - name: PI_API_KEY
+    description: "API key for the selected provider or relay. Leave blank to reuse an existing Pi /login session."
+    required: false
+    password: true
+  - name: PI_THINKING
+    description: "Reasoning effort: off, minimal, low, medium, high, xhigh, max. Leave blank for the model default."
+    required: false
+    default: off
+    options: [off, minimal, low, medium, high, xhigh, max]
+  - name: PI_TRUST_PROJECT
+    description: "Set to 1 to let Pi load project-local .pi/settings.json, extensions and skills from the working directory. OFF by default — project files are executable surface."
+    required: false
+    default: "0"
+    options: ["0", "1"]
+
+check_ready:
+  # Pi stores API keys and OAuth tokens in ~/.pi/agent/auth.json (mode 0600).
+  # Require at least one provider entry: Pi may create an empty {} file before
+  # the user logs in, and file presence alone would be a false positive.
+  creds_file: "~/.pi/agent/auth.json"
+  creds_no_parse: true
+  creds_json_has_entries: true
+  env_vars:
+    - PI_API_KEY
+    - DEEPSEEK_API_KEY
+    - ANTHROPIC_API_KEY
+    - OPENAI_API_KEY
+    - GEMINI_API_KEY
+    - OPENROUTER_API_KEY
+  saved_env_key: PI_API_KEY
+  # Pi's sign-in is the interactive TUI's /login — there is no `pi login`
+  # subcommand, so the login command opens Pi itself.
+  login_command: "pi"
+  not_ready_message: "Not configured — set a provider API key (press e), or run `pi` and use /login once."
+  unreadable_message: "Pi credentials were found but could not be read. Check permissions on ~/.pi/agent, or run `pi` and sign in again."
+
+resolve_env:
+  rules:
+    - from: LLM_API_KEY
+      to: PI_API_KEY
+    - from: LLM_BASE_URL
+      to: PI_BASE_URL
+    - from: LLM_MODEL
+      to: PI_MODEL


### PR DESCRIPTION
## Summary

This PR adds Pi as a CLI-based OpenAgents agent using Pi's headless RPC mode.

It includes the complete adapter, process and session lifecycle management, Launcher-managed provider configuration, authentication handling, documentation, registry metadata, icons, and tests.

Pi is intentionally not enabled for general installation in the Launcher yet. Its `CORE_AGENTS` entry remains commented out while the integration is validated.

## What changed

### Pi CLI adapter

- Adds a dedicated `PiAdapter` backed by `pi --mode rpc`
- Runs one persistent Pi process per active workspace channel
- Preserves conversation context with OpenAgents-managed Pi sessions
- Keeps session data isolated by workspace and agent
- Supports text, image attachments, tool events, thinking output, and final responses
- Prevents duplicate final responses when processing streamed Pi events
- Adds idle cleanup, watchdog handling, cancellation, process-tree shutdown, and recovery from broken stdin or unexpected exits
- Supports execute and plan-mode process restarts while preserving session context

### Runtime installation and compatibility

- Adds Pi to the shared agent registry
- Installs Pi into its isolated OpenAgents runtime
- Resolves npm shims, package entry points, portable Node, and platform-specific launch paths
- Validates the installed Pi and Node versions before starting
- Includes Windows-specific command shim and process handling fixes

### Launcher-managed provider configuration

Adds the following per-agent configuration fields:

- `PI_PROVIDER`
- `PI_MODEL`
- `PI_API_FORMAT`
- `PI_BASE_URL`
- `PI_API_KEY`
- `PI_THINKING`
- `PI_TRUST_PROJECT`

Supported configurations include:

- Native Anthropic
- Native OpenAI
- Native DeepSeek
- Google Gemini
- OpenRouter
- Anthropic-compatible relays
- OpenAI-compatible relays
- Existing Pi CLI subscription login sessions

Launcher-managed configurations are injected through a process-local Pi provider extension. They do not modify the user's global `~/.pi/agent/models.json` or `auth.json`.

### Authentication fixes

- Maps the unified `PI_API_KEY` to the provider's native environment variable
- Adds `DEEPSEEK_API_KEY` support
- Bypasses Pi credential-resolution failures by supplying Launcher-managed keys through `registerProvider`
- Keeps API keys out of process arguments and diagnostic output
- Distinguishes a real Pi CLI login from API-key readiness
- Does not treat an empty `auth.json` as a completed login
- Adds complete model cost metadata required by newer Pi versions

### Security and isolation

- API keys are never added to Pi command-line arguments
- Known credentials are redacted from logs, errors, and workspace messages
- Launcher configuration is scoped to the individual agent instance
- Project trust remains disabled by default
- Pi does not write trust or provider configuration into the working repository
- Sessions are stored under the OpenAgents data directory instead of the project or shared Pi session directory

### Registry and documentation

- Adds Pi registry metadata
- Adds Launcher and connector icons
- Adds English and Chinese configuration labels
- Adds Pi setup, provider, troubleshooting, and architecture documentation

## Rollout status

Pi is implemented and remains available to the connector runtime, but it is temporarily excluded from the Launcher's supported agent list:

```ts
// "pi",