### PR TITLE
feat(nodes): hold node pairings in several workspaces at once (0.2.166)

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.165",
+  "version": "0.2.166",
   "description": "OpenAgents Launcher \u2014 install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/cli.js
+++ b/packages/agent-connector/src/cli.js
@@ -440,11 +440,13 @@ async function cmdNode(connector, flags, positional) {
     print('Connecting this device to your workspace...');
     try {
       const res = await connector.redeemNodePairingCode(code, info);
-      nodeCfg.saveNode({
+      // recordPairing, not saveNode: this device can be a node in several
+      // workspaces at once, and a bare save would drop the others' pairings.
+      nodeCfg.recordPairing(info.nodeKey, {
         node_id: res.nodeId,
-        node_key: info.nodeKey,
         workspace_id: res.workspaceId,
         workspace_slug: res.workspaceSlug,
+        workspace_name: res.workspaceName,
         endpoint: connector.workspace.endpoint,
         token: res.token,
       });
@@ -484,12 +486,14 @@ async function cmdNode(connector, flags, positional) {
   }
 
   if (sub === 'status') {
-    const n = nodeCfg.loadNode();
-    if (n && n.node_id) {
-      print(`Node connected: ${n.node_id}`);
-      print(`  Workspace: ${n.workspace_slug || n.workspace_id}`);
-    } else {
+    const pairings = nodeCfg.listPairings().filter((p) => p.node_id);
+    if (!pairings.length) {
       print('No node connected. Run: agn node connect <pairing-code>');
+      return;
+    }
+    print(`Node connected to ${pairings.length} workspace(s):`);
+    for (const p of pairings) {
+      print(`  ${p.workspace_slug || p.workspace_id} — node ${p.node_id}`);
     }
     return;
   }

--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -31,7 +31,7 @@ class Daemon {
     this._statusInterval = null;
     this._cmdInterval = null;
     this._nodeHeartbeatInterval = null;  // device-level heartbeat (connect-a-node)
-    this._nodeClient = null;             // lazily-created WorkspaceClient for the node
+    this._nodeClients = new Map();       // workspace_id -> WorkspaceClient, one per pairing
     this._runningCommands = new Set();   // node-command ids currently executing
     this._runtimes = [];                 // detected agent runtimes for the node view
     this._runtimesInterval = null;
@@ -39,34 +39,78 @@ class Daemon {
   }
 
   /**
-   * Heartbeat this device (node) to its workspace, independent of any agent, so
-   * the workspace's "connected devices" view stays live even with zero agents.
-   * Best-effort: node liveness is non-critical to agent operation.
+   * Heartbeat this device (node) to EVERY workspace it is paired to,
+   * independent of any agent, so each workspace's "connected devices" view
+   * stays live even with zero agents there.
+   *
+   * One device legitimately belongs to several workspaces at once — the node
+   * row is per (workspace, device) — so this iterates the pairing list rather
+   * than the single top-level record. Each pairing gets its own roster, scoped
+   * to that workspace's agents. Best-effort: node liveness is non-critical to
+   * agent operation, and one workspace being unreachable must not stop the
+   * others from reporting, so the pairings are heartbeated concurrently and
+   * failures are contained per pairing.
    */
   async _nodeHeartbeat() {
-    try {
-      const nodeCfg = require('./node-config');
-      const n = nodeCfg.loadNode();
-      if (!n || !n.node_id || !n.token) return;  // no node connected
-      if (!this._nodeClient) {
-        this._nodeClient = new WorkspaceClient(n.endpoint);
-      }
-      const info = { ...nodeCfg.gatherDeviceInfo(), agents: this._buildRoster(), runtimes: this._runtimes, fs: this._buildFs() };
-      const resp = await this._nodeClient.nodeHeartbeat(n.node_id, n.token, info);
-      // The heartbeat response is our push channel: run any queued remote
-      // agent-management commands the workspace enqueued for this node. Fire
-      // them off without blocking the heartbeat loop (an install can take
-      // minutes — awaiting here would stall liveness and stack up commands).
-      const commands = (resp && resp.commands) || [];
-      for (const cmd of commands) {
-        const id = cmd.commandId;
-        if (!id || this._runningCommands.has(id)) continue;
-        this._runningCommands.add(id);
-        this._runNodeCommand(n, cmd).finally(() => this._runningCommands.delete(id));
-      }
-    } catch {
-      // ignore — will retry next interval
+    const nodeCfg = require('./node-config');
+    const pairings = nodeCfg.listPairings().filter((p) => p && p.node_id && p.token);
+    if (!pairings.length) return;  // no node connected
+    const info = { ...nodeCfg.gatherDeviceInfo(), runtimes: this._runtimes, fs: this._buildFs() };
+    await Promise.all(pairings.map((p) => this._nodeHeartbeatOne(nodeCfg, p, info)));
+  }
+
+  /** The WorkspaceClient for one pairing, created on first use and reused. */
+  _nodeClientFor(n) {
+    let client = this._nodeClients.get(n.workspace_id);
+    if (!client) {
+      client = new WorkspaceClient(n.endpoint);
+      this._nodeClients.set(n.workspace_id, client);
     }
+    return client;
+  }
+
+  /** One pairing's heartbeat. Never throws — see _nodeHeartbeat. */
+  async _nodeHeartbeatOne(nodeCfg, n, info) {
+    let resp;
+    try {
+      resp = await this._nodeClientFor(n).nodeHeartbeat(n.node_id, n.token, { ...info, agents: this._buildRoster(n) });
+    } catch (err) {
+      // A 404 is the workspace's definitive word that this node (or that whole
+      // workspace) no longer exists — an owner unpaired the device. Nothing
+      // local can revive it, so forget THAT pairing: keep the device key for a
+      // future re-pair, and leave every other workspace's pairing alone.
+      // Without this the launcher kept showing "connected" long after a remote
+      // removal, since node.json was only ever reconciled by the UI on demand.
+      // Transient failures (timeouts, 5xx, auth blips) say nothing about the
+      // row's existence, so those are swallowed and retried next tick.
+      if (err && err.status === 404) {
+        try { nodeCfg.clearPairing(n.workspace_id); } catch {}
+        this._nodeClients.delete(n.workspace_id);
+        this._log(`node ${n.node_id} no longer recognized by workspace ${n.workspace_slug || n.workspace_id} — pairing cleared`);
+      }
+      return;  // nothing more to do for this pairing this tick
+    }
+    // The heartbeat response is our push channel: run any queued remote
+    // agent-management commands the workspace enqueued for this node. Fire
+    // them off without blocking the heartbeat loop (an install can take
+    // minutes — awaiting here would stall liveness and stack up commands).
+    const commands = (resp && resp.commands) || [];
+    for (const cmd of commands) {
+      const id = cmd.commandId;
+      if (!id || this._runningCommands.has(id)) continue;
+      this._runningCommands.add(id);
+      this._runNodeCommand(n, cmd).finally(() => this._runningCommands.delete(id));
+    }
+  }
+
+  /**
+   * True if agent `a` is bound to the node's currently-connected workspace.
+   * A missing network never matches (guards against undefined === undefined
+   * leaking local-only agents when a node field is also unset).
+   */
+  _agentOnNodeWorkspace(a, node) {
+    if (!a || !a.network || !node) return false;
+    return a.network === node.workspace_slug || a.network === node.workspace_id;
   }
 
   /**
@@ -74,11 +118,18 @@ class Daemon {
    * from config (the source of truth for what's configured) and augmented with
    * live process state, so a removed agent drops off immediately rather than
    * lingering as a stale 'stopped' process entry.
+   *
+   * SECURITY: scoped to the node's currently-connected workspace. An agent
+   * connected to a DIFFERENT workspace (or a local-only agent with no network)
+   * must never leak into — or be controllable from — a workspace it was never
+   * added to. Each agent belongs to exactly one workspace; this node reports
+   * only the agents that belong to the one it's paired with right now.
    */
-  _buildRoster() {
+  _buildRoster(node) {
     const roster = [];
     try {
       for (const a of this.config.getAgents()) {
+        if (!this._agentOnNodeWorkspace(a, node)) continue;
         const proc = this._processes[a.name];
         // Model: per-agent env override, else the type-level saved model. Working
         // dir: the agent's configured path. Both power the workspace agent cards.
@@ -172,7 +223,18 @@ class Daemon {
     let ok = false;
     let message = '';
     let data = null;
+    // SECURITY: a workspace may only act on agents bound to it. Reject commands
+    // that target an existing agent connected to a different workspace, so a
+    // newly-paired workspace can't start/stop/remove/reconfigure agents that
+    // belong to another one (they surface in no roster of ours either).
+    const AGENT_SCOPED = new Set(['start_agent', 'stop_agent', 'remove_agent', 'configure_agent']);
     try {
+      if (AGENT_SCOPED.has(action)) {
+        const existing = this.config.getAgent(name);
+        if (!existing || !this._agentOnNodeWorkspace(existing, n)) {
+          throw new Error(`Agent '${name}' is not managed by this workspace`);
+        }
+      }
       if (action === 'create_agent') {
         const type = (args.type || '').trim();
         // Working directory: use the one the user picked, else a managed folder
@@ -245,7 +307,9 @@ class Daemon {
       message = e.message || String(e);
     }
     try {
-      await this._nodeClient.nodeCommandResult(cmd.commandId, n.token, { ok, message, data });
+      // Report back to the workspace that issued the command — with several
+      // pairings live, the result must not go out over another one's client.
+      await this._nodeClientFor(n).nodeCommandResult(cmd.commandId, n.token, { ok, message, data });
     } catch {
       // best-effort; the command stays 'running' if we can't report back
     }

--- a/packages/agent-connector/src/node-config.js
+++ b/packages/agent-connector/src/node-config.js
@@ -40,6 +40,72 @@ function getOrCreateNodeKey() {
   return key;
 }
 
+/**
+ * Every workspace this device is paired to, most recent first.
+ *
+ * All of them are live: the server-side node row is keyed per (workspace,
+ * node_key), so one device holds a membership in each workspace it paired with
+ * and the daemon heartbeats every one. Records written before `pairings`
+ * existed carry a single top-level pairing, which is reconstructed here.
+ */
+function listPairings() {
+  const record = loadNode();
+  if (!record) return [];
+  if (record.pairings && record.pairings.length) return record.pairings;
+  return record.workspace_id ? [record] : [];
+}
+
+/**
+ * Add a pairing, or refresh it if this workspace is already paired.
+ *
+ * Additive on purpose: pairing a second workspace must NOT take the device away
+ * from the ones it already belongs to (each issues its own node row). The newest
+ * pairing is mirrored at the top level, which is what a daemon predating
+ * multi-pairing reads. Mirrors the launcher's writer (`node-pairing.ts`).
+ */
+function recordPairing(nodeKey, pairing) {
+  const stamped = { ...pairing, paired_at: new Date().toISOString() };
+  const pairings = [
+    stamped,
+    ...listPairings().filter((p) => p.workspace_id !== pairing.workspace_id),
+  ];
+  saveNode({ node_key: nodeKey, ...stamped, pairings });
+}
+
+/**
+ * Forget one workspace's pairing — that workspace no longer recognizes this node.
+ *
+ * Keeps `node_key` (so a re-pair reuses the same device id) and drops just the
+ * one entry: the server-side node row for THAT workspace is gone and can only
+ * be replaced by a fresh code, while every other pairing is still good. The top
+ * level is re-pointed at whichever pairing is now first, since that is what a
+ * daemon predating multi-pairing reads. Mirrors the launcher's writer
+ * (`node-pairing.ts`) so the two stay schema-compatible.
+ *
+ * @param workspaceId which pairing to drop; defaults to the top-level one.
+ * @returns the pairing that was dropped, or null if there was no such pairing.
+ */
+function clearPairing(workspaceId) {
+  const record = loadNode();
+  if (!record) return null;
+  const target = workspaceId || record.workspace_id;
+  if (!target) return null;
+
+  const pairings = listPairings();
+  const dropped = pairings.find((p) => p.workspace_id === target);
+  if (!dropped) return null;
+
+  const remaining = pairings.filter((p) => p.workspace_id !== target);
+  saveNode({ node_key: record.node_key, ...remaining[0], pairings: remaining });
+  return {
+    node_id: dropped.node_id,
+    workspace_id: dropped.workspace_id,
+    workspace_slug: dropped.workspace_slug,
+    workspace_name: dropped.workspace_name,
+    endpoint: dropped.endpoint,
+  };
+}
+
 /** Best-effort device type from the platform (user/UI can override). */
 function inferDeviceType() {
   const p = os.platform();
@@ -64,6 +130,9 @@ function gatherDeviceInfo() {
 module.exports = {
   loadNode,
   saveNode,
+  listPairings,
+  recordPairing,
+  clearPairing,
   getOrCreateNodeKey,
   inferDeviceType,
   gatherDeviceInfo,

--- a/packages/agent-connector/src/workspace-client.js
+++ b/packages/agent-connector/src/workspace-client.js
@@ -969,6 +969,10 @@ class WorkspaceClient {
                 // Preserve structured error details (error_code, hint,
                 // quota occupancy, ...) so tool handlers can surface them.
                 if (parsed.data && typeof parsed.data === 'object') err.data = parsed.data;
+                // The HTTP status lets callers tell a definitive rejection
+                // (e.g. 404 "not found") from a transient one (5xx/timeout);
+                // the node heartbeat uses it to clear a removed pairing.
+                err.status = res.statusCode;
                 reject(err);
               }
             } else {

--- a/packages/agent-connector/test/daemon.test.js
+++ b/packages/agent-connector/test/daemon.test.js
@@ -104,11 +104,13 @@ describe('Daemon', () => {
   it('_buildRoster lists configured agents with live state', () => {
     const config = new Config(tmpDir);
     config.addAgent({ name: 'coder', type: 'claude' });
+    config.setAgentNetwork('coder', 'ws1');
     config.addAgent({ name: 'helper', type: 'codex' });
+    config.setAgentNetwork('helper', 'ws1');
     const daemon = new Daemon(config, new EnvManager(tmpDir), new Registry(tmpDir));
     // 'coder' is running; 'helper' has no process entry → reported stopped.
     daemon._processes = { coder: { state: 'running', type: 'claude', restarts: 0 } };
-    const roster = daemon._buildRoster();
+    const roster = daemon._buildRoster({ workspace_slug: 'ws1' });
     assert.deepEqual(
       roster.sort((a, b) => a.name.localeCompare(b.name)),
       [
@@ -118,16 +120,126 @@ describe('Daemon', () => {
     );
   });
 
+  // Stub node-config with a fixed pairing list, so the heartbeat tests don't
+  // touch the developer's real ~/.openagents/node.json.
+  function withPairings(pairings, body) {
+    const ncPath = require.resolve('../src/node-config');
+    const realNc = require.cache[ncPath];
+    const cleared = [];
+    require.cache[ncPath] = {
+      id: ncPath,
+      filename: ncPath,
+      loaded: true,
+      exports: {
+        listPairings: () => pairings,
+        gatherDeviceInfo: () => ({ hostname: 'h', os: 'linux', deviceType: 'server', launcherVersion: '0' }),
+        clearPairing: (wsId) => { cleared.push(wsId); return {}; },
+      },
+    };
+    return Promise.resolve(body(cleared)).finally(() => {
+      if (realNc) require.cache[ncPath] = realNc; else delete require.cache[ncPath];
+    });
+  }
+
+  const P1 = { node_id: 'n1', token: 't1', endpoint: 'https://ws1', workspace_id: 'w1', workspace_slug: 'ws1' };
+  const P2 = { node_id: 'n2', token: 't2', endpoint: 'https://ws2', workspace_id: 'w2', workspace_slug: 'ws2' };
+
+  function heartbeatDaemon() {
+    const daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
+    daemon._buildFs = () => ({});
+    daemon._runtimes = [];
+    return daemon;
+  }
+
+  // The heartbeat is the only component that continuously learns the node was
+  // removed (a 404 every 10s). It must clear node.json so the launcher stops
+  // reporting a membership that's gone — but only on that definitive signal,
+  // never on a transient blip that would unpair a device whose wifi flickered.
+  it('_nodeHeartbeat clears the pairing when the workspace 404s the node', async () => {
+    await withPairings([P1], async (cleared) => {
+      const daemon = heartbeatDaemon();
+      daemon._nodeClients.set('w1', {
+        nodeHeartbeat: async () => { const e = new Error('Node not found'); e.status = 404; throw e; },
+      });
+      await daemon._nodeHeartbeat();
+      assert.deepEqual(cleared, ['w1'], 'a 404 should clear that pairing');
+      assert.equal(daemon._nodeClients.has('w1'), false, 'the stale client should be dropped');
+    });
+  });
+
+  it('_nodeHeartbeat keeps the pairing on a transient (non-404) failure', async () => {
+    await withPairings([P1], async (cleared) => {
+      const daemon = heartbeatDaemon();
+      const client = {
+        nodeHeartbeat: async () => { const e = new Error('temporary'); e.status = 503; throw e; },
+      };
+      daemon._nodeClients.set('w1', client);
+      await daemon._nodeHeartbeat();
+      assert.deepEqual(cleared, [], 'a transient failure must not clear the pairing');
+      assert.equal(daemon._nodeClients.get('w1'), client, 'the client is retained for retry');
+    });
+  });
+
+  // A device belongs to a node row in EVERY workspace it paired with, so all of
+  // them must be reported to — one pairing does not displace another.
+  it('_nodeHeartbeat reports to every paired workspace', async () => {
+    await withPairings([P1, P2], async () => {
+      const daemon = heartbeatDaemon();
+      const seen = [];
+      for (const [ws, node] of [['w1', 'n1'], ['w2', 'n2']]) {
+        daemon._nodeClients.set(ws, {
+          nodeHeartbeat: async (nodeId, token) => { seen.push([nodeId, token]); return {}; },
+        });
+        void node;
+      }
+      await daemon._nodeHeartbeat();
+      assert.deepEqual(seen.sort(), [['n1', 't1'], ['n2', 't2']]);
+    });
+  });
+
+  // One workspace being unreachable must not stop the others from reporting.
+  it('_nodeHeartbeat keeps reporting to the other workspaces when one fails', async () => {
+    await withPairings([P1, P2], async (cleared) => {
+      const daemon = heartbeatDaemon();
+      let reachedW2 = false;
+      daemon._nodeClients.set('w1', {
+        nodeHeartbeat: async () => { const e = new Error('Node not found'); e.status = 404; throw e; },
+      });
+      daemon._nodeClients.set('w2', {
+        nodeHeartbeat: async () => { reachedW2 = true; return {}; },
+      });
+      await daemon._nodeHeartbeat();
+      assert.equal(reachedW2, true, 'the healthy pairing still heartbeats');
+      assert.deepEqual(cleared, ['w1'], 'only the 404ing pairing is cleared');
+    });
+  });
+
+  // Each workspace only ever sees the agents bound to it (see _buildRoster).
+  it('_nodeHeartbeat sends each workspace its own roster', async () => {
+    await withPairings([P1, P2], async () => {
+      const daemon = heartbeatDaemon();
+      daemon._buildRoster = (n) => [{ name: `agent-for-${n.workspace_slug}` }];
+      const rosters = {};
+      for (const ws of ['w1', 'w2']) {
+        daemon._nodeClients.set(ws, {
+          nodeHeartbeat: async (_id, _tok, info) => { rosters[ws] = info.agents; return {}; },
+        });
+      }
+      await daemon._nodeHeartbeat();
+      assert.deepEqual(rosters.w1, [{ name: 'agent-for-ws1' }]);
+      assert.deepEqual(rosters.w2, [{ name: 'agent-for-ws2' }]);
+    });
+  });
+
   it('_runNodeCommand create_agent runs create+connect and reports ok', async () => {
     const daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
     const calls = [];
     daemon._runAgn = async (args) => { calls.push(args); return { code: 0, stdout: '', stderr: '' }; };
     let reported = null;
-    daemon._nodeClient = { nodeCommandResult: async (id, tok, res) => { reported = { id, res }; } };
-
+    daemon._nodeClients.set('w1', { nodeCommandResult: async (id, tok, res) => { reported = { id, res }; } });
     const wd = path.join(tmpDir, 'wd');
     await daemon._runNodeCommand(
-      { node_id: 'n1', token: 'tok', endpoint: 'https://ws' },
+      { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws' },
       { commandId: 'c1', action: 'create_agent', args: { name: 'coder', type: 'claude', apiKey: 'sk-x', workingDir: wd } },
     );
 
@@ -142,14 +254,13 @@ describe('Daemon', () => {
     const daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
     const calls = [];
     daemon._runAgn = async (args) => { calls.push(args); return { code: 0, stdout: '', stderr: '' }; };
-    daemon._nodeClient = { nodeCommandResult: async () => {} };
-
+    daemon._nodeClients.set('w1', { nodeCommandResult: async () => {} });
     // Sandbox HOME so the managed folder is created under tmp, not the real home.
     const origHome = process.env.HOME;
     process.env.HOME = tmpDir;
     try {
       await daemon._runNodeCommand(
-        { node_id: 'n1', token: 'tok', endpoint: 'https://ws' },
+        { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws' },
         { commandId: 'c3', action: 'create_agent', args: { name: 'coder', type: 'claude' } },
       );
     } finally {
@@ -177,10 +288,9 @@ describe('Daemon', () => {
     daemon._refreshRuntimes = async () => { refreshed = true; daemon._runtimes = [{ type: 'claude' }]; };
     daemon._nodeHeartbeat = async () => {};
     let reported = null;
-    daemon._nodeClient = { nodeCommandResult: async (id, tok, res) => { reported = res; } };
-
+    daemon._nodeClients.set('w1', { nodeCommandResult: async (id, tok, res) => { reported = res; } });
     await daemon._runNodeCommand(
-      { node_id: 'n1', token: 'tok', endpoint: 'https://ws' },
+      { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws' },
       { commandId: 'c4', action: 'detect_runtimes', args: {} },
     );
     assert.equal(refreshed, true);
@@ -190,22 +300,37 @@ describe('Daemon', () => {
   it('_buildRoster includes model and workingDir', () => {
     const config = new Config(tmpDir);
     config.addAgent({ name: 'coder', type: 'claude', path: '/home/ubuntu/proj', env: { LLM_MODEL: 'sonnet' } });
+    config.setAgentNetwork('coder', 'ws1');
     const daemon = new Daemon(config, new EnvManager(tmpDir), new Registry(tmpDir));
     daemon._processes = { coder: { state: 'running', type: 'claude' } };
-    const roster = daemon._buildRoster();
+    const roster = daemon._buildRoster({ workspace_slug: 'ws1' });
     assert.equal(roster[0].model, 'sonnet');
     assert.equal(roster[0].workingDir, '/home/ubuntu/proj');
   });
 
+  it('_buildRoster hides agents connected to a different workspace', () => {
+    const config = new Config(tmpDir);
+    config.addAgent({ name: 'mine', type: 'claude' });
+    config.setAgentNetwork('mine', 'ws1');
+    config.addAgent({ name: 'foreign', type: 'claude' });
+    config.setAgentNetwork('foreign', 'ws2');
+    config.addAgent({ name: 'local-only', type: 'claude' }); // no network
+    const daemon = new Daemon(config, new EnvManager(tmpDir), new Registry(tmpDir));
+    const roster = daemon._buildRoster({ workspace_slug: 'ws1' });
+    assert.deepEqual(roster.map((a) => a.name), ['mine']);
+  });
+
   it('_runNodeCommand configure_agent updates model then restarts', async () => {
-    const daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
+    const config = new Config(tmpDir);
+    config.addAgent({ name: 'coder', type: 'gemini' });
+    config.setAgentNetwork('coder', 'ws1');
+    const daemon = new Daemon(config, new EnvManager(tmpDir), new Registry(tmpDir));
     const calls = [];
     daemon._runAgn = async (args) => { calls.push(args); return { code: 0, stdout: '', stderr: '' }; };
     let reported = null;
-    daemon._nodeClient = { nodeCommandResult: async (id, tok, res) => { reported = res; } };
-
+    daemon._nodeClients.set('w1', { nodeCommandResult: async (id, tok, res) => { reported = res; } });
     await daemon._runNodeCommand(
-      { node_id: 'n1', token: 'tok', endpoint: 'https://ws' },
+      { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws', workspace_slug: 'ws1' },
       { commandId: 'c9', action: 'configure_agent', args: { name: 'coder', type: 'gemini', model: 'gemini-2.5-flash' } },
     );
     // Sets the generic LLM_MODEL plus gemini's native GEMINI_MODEL, then restarts.
@@ -239,9 +364,9 @@ describe('Daemon', () => {
     const daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
     fs.mkdirSync(path.join(tmpDir, 'proj'));
     let reported = null;
-    daemon._nodeClient = { nodeCommandResult: async (id, tok, res) => { reported = res; } };
+    daemon._nodeClients.set('w1', { nodeCommandResult: async (id, tok, res) => { reported = res; } });
     await daemon._runNodeCommand(
-      { node_id: 'n1', token: 'tok', endpoint: 'https://ws' },
+      { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws' },
       { commandId: 'cd', action: 'list_dir', args: { path: tmpDir } },
     );
     assert.equal(reported.ok, true);
@@ -249,17 +374,38 @@ describe('Daemon', () => {
   });
 
   it('_runNodeCommand reports error when a step fails', async () => {
-    const daemon = new Daemon(new Config(tmpDir), new EnvManager(tmpDir), new Registry(tmpDir));
+    const config = new Config(tmpDir);
+    config.addAgent({ name: 'coder', type: 'claude' });
+    config.setAgentNetwork('coder', 'ws1');
+    const daemon = new Daemon(config, new EnvManager(tmpDir), new Registry(tmpDir));
     daemon._runAgn = async () => ({ code: 1, stdout: '', stderr: 'boom' });
     let reported = null;
-    daemon._nodeClient = { nodeCommandResult: async (id, tok, res) => { reported = res; } };
-
+    daemon._nodeClients.set('w1', { nodeCommandResult: async (id, tok, res) => { reported = res; } });
     await daemon._runNodeCommand(
-      { node_id: 'n1', token: 'tok', endpoint: 'https://ws' },
+      { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws', workspace_slug: 'ws1' },
       { commandId: 'c2', action: 'stop_agent', args: { name: 'coder' } },
     );
     assert.equal(reported.ok, false);
     assert.match(reported.message, /boom/);
+  });
+
+  it('_runNodeCommand refuses to act on an agent from another workspace', async () => {
+    const config = new Config(tmpDir);
+    config.addAgent({ name: 'foreign', type: 'claude' });
+    config.setAgentNetwork('foreign', 'ws2'); // belongs to another workspace
+    const daemon = new Daemon(config, new EnvManager(tmpDir), new Registry(tmpDir));
+    let ranAgn = false;
+    daemon._runAgn = async () => { ranAgn = true; return { code: 0, stdout: '', stderr: '' }; };
+    let reported = null;
+    daemon._nodeClients.set('w1', { nodeCommandResult: async (id, tok, res) => { reported = res; } });
+    await daemon._runNodeCommand(
+      { node_id: 'n1', workspace_id: 'w1', token: 'tok', endpoint: 'https://ws', workspace_slug: 'ws1' },
+      { commandId: 'cx', action: 'stop_agent', args: { name: 'foreign' } },
+    );
+    // The command must NOT run and must report a clear refusal.
+    assert.equal(ranAgn, false);
+    assert.equal(reported.ok, false);
+    assert.match(reported.message, /not managed by this workspace/);
   });
 
   it('_getLaunchCommand returns null for unknown type', () => {

--- a/packages/agent-connector/test/node-config.test.js
+++ b/packages/agent-connector/test/node-config.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// node-config resolves ~/.openagents at require time, so each test gets an
+// isolated HOME and a freshly-required copy of the module (cache busted). The
+// aider tests use the same HOME-redirect trick.
+let tmpHome;
+let savedHome;
+let nodeCfg;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-nodecfg-'));
+  savedHome = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  delete require.cache[require.resolve('../src/node-config')];
+  nodeCfg = require('../src/node-config');
+});
+
+afterEach(() => {
+  if (savedHome.HOME === undefined) delete process.env.HOME; else process.env.HOME = savedHome.HOME;
+  if (savedHome.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = savedHome.USERPROFILE;
+  delete require.cache[require.resolve('../src/node-config')];
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+const W1 = { node_id: 'n1', workspace_id: 'w1', workspace_slug: 'ws1', endpoint: 'https://ws1', token: 'secret' };
+const W2 = { node_id: 'n2', workspace_id: 'w2', workspace_slug: 'ws2', endpoint: 'https://ws2', token: 'other' };
+
+describe('node-config listPairings', () => {
+  it('returns every paired workspace — they are all live', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W2, pairings: [W2, W1] });
+
+    assert.deepEqual(
+      nodeCfg.listPairings().map((p) => p.workspace_id),
+      ['w2', 'w1'],
+    );
+  });
+
+  // node.json written before `pairings` existed carries one top-level pairing.
+  it('reconstructs the list from a legacy single-pairing file', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W1 });
+
+    assert.deepEqual(
+      nodeCfg.listPairings().map((p) => p.workspace_id),
+      ['w1'],
+    );
+  });
+
+  it('is empty when nothing is paired', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key' });
+    assert.deepEqual(nodeCfg.listPairings(), []);
+  });
+});
+
+describe('node-config clearPairing', () => {
+  it('drops the named workspace but keeps the device key', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W1, pairings: [W1] });
+
+    const dropped = nodeCfg.clearPairing('w1');
+
+    assert.equal(dropped.workspace_id, 'w1');
+    const after = nodeCfg.loadNode();
+    assert.equal(after.node_key, 'dev-key', 'the device key survives, so a re-pair reuses the same id');
+    assert.equal(after.workspace_id, undefined, 'the binding is gone');
+    assert.equal(after.token, undefined, 'the workspace token is gone');
+    assert.deepEqual(after.pairings, [], 'the dropped workspace is removed');
+  });
+
+  // The whole point of multi-pairing: one workspace forgetting this device says
+  // nothing about the others, which must go on heartbeating.
+  it('leaves every other paired workspace intact', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W1, pairings: [W1, W2] });
+
+    nodeCfg.clearPairing('w1');
+
+    const after = nodeCfg.loadNode();
+    assert.deepEqual(after.pairings.map((p) => p.workspace_id), ['w2']);
+    assert.equal(after.workspace_id, 'w2', 'a survivor is promoted to the top level');
+    assert.equal(after.token, 'other', 'with its own token, so it can still heartbeat');
+  });
+
+  it('defaults to the top-level pairing', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W2, pairings: [W2, W1] });
+
+    assert.equal(nodeCfg.clearPairing().workspace_id, 'w2');
+    assert.deepEqual(nodeCfg.listPairings().map((p) => p.workspace_id), ['w1']);
+  });
+
+  it('never returns the dropped pairing\'s token', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W1, pairings: [W1] });
+    assert.equal(nodeCfg.clearPairing('w1').token, undefined);
+  });
+
+  it('is a no-op for a workspace that is not paired', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key', ...W1, pairings: [W1] });
+
+    assert.equal(nodeCfg.clearPairing('w-nope'), null);
+    assert.deepEqual(nodeCfg.listPairings().map((p) => p.workspace_id), ['w1']);
+  });
+
+  it('is a no-op when nothing is paired', () => {
+    nodeCfg.saveNode({ node_key: 'dev-key' });
+    assert.equal(nodeCfg.clearPairing(), null);
+    assert.equal(nodeCfg.loadNode().node_key, 'dev-key');
+  });
+});


### PR DESCRIPTION
## 为什么

node 行是按 (workspace, device) 建的，一台设备本来就可以同时属于多个 workspace —— 但 `node.json` 只描述得了一个。配对第二个 workspace 会把第一个覆盖掉，daemon 也只给"排在最上面"的那个发心跳，于是其它 workspace 的"已连接设备"视图就一直是旧的。

## 改了什么

**`node-config.js` 改成维护一份配对列表**
- `listPairings()` —— 旧格式（只有顶层单条配对）会被重建成列表，向后兼容
- `recordPairing()` —— 新增或刷新一条，不动其它配对
- `clearPairing(workspaceId)` —— 取代 `clearActivePairing()`，只丢掉指定的那条
- 最新的配对仍然镜像在顶层字段上，所以早于多配对的 daemon 照常工作

**`daemon.js` 按配对逐个心跳**
- 每条配对一个 `WorkspaceClient`（按 `workspace_id` 缓存），roster 也按该 workspace 的 agent 过滤
- 并发发送、失败按配对隔离：某个 workspace 不可达不会拖住其它的
- 404 只清掉那一条配对
- 远程命令的结果回报走"下发该命令的那个 workspace"的 client，不会串到别的

**`cli.js`**
- `agn node connect` 改为增量记录
- `agn node status` 列出设备所属的全部 workspace

## 说明

- 这个分支同时带上了 `feat/launcher-node-pairing` 上两个还没进 develop 的 core commit（roster/命令按已连接 workspace 收敛、心跳 404 清配对），因为本次改动直接建在它们之上。
- 0.2.165 的 Windows 控制台窗口修复原样保留。
- 版本 0.2.165 → 0.2.166，daemon 需要发包才能拿到；launcher 的 bundled 依赖等发布后另外提。

## 验证

`node --test`（CI 那条命令，排除 mini）：935 tests / 933 pass / 2 skipped / 0 fail。`agn node status` 与 `require('./src/index.js')` 冒烟通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)