### PR TITLE
fix(githooks): make the commit-msg hook work on macOS, and match CI's casing

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,6 +1,47 @@
 #!/usr/bin/env bash
-# Strip Co-Authored-By lines from commit messages.
-# To enable: git config core.hooksPath .githooks
-sed -i '/^Co-Authored-By:/d' "$1"
-# Remove trailing blank lines left behind
-sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "$1"
+#
+# Strip Co-Authored-By trailers from commit messages.
+#
+# CI rejects any commit carrying one (.github/workflows/check-commits.yml), and
+# by then the only fix is an interactive rebase. Catching it here is the
+# difference between a clean push and a PR you have to rewrite.
+#
+# Enable with:  git config core.hooksPath .githooks
+#
+# Two things this hook has to get right, both of which the first version didn't:
+#
+#   * Portability. It used `sed -i` with no backup suffix plus a GNU-only branch
+#     script. BSD sed (macOS) reads `-i`'s argument as the suffix, so it took the
+#     delete expression as the suffix and then parsed the FILE PATH as its
+#     script — "undefined label" — and exited non-zero. A commit-msg hook that
+#     exits non-zero ABORTS THE COMMIT, so every Mac user who followed the
+#     instructions above lost the ability to commit at all. Nothing here may use
+#     `sed -i` or any GNU-only expression again.
+#
+#   * Case. The trailer is written "Co-Authored-By" by some tools and
+#     "Co-authored-by" by GitHub, and CI matches case-INsensitively. A
+#     case-sensitive hook passes commits that CI then rejects, which is worse
+#     than no hook: it looks like it's protecting you.
+
+set -eu
+
+msg=$1
+tmp=$msg.oa-hook.$$
+trap 'rm -f "$tmp"' EXIT
+
+# Same pattern CI greps for, so the two can't disagree about what counts.
+if ! grep -qi '^Co-authored-by:' "$msg"; then
+  exit 0
+fi
+
+# Drop the trailers. `|| true` because grep -v exits 1 when it prints nothing,
+# which under `set -e` would abort the commit — the exact failure mode above.
+grep -vi '^Co-authored-by:' "$msg" >"$tmp" || true
+
+# Then drop the blank lines the removal stranded at the end (a trailer block is
+# usually the last thing in the message, preceded by its own blank line).
+awk '
+  NF { last = NR }
+  { line[NR] = $0 }
+  END { for (i = 1; i <= last; i++) print line[i] }
+' "$tmp" >"$msg"


### PR DESCRIPTION
## The problem

`.githooks/commit-msg` strips `Co-Authored-By` trailers so they never reach CI, which rejects them (`check-commits.yml`). It did neither of the two things it needed to do.

**1. It aborted every commit on macOS.**

```sh
sed -i '/^Co-Authored-By:/d' "$1"
```

BSD sed reads `-i`'s next argument as the *backup suffix*, so on a Mac it took the delete expression as the suffix and then parsed the **file path** as its script:

```
sed: 2: "/private/tmp/...": undefined label 'mp/claude-501/...'
sed: 2: ":a": unused label 'a'
sed: -e: No such file or directory
```

It exits 1 — and **a `commit-msg` hook that exits non-zero aborts the commit**. Verified in a throwaway repo: with the old hook enabled, `git commit` produces no commit at all. So anyone on macOS who followed the instructions printed by `check-commits.yml` (`git config core.hooksPath .githooks`) lost the ability to commit. Enabling it was strictly worse than leaving it off, which is presumably why it was off everywhere and the trailers keep reaching CI.

**2. It matched case-sensitively while CI does not.**

CI greps `-qi '^Co-Authored-By:'`. The hook's sed matched only that exact casing. GitHub's own convention is `Co-authored-by:` — that spelling sailed past the hook and got rejected by CI anyway. A hook that catches less than the check it exists to satisfy is worse than no hook: it looks like protection.

## The fix

Rewritten with `grep` + `awk`. No in-place sed, no GNU-only expressions, and the same case-insensitive pattern CI uses so the two can't drift apart. Early-exits untouched when there's no trailer.

## Verified on macOS

End to end through a real `git commit`, plus each case directly:

| input | result |
|---|---|
| `Co-Authored-By:` (tool spelling) | stripped, stranded blank line cleaned |
| `Co-authored-by:` (GitHub spelling) | stripped |
| `CO-AUTHORED-BY:` | stripped |
| `Signed-off-by:` alongside it | preserved |
| no trailer | file untouched, exit 0 |
| "we reject Co-Authored-By: lines" mid-body | left alone (CI anchors on `^`, so the hook does too) |

After the fix, a commit carrying the trailer succeeds and `git log -1 --format=%B \| grep -qi '^Co-Authored-By:'` — the exact check CI runs — comes back clean.

## To actually get the benefit

The hook is opt-in per clone; nothing about it is automatic:

```sh
git config core.hooksPath .githooks
```

Worth telling the team once this lands, since the advice was previously a trap on macOS.