### PR TITLE
fix(claude-adapter): stop stripping the subscription token from the child env

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.151",
+  "version": "0.2.152",
   "description": "OpenAgents Launcher \u2014 install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/adapters/claude.js
+++ b/packages/agent-connector/src/adapters/claude.js
@@ -26,6 +26,60 @@ const IS_WINDOWS = process.platform === 'win32';
 
 class ClaudeAdapter extends BaseAdapter {
   /**
+   * The env the spawned `claude` CLI runs with. Pure — takes the agent's env
+   * and returns a new object; nothing here reads `this`.
+   *
+   * Two jobs:
+   *
+   * 1. Strip the CLAUDE_* / AI_AGENT variables that make the child think it is
+   *    running under an SDK harness (it then takes the org-scoped auth path and
+   *    gets a 403). Cloud-provider and model config is kept, and so is the
+   *    subscription token from `claude setup-token` — that one IS the
+   *    credential, and sweeping it up as a stray CLAUDE_* left anyone who
+   *    pasted one authenticating as nobody, silently.
+   *
+   * 2. Mirror the API key into ANTHROPIC_AUTH_TOKEN for third-party relays. The
+   *    CLI sends ANTHROPIC_API_KEY as `x-api-key`, which most Anthropic-
+   *    compatible relays ignore — they only honor `Authorization: Bearer`, and
+   *    reject everything else as 401 "invalid token / 无效的令牌". The auth token
+   *    is sent as Bearer and outranks the key in Claude Code's precedence. The
+   *    launcher normally sets this when saving env; this is the runtime backstop
+   *    for envs saved by an older launcher or coming from anywhere else. Only
+   *    for a NON-official base — api.anthropic.com wants x-api-key.
+   *
+   * @param {Record<string, string>} baseEnv
+   * @returns {Record<string, string>}
+   */
+  static _buildChildEnv(baseEnv) {
+    const KEEP = new Set([
+      'CLAUDE_CODE_USE_VERTEX',
+      'CLAUDE_CODE_USE_BEDROCK',
+      'CLAUDE_MODEL',
+      'CLAUDE_API_KEY',
+      'CLAUDE_CODE_MAX_TURNS',
+      'CLAUDE_CODE_OAUTH_TOKEN',
+    ]);
+    const env = { ...(baseEnv || {}) };
+    for (const k of Object.keys(env)) {
+      if ((k.startsWith('CLAUDE_') && !KEEP.has(k)) || k === 'CLAUDECODE' || k === 'AI_AGENT') {
+        delete env[k];
+      }
+    }
+
+    const base = (env.ANTHROPIC_BASE_URL || '').trim();
+    const key = (env.ANTHROPIC_API_KEY || '').trim();
+    if (key && base && !(env.ANTHROPIC_AUTH_TOKEN || '').trim()) {
+      let official = false;
+      try {
+        const host = new URL(base).hostname.toLowerCase();
+        official = host === 'anthropic.com' || host.endsWith('.anthropic.com');
+      } catch { official = false; }
+      if (!official) env.ANTHROPIC_AUTH_TOKEN = key;
+    }
+    return env;
+  }
+
+  /**
    * @param {object} opts - BaseAdapter opts plus:
    * @param {Set} [opts.disabledModules]
    * @param {string} [opts.workingDir]
@@ -1216,47 +1270,7 @@ class ClaudeAdapter extends BaseAdapter {
     let mcpConfigFile = null;
     let cmd;
 
-    // Clean env: strip CLAUDE_* / AI_AGENT variables that make the spawned
-    // `claude` think it's running under an SDK harness (org-scoped auth
-    // path → 403). But preserve config vars the child needs for cloud
-    // provider auth (Vertex, Bedrock) and model selection.
-    const CLAUDE_ENV_KEEP = new Set([
-      'CLAUDE_CODE_USE_VERTEX',
-      'CLAUDE_CODE_USE_BEDROCK',
-      'CLAUDE_MODEL',
-      'CLAUDE_API_KEY',
-      'CLAUDE_CODE_MAX_TURNS',
-    ]);
-    const cleanEnv = { ...(this.agentEnv || process.env) };
-    for (const k of Object.keys(cleanEnv)) {
-      if ((k.startsWith('CLAUDE_') && !CLAUDE_ENV_KEEP.has(k)) || k === 'CLAUDECODE' || k === 'AI_AGENT') {
-        delete cleanEnv[k];
-      }
-    }
-
-    // Third-party Anthropic-compatible relays (the common reason a custom
-    // ANTHROPIC_BASE_URL is set) authenticate via `Authorization: Bearer`, which
-    // the Claude CLI only sends when ANTHROPIC_AUTH_TOKEN is set. With just
-    // ANTHROPIC_API_KEY the CLI sends `x-api-key`, which most relays ignore — the
-    // relay then rejects every request as 401 "invalid token / 无效的令牌". When a
-    // non-official base URL is configured and no auth token was provided, mirror
-    // the API key into ANTHROPIC_AUTH_TOKEN (it outranks the API key in Claude
-    // Code's auth precedence) so the CLI uses Bearer auth. The launcher normally
-    // sets this when saving env; this is the runtime backstop for envs saved by
-    // an older launcher or coming from any other source. The official
-    // api.anthropic.com endpoint keeps x-api-key, so it is left untouched.
-    const anthropicBase = (cleanEnv.ANTHROPIC_BASE_URL || '').trim();
-    const anthropicKey = (cleanEnv.ANTHROPIC_API_KEY || '').trim();
-    if (anthropicKey && anthropicBase && !(cleanEnv.ANTHROPIC_AUTH_TOKEN || '').trim()) {
-      let officialAnthropic = false;
-      try {
-        const host = new URL(anthropicBase).hostname.toLowerCase();
-        officialAnthropic = host === 'anthropic.com' || host.endsWith('.anthropic.com');
-      } catch { officialAnthropic = false; }
-      if (!officialAnthropic) {
-        cleanEnv.ANTHROPIC_AUTH_TOKEN = anthropicKey;
-      }
-    }
+    const cleanEnv = ClaudeAdapter._buildChildEnv(this.agentEnv || process.env);
 
     // Spawn a persistent process and send the first message via stdin
     let effectiveContent = content;

--- a/packages/agent-connector/test/claude-child-env.test.js
+++ b/packages/agent-connector/test/claude-child-env.test.js
@@ -1,0 +1,90 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const ClaudeAdapter = require('../src/adapters/claude');
+
+const build = (env) => ClaudeAdapter._buildChildEnv(env);
+
+describe('ClaudeAdapter._buildChildEnv — SDK-harness stripping', () => {
+  test('drops the variables that push the CLI onto the org-scoped auth path', () => {
+    const env = build({
+      CLAUDECODE: '1',
+      AI_AGENT: 'openagents',
+      CLAUDE_CODE_ENTRYPOINT: 'sdk-ts',
+      PATH: '/usr/bin',
+    });
+    assert.strictEqual(env.CLAUDECODE, undefined);
+    assert.strictEqual(env.AI_AGENT, undefined);
+    assert.strictEqual(env.CLAUDE_CODE_ENTRYPOINT, undefined);
+    assert.strictEqual(env.PATH, '/usr/bin');
+  });
+
+  test('keeps the cloud-provider and model config the child needs', () => {
+    const env = build({
+      CLAUDE_CODE_USE_VERTEX: '1',
+      CLAUDE_CODE_USE_BEDROCK: '1',
+      CLAUDE_MODEL: 'claude-sonnet-4-6',
+      CLAUDE_API_KEY: 'k',
+      CLAUDE_CODE_MAX_TURNS: '10',
+    });
+    assert.strictEqual(env.CLAUDE_CODE_USE_VERTEX, '1');
+    assert.strictEqual(env.CLAUDE_CODE_USE_BEDROCK, '1');
+    assert.strictEqual(env.CLAUDE_MODEL, 'claude-sonnet-4-6');
+    assert.strictEqual(env.CLAUDE_API_KEY, 'k');
+    assert.strictEqual(env.CLAUDE_CODE_MAX_TURNS, '10');
+  });
+
+  // The credential a Pro/Max user pastes in from `claude setup-token`. It was
+  // being swept up by the CLAUDE_* strip, so the CLI ran with no credential at
+  // all and failed as if nothing had been configured.
+  test('keeps the subscription token — it IS the credential, not harness noise', () => {
+    const env = build({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-abc' });
+    assert.strictEqual(env.CLAUDE_CODE_OAUTH_TOKEN, 'sk-ant-oat01-abc');
+  });
+
+  test('does not mutate the env it was handed', () => {
+    const input = { CLAUDECODE: '1', ANTHROPIC_API_KEY: 'k' };
+    build(input);
+    assert.strictEqual(input.CLAUDECODE, '1');
+  });
+});
+
+describe('ClaudeAdapter._buildChildEnv — relay Bearer auth', () => {
+  test('mirrors the key into ANTHROPIC_AUTH_TOKEN for a third-party relay', () => {
+    const env = build({
+      ANTHROPIC_API_KEY: 'sk-relay',
+      ANTHROPIC_BASE_URL: 'https://yinli.one',
+    });
+    assert.strictEqual(env.ANTHROPIC_AUTH_TOKEN, 'sk-relay');
+  });
+
+  test('leaves the official endpoint on x-api-key', () => {
+    const env = build({
+      ANTHROPIC_API_KEY: 'sk-official',
+      ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+    });
+    assert.strictEqual(env.ANTHROPIC_AUTH_TOKEN, undefined);
+  });
+
+  test('never overwrites an auth token the user set themselves', () => {
+    const env = build({
+      ANTHROPIC_API_KEY: 'sk-relay',
+      ANTHROPIC_BASE_URL: 'https://relay.example',
+      ANTHROPIC_AUTH_TOKEN: 'explicit',
+    });
+    assert.strictEqual(env.ANTHROPIC_AUTH_TOKEN, 'explicit');
+  });
+
+  test('a malformed base URL is treated as non-official, not as a crash', () => {
+    const env = build({
+      ANTHROPIC_API_KEY: 'sk-relay',
+      ANTHROPIC_BASE_URL: 'not a url',
+    });
+    assert.strictEqual(env.ANTHROPIC_AUTH_TOKEN, 'sk-relay');
+  });
+
+  test('no key means nothing to mirror', () => {
+    const env = build({ ANTHROPIC_BASE_URL: 'https://relay.example' });
+    assert.strictEqual(env.ANTHROPIC_AUTH_TOKEN, undefined);
+  });
+});


### PR DESCRIPTION
## What

`claude setup-token` mints a long-lived `CLAUDE_CODE_OAUTH_TOKEN` — the credential that lets a Pro/Max user reuse their subscription on another machine with no API credit and no browser flow. The Claude adapter was **deleting it before spawning the CLI**.

The child env is scrubbed of `CLAUDE_*` variables so the spawned `claude` doesn't think it's running under an SDK harness (that path is org-scoped and 403s). The filter is prefix-based, so it swept up the one `CLAUDE_*` variable that is a credential rather than harness noise. A user who pasted a token got a CLI running with no credential at all — failing exactly like an agent that was never configured, with nothing pointing at the env.

## Changes

- `CLAUDE_CODE_OAUTH_TOKEN` added to the keep list.
- The env build extracted into a pure `ClaudeAdapter._buildChildEnv(baseEnv)`. Behaviour is otherwise byte-for-byte the same — it just became testable.
- New `test/claude-child-env.test.js` (9 cases) covering both halves, neither of which had any coverage and both of which fail silently:
  - harness stripping (`CLAUDECODE`, `AI_AGENT`, `CLAUDE_CODE_ENTRYPOINT`) while keeping Vertex/Bedrock/model config **and** the subscription token;
  - the `ANTHROPIC_AUTH_TOKEN` mirroring that gives third-party relays their `Authorization: Bearer` header — official endpoint untouched, an explicit user-set token never overwritten, a malformed base URL treated as non-official instead of throwing.
- Version bumped `0.2.151` → `0.2.152` so merging to `develop` actually publishes (the workflow skips publish when the version already exists on npm).

## Why now

The launcher side of this — a pasteable "subscription token" field in the Claude config, counted as real credentials for readiness — is ready in a follow-up PR, but it is dead on arrival until this ships: the launcher can save the token all it likes, the daemon strips it on spawn. So this goes first and gets verified against a published core.

## Verification

`npm test` in `packages/agent-connector`: **787 pass / 0 fail** (was 778 — +9 new).