### PR TITLE
fix(daemon): stop Windows popping a console window for child processe…

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.164",
+  "version": "0.2.165",
   "description": "OpenAgents Launcher \u2014 install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// Before ./index so the daemon and every `agn` subprocess inherit the same
+// no-stray-console-window default on Windows. See win-console.js.
+require('./win-console').installWindowsHideDefault();
+
 const { AgentConnector, Daemon } = require('./index');
 const { hasCredentialMetadata, formatAuthGuidance } = require('./auth-guidance');
 

--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -265,6 +265,10 @@ class Daemon {
         // Run from home so a created agent's default working dir is sensible
         // (not the ~/.openagents config dir).
         cwd: os.homedir(),
+        // The daemon has no console of its own (it is spawned DETACHED), so a
+        // child without this gets a fresh console window — the blank black box
+        // that used to appear every time _refreshRuntimes() ran.
+        windowsHide: true,
       });
       let stdout = '';
       let stderr = '';
@@ -921,6 +925,9 @@ class Daemon {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: getEnhancedEnv(opts.env),
       cwd: opts.cwd,
+      // Windows: cmd.exe would otherwise open a console window per agent (the
+      // daemon has none to inherit) and leave it up for the agent's lifetime.
+      windowsHide: true,
     };
 
     if (IS_WINDOWS) {

--- a/packages/agent-connector/src/index.js
+++ b/packages/agent-connector/src/index.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// Must run before anything captures a child_process reference: on Windows it
+// keeps every spawn from popping a stray console window. See win-console.js.
+require('./win-console').installWindowsHideDefault();
+
 const { Config } = require('./config');
 const { EnvManager } = require('./env');
 const { Registry } = require('./registry');

--- a/packages/agent-connector/src/win-console.js
+++ b/packages/agent-connector/src/win-console.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * Stop Windows from popping a console window for every child process we spawn.
+ *
+ * Neither process that runs this code owns a console: the daemon is spawned
+ * DETACHED (`agn up --foreground`), and the launcher's Electron main process is
+ * a GUI app. On Windows, when a console-less process launches a console
+ * executable *without* CREATE_NO_WINDOW, the OS allocates a brand-new console
+ * for the child — an empty black cmd/Windows-Terminal window that pops to the
+ * foreground and steals focus. With stdio piped nothing is ever drawn in it,
+ * so what the user sees is a blank window appearing out of nowhere.
+ *
+ * That is the "命令框 keeps popping up" report: `_refreshRuntimes()` shells out
+ * to `agn runtimes --json` every two minutes, and the probe it runs keeps the
+ * window on screen for as long as it takes to check every installed CLI.
+ *
+ * Node exposes CREATE_NO_WINDOW as the `windowsHide` spawn option and most call
+ * sites pass it — but there are ~60 of them across the adapters and a single
+ * miss brings the window back. So the default lives here, applied once at the
+ * process entry points (src/index.js, src/cli.js) before any module has
+ * captured a reference to child_process.
+ *
+ * Two things this deliberately does NOT do:
+ *   - override an explicit `windowsHide: false` — the launcher opens a real
+ *     terminal for CLI sign-in that way, and that window is the point; and
+ *   - break interactive output: libuv only applies CREATE_NO_WINDOW when no
+ *     stdio handle is inherited, so `agn` run from a terminal (stdio 'inherit')
+ *     is unaffected by this and still prints where the user can see it.
+ */
+
+const childProcess = require('child_process');
+
+const PATCHED = Symbol.for('openagents.windowsHideDefault');
+const WRAPPED = ['spawn', 'spawnSync', 'exec', 'execSync', 'execFile', 'execFileSync'];
+
+/**
+ * Return a copy of `args` whose options object carries `windowsHide: true`.
+ *
+ * Every child_process signature ends with `[options][, callback]`, so the
+ * options object — if there is one — is the last non-function argument. The
+ * caller's object is copied rather than mutated: callers reuse option objects
+ * and must not see ours leak into their state.
+ */
+function withWindowsHide(args) {
+  const out = args.slice();
+  const cbIdx = typeof out[out.length - 1] === 'function' ? out.length - 1 : -1;
+  const optIdx = cbIdx === -1 ? out.length - 1 : cbIdx - 1;
+  const opts = optIdx >= 0 ? out[optIdx] : undefined;
+
+  if (opts && typeof opts === 'object' && !Array.isArray(opts)) {
+    if ('windowsHide' in opts) return args;  // explicit wins, either way
+    out[optIdx] = { ...opts, windowsHide: true };
+    return out;
+  }
+  // No options argument at all — insert one ahead of any callback.
+  out.splice(cbIdx === -1 ? out.length : cbIdx, 0, { windowsHide: true });
+  return out;
+}
+
+/**
+ * Default `windowsHide: true` for this process's child_process calls.
+ * No-op off Windows, and idempotent.
+ */
+function installWindowsHideDefault() {
+  if (process.platform !== 'win32') return;
+  if (childProcess[PATCHED]) return;
+
+  for (const name of WRAPPED) {
+    const original = childProcess[name];
+    if (typeof original !== 'function') continue;
+    const wrapper = function (...args) {
+      return original.apply(this, withWindowsHide(args));
+    };
+    // Keep util.promisify(exec) and friends working.
+    for (const sym of Object.getOwnPropertySymbols(original)) {
+      wrapper[sym] = original[sym];
+    }
+    Object.defineProperty(wrapper, 'name', { value: name });
+    childProcess[name] = wrapper;
+  }
+  childProcess[PATCHED] = true;
+}
+
+module.exports = { installWindowsHideDefault, withWindowsHide };

--- a/packages/agent-connector/test/win-console.test.js
+++ b/packages/agent-connector/test/win-console.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { withWindowsHide } = require('../src/win-console');
+
+describe('withWindowsHide', () => {
+  it('adds windowsHide to an existing options object', () => {
+    const opts = { cwd: '/tmp', stdio: 'pipe' };
+    const out = withWindowsHide(['node', ['--version'], opts]);
+    assert.deepEqual(out[2], { cwd: '/tmp', stdio: 'pipe', windowsHide: true });
+    // The caller's object must not be mutated — option objects get reused.
+    assert.deepEqual(opts, { cwd: '/tmp', stdio: 'pipe' });
+  });
+
+  it('leaves an explicit windowsHide alone, including false', () => {
+    const args = ['cmd', { shell: true, windowsHide: false }];
+    assert.equal(withWindowsHide(args), args);
+    assert.equal(withWindowsHide(['cmd', { windowsHide: true }])[1].windowsHide, true);
+  });
+
+  it('appends options when the call has none', () => {
+    assert.deepEqual(withWindowsHide(['whoami']), ['whoami', { windowsHide: true }]);
+    assert.deepEqual(withWindowsHide(['node', ['-v']]), [
+      'node',
+      ['-v'],
+      { windowsHide: true },
+    ]);
+  });
+
+  it('inserts options ahead of a trailing callback', () => {
+    const cb = () => {};
+    assert.deepEqual(withWindowsHide(['whoami', cb]), [
+      'whoami',
+      { windowsHide: true },
+      cb,
+    ]);
+    const out = withWindowsHide(['taskkill', ['/pid', '1'], { timeout: 5000 }, cb]);
+    assert.deepEqual(out, [
+      'taskkill',
+      ['/pid', '1'],
+      { timeout: 5000, windowsHide: true },
+      cb,
+    ]);
+  });
+
+  it('does not mistake an args array for an options object', () => {
+    const out = withWindowsHide(['git', ['--version']]);
+    assert.deepEqual(out[1], ['--version']);
+    assert.deepEqual(out[2], { windowsHide: true });
+  });
+});


### PR DESCRIPTION
…s (0.2.165)

The daemon is spawned DETACHED, so on Windows it owns no console of its own. Every console child it then launches without CREATE_NO_WINDOW gets a *fresh* console allocated by the OS — a blank black cmd/Terminal window that pops to the foreground and steals focus (stdio is piped, so nothing is ever drawn in it). The launcher's Electron main process, which loads this package in-process, is a GUI process and sits in the same position.

_refreshRuntimes() shells out to `agn runtimes --json` every two minutes without windowsHide — that is the window Windows users kept seeing appear on its own, staying up for as long as the runtime probe ran. Agents spawned through _spawnAgent (shell: true, i.e. cmd.exe) kept one up for their entire lifetime.

Both call sites now pass windowsHide, and src/win-console.js defaults it process-wide from the two entry points (src/index.js, src/cli.js), before any module has captured a child_process reference: there are ~60 spawn sites across the adapters and a single miss brings the window back.

An explicit windowsHide: false still wins — the launcher opens a real terminal for CLI sign-in that way — and stdio-inheriting children are untouched, since libuv only applies CREATE_NO_WINDOW when no stdio handle is inherited. `agn` run from a terminal still prints where you can see it.