### PR TITLE
fix(installer): don't record a Cursor install that never landed a binary

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.152",
+  "version": "0.2.153",
   "description": "OpenAgents Launcher \u2014 install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execSync, exec } = require('child_process');
-const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache, aiderBinDirs } = require('./paths');
+const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache, aiderBinDirs, resolveBinaryInKnownDirs } = require('./paths');
 const { EnvManager } = require('./env');
 const { readinessReason, REASON } = require('./adapters/health-status');
 
@@ -392,6 +392,44 @@ class Installer {
       try { if (c && fs.existsSync(c)) { found = c; break; } } catch {}
     }
     return found ? { path: found } : null;
+  }
+
+  /**
+   * Confirm a real cursor-agent binary landed, for verify-before-mark.
+   *
+   * Cursor's Windows one-liner (`irm 'https://cursor.com/install?win32=true' |
+   * iex`) downloads the CLI with Invoke-WebRequest. When that download fails —
+   * an "unexpected EOF or 0 bytes" IOException is what users behind a filtering
+   * network get — PowerShell treats it as NON-terminating: the script carries
+   * on, prints "Start using Cursor Agent" and "Happy coding!", and exits 0. All
+   * that's left on disk is an empty %LOCALAPPDATA%\cursor-agent\versions\.
+   *
+   * Same defect hermes and amp already guard against here. Without this the
+   * marker gets written, the launcher reports Cursor installed, offers a
+   * sign-in, and the only way the user finds out is a terminal saying
+   * "'cursor-agent' is not recognized".
+   */
+  _verifyCursorBinary() {
+    try { clearBinaryLookupCache(); } catch {}
+    const resolved = this._whichBinary('cursor');
+    if (resolved && fs.existsSync(resolved)) return { path: resolved };
+    return null;
+  }
+
+  _cursorBinaryNotFoundMessage() {
+    const localAppData =
+      process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    const isWin = process.platform === 'win32';
+    const expected = isWin
+      ? path.join(localAppData, 'cursor-agent')
+      : path.join(os.homedir(), '.local', 'bin', 'cursor-agent');
+    return (
+      'Cursor install command completed, but the cursor-agent binary could not be found\n' +
+      "(its installer prints \"Happy coding!\" and exits 0 even when the download failed —\n" +
+      'look for "unexpected EOF" or a network error in the log above).\n\n' +
+      `Expected under:\n${expected}\n\n` +
+      'Retry the install, or check that cursor.com is reachable from this network.'
+    );
   }
 
   _hermesBinaryNotFoundMessage() {
@@ -1066,6 +1104,18 @@ class Installer {
             }
             if (onData) onData(`\nHermes CLI resolved: ${hermes.path}\n`);
           }
+          // Cursor-only: same failure shape as hermes above — its installer
+          // exits 0 after a failed download. See _verifyCursorBinary.
+          if (agentType === 'cursor') {
+            const cursor = this._verifyCursorBinary();
+            if (!cursor) {
+              const msg = this._cursorBinaryNotFoundMessage();
+              if (onData) onData(`\n${msg}\n`);
+              reject(new Error(msg));
+              return;
+            }
+            if (onData) onData(`\nCursor CLI resolved: ${cursor.path}\n`);
+          }
           this._markInstalled(agentType);
           if (onData) onData(`\nDone! ${agentType} is now installed.\n`);
           resolve({ success: true, command: displayCmd });
@@ -1296,7 +1346,14 @@ class Installer {
     // runnable. Generic and backward-compatible — only runs after PATH misses.
     const pkgBin = this._resolvePackageBin(agentType, entry, binary);
     if (pkgBin) return pkgBin;
-    return null;
+    // Last: check the known install dirs on disk. A PATH lookup misses a CLI
+    // whose installer only edited the *registry* PATH (Cursor, Amp, Hermes on
+    // Windows) until the process restarts, and the launcher — which resolves
+    // through here — then reports a working install as missing and offers a
+    // terminal running a bare command that cannot resolve either. Each adapter
+    // already does this search; this puts it in the one place the launcher
+    // actually calls.
+    return resolveBinaryInKnownDirs([binary, ...aliases], agentType);
   }
 
   /**

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -517,12 +517,69 @@ function aiderBinDirs() {
   return dirs;
 }
 
+/** Executable suffixes to try for a bare binary name, per platform. */
+const BIN_EXTS = IS_WINDOWS ? ['.cmd', '.exe', '.bat', ''] : [''];
+
+/**
+ * Last-resort binary lookup: walk the directories we already know agent CLIs
+ * land in and check the filesystem directly, instead of asking the shell.
+ *
+ * `where`/`which` is not enough on Windows. The Cursor, Amp and Hermes
+ * installers edit the *registry* PATH, which an already-running process never
+ * inherits — so a perfectly good install is invisible to a PATH lookup until
+ * the machine (or at least the app) is restarted. Every adapter grew its own
+ * tiered search to cope; the launcher had none, so it alone reported "can't
+ * find it" and then opened a terminal running a bare command that could only
+ * fail with "'cursor-agent' is not recognized".
+ *
+ * Deliberately reuses getExtraBinDirs() rather than a second hardcoded list:
+ * that list already IS the curated set, and a copy of it is exactly how the
+ * launcher and the adapters drifted apart in the first place.
+ *
+ * Runs only after a PATH lookup has already missed, so it can add resolutions
+ * but never change one that already works.
+ *
+ * @param {string|string[]} names  binary name(s), e.g. ['cursor-agent','agent']
+ * @param {string} [agentType]     adds that agent's isolated runtime bin dir
+ * @returns {string|null} absolute path, or null
+ */
+function resolveBinaryInKnownDirs(names, agentType) {
+  const list = (Array.isArray(names) ? names : [names]).filter(Boolean);
+  if (!list.length) return null;
+
+  const dirs = [];
+  const push = (d) => { if (d && !dirs.includes(d)) dirs.push(d); };
+
+  // The agent's own isolated runtime first — it is the copy this launcher
+  // installed, and should win over anything the user happens to have globally.
+  if (agentType) push(path.join(getRuntimePrefix(agentType), 'node_modules', '.bin'));
+  push(path.join(HOME, '.openagents', 'nodejs', 'node_modules', '.bin'));
+  try { push(path.dirname(process.execPath)); } catch {}
+  for (const d of getExtraBinDirs()) push(d);
+
+  for (const dir of dirs) {
+    for (const name of list) {
+      for (const ext of BIN_EXTS) {
+        const candidate = path.join(dir, `${name}${ext}`);
+        try {
+          if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+        } catch {
+          /* unreadable path — keep looking */
+        }
+      }
+    }
+  }
+  return null;
+}
+
+
 module.exports = {
   getExtraBinDirs,
   getEnhancedPATH,
   getEnhancedEnv,
   whichBinary,
   whereBinary,
+  resolveBinaryInKnownDirs,
   clearBinaryLookupCache,
   getRuntimePrefix,
   getCorePrefix,

--- a/packages/agent-connector/test/resolve-binary-known-dirs.test.js
+++ b/packages/agent-connector/test/resolve-binary-known-dirs.test.js
@@ -1,0 +1,110 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveBinaryInKnownDirs, IS_WINDOWS } = require('../src/paths');
+
+/**
+ * The launcher resolves agent binaries through installer.which(), which was a
+ * PATH lookup and nothing else. On Windows the Cursor/Amp/Hermes installers
+ * edit the *registry* PATH, which an already-running process never inherits —
+ * so `where cursor-agent` comes back empty for a perfectly good install, the
+ * launcher calls it missing, and its terminal fallback then runs a bare
+ * `cursor-agent login` that dies with "is not recognized". Every adapter had
+ * grown its own filesystem search to cope; the launcher had none.
+ */
+describe('resolveBinaryInKnownDirs', () => {
+  test('finds a binary in the agent\'s isolated runtime bin dir', () => {
+    const dir = path.join(os.homedir(), '.openagents', 'runtimes', '__probe__', 'node_modules', '.bin');
+    const name = `oa-test-${process.pid}`;
+    const file = path.join(dir, IS_WINDOWS ? `${name}.cmd` : name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(file, '');
+    try {
+      assert.strictEqual(resolveBinaryInKnownDirs([name], '__probe__'), file);
+    } finally {
+      fs.rmSync(file, { force: true });
+    }
+  });
+
+  test('tries every alias, not just the first', () => {
+    const dir = path.join(os.homedir(), '.openagents', 'runtimes', '__probe__', 'node_modules', '.bin');
+    const name = `oa-alias-${process.pid}`;
+    const file = path.join(dir, IS_WINDOWS ? `${name}.cmd` : name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(file, '');
+    try {
+      // Mirrors cursor: install.binary is "cursor-agent", the alias is "agent",
+      // and on some layouts only the alias exists on disk.
+      assert.strictEqual(resolveBinaryInKnownDirs(['oa-missing-name', name], '__probe__'), file);
+    } finally {
+      fs.rmSync(file, { force: true });
+    }
+  });
+
+  test('returns null rather than a path that is not there', () => {
+    assert.strictEqual(resolveBinaryInKnownDirs([`oa-absent-${process.pid}`], '__probe__'), null);
+  });
+
+  test('is not fooled by a directory sharing the binary name', () => {
+    const dir = path.join(os.homedir(), '.openagents', 'runtimes', '__probe__', 'node_modules', '.bin');
+    const name = `oa-dir-${process.pid}`;
+    const asDir = path.join(dir, name);
+    fs.mkdirSync(asDir, { recursive: true });
+    try {
+      assert.strictEqual(resolveBinaryInKnownDirs([name], '__probe__'), null);
+    } finally {
+      fs.rmSync(asDir, { recursive: true, force: true });
+    }
+  });
+
+  test('handles empty and missing input without throwing', () => {
+    assert.strictEqual(resolveBinaryInKnownDirs([], 'cursor'), null);
+    assert.strictEqual(resolveBinaryInKnownDirs(null, 'cursor'), null);
+    assert.strictEqual(resolveBinaryInKnownDirs(['x'], undefined), null);
+  });
+});
+
+/**
+ * Cursor's Windows installer downloads the CLI with Invoke-WebRequest, and a
+ * failed download is a NON-terminating error in PowerShell: the script prints
+ * "Happy coding!" and exits 0, leaving an empty %LOCALAPPDATA%\cursor-agent\.
+ * Observed directly — an "unexpected EOF or 0 bytes" IOException on line 22 of
+ * their script, followed by the success banner. aider/amp/hermes already
+ * verify-before-mark for exactly this; cursor was the one left out, so the
+ * marker got written and the launcher offered a sign-in for a missing CLI.
+ */
+describe('cursor verify-before-mark', () => {
+  const { Installer } = require('../src/installer');
+  const inst = Object.create(Installer.prototype);
+
+  test('reports no binary when the install left nothing behind', () => {
+    inst._whichBinary = () => null;
+    assert.strictEqual(inst._verifyCursorBinary(), null);
+  });
+
+  test('accepts a resolved binary that is really on disk', () => {
+    const real = path.join(os.tmpdir(), `oa-cursor-${process.pid}`);
+    fs.writeFileSync(real, '');
+    inst._whichBinary = () => real;
+    try {
+      assert.deepStrictEqual(inst._verifyCursorBinary(), { path: real });
+    } finally {
+      fs.rmSync(real, { force: true });
+    }
+  });
+
+  test('rejects a resolved path that no longer exists', () => {
+    inst._whichBinary = () => path.join(os.tmpdir(), `oa-gone-${process.pid}`);
+    assert.strictEqual(inst._verifyCursorBinary(), null);
+  });
+
+  test('the failure message names the cause and where it looked', () => {
+    const msg = inst._cursorBinaryNotFoundMessage();
+    assert.match(msg, /could not be found/);
+    assert.match(msg, /exits 0 even when the download failed/);
+    assert.match(msg, /cursor-agent/);
+  });
+});


### PR DESCRIPTION
Cursor's Windows installer **reports success after failing**, and we believed it. Captured on a user's machine running the exact command we ship:

```
Invoke-WebRequest : 从传输流收到意外的 EOF 或 0 个字节。
所在位置 行:22 字符:9
+     Invoke-WebRequest -Uri $fullUrl -OutFile $tempFile
    + FullyQualifiedErrorId : System.IO.IOException,…InvokeWebRequestCommand

Start using Cursor Agent:
   agent

Happy coding!
```

```
> cursor-agent
'cursor-agent' 无法将…识别为 cmdlet、函数、脚本文件或可运行程序的名称。
```

## Why it ends up like that

Their script (`cursor.com/install?win32=true`, fetched and read) runs three things in order:

1. `Initialize-CursorAgent` — **deletes** `%LOCALAPPDATA%\cursor-agent` outright, recreates it plus an empty `versions\`, and adds it to the **user PATH**
2. `Download-InstallPackage` — pulls a 75 MB zip from `downloads.cursor.com`
3. `Print-CursorAgentInstructions` — "Happy coding!"

The download sits in a `try`/`finally` with **no `catch`**, so a network failure is non-terminating: execution continues, the banner prints, PowerShell exits 0. What's left on disk is two empty directories and a PATH entry pointing at them — and step 1 means **every retry destroys whatever was there before**.

We then wrote the install marker. So the launcher showed Cursor as installed, offered a sign-in, and the user found out from a terminal saying `'cursor-agent' is not recognized`.

## The fix

**Verify before mark, for Cursor.** `aider`, `amp` and `hermes` already do this — hermes for the identical reason, per its own comment: *"its install.ps1 can exit 0 after a failed uv/setup step"*. Cursor was simply left out of the list. It joins them: no binary → no marker → an error naming the cause and where we looked, instead of a success toast.

```
Cursor install command completed, but the cursor-agent binary could not be found
(its installer prints "Happy coding!" and exits 0 even when the download failed —
look for "unexpected EOF" or a network error in the log above).

Expected under:
C:\Users\…\AppData\Local\cursor-agent

Retry the install, or check that cursor.com is reachable from this network.
```

Because a failed install now writes no marker, the marker-trust fallback in `getInstallInfo` keeps doing its job (a *successful* install whose binary detection lags) and stops covering for installs that produced nothing — **no change to that policy, and the regression test guarding it still passes.**

**And a stronger lookup underneath it.** `installer._whichBinary()` asked the shell and nothing else, while every adapter carries its own multi-tier search — making the launcher, which resolves through here, the weakest resolver in the repo. It now falls back to checking the known install dirs on disk, which is what finds a CLI whose installer only edited the *registry* PATH (Cursor, Amp, Hermes on Windows) and that an already-running process cannot see. It reuses `getExtraBinDirs()` rather than adding a fourth copy of the path list — a copy is exactly how the launcher and the adapters drifted apart — and runs only after every existing lookup has missed, so it can add resolutions but never change one that already works.

## Scope

`0.2.152` → `0.2.153` so it publishes. **796 tests pass** (was 792; +4 new, plus 5 for the resolver).

**This does not fix the reporting user's install** — `downloads.cursor.com` is unreachable from their network (the same URL serves `200 application/zip`, 75 MB, from here). It makes the failure legible instead of silent, which is the part that was ours.

The launcher-side half — not opening a terminal that can only print "not recognized" when no binary resolved — is in #605 and needs this release first.