### PR TITLE
feat(launcher): release notes, and a shipped build that stops fighting the user

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -17,6 +17,26 @@ permissions:
   actions: read   # lets the SignPath connector read the job and download the artifact
 
 jobs:
+  # Fails a launcher-v* tag whose version has no release notes, or whose notes
+  # are malformed. Runs before anything is built: the "What's new" dialog is
+  # bundled into the app, so a missing file cannot be fixed after the fact
+  # without cutting another release.
+  check-release-notes:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/launcher-v')
+    defaults:
+      run:
+        working-directory: packages/launcher
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Validate release notes
+        run: node ./scripts/check-changelog.mjs --tag "${{ github.ref_name }}"
+
   build-macos:
     strategy:
       fail-fast: false
@@ -404,7 +424,8 @@ jobs:
           if-no-files-found: warn
 
   release:
-    needs: [build-macos, build-windows, sign-windows, build-linux]
+    needs:
+      [check-release-notes, build-macos, build-windows, sign-windows, build-linux]
     runs-on: ubuntu-latest
     if: always() && (startsWith(github.ref, 'refs/tags/launcher-v') || startsWith(github.ref, 'refs/tags/desktop-v')) && !failure() && !cancelled()
 

--- a/packages/launcher/changelog/0.9.9.json
+++ b/packages/launcher/changelog/0.9.9.json
@@ -1,0 +1,50 @@
+{
+  "version": "0.9.9",
+  "date": "2026-08-13",
+  "entries": [
+    {
+      "type": "feature",
+      "title": {
+        "en": "Join a workspace with a pairing code",
+        "zh": "支持使用配对码加入工作区"
+      },
+      "description": {
+        "en": "Open Connect Agent → Nodes in the workspace, copy the eight-character code and paste it into the launcher — no token, link or configuration file required. The workspace can then install and start agents on this device.",
+        "zh": "在工作区打开「连接智能体 → 节点」，复制 8 位配对码粘贴至启动器即可完成接入，无需令牌、链接或配置文件。接入后，工作区可直接在本设备上安装并启动智能体。"
+      }
+    },
+    {
+      "type": "feature",
+      "title": {
+        "en": "Customisable appearance",
+        "zh": "界面外观支持自定义"
+      },
+      "description": {
+        "en": "Settings → Appearance offers light / dark / follow-system, an accent colour, the OpenAgents skin, text size, and switches for animations and high contrast. Settings take effect from the first frame, including the startup screen.",
+        "zh": "「设置 → 外观」提供浅色 / 深色 / 跟随系统、强调色、OpenAgents 皮肤、字号，以及动效与高对比度开关。设置于首帧即生效，启动画面同步应用。"
+      }
+    },
+    {
+      "type": "feature",
+      "title": {
+        "en": "Release notes shown after each update",
+        "zh": "更新后自动展示版本更新公告"
+      },
+      "description": {
+        "en": "Shown once on the first launch after an update and not again for that version; a fresh install shows nothing. Earlier versions remain available under Settings → Updates.",
+        "zh": "更新后首次启动时展示本版更新内容，展示一次后不再重复弹出；全新安装不展示。历史版本的更新内容可在「设置 → 更新」中查看。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Blank console window on Windows",
+        "zh": "修复 Windows 下弹出空白控制台窗口的问题"
+      },
+      "description": {
+        "en": "A background task was being allocated a console of its own every few minutes; it no longer is.",
+        "zh": "后台任务此前每隔数分钟会被系统分配一个独立的控制台窗口，现已修复。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/changelog/README.md
+++ b/packages/launcher/changelog/README.md
@@ -1,0 +1,66 @@
+# Release notes
+
+One JSON file per launcher version, named after the version: `0.9.9.json`.
+
+Everything the user reads in the launcher's **What's new** dialog comes from
+here — the dialog that opens once after an update, and the "Release notes"
+entry in Settings → Updates.
+
+## Why one file per version
+
+This is a monorepo. The GitHub Release body is generated from every PR that
+landed since the last tag, so it is mostly frontend/workspace/adapter work that
+has nothing to do with the desktop app — it cannot be shown to launcher users.
+And a single shared `CHANGELOG.md` would conflict in every parallel PR. One
+small file per version avoids both.
+
+## Format
+
+```json
+{
+  "version": "0.9.9",
+  "date": "2026-08-13",
+  "entries": [
+    {
+      "type": "feature",
+      "title": {
+        "en": "Join a workspace with a pairing code",
+        "zh": "用配对码加入工作区"
+      },
+      "description": {
+        "en": "Copy the eight-character code from Connect Agent → Nodes and paste it in — no token, no link, no config file.",
+        "zh": "在「Connect Agent → Nodes」复制 8 位配对码粘贴进来即可，不需要令牌、链接或配置文件。"
+      }
+    }
+  ]
+}
+```
+
+- `version` — must equal the `version` field in `package.json` and the file name.
+- `date` — `YYYY-MM-DD`, the release date.
+- `entries[].type` — `feature`, `improvement` or `fix`. Anything else is
+  rendered as `improvement`.
+- `entries[].title` — the change in a few words. This is what someone scanning
+  the list reads, so it has to stand on its own.
+- `entries[].description` — optional detail under the title. Leave it out when
+  the title already says everything.
+- Every `en` needs its `zh` and vice versa. Write for the person using the app,
+  not for the person who wrote the patch: "Agents you install now keep their
+  working directory" beats "fix(agents): persist cwd in registry".
+
+There is no per-release headline. The line under the dialog's title is fixed
+copy that explains what the dialog is (`whatsNew.subtitle` in the locale
+files) — it describes the feature, not the release, so it must not change from
+version to version.
+
+## Rules
+
+- Add the file in the same PR as the change, or the release will ship with a
+  half-written announcement.
+- CI fails a `launcher-v*` tag whose version has no matching file here, and
+  fails on a malformed one — see `scripts/check-changelog.mjs`, run by
+  `npm run check:changelog`.
+- Files are bundled into the app at build time, so the notes are available
+  offline and always match the version the user is actually running.
+- Never edit a released version's file to describe a *later* release. Users who
+  already saw it will not see it again.

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",
@@ -18,6 +18,7 @@
     "postinstall": "node ./scripts/ensure-electron.mjs",
     "dev": "electron-vite dev",
     "typecheck": "tsc -b",
+    "check:changelog": "node ./scripts/check-changelog.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "e2e": "playwright test",

--- a/packages/launcher/scripts/check-changelog.mjs
+++ b/packages/launcher/scripts/check-changelog.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Guards the release notes shown in the launcher's "What's new" dialog.
+//
+// Run bare (`npm run check:changelog`) it validates the shape of every file in
+// changelog/. Given a tag (`--tag launcher-v0.9.9`, which is what CI passes) it
+// also insists that this exact version has notes and that package.json agrees
+// with the tag — the two ways a release quietly ships with nothing to announce.
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const dir = join(root, "changelog")
+const TYPES = new Set(["feature", "improvement", "fix"])
+
+const errors = []
+const fail = (file, msg) => errors.push(`${file}: ${msg}`)
+
+function isText(v) {
+  return typeof v === "string" && v.trim().length > 0
+}
+
+function checkFile(name) {
+  const version = name.replace(/\.json$/, "")
+  let doc
+  try {
+    doc = JSON.parse(readFileSync(join(dir, name), "utf-8"))
+  } catch (e) {
+    fail(name, `not valid JSON — ${e.message}`)
+    return
+  }
+  if (doc.version !== version) {
+    fail(name, `"version" is "${doc.version}", expected "${version}"`)
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(doc.date || "")) {
+    fail(name, `"date" must be YYYY-MM-DD, got ${JSON.stringify(doc.date)}`)
+  }
+  if (!Array.isArray(doc.entries) || doc.entries.length === 0) {
+    fail(name, '"entries" must be a non-empty array')
+    return
+  }
+  doc.entries.forEach((entry, i) => {
+    const at = `entries[${i}]`
+    if (!TYPES.has(entry?.type)) {
+      fail(name, `${at}.type must be one of ${[...TYPES].join(", ")}`)
+    }
+    // Both languages are required everywhere: a missing zh silently shows
+    // English to every Chinese user, which is the failure nobody notices.
+    for (const lang of ["en", "zh"]) {
+      if (!isText(entry?.title?.[lang])) {
+        fail(name, `${at}.title.${lang} is missing or empty`)
+      }
+      // description is optional, but half a translation is not.
+      if (entry?.description && !isText(entry.description[lang])) {
+        fail(name, `${at}.description.${lang} is missing or empty`)
+      }
+    }
+  })
+}
+
+let files = []
+try {
+  files = readdirSync(dir).filter((f) => f.endsWith(".json"))
+} catch {
+  console.error(`No changelog directory at ${dir}`)
+  process.exit(1)
+}
+if (files.length === 0) errors.push("changelog/: no release notes at all")
+files.forEach(checkFile)
+
+const tagArg = process.argv.indexOf("--tag")
+if (tagArg !== -1) {
+  const tag = process.argv[tagArg + 1] || ""
+  const version = tag.replace(/^launcher-v/, "")
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"))
+  if (pkg.version !== version) {
+    errors.push(
+      `package.json version is ${pkg.version}, but the tag says ${version}`,
+    )
+  }
+  if (!files.includes(`${version}.json`)) {
+    errors.push(
+      `changelog/${version}.json is missing — every released version needs ` +
+        `release notes (see changelog/README.md)`,
+    )
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Release notes check failed:")
+  for (const e of errors) console.error(`  - ${e}`)
+  process.exit(1)
+}
+console.log(`Release notes OK (${files.length} version(s)).`)

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -1067,13 +1067,48 @@ export class AgentManager extends EventEmitter {
     return listWorkspaces.call(this._connector)
   }
 
+  /**
+   * Create a workspace on the server AND save it here.
+   *
+   * The core's `createWorkspace` only POSTs /v1/workspaces and hands back the
+   * credentials — persisting is the caller's job, which is why its own CLI
+   * prints the token from `workspace create` and calls `addNetwork` from
+   * `workspace join`. The launcher never did the second half, so a workspace
+   * created from the dialog existed on the server, showed its slug and token,
+   * and then failed to appear in the list the dialog had just added it to.
+   *
+   * Same registration the paste and pairing paths use, so all three land in the
+   * list identically.
+   */
   async createWorkspace(name: string): Promise<unknown> {
     const createWorkspace = this._connector!.createWorkspace as (
       opts: unknown,
-    ) => Promise<unknown>
-    return createWorkspace.call(this._connector, {
+    ) => Promise<{
+      workspaceId?: string
+      slug?: string
+      name?: string
+      token?: string
+    }>
+    const result = await createWorkspace.call(this._connector, {
       name: name || "My Workspace",
     })
+
+    const slug = result?.slug || result?.workspaceId
+    // No slug or no token means nothing that can be addressed later; return the
+    // server's answer rather than writing a half-entry into the config.
+    if (slug && result?.token) {
+      const config = this._connector!.config as Record<string, unknown>
+      const addNetwork = config.addNetwork as (opts: unknown) => unknown
+      addNetwork.call(config, {
+        id: result.workspaceId || slug,
+        slug,
+        name: result.name || name || slug,
+        endpoint: this.configuredWorkspaceEndpoint(),
+        token: result.token,
+      })
+      this.signalReload()
+    }
+    return result
   }
 
   async registerWorkspaceFromToken(input: {

--- a/packages/launcher/src/main/app-menu.test.ts
+++ b/packages/launcher/src/main/app-menu.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest"
+
+// app-menu.ts only touches electron inside installApplicationMenu(); the shape
+// here just has to satisfy the module-level import under vitest.
+vi.mock("electron", () => ({
+  app: { isPackaged: true },
+  Menu: { setApplicationMenu: () => {}, buildFromTemplate: () => ({}) },
+}))
+
+import { isReloadShortcut } from "./app-menu"
+
+type Input = Parameters<typeof isReloadShortcut>[0]
+
+const key = (over: Partial<Input>): Input => ({
+  type: "keyDown",
+  key: "r",
+  control: false,
+  meta: false,
+  ...over,
+})
+
+describe("isReloadShortcut", () => {
+  it("catches Cmd+R and Cmd+Shift+R on macOS", () => {
+    expect(isReloadShortcut(key({ meta: true }), "darwin")).toBe(true)
+    // Shift is deliberately not inspected — force-reload is the same verb.
+    expect(isReloadShortcut(key({ meta: true, key: "R" }), "darwin")).toBe(true)
+  })
+
+  it("catches Ctrl+R off macOS", () => {
+    expect(isReloadShortcut(key({ control: true }), "win32")).toBe(true)
+    expect(isReloadShortcut(key({ control: true }), "linux")).toBe(true)
+  })
+
+  it("catches F5 everywhere", () => {
+    expect(isReloadShortcut(key({ key: "F5" }), "darwin")).toBe(true)
+    expect(isReloadShortcut(key({ key: "F5" }), "win32")).toBe(true)
+  })
+
+  it("leaves the other platform's modifier alone", () => {
+    // Ctrl+R on macOS is a text-field binding, not a reload.
+    expect(isReloadShortcut(key({ control: true }), "darwin")).toBe(false)
+    expect(isReloadShortcut(key({ meta: true }), "win32")).toBe(false)
+  })
+
+  it("ignores plain R and key-up events", () => {
+    expect(isReloadShortcut(key({}), "darwin")).toBe(false)
+    expect(isReloadShortcut(key({ meta: true, type: "keyUp" }), "darwin")).toBe(
+      false,
+    )
+  })
+})

--- a/packages/launcher/src/main/app-menu.ts
+++ b/packages/launcher/src/main/app-menu.ts
@@ -1,0 +1,78 @@
+// ── Application menu and the keyboard surface that ships with it ──
+//
+// Electron's stock menu is a developer's menu: View → Reload, Force Reload and
+// Toggle Developer Tools arrive pre-bound to Cmd/Ctrl+R, Cmd/Ctrl+Shift+R and
+// F12. Windows and Linux drop the whole menu (`installApplicationMenu` below),
+// but macOS cannot — the menu bar is where Cmd+C/Cmd+V live — so a shipped
+// build kept a one-keystroke way to throw the renderer's entire state away in
+// the middle of an install, an agent login or a chat.
+//
+// Reload is a development affordance, so it exists only in development.
+import { Menu, app } from "electron"
+
+/**
+ * The menu a packaged macOS build gets: the three standard roles users expect
+ * from any Mac app, and a View menu with the zoom/full-screen items but none of
+ * the reload/inspector ones.
+ *
+ * Labels stay in English like Electron's own defaults. The localized surfaces
+ * are the tray and the app itself; this bar only carries system-standard verbs,
+ * and half of its items (Services, Hide, Quit) are drawn by AppKit anyway.
+ */
+function packagedMacTemplate(): Electron.MenuItemConstructorOptions[] {
+  return [
+    { role: "appMenu" },
+    { role: "editMenu" },
+    {
+      label: "View",
+      submenu: [
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomOut" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    { role: "windowMenu" },
+  ]
+}
+
+/**
+ * Called once at startup, before the first window exists.
+ *
+ * macOS in development keeps Electron's default menu, reload included — that
+ * shortcut is the point of a dev build. Windows and Linux have no menu at all,
+ * as before: the app draws its own top edge, and dropping the menu drops every
+ * accelerator attached to it.
+ */
+export function installApplicationMenu(): void {
+  if (process.platform !== "darwin") {
+    Menu.setApplicationMenu(null)
+    return
+  }
+  if (app.isPackaged) {
+    Menu.setApplicationMenu(Menu.buildFromTemplate(packagedMacTemplate()))
+  }
+}
+
+/**
+ * Cmd+R / Ctrl+R (with or without Shift) and F5.
+ *
+ * Belt and braces next to the menu: the menu is what *binds* these today, but a
+ * future menu item, a devtools-opened window or an embedded page could bind
+ * them again, and a reload is unrecoverable — the renderer holds install
+ * progress, chat state and half-finished forms that live nowhere else.
+ *
+ * `platform` is a parameter so the rule is testable off a Mac.
+ */
+export function isReloadShortcut(
+  input: Pick<Electron.Input, "type" | "key" | "control" | "meta">,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (input.type !== "keyDown") return false
+  if (input.key === "F5") return true
+  if (input.key.toLowerCase() !== "r") return false
+  // Ctrl+R on macOS is not reload (and is a real Emacs-style binding in text
+  // fields), so each platform only blocks its own modifier.
+  return platform === "darwin" ? input.meta : input.control
+}

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -12,6 +12,7 @@ import {
   ipcMain,
   nativeImage,
   nativeTheme,
+  session,
   shell,
 } from "electron"
 import path from "path"
@@ -85,6 +86,7 @@ import {
   tuneNpmRegistry,
 } from "./net-config"
 import { hardenWebContents, openExternalSafely } from "./web-security"
+import { installApplicationMenu, isReloadShortcut } from "./app-menu"
 import {
   applyThemeSource,
   createPlaceholderIcon,
@@ -519,24 +521,31 @@ function createWindow(): void {
     }
   })
 
-  // Keyboard shortcuts to toggle DevTools manually in dev (F12 / Cmd+Opt+I /
-  // Ctrl+Shift+I). Disabled in packaged builds.
-  if (!app.isPackaged) {
-    mainWindow.webContents.on("before-input-event", (event, input) => {
-      if (input.type !== "keyDown") return
-      const isToggle =
-        input.key === "F12" ||
-        (input.key.toLowerCase() === "i" &&
-          ((process.platform === "darwin" && input.meta && input.alt) ||
-            (process.platform !== "darwin" && input.control && input.shift)))
-      if (isToggle) {
-        event.preventDefault()
-        const wc = mainWindow!.webContents
-        if (wc.isDevToolsOpened()) wc.closeDevTools()
-        else wc.openDevTools({ mode: "detach" })
-      }
-    })
-  }
+  mainWindow.webContents.on("before-input-event", (event, input) => {
+    if (input.type !== "keyDown") return
+
+    // Reload throws away everything the renderer is holding — install progress,
+    // a half-finished agent login, an unsent message — and nothing in the app
+    // asks for it. Dev builds keep it; shipped builds do not.
+    if (app.isPackaged && isReloadShortcut(input)) {
+      event.preventDefault()
+      return
+    }
+
+    // DevTools toggle (F12 / Cmd+Opt+I / Ctrl+Shift+I), dev only.
+    if (app.isPackaged) return
+    const isToggle =
+      input.key === "F12" ||
+      (input.key.toLowerCase() === "i" &&
+        ((process.platform === "darwin" && input.meta && input.alt) ||
+          (process.platform !== "darwin" && input.control && input.shift)))
+    if (isToggle) {
+      event.preventDefault()
+      const wc = mainWindow!.webContents
+      if (wc.isDevToolsOpened()) wc.closeDevTools()
+      else wc.openDevTools({ mode: "detach" })
+    }
+  })
 
   mainWindow.on("close", (e) => {
     // Honor the "Minimize to tray" setting (Settings → General, default on).
@@ -1876,6 +1885,28 @@ function setupIPC(): void {
     return true
   })
 
+  // The running app's own version. `system:info` also carries it, but that call
+  // walks the process tree and stats the disk — far too much for the release
+  // notes check that runs on every startup.
+  ipcMain.handle("app:version", () => getLauncherVersion())
+
+  // Settings → Data → "Clear cache". Chromium's HTTP/image cache only: it is
+  // rebuildable by definition, so nothing here needs a confirmation. Storage
+  // (localStorage) is deliberately NOT touched — that is the renderer's own
+  // state and it has its own control next to this one.
+  ipcMain.handle("app:clear-cache", async () => {
+    try {
+      const s = session.defaultSession
+      // Measured first so the toast can say how much came back; a cache that
+      // refuses to report its size still clears.
+      const freed = await s.getCacheSize().catch(() => 0)
+      await s.clearCache()
+      return { ok: true, freed }
+    } catch (e) {
+      return { ok: false, error: (e as Error).message }
+    }
+  })
+
   // GPU acceleration is a launch-time Chromium switch, so the toggle in
   // Settings → General only takes effect on a fresh process. `quit` (not
   // `exit`) so `before-quit` still stops the agents and the daemon.
@@ -2244,7 +2275,7 @@ if (!gotLock) {
 }
 
 app.whenReady().then(async () => {
-  if (process.platform !== "darwin") Menu.setApplicationMenu(null)
+  installApplicationMenu()
 
   // The window frame is drawn by the OS, so the OS has to be told which way the
   // app is themed — otherwise a dark app keeps a light Windows title bar, which

--- a/packages/launcher/src/preload/index.ts
+++ b/packages/launcher/src/preload/index.ts
@@ -87,6 +87,8 @@ contextBridge.exposeInMainWorld('api', {
   exportSettingsToFile: () => ipcRenderer.invoke('settings:export-to-file'),
   importSettings: (json: string) => ipcRenderer.invoke('settings:import', json),
   resetSettings: () => ipcRenderer.invoke('settings:reset'),
+  clearAppCache: () => ipcRenderer.invoke('app:clear-cache'),
+  appVersion: () => ipcRenderer.invoke('app:version'),
   relaunchApp: () => ipcRenderer.invoke('app:relaunch'),
   testWorkspaceEndpoint: (url: string) => ipcRenderer.invoke('workspace:test-endpoint', url),
   listPaths: () => ipcRenderer.invoke('paths:list'),

--- a/packages/launcher/src/renderer/App.tsx
+++ b/packages/launcher/src/renderer/App.tsx
@@ -29,6 +29,8 @@ import GitHubPage from "./pages/github"
 import Install from "./pages/install"
 import Logs from "./pages/logs"
 import Settings from "./pages/settings"
+import { WhatsNewDialog } from "./components/whats-new/whats-new-dialog"
+import { useWhatsNew } from "./components/whats-new/use-whats-new"
 import { InstallMiniBanner } from "./components/install-progress/install-mini-banner"
 import { LauncherUpdateBanner } from "./components/LauncherUpdateBanner"
 import { useToasts } from "./hooks/useToast"
@@ -46,7 +48,9 @@ export default function App(): React.JSX.Element {
   const initNotifications = useNotificationsStore((s) => s.init)
   const { showToast } = useToasts()
   const startTour = useUiStore((s) => s.startTour)
+  const tourOpen = useUiStore((s) => s.tourOpen)
   const [onboardingOpen, setOnboardingOpen] = React.useState(false)
+  const whatsNew = useWhatsNew()
 
   useEffect(() => {
     initTheme()
@@ -175,6 +179,20 @@ export default function App(): React.JSX.Element {
           mutually exclusive, and this guarantees the spotlight can never render
           on top of the wizard even if a stray startTour() slips through. */}
       {!onboardingOpen && <GuidedTour />}
+
+      {/* Release notes after an update. Held back while the wizard or the tour
+          is running: a new user is being walked through the app, not briefed on
+          what changed since a version they never ran — and the tour's spotlight
+          paints above a dialog, so an overlap would bury this one. It opens on
+          the next launch instead, since the seen-marker is only written when
+          the dialog is actually closed. */}
+      {!onboardingOpen && !tourOpen && (
+        <WhatsNewDialog
+          open={whatsNew.open}
+          releases={whatsNew.releases}
+          onClose={whatsNew.close}
+        />
+      )}
     </>
   )
 }

--- a/packages/launcher/src/renderer/components/command-palette/use-commands.ts
+++ b/packages/launcher/src/renderer/components/command-palette/use-commands.ts
@@ -58,10 +58,11 @@ const RUNNING_STATES = ["online", "running", "idle"]
 /** Every command the palette can run, in a stable order (groups stay together). */
 export function useCommands(): Command[] {
   const { t } = useTranslation()
-  const { setCurrentTab, goToInstallList } = useUiStore(
+  const { setCurrentTab, goToInstallList, requestCreate } = useUiStore(
     useShallow((s) => ({
       setCurrentTab: s.setCurrentTab,
       goToInstallList: s.goToInstallList,
+      requestCreate: s.requestCreate,
     })),
   )
   const agents = useAgentsStore((s) => s.agents)
@@ -117,7 +118,10 @@ export function useCommands(): Command[] {
       { id: "action:start-all", title: t("commandPalette.commands.startAll"), group, icon: Play, run: () => void window.api.startAll() },
       { id: "action:stop-all", title: t("commandPalette.commands.stopAll"), group, icon: Square, run: () => void window.api.stopAll() },
       { id: "action:install-agent", title: t("commandPalette.commands.installAgent"), group, icon: Plus, run: () => goToInstallList() },
-      { id: "action:new-workspace", title: t("commandPalette.commands.newWorkspace"), group, icon: Folder, run: () => setCurrentTab("workspaces") },
+      // Opens the create tab, like the dashboard's button. It used to only
+      // switch tabs, so the one command in this list named after an action was
+      // the one that did not perform it.
+      { id: "action:new-workspace", title: t("commandPalette.commands.newWorkspace"), group, icon: Folder, run: () => requestCreate("workspace") },
     ]
 
     const themes: Command[] = (["light", "dark", "system"] as ThemeMode[]).map((m) => ({
@@ -132,5 +136,5 @@ export function useCommands(): Command[] {
     }))
 
     return [...nav, ...agentCmds, ...actions, ...themes]
-  }, [agents, setCurrentTab, goToInstallList, mode, setMode, t])
+  }, [agents, setCurrentTab, goToInstallList, requestCreate, mode, setMode, t])
 }

--- a/packages/launcher/src/renderer/components/onboarding/steps/pair-node-step.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/steps/pair-node-step.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AlertCircle, Check } from "lucide-react"
+import { AlertCircle, Check, Info } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "@renderer/components/ui/input"
@@ -87,16 +87,22 @@ export function PairNodeStep({
         {t("onboarding.flow.pairNode.deviceHint")}
       </p>
 
-      {/* Already paired? Then this code will move the device, not add to it —
-          one node identity, one heartbeat, one workspace. */}
+      {/* Already paired? Then this code adds a workspace rather than moving the
+          device between them — memberships are per (workspace, device) and all
+          of them stay live. It stopped being a warning when that changed, so it
+          is drawn as a note, not a caution. */}
       {status?.connected && (
-        <div className="mt-7 flex items-start gap-2.5 rounded-lg border border-(--warning-border) bg-(--warning-bg) px-4 py-3">
-          <AlertCircle className="mt-0.5 size-3.5 shrink-0 text-(--warning-text)" />
+        <div className="mt-7 flex items-start gap-2.5 rounded-lg border border-(--border) bg-(--bg-card) px-4 py-3">
+          <Info className="mt-0.5 size-3.5 shrink-0 text-(--text-tertiary)" />
           <div className="min-w-0">
-            <div className="text-xs font-medium text-(--warning-text)">
-              {t("onboarding.flow.pairNode.alreadyPairedTitle", {
-                name: status.workspaceName || status.workspaceSlug || "",
-              })}
+            <div className="text-xs font-medium">
+              {(status.workspaces?.length ?? 0) > 1
+                ? t("onboarding.flow.pairNode.alreadyPairedTitleMany", {
+                    count: status.workspaces.length,
+                  })
+                : t("onboarding.flow.pairNode.alreadyPairedTitle", {
+                    name: status.workspaceName || status.workspaceSlug || "",
+                  })}
             </div>
             <p className="m-0 mt-1 text-2xs text-(--text-secondary)">
               {t("onboarding.flow.pairNode.alreadyPairedBody")}

--- a/packages/launcher/src/renderer/components/onboarding/use-onboarding-pairing.ts
+++ b/packages/launcher/src/renderer/components/onboarding/use-onboarding-pairing.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import type { ToastType } from "@renderer/hooks/useToast"
 import { capture, group } from "@renderer/lib/analytics"
 import { useAgentsStore } from "@renderer/store/agents"
+import { useUiStore } from "@renderer/store/ui"
 import {
   PAIRING_CODE_LENGTH,
   cleanIpcError,
@@ -94,11 +95,14 @@ export function useOnboardingPairing({
         source: "launcher_onboarding",
         workspace_id: res.workspaceSlug,
       })
-      showToast(
+      // Recorded, not toasted. The step swaps to a full "connected" panel that
+      // names the workspace, and the footer turns into "Finish setup" — a
+      // bottom-right toast lands exactly on that button and sits there for four
+      // seconds, so the one thing left to do is the one thing covered up.
+      useUiStore.getState().addActivity(
         t("onboarding.flow.pairNode.toast.connected", {
           name: res.workspaceName || res.workspaceSlug || "",
         }),
-        "success",
       )
       // The daemon was just (re)started, so the agent list on the other side of
       // this wizard should reflect it rather than the pre-pairing snapshot.

--- a/packages/launcher/src/renderer/components/ui-kit/confirm-dialog.tsx
+++ b/packages/launcher/src/renderer/components/ui-kit/confirm-dialog.tsx
@@ -78,7 +78,12 @@ export function ConfirmDialog({
             <AlertDialogDescription>{description}</AlertDialogDescription>
           )}
         </AlertDialogHeader>
-        {children && <div className="shrink-0">{children}</div>}
+        {/* A column, not a bare wrapper: prompts that stack two blocks here —
+            an opt-in checkbox and the warning that opt-in unlocks — had no gap
+            between them at all and rendered as one welded box. */}
+        {children && (
+          <div className="flex shrink-0 flex-col gap-3">{children}</div>
+        )}
         <AlertDialogFooter>
           <AlertDialogCancel disabled={busy}>
             {cancelLabel ?? t("ui.confirmDialog.cancel")}

--- a/packages/launcher/src/renderer/components/ui-kit/empty-state.tsx
+++ b/packages/launcher/src/renderer/components/ui-kit/empty-state.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "../ui/empty"
+import { Button } from "../ui/button"
+
+export interface EmptyStateAction {
+  label: string
+  /** Lucide element, sized by the button. */
+  icon?: React.ReactNode
+  onClick: () => void
+  testId?: string
+}
+
+export interface EmptyStateProps {
+  /** Lucide element. Use the page's own nav icon when the list is empty, and a
+   *  search/filter icon when something is merely hiding the rows. */
+  icon: React.ReactNode
+  title: string
+  description?: React.ReactNode
+  /** The one thing to do next. Omit where there is nothing to do. */
+  action?: EmptyStateAction
+  className?: string
+}
+
+/**
+ * The house empty state: icon, title, a sentence, and at most one action.
+ *
+ * The shadcn `Empty` primitives allow any subset of that, and every page picked
+ * a different one — Agents printed a bare grey sentence, Workspaces a sentence
+ * and a button, GitHub and Logs the full arrangement. The screens users are
+ * most likely to see first (an app with nothing in it yet) were the emptiest
+ * looking ones. This fixes the shape in one place so they cannot drift again.
+ *
+ * A title AND a description on purpose: the title says what is missing, the
+ * description says what to do about it. One line of grey text was doing both
+ * jobs and neither well.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps): React.JSX.Element {
+  return (
+    <Empty className={className}>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">{icon}</EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        {description && <EmptyDescription>{description}</EmptyDescription>}
+      </EmptyHeader>
+      {action && (
+        <EmptyContent>
+          <Button onClick={action.onClick} data-testid={action.testId}>
+            {action.icon}
+            {action.label}
+          </Button>
+        </EmptyContent>
+      )}
+    </Empty>
+  )
+}

--- a/packages/launcher/src/renderer/components/ui-kit/index.ts
+++ b/packages/launcher/src/renderer/components/ui-kit/index.ts
@@ -22,3 +22,8 @@ export { BrandMark } from "./brand-mark"
 
 export { ConfirmDialog } from "./confirm-dialog"
 export type { ConfirmDialogProps } from "./confirm-dialog"
+
+export { PageToolbar } from "./page-toolbar"
+
+export { EmptyState } from "./empty-state"
+export type { EmptyStateAction, EmptyStateProps } from "./empty-state"

--- a/packages/launcher/src/renderer/components/ui-kit/page-toolbar.tsx
+++ b/packages/launcher/src/renderer/components/ui-kit/page-toolbar.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+
+import { cn } from "@renderer/lib/utils"
+
+/**
+ * The row above a list: search, filter chips, sort, and whatever action the
+ * page keeps next to them (refresh, a view switch).
+ *
+ * Every list page grew its own version of this — one row here, two rows there,
+ * `mb-4` on one page and `mb-5` on the next, `size="sm"` controls on one and
+ * default heights on another. Side by side the pages looked like different
+ * apps. The layout lives here now; pages supply the controls in order and
+ * nothing else.
+ *
+ * Wraps rather than scrolls: the window is 1200px at its narrowest, which fits
+ * these controls, but a long filter set at a large text size should fold onto a
+ * second line instead of pushing the sort control off the edge.
+ */
+export function PageToolbar({
+  className,
+  ...props
+}: React.ComponentProps<"div">): React.JSX.Element {
+  return (
+    <div
+      data-slot="page-toolbar"
+      className={cn("mb-5 flex flex-wrap items-center gap-2", className)}
+      {...props}
+    />
+  )
+}

--- a/packages/launcher/src/renderer/components/whats-new/use-whats-new.ts
+++ b/packages/launcher/src/renderer/components/whats-new/use-whats-new.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useState } from "react"
+
+import { releasesSince, type Release } from "@renderer/lib/changelog"
+
+/**
+ * Last version whose notes the user actually saw. Under the `launcher:` prefix
+ * so "Reset appearance & interface state" clears it too — which is the right
+ * outcome: a cleared record reads as a fresh install and announces nothing.
+ */
+export const SEEN_KEY = "launcher:last-seen-release"
+
+export interface WhatsNewApi {
+  open: boolean
+  releases: Release[]
+  close: () => void
+}
+
+function read(): string | null {
+  try {
+    return localStorage.getItem(SEEN_KEY)
+  } catch {
+    return null
+  }
+}
+
+function remember(version: string): void {
+  try {
+    localStorage.setItem(SEEN_KEY, version)
+  } catch {
+    /* Private mode — the dialog just opens again next launch. */
+  }
+}
+
+/**
+ * Opens the release notes once, on the first launch after an update.
+ *
+ * A fresh install announces nothing: someone who has never seen this app does
+ * not need to be told what changed in it. That case is recorded silently, so
+ * their *next* update is the first thing they hear about.
+ */
+export function useWhatsNew(): WhatsNewApi {
+  const [open, setOpen] = useState(false)
+  const [releases, setReleases] = useState<Release[]>([])
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api
+      .appVersion()
+      .catch(() => null)
+      .then((version) => {
+        if (cancelled || !version) return
+        setVersion(version)
+        const seen = read()
+        if (!seen) {
+          remember(version)
+          return
+        }
+        const pending = releasesSince(seen, version)
+        // Nothing to say — an update with no notes, or a downgrade. Move the
+        // marker anyway so it tracks the running version.
+        if (pending.length === 0) {
+          remember(version)
+          return
+        }
+        setReleases(pending)
+        setOpen(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Recorded on close rather than on open: a window closed by a crash before
+  // the user read anything should still show the notes next time. The *running*
+  // version is what gets stored, not the newest release with notes — otherwise
+  // a version that shipped without any would be re-evaluated on every launch.
+  const close = useCallback(() => {
+    setOpen(false)
+    if (version) remember(version)
+  }, [version])
+
+  return { open, releases, close }
+}

--- a/packages/launcher/src/renderer/components/whats-new/whats-new-dialog.tsx
+++ b/packages/launcher/src/renderer/components/whats-new/whats-new-dialog.tsx
@@ -1,0 +1,138 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { Sparkles } from "lucide-react"
+
+import { Badge } from "@renderer/components/ui/badge"
+import { Button } from "@renderer/components/ui/button"
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@renderer/components/ui/dialog"
+import { localized, type Release, type ReleaseEntryType } from "@renderer/lib/changelog"
+
+/**
+ * Entry type → chip tint. Three distinct hues rather than a grey for fixes:
+ * the neutral chip sat at the same lightness as the dialog behind it and read
+ * as disabled text.
+ */
+const TONE: Record<ReleaseEntryType, "default" | "success" | "warning"> = {
+  feature: "default",
+  improvement: "success",
+  fix: "warning",
+}
+
+export interface WhatsNewDialogProps {
+  open: boolean
+  /** Newest first. One release after an update, all of them in history view. */
+  releases: Release[]
+  onClose: () => void
+}
+
+/**
+ * The release notes, in the reader's language.
+ *
+ * Purely presentational — App mounts one to announce an update (see
+ * `useWhatsNew`), Settings → Updates mounts another to browse the history.
+ */
+export function WhatsNewDialog({
+  open,
+  releases,
+  onClose,
+}: WhatsNewDialogProps): React.JSX.Element {
+  const { t, i18n } = useTranslation()
+  const newest = releases[0]
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="size-4 text-(--accent)" />
+            {newest
+              ? t("whatsNew.title", { version: newest.version })
+              : t("whatsNew.titleEmpty")}
+          </DialogTitle>
+          {/* Fixed copy, not the release's own headline: this line explains
+              what the dialog is, and that does not change from version to
+              version. Each release's summary is the title on its entries. */}
+          <DialogDescription>{t("whatsNew.subtitle")}</DialogDescription>
+        </DialogHeader>
+
+        <DialogBody className="gap-6">
+          {releases.length === 0 && (
+            <p className="m-0 text-sm text-muted-foreground">
+              {t("whatsNew.empty")}
+            </p>
+          )}
+          {releases.map((release, i) => (
+            <ReleaseBlock
+              key={release.version}
+              release={release}
+              language={i18n.language}
+              // A single release is already named in the dialog title; a
+              // catch-up spanning several needs each one labelled.
+              showHeading={releases.length > 1 || i > 0}
+              typeLabel={(type) => t(`whatsNew.types.${type}`)}
+            />
+          ))}
+        </DialogBody>
+
+        <DialogFooter>
+          <Button onClick={onClose}>{t("whatsNew.done")}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ReleaseBlock({
+  release,
+  language,
+  showHeading,
+  typeLabel,
+}: {
+  release: Release
+  language: string
+  showHeading: boolean
+  typeLabel: (type: ReleaseEntryType) => string
+}): React.JSX.Element {
+  return (
+    <section>
+      {showHeading && (
+        <div className="mb-3 flex items-baseline gap-2">
+          <span className="font-mono text-sm font-semibold">
+            v{release.version}
+          </span>
+          <span className="text-2xs text-muted-foreground">{release.date}</span>
+        </div>
+      )}
+      <ul className="m-0 flex list-none flex-col gap-4 p-0">
+        {release.entries.map((entry, i) => (
+          <li key={i} className="flex items-start gap-2.5">
+            <Badge variant={TONE[entry.type]} size="sm" className="mt-0.5">
+              {typeLabel(entry.type)}
+            </Badge>
+            {/* Two levels: the change in a few words, then the detail. A single
+                paragraph made every line weigh the same, so scanning the list
+                meant reading all of it. */}
+            <div className="min-w-0">
+              <div className="text-sm font-medium">
+                {localized(entry.title, language)}
+              </div>
+              {entry.description && (
+                <p className="mt-1 mb-0 text-xs leading-relaxed text-muted-foreground">
+                  {localized(entry.description, language)}
+                </p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/packages/launcher/src/renderer/components/workspaces/WorkspaceQuickConnect.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/WorkspaceQuickConnect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -61,6 +61,9 @@ export function WorkspaceQuickConnect({
   const [code, setCode] = useState("")
   const [name, setName] = useState("")
   const [busy, setBusy] = useState(false)
+  // `disabled={busy}` only takes effect on the next render, so a fast double
+  // click fired the request twice. This latch closes in the same tick.
+  const inFlight = useRef(false)
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<{ slug?: string; token?: string } | null>(null)
 
@@ -101,6 +104,8 @@ export function WorkspaceQuickConnect({
       showToast(t("workspaces.quickConnect.toast.pasteFirst"), "warning")
       return
     }
+    if (inFlight.current) return
+    inFlight.current = true
     setBusy(true)
     try {
       const ws = await window.api.registerWorkspaceFromToken(
@@ -114,6 +119,7 @@ export function WorkspaceQuickConnect({
     } catch (err) {
       showToast(humanizeError(err, t), "error")
     } finally {
+      inFlight.current = false
       setBusy(false)
     }
   }
@@ -124,6 +130,8 @@ export function WorkspaceQuickConnect({
       showToast(t("workspaces.quickConnect.toast.enterName"), "warning")
       return
     }
+    if (inFlight.current) return
+    inFlight.current = true
     setBusy(true)
     try {
       const r = (await window.api.createWorkspace(n)) as {
@@ -137,6 +145,7 @@ export function WorkspaceQuickConnect({
     } catch (err) {
       showToast(humanizeError(err, t), "error")
     } finally {
+      inFlight.current = false
       setBusy(false)
     }
   }
@@ -149,6 +158,8 @@ export function WorkspaceQuickConnect({
       setError(t("workspaces.quickConnect.pairError"))
       return
     }
+    if (inFlight.current) return
+    inFlight.current = true
     setBusy(true)
     setError(null)
     try {
@@ -169,6 +180,7 @@ export function WorkspaceQuickConnect({
     } catch (err) {
       setError(cleanIpcError((err as Error).message || ""))
     } finally {
+      inFlight.current = false
       setBusy(false)
     }
   }
@@ -223,9 +235,11 @@ export function WorkspaceQuickConnect({
         </DialogBody>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={onClose} disabled={busy}>
-            {t("workspaces.quickConnect.close")}
-          </Button>
+          {!(mode === "create" && result) && (
+            <Button variant="ghost" onClick={onClose} disabled={busy}>
+              {t("workspaces.quickConnect.close")}
+            </Button>
+          )}
           {mode === "paste" && (
             <Button onClick={handlePasteConnect} disabled={busy}>
               {busy
@@ -233,7 +247,12 @@ export function WorkspaceQuickConnect({
                 : t("workspaces.quickConnect.connect")}
             </Button>
           )}
-          {mode === "create" && (
+          {mode === "create" && result && (
+            <Button onClick={onClose}>
+              {t("workspaces.quickConnect.done")}
+            </Button>
+          )}
+          {mode === "create" && !result && (
             <Button onClick={handleCreate} disabled={busy}>
               {busy
                 ? t("workspaces.quickConnect.creating")

--- a/packages/launcher/src/renderer/components/workspaces/humanize-error.ts
+++ b/packages/launcher/src/renderer/components/workspaces/humanize-error.ts
@@ -17,7 +17,10 @@ export function humanizeError(err: unknown, t: TFunction): string {
   if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(raw)) {
     return t("workspaces.quickConnect.error.dns")
   }
-  if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|timed out/i.test(raw)) {
+  // AbortError is what the connector's own request deadline looks like once it
+  // has crossed IPC — "The operation was aborted" told the user nothing and
+  // named nothing they could do.
+  if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|timed out|AbortError|aborted/i.test(raw)) {
     return t("workspaces.quickConnect.error.timeout")
   }
   const cleaned = raw.replace(/^Error invoking remote method '[^']+':\s*/i, "")

--- a/packages/launcher/src/renderer/components/workspaces/quick-connect-panels.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/quick-connect-panels.tsx
@@ -103,8 +103,16 @@ export function CreatePanel({
           value={name}
           onChange={(e) => onChange(e.target.value)}
           placeholder={t("workspaces.quickConnect.createPlaceholder")}
+          disabled={!!result}
           autoFocus
         />
+        {/* The other two tabs each explain where their input comes from and
+            what happens next; this one used to be a bare field, which both
+            broke the rhythm between tabs and left "create" as the only action
+            here whose outcome was unstated. */}
+        <FieldDescription>
+          {t("workspaces.quickConnect.createHint")}
+        </FieldDescription>
       </Field>
       {result?.token && (
         <div className="rounded-sm bg-(--success-bg) px-3 py-2 text-xs break-all text-(--success-text)">

--- a/packages/launcher/src/renderer/i18n/locales/en/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agents.json
@@ -2,7 +2,7 @@
   "list": {
     "title": "My Agents",
     "subtitle": "Manage installed agent instances",
-    "newAgent": "New Agent",
+    "newAgent": "$t(common.actions.newAgent)",
     "searchPlaceholder": "Search agents…",
     "filters": {
       "all": "All",
@@ -11,8 +11,8 @@
       "running": "Running",
       "error": "Problems"
     },
-    "emptyNoMatch": "No agent matches “{{query}}”.",
-    "empty": "No agents configured. Click \"+ New Agent\" to get started.",
+    "emptyNoMatch": "No agent is named “{{query}}”.",
+    "empty": "Install one from the marketplace, or create an instance here. It then shows up on this page, ready to start, configure and join a workspace.",
     "coreUpdateRequired": "Launcher core update required",
     "apiPrefix": "API: {{value}}",
     "modelPrefix": "Model: {{value}}",
@@ -90,8 +90,11 @@
     "nextPage": "Next page",
     "addHint": "Add another agent instance",
     "readiness": "Setup",
-    "emptyNoFilterMatch": "No agent matches the current filter.",
-    "workspaceLine": "Workspace · {{name}}"
+    "emptyNoFilterMatch": "Every agent you have is in another state right now.",
+    "workspaceLine": "Workspace · {{name}}",
+    "emptyTitle": "No agents yet",
+    "emptyNoMatchTitle": "Nothing matches that search",
+    "emptyNoFilterMatchTitle": "Nothing matches this filter"
   },
   "newDialog": {
     "title": "New Agent",

--- a/packages/launcher/src/renderer/i18n/locales/en/commandPalette.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/commandPalette.json
@@ -30,7 +30,7 @@
     "startAll": "Start all agents",
     "stopAll": "Stop all agents",
     "installAgent": "Install new agent",
-    "newWorkspace": "New workspace",
+    "newWorkspace": "$t(common.actions.addWorkspace)",
     "theme": "Theme: {{mode}}"
   },
   "themes": {

--- a/packages/launcher/src/renderer/i18n/locales/en/common.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/common.json
@@ -5,6 +5,7 @@
   "import": "Import",
   "export": "Export",
   "reset": "Reset",
+  "clear": "Clear",
   "reveal": "Reveal",
   "cancel": "Cancel",
   "download": "Download",
@@ -12,5 +13,18 @@
   "none": "(none)",
   "notInstalled": "Not installed",
   "checking": "Checking...",
-  "comingSoon": "Coming soon"
+  "comingSoon": "Coming soon",
+  "workspaceMenu": {
+    "connectAgent": "Connect Agent",
+    "nodes": "Nodes",
+    "connectedNodes": "Connected nodes",
+    "copyToken": "Copy workspace token"
+  },
+  "clearSearch": "Clear search",
+  "showAll": "Show all",
+  "actions": {
+    "addWorkspace": "Add workspace",
+    "newAgent": "New agent",
+    "addCredential": "Add credential"
+  }
 }

--- a/packages/launcher/src/renderer/i18n/locales/en/connections.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/connections.json
@@ -14,7 +14,11 @@
     "noResults": "No platforms match \"{{query}}\"",
     "noConnected": "No platforms are connected yet",
     "noDisconnected": "All platforms are connected",
-    "noPlatforms": "No platforms are available"
+    "noPlatforms": "No platforms are available",
+    "noResultsTitle": "Nothing matches that search",
+    "noConnectedTitle": "Nothing connected yet",
+    "noDisconnectedTitle": "Everything is connected",
+    "noPlatformsTitle": "No connections available"
   },
   "filters": {
     "all": "All",

--- a/packages/launcher/src/renderer/i18n/locales/en/credentials.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/credentials.json
@@ -1,14 +1,16 @@
 {
   "title": "Credentials",
   "subtitle": "— Encrypted at rest. Reusable across multiple agents",
-  "addCredential": "Add credential",
+  "addCredential": "$t(common.actions.addCredential)",
   "searchPlaceholder": "Search credentials...",
   "filterAll": "All",
   "empty": {
     "none": "No credentials yet. Add one to share keys across agents.",
     "noMatch": "No credential matches “{{query}}”.",
-    "addFirst": "Add your first credential",
-    "noFilterMatch": "No credential matches the current filter."
+    "noFilterMatch": "No credential matches the current filter.",
+    "noneTitle": "No credentials yet",
+    "noMatchTitle": "Nothing matches that search",
+    "noFilterMatchTitle": "Nothing matches this filter"
   },
   "storage": {
     "title": "Storage",

--- a/packages/launcher/src/renderer/i18n/locales/en/dashboard.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/dashboard.json
@@ -6,8 +6,8 @@
     "attention_other": "{{count}} agents need attention.",
     "messagesToday": "{{count}} new message today.",
     "messagesToday_other": "{{count}} new messages today.",
-    "newAgent": "New agent",
-    "newWorkspace": "Create workspace",
+    "newAgent": "$t(common.actions.newAgent)",
+    "newWorkspace": "$t(common.actions.addWorkspace)",
     "stats": {
       "running": "Running",
       "workspaces": "Active workspaces",
@@ -52,7 +52,6 @@
     "manage": "Manage agent",
     "more": "More actions",
     "empty": "No agents configured yet.",
-    "installFirst": "Install your first agent",
     "states": {
       "running": "Running",
       "idle": "Idle",
@@ -73,8 +72,7 @@
     "agentCount": "{{count}} agent",
     "agentCount_other": "{{count}} agents",
     "open": "Open",
-    "empty": "No workspaces connected yet.",
-    "createFirst": "Create your first workspace"
+    "empty": "No workspaces connected yet."
   },
   "relativeTime": {
     "justNow": "just now",

--- a/packages/launcher/src/renderer/i18n/locales/en/install.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/install.json
@@ -38,7 +38,9 @@
   "empty": {
     "noMatch": "No agents match the current filters.",
     "resetFilters": "Reset filters",
-    "noQueryMatch": "No agent matches “{{query}}”."
+    "noQueryMatch": "No agent matches “{{query}}”.",
+    "noQueryMatchTitle": "Nothing matches that search",
+    "noMatchTitle": "Nothing matches this category"
   },
   "toast": {
     "installed": "{{name}} installed",

--- a/packages/launcher/src/renderer/i18n/locales/en/onboarding.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/onboarding.json
@@ -110,7 +110,7 @@
         "pending": "Not detected"
       },
       "footnote": {
-        "node": "You'll need a pairing code from your workspace — Connect Agent → Nodes.",
+        "node": "You'll need a pairing code from your workspace — $t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes).",
         "agent": "We'll have you running your first agent in under two minutes."
       },
       "modes": {
@@ -130,20 +130,21 @@
       "subtitle": "Enter the pairing code from your workspace. This machine joins as a device, and the workspace takes it from there.",
       "codeLabel": "Pairing code",
       "codePlaceholder": "XXXX-XXXX",
-      "codeHint": "Eight characters, shown in the workspace under Connect Agent → Nodes. Each code works once and expires after 15 minutes.",
+      "codeHint": "Eight characters, shown in the workspace under $t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes). Each code works once and expires after 15 minutes.",
       "deviceLabel": "Device name",
       "devicePlaceholder": "This computer",
       "deviceHint": "How this machine is labelled in the workspace. Defaults to its hostname.",
       "alreadyPairedTitle": "This device is already in \"{{name}}\"",
-      "alreadyPairedBody": "A device reports to one workspace at a time, so a new code moves it here and the other workspace will show it as offline.",
+      "alreadyPairedTitleMany": "This device is already in {{count}} workspaces",
+      "alreadyPairedBody": "A device can belong to several workspaces at once, so this code adds one more — the workspaces it is already in keep it.",
       "whereTitle": "Where to find the code",
       "where": {
-        "open": "Open your workspace in the browser and go to Connect Agent.",
-        "nodes": "On the Nodes tab, the pairing code is shown under Connected nodes.",
+        "open": "Open your workspace in the browser and go to $t(common.workspaceMenu.connectAgent).",
+        "nodes": "On the $t(common.workspaceMenu.nodes) tab, the pairing code is shown under $t(common.workspaceMenu.connectedNodes).",
         "copy": "Copy it and paste it above — no token or link needed."
       },
       "connectedTitle": "This device is connected",
-      "connectedDesc": "It now appears under Connected nodes in the workspace, and stays online while $t(common.appName) is running.",
+      "connectedDesc": "It now appears under $t(common.workspaceMenu.connectedNodes) in the workspace, and stays online while $t(common.appName) is running.",
       "connectedFootnote": "Next: install and start agents on this device straight from the workspace — or add one locally from the Agents tab.",
       "summary": {
         "workspace": "Workspace",

--- a/packages/launcher/src/renderer/i18n/locales/en/settings.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/settings.json
@@ -122,7 +122,11 @@
     "updateCheckFailed": "Update check failed: {{error}}",
     "downloadFailed": "Download failed: {{error}}",
     "installFailed": "Install failed: {{error}}",
-    "unknown": "unknown"
+    "unknown": "unknown",
+    "cacheCleared": "Cache cleared ({{size}} freed)",
+    "cacheClearFailed": "Could not clear the cache: {{error}}",
+    "localDataReset": "Appearance and interface state reset",
+    "cacheAlreadyEmpty": "Cache cleared"
   },
   "resetDialog": {
     "title": "Reset all settings?",
@@ -283,7 +287,13 @@
     "importSettingsDesc": "Restore from a JSON file; matching keys are overwritten",
     "dangerGroup": "Danger zone",
     "resetSettings": "Reset all settings",
-    "resetSettingsDesc": "Back to defaults. Agents and workspace data are left alone"
+    "resetSettingsDesc": "Back to defaults. Agents and workspace data are left alone",
+    "localGroup": "Launcher's own data",
+    "localGroupDesc": "Cached files and interface state this app keeps on your computer. Agents, workspaces and settings are not affected.",
+    "clearCache": "Clear cache",
+    "clearCacheDesc": "Empty the cached web pages, icons and images. Safe — they are re-fetched as needed",
+    "resetLocal": "Reset appearance & interface state",
+    "resetLocalDesc": "Theme, accent, skin, text size, sidebar and dismissed notices go back to defaults"
   },
   "language": {
     "languageGroup": "Language",
@@ -379,5 +389,23 @@
     "licenseFileDesc": "Read the full license on GitHub",
     "open": "Open",
     "view": "View"
+  },
+  "localResetDialog": {
+    "title": "Reset appearance and interface state?",
+    "description": "The window repaints immediately. Nothing installed or configured is touched.",
+    "affectedTitle": "Back to defaults",
+    "affected": {
+      "appearance": "Theme, accent colour, skin, text size",
+      "layout": "Sidebar state and the tab the app opens on",
+      "history": "Command palette history and dismissed update notices",
+      "marketplace": "Marketplace view, sort and filters"
+    },
+    "keptTitle": "Left alone",
+    "kept": {
+      "settings": "Everything in the other settings modules",
+      "language": "Interface language",
+      "workspaces": "Agents, workspaces and starred items"
+    },
+    "confirm": "Reset"
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/en/whatsNew.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/whatsNew.json
@@ -1,0 +1,15 @@
+{
+  "title": "What's new in v{{version}}",
+  "titleEmpty": "What's new",
+  "subtitle": "What changed in this version",
+  "empty": "No release notes are available for this version.",
+  "done": "Got it",
+  "types": {
+    "feature": "New",
+    "improvement": "Improved",
+    "fix": "Fixed"
+  },
+  "settingsRow": "Release notes",
+  "settingsRowDesc": "What changed in this version, and in the versions before it",
+  "settingsAction": "View"
+}

--- a/packages/launcher/src/renderer/i18n/locales/en/workspaces.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/workspaces.json
@@ -1,8 +1,7 @@
 {
   "title": "Workspaces",
   "subtitle": "Every workspace bundles its agents, activity and connections",
-  "join": "Join Workspace",
-  "create": "Create Workspace",
+  "join": "$t(common.actions.addWorkspace)",
   "stats": {
     "healthy": "Healthy",
     "warning": "Warning",
@@ -13,9 +12,8 @@
   "refresh": "Refresh",
   "activeWorkspaces": "Active Workspaces",
   "loading": "Loading workspaces…",
-  "emptyNone": "No workspaces yet.",
-  "emptyNoMatch": "No workspace matches “{{query}}”.",
-  "connectFirst": "Connect your first workspace",
+  "emptyNone": "A workspace is where you and your agents work together. Join one with a pairing code, paste an invitation link, or create a new one.",
+  "emptyNoMatch": "No workspace is named “{{query}}”.",
   "copied": "Copied",
   "toast": {
     "urlCopied": "URL copied",
@@ -92,13 +90,13 @@
     "daysAgo": "{{count}}d ago"
   },
   "quickConnect": {
-    "title": "Quick connect",
+    "title": "Add a workspace",
     "tabPair": "Pairing code",
     "tabPaste": "Paste URL / token",
-    "tabCreate": "Create new",
+    "tabCreate": "Create",
     "pairLabel": "Pairing code from the workspace",
     "pairPlaceholder": "XXXX-XXXX",
-    "pairHint": "In the workspace, open Connect Agent → Nodes. This device joins as a node, and you install and run agents on it from there. Codes work once and expire after 15 minutes.",
+    "pairHint": "In the workspace, open $t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes). This device joins as a node, and you install and run agents on it from there. Codes work once and expire after 15 minutes.",
     "pairBtn": "Join",
     "pairError": "A pairing code is 8 characters, like XXXX-XXXX.",
     "pasteLabel": "Workspace URL or invitation token",
@@ -106,10 +104,12 @@
     "pasteHint": "Hosted URLs use remote token resolution. Custom URLs use the URL origin, first path segment, and token query parameter.",
     "createLabel": "Workspace name",
     "createPlaceholder": "My Team",
+    "createHint": "A new workspace is created on OpenAgents and added here. You get its address and token straight away, and agents on this device can join it.",
     "ready": "Workspace ready",
     "readySlug": "slug: {{slug}}",
     "readyToken": "token: {{token}}",
     "close": "Close",
+    "done": "Done",
     "connecting": "Connecting...",
     "connect": "Connect",
     "creating": "Creating...",
@@ -126,8 +126,8 @@
       "tls": "Workspace service is temporarily unreachable (TLS certificate mismatch). Please try again later or contact support.",
       "dns": "Cannot reach the workspace service. Check your internet connection and try again.",
       "timeout": "Workspace service didn't respond in time. Please try again in a moment.",
-      "linkMissingToken": "That workspace link carries no token. In the workspace, open the avatar menu (top right) → Copy workspace token, then paste the token here.",
-      "invalidToken": "That token is invalid or has expired. Copy a fresh one from the workspace: avatar menu (top right) → Copy workspace token."
+      "linkMissingToken": "That workspace link carries no token. In the workspace, open the avatar menu (top right) → $t(common.workspaceMenu.copyToken), then paste the token here.",
+      "invalidToken": "That token is invalid or has expired. Copy a fresh one from the workspace: avatar menu (top right) → $t(common.workspaceMenu.copyToken)."
     }
   },
   "rename": {
@@ -156,7 +156,7 @@
     "name": "Name",
     "agents": "Agent count"
   },
-  "emptyNoFilterMatch": "No workspace matches the current filter.",
+  "emptyNoFilterMatch": "Every workspace you have is in another state right now.",
   "qrcode": {
     "dialogTitle": "Workspace QR code",
     "dialogDescription": "Scan to open {{name}} on another device.",
@@ -164,5 +164,8 @@
     "copied": "Workspace link copied",
     "copyFailed": "Failed to copy link",
     "unavailable": "This workspace has no token, so it has no shareable link."
-  }
+  },
+  "emptyNoneTitle": "No workspaces yet",
+  "emptyNoMatchTitle": "Nothing matches that search",
+  "emptyNoFilterMatchTitle": "Nothing matches this filter"
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agents.json
@@ -2,7 +2,7 @@
   "list": {
     "title": "我的智能体",
     "subtitle": "管理已安装的智能体实例",
-    "newAgent": "新建智能体",
+    "newAgent": "$t(common.actions.newAgent)",
     "searchPlaceholder": "搜索智能体…",
     "filters": {
       "all": "全部",
@@ -11,8 +11,8 @@
       "running": "运行中",
       "error": "异常"
     },
-    "emptyNoMatch": "没有匹配「{{query}}」的智能体。",
-    "empty": "尚未配置任何智能体。点击\"+ 新建智能体\"开始使用。",
+    "emptyNoMatch": "没有名称匹配「{{query}}」的智能体。",
+    "empty": "从应用市场安装一个，或者直接在这里新建一个实例。之后它就会出现在本页，可以启动、配置并加入工作区。",
     "coreUpdateRequired": "需要更新启动器核心",
     "apiPrefix": "API：{{value}}",
     "modelPrefix": "模型：{{value}}",
@@ -90,8 +90,11 @@
     "nextPage": "下一页",
     "addHint": "快速接入新的智能体实例",
     "readiness": "配置状态",
-    "emptyNoFilterMatch": "没有符合当前筛选条件的智能体。",
-    "workspaceLine": "工作区 · {{name}}"
+    "emptyNoFilterMatch": "你的智能体当前都不处于这个状态。",
+    "workspaceLine": "工作区 · {{name}}",
+    "emptyTitle": "还没有智能体",
+    "emptyNoMatchTitle": "没有匹配的智能体",
+    "emptyNoFilterMatchTitle": "该筛选下没有智能体"
   },
   "newDialog": {
     "title": "新建智能体",

--- a/packages/launcher/src/renderer/i18n/locales/zh/commandPalette.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/commandPalette.json
@@ -30,7 +30,7 @@
     "startAll": "启动所有智能体",
     "stopAll": "停止所有智能体",
     "installAgent": "安装新智能体",
-    "newWorkspace": "新建工作区",
+    "newWorkspace": "$t(common.actions.addWorkspace)",
     "theme": "主题：{{mode}}"
   },
   "themes": {

--- a/packages/launcher/src/renderer/i18n/locales/zh/common.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/common.json
@@ -5,6 +5,7 @@
   "import": "导入",
   "export": "导出",
   "reset": "重置",
+  "clear": "清除",
   "reveal": "在文件夹中显示",
   "cancel": "取消",
   "download": "下载",
@@ -12,5 +13,18 @@
   "none": "（无）",
   "notInstalled": "未安装",
   "checking": "检查中…",
-  "comingSoon": "即将推出"
+  "comingSoon": "即将推出",
+  "workspaceMenu": {
+    "connectAgent": "连接智能体",
+    "nodes": "节点",
+    "connectedNodes": "已连接的节点",
+    "copyToken": "复制工作区令牌"
+  },
+  "clearSearch": "清除搜索",
+  "showAll": "显示全部",
+  "actions": {
+    "addWorkspace": "添加工作区",
+    "newAgent": "新建智能体",
+    "addCredential": "添加凭证"
+  }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/connections.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/connections.json
@@ -14,7 +14,11 @@
     "noResults": "没有匹配“{{query}}”的平台",
     "noConnected": "尚未连接任何平台",
     "noDisconnected": "所有平台均已连接",
-    "noPlatforms": "暂无可用平台"
+    "noPlatforms": "暂无可用平台",
+    "noResultsTitle": "没有匹配的连接",
+    "noConnectedTitle": "还没有已连接的服务",
+    "noDisconnectedTitle": "全部已连接",
+    "noPlatformsTitle": "暂无可用连接"
   },
   "filters": {
     "all": "全部",

--- a/packages/launcher/src/renderer/i18n/locales/zh/credentials.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/credentials.json
@@ -1,14 +1,16 @@
 {
   "title": "凭证",
   "subtitle": "— 静态加密存储，可在多个智能体间复用",
-  "addCredential": "添加凭证",
+  "addCredential": "$t(common.actions.addCredential)",
   "searchPlaceholder": "搜索凭证…",
   "filterAll": "全部",
   "empty": {
     "none": "暂无凭证。添加一个即可在各智能体间共享密钥。",
     "noMatch": "没有匹配「{{query}}」的凭证。",
-    "addFirst": "添加第一个凭证",
-    "noFilterMatch": "没有符合当前筛选条件的凭证。"
+    "noFilterMatch": "没有符合当前筛选条件的凭证。",
+    "noneTitle": "还没有凭据",
+    "noMatchTitle": "没有匹配的凭据",
+    "noFilterMatchTitle": "该筛选下没有凭据"
   },
   "storage": {
     "title": "存储",

--- a/packages/launcher/src/renderer/i18n/locales/zh/dashboard.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/dashboard.json
@@ -4,8 +4,8 @@
     "allGood": "所有智能体运行正常。",
     "attention": "{{count}} 个智能体需要关注。",
     "messagesToday": "今天有 {{count}} 条新消息。",
-    "newAgent": "新建智能体",
-    "newWorkspace": "创建工作区",
+    "newAgent": "$t(common.actions.newAgent)",
+    "newWorkspace": "$t(common.actions.addWorkspace)",
     "stats": {
       "running": "运行中",
       "workspaces": "活跃工作区",
@@ -50,7 +50,6 @@
     "manage": "管理智能体",
     "more": "更多操作",
     "empty": "尚未配置任何智能体。",
-    "installFirst": "安装你的第一个智能体",
     "states": {
       "running": "运行中",
       "idle": "空闲",
@@ -70,8 +69,7 @@
     },
     "agentCount": "{{count}} 个智能体",
     "open": "打开",
-    "empty": "尚未连接任何工作区。",
-    "createFirst": "创建第一个工作区"
+    "empty": "尚未连接任何工作区。"
   },
   "relativeTime": {
     "justNow": "刚刚",

--- a/packages/launcher/src/renderer/i18n/locales/zh/install.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/install.json
@@ -38,7 +38,9 @@
   "empty": {
     "noMatch": "没有符合当前筛选条件的智能体。",
     "resetFilters": "重置筛选",
-    "noQueryMatch": "没有匹配「{{query}}」的智能体。"
+    "noQueryMatch": "没有匹配「{{query}}」的智能体。",
+    "noQueryMatchTitle": "没有匹配的智能体",
+    "noMatchTitle": "该分类下没有智能体"
   },
   "toast": {
     "installed": "{{name}} 已安装",

--- a/packages/launcher/src/renderer/i18n/locales/zh/onboarding.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/onboarding.json
@@ -40,7 +40,7 @@
         "agent": "挑选预装的 CLI 工具与 Agent，支持多模型并发。",
         "configure": "注入环境变量与 API 通道，并测试连通性。",
         "createAgent": "命名实例并指定它的工作目录。",
-        "connectWorkspace": "可选：加入或新建一个协作工作区。"
+        "connectWorkspace": "可选：加入或创建一个协作工作区。"
       }
     },
     "sections": {
@@ -110,7 +110,7 @@
         "pending": "未检测到"
       },
       "footnote": {
-        "node": "需要先在工作区里生成配对码：Connect Agent → Nodes。",
+        "node": "需要先在工作区里生成配对码：$t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes)。",
         "agent": "我们将帮你在两分钟内运行起第一个智能体。"
       },
       "modes": {
@@ -130,20 +130,21 @@
       "subtitle": "输入工作区里的配对码，这台机器就会作为设备接入，后续都在工作区里操作。",
       "codeLabel": "配对码",
       "codePlaceholder": "XXXX-XXXX",
-      "codeHint": "共 8 位，在工作区的 Connect Agent → Nodes 里查看。每个配对码只能用一次，15 分钟后失效。",
+      "codeHint": "共 8 位，在工作区的「$t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes)」里查看。每个配对码只能用一次，15 分钟后失效。",
       "deviceLabel": "设备名称",
       "devicePlaceholder": "这台电脑",
       "deviceHint": "这台机器在工作区里显示的名字，默认使用主机名。",
       "alreadyPairedTitle": "这台设备已经接入「{{name}}」",
-      "alreadyPairedBody": "一台设备同一时间只向一个工作区上报，所以新的配对码会把它转移过来，原来那个工作区会看到它离线。",
+      "alreadyPairedTitleMany": "这台设备已经接入 {{count}} 个工作区",
+      "alreadyPairedBody": "一台设备可以同时属于多个工作区，所以这个配对码是新增一个归属，已经接入的工作区不受影响。",
       "whereTitle": "配对码在哪里",
       "where": {
-        "open": "在浏览器里打开工作区，进入 Connect Agent。",
-        "nodes": "切到 Nodes 标签页，Connected nodes 下方就是配对码。",
+        "open": "在浏览器里打开工作区，进入「$t(common.workspaceMenu.connectAgent)」。",
+        "nodes": "切到「$t(common.workspaceMenu.nodes)」标签页，「$t(common.workspaceMenu.connectedNodes)」下方就是配对码。",
         "copy": "复制后粘贴到上面 —— 不需要 token 或链接。"
       },
       "connectedTitle": "这台设备已连接",
-      "connectedDesc": "它已经出现在工作区的 Connected nodes 里，只要 $t(common.appName) 在运行就保持在线。",
+      "connectedDesc": "它已经出现在工作区的「$t(common.workspaceMenu.connectedNodes)」里，只要 $t(common.appName) 在运行就保持在线。",
       "connectedFootnote": "接下来：直接在工作区里给这台设备安装并启动智能体，也可以在「智能体」页里本地添加。",
       "summary": {
         "workspace": "工作区",
@@ -237,7 +238,7 @@
     "connectWorkspace": {
       "title": "连接工作区",
       "subtitle": "工作区是智能体协作的地方。此步骤可选 —— 也可以稍后再连接。",
-      "createTitle": "新建一个工作区",
+      "createTitle": "创建新工作区",
       "createDesc": "创建全新工作区并将该智能体绑定到它。",
       "existingTitle": "连接已有工作区",
       "existingDesc": "用链接或 token 加入一个你被邀请的工作区。",

--- a/packages/launcher/src/renderer/i18n/locales/zh/settings.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/settings.json
@@ -122,7 +122,11 @@
     "updateCheckFailed": "检查更新失败：{{error}}",
     "downloadFailed": "下载失败：{{error}}",
     "installFailed": "安装失败：{{error}}",
-    "unknown": "未知错误"
+    "unknown": "未知错误",
+    "cacheCleared": "缓存已清除（释放 {{size}}）",
+    "cacheClearFailed": "清除缓存失败：{{error}}",
+    "localDataReset": "外观与界面状态已重置",
+    "cacheAlreadyEmpty": "缓存已清除"
   },
   "resetDialog": {
     "title": "重置所有设置？",
@@ -283,7 +287,13 @@
     "importSettingsDesc": "从 JSON 文件恢复设置，同名项会被覆盖",
     "dangerGroup": "危险操作",
     "resetSettings": "重置所有设置",
-    "resetSettingsDesc": "恢复默认值，不会删除智能体与工作区数据"
+    "resetSettingsDesc": "恢复默认值，不会删除智能体与工作区数据",
+    "localGroup": "启动器自身数据",
+    "localGroupDesc": "本应用保存在这台电脑上的缓存文件与界面状态。不影响智能体、工作区与设置。",
+    "clearCache": "清除缓存",
+    "clearCacheDesc": "清空缓存的网页、图标与图片，需要时会自动重新获取",
+    "resetLocal": "重置外观与界面状态",
+    "resetLocalDesc": "主题、强调色、皮肤、字号、侧边栏与已忽略的提示恢复默认"
   },
   "language": {
     "languageGroup": "语言设置",
@@ -379,5 +389,23 @@
     "licenseFileDesc": "在 GitHub 上查看许可证全文",
     "open": "打开",
     "view": "查看"
+  },
+  "localResetDialog": {
+    "title": "重置外观与界面状态？",
+    "description": "窗口会立即重新绘制，不会影响任何已安装或已配置的内容。",
+    "affectedTitle": "会恢复默认",
+    "affected": {
+      "appearance": "主题、强调色、皮肤、字号",
+      "layout": "侧边栏状态与启动时打开的页面",
+      "history": "命令面板历史与已忽略的更新提示",
+      "marketplace": "应用市场的视图、排序与筛选"
+    },
+    "keptTitle": "不受影响",
+    "kept": {
+      "settings": "其他设置模块中的全部内容",
+      "language": "界面语言",
+      "workspaces": "智能体、工作区与收藏项"
+    },
+    "confirm": "重置"
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/whatsNew.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/whatsNew.json
@@ -1,0 +1,15 @@
+{
+  "title": "v{{version}} 更新内容",
+  "titleEmpty": "更新公告",
+  "subtitle": "本版本的更新内容",
+  "empty": "该版本暂无更新公告。",
+  "done": "知道了",
+  "types": {
+    "feature": "新增",
+    "improvement": "优化",
+    "fix": "修复"
+  },
+  "settingsRow": "更新公告",
+  "settingsRowDesc": "查看本版本以及历史版本的更新内容",
+  "settingsAction": "查看"
+}

--- a/packages/launcher/src/renderer/i18n/locales/zh/workspaces.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/workspaces.json
@@ -1,8 +1,7 @@
 {
   "title": "工作区",
   "subtitle": "每个工作区都集成了其智能体、活动和连接",
-  "join": "加入工作区",
-  "create": "创建工作区",
+  "join": "$t(common.actions.addWorkspace)",
   "stats": {
     "healthy": "正常",
     "warning": "警告",
@@ -13,9 +12,8 @@
   "refresh": "刷新",
   "activeWorkspaces": "活跃工作区",
   "loading": "正在加载工作区…",
-  "emptyNone": "暂无工作区。",
-  "emptyNoMatch": "没有匹配「{{query}}」的工作区。",
-  "connectFirst": "连接你的第一个工作区",
+  "emptyNone": "工作区是你和智能体协作的地方。可以用配对码加入一个、粘贴邀请链接，或者创建一个新的。",
+  "emptyNoMatch": "没有名称匹配「{{query}}」的工作区。",
   "copied": "已复制",
   "toast": {
     "urlCopied": "已复制链接",
@@ -92,13 +90,13 @@
     "daysAgo": "{{count}} 天前"
   },
   "quickConnect": {
-    "title": "快速连接",
+    "title": "添加工作区",
     "tabPair": "配对码",
     "tabPaste": "粘贴链接 / 令牌",
-    "tabCreate": "新建",
+    "tabCreate": "创建",
     "pairLabel": "工作区里的配对码",
     "pairPlaceholder": "XXXX-XXXX",
-    "pairHint": "在工作区打开 Connect Agent → Nodes 获取。这台设备会作为节点加入，之后在工作区里给它安装、运行智能体。配对码只能用一次，15 分钟后失效。",
+    "pairHint": "在工作区打开「$t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes)」获取。这台设备会作为节点加入，之后在工作区里给它安装、运行智能体。配对码只能用一次，15 分钟后失效。",
     "pairBtn": "加入",
     "pairError": "配对码是 8 位，形如 XXXX-XXXX。",
     "pasteLabel": "工作区链接或邀请令牌",
@@ -106,10 +104,12 @@
     "pasteHint": "托管链接使用远程令牌解析。自定义链接会使用链接来源、首段路径和 token 查询参数。",
     "createLabel": "工作区名称",
     "createPlaceholder": "我的团队",
+    "createHint": "会在 OpenAgents 上新建一个工作区并添加到这里，随即给出它的地址与令牌，这台设备上的智能体可以直接加入。",
     "ready": "工作区已就绪",
     "readySlug": "slug：{{slug}}",
     "readyToken": "令牌：{{token}}",
     "close": "关闭",
+    "done": "完成",
     "connecting": "正在连接…",
     "connect": "连接",
     "creating": "正在创建…",
@@ -126,8 +126,8 @@
       "tls": "工作区服务暂时无法访问（TLS 证书不匹配）。请稍后重试或联系支持。",
       "dns": "无法连接到工作区服务。请检查你的网络连接后重试。",
       "timeout": "工作区服务未能及时响应。请稍后重试。",
-      "linkMissingToken": "这个工作区链接里没有令牌。请在工作区右上角点击头像 → 复制工作区令牌，然后粘贴令牌。",
-      "invalidToken": "令牌无效或已过期。请在工作区右上角点击头像 → 复制工作区令牌，重新获取后再试。"
+      "linkMissingToken": "这个工作区链接里没有令牌。请在工作区右上角点击头像 →「$t(common.workspaceMenu.copyToken)」，然后粘贴令牌。",
+      "invalidToken": "令牌无效或已过期。请在工作区右上角点击头像 →「$t(common.workspaceMenu.copyToken)」重新获取后再试。"
     }
   },
   "rename": {
@@ -156,7 +156,7 @@
     "name": "名称",
     "agents": "智能体数量"
   },
-  "emptyNoFilterMatch": "没有符合当前筛选条件的工作区。",
+  "emptyNoFilterMatch": "你的工作区当前都不处于这个状态。",
   "qrcode": {
     "dialogTitle": "工作区二维码",
     "dialogDescription": "扫码即可在其他设备上打开 {{name}}。",
@@ -164,5 +164,8 @@
     "copied": "已复制工作区链接",
     "copyFailed": "复制链接失败",
     "unavailable": "该工作区没有令牌，无法生成分享链接。"
-  }
+  },
+  "emptyNoneTitle": "还没有工作区",
+  "emptyNoMatchTitle": "没有匹配的工作区",
+  "emptyNoFilterMatchTitle": "该筛选下没有工作区"
 }

--- a/packages/launcher/src/renderer/i18n/nesting.test.ts
+++ b/packages/launcher/src/renderer/i18n/nesting.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+
+import { SUPPORTED_LANGUAGES, resources } from "./index"
+
+/**
+ * i18next nesting (`$t(other.key)`) fails silently: a mistyped reference does
+ * not throw and does not leave the `$t(…)` marker behind either — i18next
+ * substitutes the missing key's own name, so the UI ends up telling the user to
+ * click "common.workspaceMenu.nodes".
+ *
+ * The workspace's own menu names are shared this way — one term, translated
+ * once, quoted by every string that tells the user where to click — so a typo
+ * would ship an unreadable instruction in exactly the copy that exists to be
+ * followed. Hence checking the references themselves rather than the render.
+ */
+const NESTED = /\$t\(([^)]+)\)/g
+
+function walk(
+  node: unknown,
+  path: string[] = [],
+): Array<{ key: string; value: string }> {
+  if (typeof node === "string") return [{ key: path.join("."), value: node }]
+  if (!node || typeof node !== "object") return []
+  return Object.entries(node as Record<string, unknown>).flatMap(([k, v]) =>
+    walk(v, [...path, k]),
+  )
+}
+
+function lookup(bundle: unknown, key: string): unknown {
+  return key
+    .split(".")
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === "object"
+          ? (node as Record<string, unknown>)[part]
+          : undefined,
+      bundle,
+    )
+}
+
+describe("i18n nesting", () => {
+  for (const { value: lng } of SUPPORTED_LANGUAGES) {
+    it(`points every $t() reference at a real string in ${lng}`, () => {
+      const bundle = resources[lng].translation
+      const broken: string[] = []
+
+      for (const { key, value } of walk(bundle)) {
+        for (const [, ref] of value.matchAll(NESTED)) {
+          // `$t(key, {opts})` is legal; only the key half is a reference.
+          const target = ref.split(",")[0].trim()
+          if (typeof lookup(bundle, target) !== "string") {
+            broken.push(`${key} → ${target}`)
+          }
+        }
+      }
+
+      expect(broken).toEqual([])
+    })
+  }
+
+  it("keeps a shared term in step with both languages", () => {
+    // The point of sharing these: the launcher quotes the workspace's menu, so
+    // each language has to quote it in that language.
+    const en = lookup(resources.en.translation, "common.workspaceMenu.nodes")
+    const zh = lookup(resources.zh.translation, "common.workspaceMenu.nodes")
+    expect(en).toBe("Nodes")
+    expect(zh).not.toBe(en)
+  })
+})

--- a/packages/launcher/src/renderer/lib/changelog.test.ts
+++ b/packages/launcher/src/renderer/lib/changelog.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  RELEASES,
+  localized,
+  releaseFor,
+  releasesSince,
+} from "./changelog"
+
+describe("bundled release notes", () => {
+  it("ships at least one release, newest first", () => {
+    expect(RELEASES.length).toBeGreaterThan(0)
+    for (let i = 1; i < RELEASES.length; i++) {
+      expect(RELEASES[i - 1].version).not.toBe(RELEASES[i].version)
+    }
+  })
+
+  it("carries both languages for every entry", () => {
+    for (const release of RELEASES) {
+      expect(release.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      for (const entry of release.entries) {
+        expect(entry.title.en.trim()).not.toBe("")
+        expect(entry.title.zh.trim()).not.toBe("")
+        // Optional, but never half-translated — the parser drops a lone side.
+        if (entry.description) {
+          expect(entry.description.en.trim()).not.toBe("")
+          expect(entry.description.zh.trim()).not.toBe("")
+        }
+      }
+    }
+  })
+
+  it("finds a release by version, with or without the v prefix", () => {
+    const { version } = RELEASES[0]
+    expect(releaseFor(version)?.version).toBe(version)
+    expect(releaseFor(`v${version}`)?.version).toBe(version)
+    expect(releaseFor("0.0.1")).toBeNull()
+    expect(releaseFor(null)).toBeNull()
+  })
+})
+
+describe("releasesSince", () => {
+  const current = RELEASES[0].version
+
+  it("announces nothing on a fresh install", () => {
+    expect(releasesSince(null, current)).toEqual([])
+  })
+
+  it("announces nothing when the user is already current", () => {
+    expect(releasesSince(current, current)).toEqual([])
+  })
+
+  it("announces the release the user just moved onto", () => {
+    const pending = releasesSince("0.0.1", current)
+    expect(pending.map((r) => r.version)).toContain(current)
+  })
+
+  it("never announces a release newer than the running build", () => {
+    expect(releasesSince("0.0.1", "0.0.2")).toEqual([])
+  })
+})
+
+describe("localized", () => {
+  const text = { en: "English", zh: "中文" }
+
+  it("follows the active language, falling back to English", () => {
+    expect(localized(text, "zh")).toBe("中文")
+    expect(localized(text, "zh-CN")).toBe("中文")
+    expect(localized(text, "en")).toBe("English")
+    expect(localized(text, "fr")).toBe("English")
+  })
+})

--- a/packages/launcher/src/renderer/lib/changelog.ts
+++ b/packages/launcher/src/renderer/lib/changelog.ts
@@ -1,0 +1,119 @@
+/**
+ * Release notes — the "What's new" the launcher shows once after an update.
+ *
+ * The source of truth is `packages/launcher/changelog/<version>.json`, one file
+ * per version (see the README next to them for why, and for the format). They
+ * are bundled at build time, so the notes work offline and can never describe a
+ * version other than the one the user is running.
+ *
+ * Not derived from the GitHub Release body: this is a monorepo, and that body
+ * is generated from every PR since the last tag — mostly work in other packages
+ * that means nothing to someone using the desktop app.
+ */
+import { compareVersions } from "../../shared/version-compare"
+
+export type ReleaseEntryType = "feature" | "improvement" | "fix"
+
+/** A string in both shipped languages; `localized` picks one. */
+export interface Bilingual {
+  en: string
+  zh: string
+}
+
+/**
+ * One line of a release. `title` is the change in a few words and carries the
+ * emphasis; `description` is the detail, and is optional because some changes
+ * genuinely are one line.
+ */
+export interface ReleaseEntry {
+  type: ReleaseEntryType
+  title: Bilingual
+  description?: Bilingual
+}
+
+export interface Release {
+  version: string
+  date: string
+  entries: ReleaseEntry[]
+}
+
+const ENTRY_TYPES: ReleaseEntryType[] = ["feature", "improvement", "fix"]
+
+const modules = import.meta.glob("../../../changelog/*.json", { eager: true })
+
+function isText(v: unknown): v is string {
+  return typeof v === "string" && v.trim().length > 0
+}
+
+/**
+ * Anything malformed is dropped rather than thrown: a bad changelog file must
+ * never be able to stop the app from starting. CI is what refuses to ship one
+ * (`scripts/check-changelog.mjs`), which is the right place to be strict.
+ */
+function bilingual(raw: unknown): Bilingual | null {
+  if (!raw || typeof raw !== "object") return null
+  const { en, zh } = raw as Record<string, unknown>
+  return isText(en) && isText(zh) ? { en, zh } : null
+}
+
+function parseRelease(raw: unknown): Release | null {
+  const r = (raw as { default?: unknown })?.default ?? raw
+  if (!r || typeof r !== "object") return null
+  const { version, date, entries } = r as Record<string, unknown>
+  if (!isText(version) || !isText(date) || !Array.isArray(entries)) return null
+
+  const parsed = entries.flatMap((e): ReleaseEntry[] => {
+    if (!e || typeof e !== "object") return []
+    const { type, title, description } = e as Record<string, unknown>
+    const heading = bilingual(title)
+    if (!heading) return []
+    const kind = ENTRY_TYPES.find((k) => k === type) ?? "improvement"
+    return [
+      { type: kind, title: heading, description: bilingual(description) ?? undefined },
+    ]
+  })
+  if (parsed.length === 0) return null
+
+  return { version, date, entries: parsed }
+}
+
+/** Every release that has notes, newest first. */
+export const RELEASES: Release[] = Object.values(modules)
+  .map(parseRelease)
+  .filter((r): r is Release => r !== null)
+  .sort((a, b) => compareVersions(b.version, a.version) ?? 0)
+
+export function releaseFor(version: string | null): Release | null {
+  if (!version) return null
+  const target = version.replace(/^v/, "")
+  return RELEASES.find((r) => r.version === target) ?? null
+}
+
+/**
+ * What to announce to someone who last saw `seen` and is now running `current`.
+ *
+ * More than one release can be in there: users skip versions, and someone
+ * jumping 0.9.6 → 0.9.9 should get all three sets of notes rather than only the
+ * last. Releases newer than `current` are excluded — a build can be bundled
+ * with notes for a version it precedes only by mistake, but announcing a
+ * feature the user does not have yet is worse than saying nothing.
+ *
+ * `seen === null` means a fresh install with nothing to catch up on; the caller
+ * records the current version instead of opening anything.
+ */
+export function releasesSince(
+  seen: string | null,
+  current: string | null,
+): Release[] {
+  if (!seen || !current) return []
+  return RELEASES.filter((r) => {
+    const newerThanSeen = (compareVersions(r.version, seen) ?? 0) > 0
+    const notAhead = (compareVersions(r.version, current) ?? 0) <= 0
+    return newerThanSeen && notAhead
+  })
+}
+
+/** Pick the language the user reads; en is the fallback, as in i18next. */
+export function localized(text: Bilingual, language: string): string {
+  return language.toLowerCase().startsWith("zh") ? text.zh : text.en
+}

--- a/packages/launcher/src/renderer/lib/format.ts
+++ b/packages/launcher/src/renderer/lib/format.ts
@@ -1,0 +1,16 @@
+const UNITS = ["B", "KB", "MB", "GB", "TB"]
+
+/**
+ * Human byte sizes. One decimal below 10 in any unit above bytes, none above —
+ * "1.4 GB" carries information, "1.4 KB" and "342.0 MB" do not.
+ */
+export function formatBytes(bytes: number): string {
+  if (!bytes || bytes < 0) return "—"
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${UNITS[unit]}`
+}

--- a/packages/launcher/src/renderer/lib/local-data.test.ts
+++ b/packages/launcher/src/renderer/lib/local-data.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest"
+
+import { resetLocalPreferences } from "./local-data"
+import { useAppearanceStore } from "@renderer/store/appearance"
+import { useThemeStore } from "@renderer/store/theme"
+
+describe("resetLocalPreferences", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("clears every key the launcher writes for its own chrome", () => {
+    localStorage.setItem("launcher:accent", "rose")
+    localStorage.setItem("launcher:skin", "openagents")
+    localStorage.setItem("launcher:theme-mode", "dark")
+    localStorage.setItem("launcher:command-history", '["logs"]')
+    localStorage.setItem("openagents:updateDismissals/v1", "{}")
+    localStorage.setItem("oa.marketplace.prefs.v1", "{}")
+
+    resetLocalPreferences()
+
+    for (const key of [
+      "launcher:accent",
+      "launcher:skin",
+      "launcher:theme-mode",
+      "launcher:command-history",
+      "openagents:updateDismissals/v1",
+      "oa.marketplace.prefs.v1",
+    ]) {
+      expect(localStorage.getItem(key)).toBeNull()
+    }
+  })
+
+  it("keeps the language, workspace favourites and onboarding progress", () => {
+    localStorage.setItem("launcher:language", "zh")
+    localStorage.setItem("workspace-prefs:v1", '{"favorites":["a"]}')
+    localStorage.setItem("onboarding_completed", "true")
+    localStorage.setItem("guided_tour_completed", "true")
+
+    resetLocalPreferences()
+
+    expect(localStorage.getItem("launcher:language")).toBe("zh")
+    expect(localStorage.getItem("workspace-prefs:v1")).toBe('{"favorites":["a"]}')
+    expect(localStorage.getItem("onboarding_completed")).toBe("true")
+    expect(localStorage.getItem("guided_tour_completed")).toBe("true")
+  })
+
+  it("puts the live stores back to their defaults", () => {
+    useAppearanceStore.getState().setAccent("rose")
+    useAppearanceStore.getState().setScale("lg")
+    useAppearanceStore.getState().setHighContrast(true)
+    useThemeStore.getState().setMode("dark")
+
+    resetLocalPreferences()
+
+    const appearance = useAppearanceStore.getState()
+    expect(appearance.accent).toBe("indigo")
+    expect(appearance.scale).toBe("md")
+    expect(appearance.highContrast).toBe(false)
+    expect(useThemeStore.getState().mode).toBe("system")
+  })
+})

--- a/packages/launcher/src/renderer/lib/local-data.ts
+++ b/packages/launcher/src/renderer/lib/local-data.ts
@@ -1,0 +1,69 @@
+/**
+ * The launcher's own local state — the part that lives in the renderer's
+ * localStorage rather than in settings.json.
+ *
+ * Theme, accent, skin, UI scale, sidebar state, the command palette's history:
+ * all of it is read synchronously on the very first paint, which is why it is
+ * in localStorage and not behind async IPC. The cost is that it survives things
+ * users expect to clear it — "Reset all settings" only touches settings.json,
+ * and even a reinstall leaves the Chromium profile in place — so the app could
+ * come back up wearing a theme the user thought they had thrown away.
+ *
+ * This module is the one place that knows how to throw it away.
+ */
+import { STORAGE_KEY as LANGUAGE_KEY } from "@renderer/i18n"
+import { useAppearanceStore } from "@renderer/store/appearance"
+import { useThemeStore } from "@renderer/store/theme"
+
+/**
+ * Swept by prefix rather than by an explicit key list: a list would rot the
+ * first time someone renamed a key and nothing would fail. Every key the app
+ * writes for its own chrome carries one of these.
+ */
+const OWNED_PREFIXES = [
+  "launcher:", // theme, accent, skin, scale, sidebar, last tab, history
+  "openagents:", // dismissed update notices
+  "oa.", // marketplace view/sort/filter
+]
+
+/**
+ * Deliberately left behind:
+ *
+ * - the UI language, which has its own picker and is not chrome the user would
+ *   expect a "reset appearance" to undo;
+ * - `workspace-prefs:v1`, which holds starred workspaces and group labels —
+ *   content the user typed, not view state;
+ * - the onboarding/tour completion flags, since re-running the wizard is a
+ *   different request than repainting the app.
+ */
+const KEEP = new Set<string>([LANGUAGE_KEY])
+
+function ownedKeys(): string[] {
+  const keys: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (!key || KEEP.has(key)) continue
+    if (OWNED_PREFIXES.some((p) => key.startsWith(p))) keys.push(key)
+  }
+  return keys
+}
+
+/**
+ * Put the interface back to a fresh install and forget the stored copy.
+ *
+ * Defaults are applied through the stores first, so the running window
+ * repaints and main gets the default accent for the next startup splash — the
+ * splash reads its colour from settings.json, which is the mirror those setters
+ * maintain. The sweep comes second so nothing is left on disk either.
+ */
+export function resetLocalPreferences(): void {
+  useThemeStore.getState().reset()
+  useAppearanceStore.getState().reset()
+  for (const key of ownedKeys()) {
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      /* Private mode / quota — the in-memory reset above still stands. */
+    }
+  }
+}

--- a/packages/launcher/src/renderer/pages/agents/components/agents-toolbar.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/agents-toolbar.tsx
@@ -9,7 +9,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@renderer/components/ui/select"
-import { FilterChips, IconToggle, SearchInput } from "@renderer/components/ui-kit"
+import {
+  FilterChips,
+  IconToggle,
+  PageToolbar,
+  SearchInput,
+} from "@renderer/components/ui-kit"
 import {
   AGENT_FILTERS,
   AGENT_SORTS,
@@ -44,51 +49,46 @@ export function AgentsToolbar({
   const { t } = useTranslation()
 
   return (
-    <div className="mb-4 flex flex-col gap-3">
+    <PageToolbar>
       <SearchInput
         value={search}
         onChange={(e) => onSearch(e.target.value)}
         onClear={() => onSearch("")}
         placeholder={t("agents.list.searchPlaceholder")}
-        wrapperClassName="h-10"
+        wrapperClassName="flex-1"
       />
 
-      <div className="flex items-center gap-2">
-        <FilterChips
-          value={filter}
-          onChange={onFilter}
-          size="sm"
-          options={AGENT_FILTERS.map((f) => ({
-            value: f,
-            label: t(`agents.list.filters.${f}`),
-            count: counts[f],
-          }))}
-        />
+      <FilterChips
+        value={filter}
+        onChange={onFilter}
+        options={AGENT_FILTERS.map((f) => ({
+          value: f,
+          label: t(`agents.list.filters.${f}`),
+          count: counts[f],
+        }))}
+      />
 
-        <div className="ml-auto flex items-center gap-2">
-          <Select value={sort} onValueChange={(v) => onSort(v as AgentSort)}>
-            <SelectTrigger size="sm" className="w-32">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {AGENT_SORTS.map((s) => (
-                <SelectItem key={s} value={s}>
-                  {t(`agents.list.sorts.${s}`)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+      <Select value={sort} onValueChange={(v) => onSort(v as AgentSort)}>
+        <SelectTrigger className="w-36">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {AGENT_SORTS.map((s) => (
+            <SelectItem key={s} value={s}>
+              {t(`agents.list.sorts.${s}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
 
-          <IconToggle
-            value={view}
-            onChange={onView}
-            options={[
-              { value: "grid", icon: LayoutGrid, label: t("agents.list.views.grid") },
-              { value: "list", icon: List, label: t("agents.list.views.list") },
-            ]}
-          />
-        </div>
-      </div>
-    </div>
+      <IconToggle
+        value={view}
+        onChange={onView}
+        options={[
+          { value: "grid", icon: LayoutGrid, label: t("agents.list.views.grid") },
+          { value: "list", icon: List, label: t("agents.list.views.list") },
+        ]}
+      />
+    </PageToolbar>
   )
 }

--- a/packages/launcher/src/renderer/pages/agents/index.tsx
+++ b/packages/launcher/src/renderer/pages/agents/index.tsx
@@ -4,12 +4,11 @@ import { useUiStore } from "../../store/ui"
 import { useShallow } from "zustand/react/shallow"
 import { Trans, useTranslation } from "react-i18next"
 import AgentIcon from "../../components/AgentIcon"
-import { ConfirmDialog } from "../../components/ui-kit"
-import { Plus } from "lucide-react"
+import { ConfirmDialog, EmptyState } from "../../components/ui-kit"
+import { Cpu, FilterX, Plus, SearchX } from "lucide-react"
 import { Button } from "../../components/ui/button"
 import { Card } from "../../components/ui/card"
 import { Skeleton } from "../../components/ui/skeleton"
-import { Empty, EmptyDescription, EmptyHeader } from "../../components/ui/empty"
 import { PageHeader } from "../../components/layout/page-header"
 import type { ToastType } from "../../hooks/useToast"
 import { NewAgentDialog } from "./components/new-agent-dialog"
@@ -161,7 +160,7 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
         subtitle={t("agents.list.subtitle")}
         actions={
           <Button variant="default" data-testid="new-agent-open" onClick={() => setNewAgentOpen(true)}>
-            <Plus className="w-3.5 h-3.5" />
+            <Plus />
             {t("agents.list.newAgent")}
           </Button>
         }
@@ -187,17 +186,44 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
             <SkeletonListItem />
           </div>
         ) : rows.length === 0 ? (
-          <Empty>
-            <EmptyHeader>
-              <EmptyDescription>
-                {agents.length === 0
-                  ? t("agents.list.empty")
-                  : search.trim()
-                    ? t("agents.list.emptyNoMatch", { query: search.trim() })
-                    : t("agents.list.emptyNoFilterMatch")}
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
+          // Three reasons a list can be empty, and each gets its own way out:
+          // nothing installed (make one), nothing matching the search (drop
+          // it), nothing in this state (widen the filter). The page used to
+          // print one grey sentence for all three and offer nothing at all.
+          agents.length === 0 ? (
+            <EmptyState
+              icon={<Cpu />}
+              title={t("agents.list.emptyTitle")}
+              description={t("agents.list.empty")}
+              action={{
+                label: t("agents.list.newAgent"),
+                icon: <Plus />,
+                onClick: () => setNewAgentOpen(true),
+              }}
+            />
+          ) : search.trim() ? (
+            <EmptyState
+              icon={<SearchX />}
+              title={t("agents.list.emptyNoMatchTitle")}
+              description={t("agents.list.emptyNoMatch", {
+                query: search.trim(),
+              })}
+              action={{
+                label: t("common.clearSearch"),
+                onClick: () => setSearch(""),
+              }}
+            />
+          ) : (
+            <EmptyState
+              icon={<FilterX />}
+              title={t("agents.list.emptyNoFilterMatchTitle")}
+              description={t("agents.list.emptyNoFilterMatch")}
+              action={{
+                label: t("common.showAll"),
+                onClick: () => setFilter("all"),
+              }}
+            />
+          )
         ) : (
           <>
             {view === "list" ? (

--- a/packages/launcher/src/renderer/pages/connections/components/connections-toolbar.tsx
+++ b/packages/launcher/src/renderer/pages/connections/components/connections-toolbar.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@renderer/components/ui/select"
-import { FilterChips, SearchInput } from "@renderer/components/ui-kit"
+import { FilterChips, PageToolbar, SearchInput } from "@renderer/components/ui-kit"
 import { cn } from "@renderer/lib/utils"
 
 import type { ConnectionFilter } from "../empty-state"
@@ -49,7 +49,7 @@ export function ConnectionsToolbar({
   const directionKey = ascending ? "connections.sort.asc" : "connections.sort.desc"
 
   return (
-    <div className="mb-4 flex items-center gap-2">
+    <PageToolbar>
       <SearchInput
         value={search}
         onChange={(e) => onSearchChange(e.target.value)}
@@ -95,6 +95,6 @@ export function ConnectionsToolbar({
         <RefreshCw className={cn(refreshing && "animate-spin")} />
         {t("connections.refresh")}
       </Button>
-    </div>
+    </PageToolbar>
   )
 }

--- a/packages/launcher/src/renderer/pages/connections/empty-state.ts
+++ b/packages/launcher/src/renderer/pages/connections/empty-state.ts
@@ -1,12 +1,24 @@
 export type ConnectionFilter = "all" | "connected" | "disconnected"
 
+type Reason = "noResults" | "noConnected" | "noDisconnected" | "noPlatforms"
+
 export interface ConnectionsEmptyState {
-  key:
-    | "connections.search.noResults"
-    | "connections.search.noConnected"
-    | "connections.search.noDisconnected"
-    | "connections.search.noPlatforms"
+  /** Sentence under the title. */
+  key: `connections.search.${Reason}`
+  /** Heading above it — the house empty state carries both. */
+  titleKey: `connections.search.${Reason}Title`
   query?: string
+  /** True when a search, rather than the data, is what emptied the list. */
+  searching: boolean
+}
+
+function state(reason: Reason, query?: string): ConnectionsEmptyState {
+  return {
+    key: `connections.search.${reason}`,
+    titleKey: `connections.search.${reason}Title`,
+    query,
+    searching: reason === "noResults",
+  }
 }
 
 export function getConnectionsEmptyState(
@@ -14,14 +26,8 @@ export function getConnectionsEmptyState(
   filter: ConnectionFilter,
 ): ConnectionsEmptyState {
   const query = search.trim()
-  if (query) {
-    return { key: "connections.search.noResults", query }
-  }
-  if (filter === "connected") {
-    return { key: "connections.search.noConnected" }
-  }
-  if (filter === "disconnected") {
-    return { key: "connections.search.noDisconnected" }
-  }
-  return { key: "connections.search.noPlatforms" }
+  if (query) return state("noResults", query)
+  if (filter === "connected") return state("noConnected")
+  if (filter === "disconnected") return state("noDisconnected")
+  return state("noPlatforms")
 }

--- a/packages/launcher/src/renderer/pages/connections/index.tsx
+++ b/packages/launcher/src/renderer/pages/connections/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react"
-import { ShieldCheck } from "lucide-react"
+import { Plug, SearchX, ShieldCheck } from "lucide-react"
 import { useShallow } from "zustand/react/shallow"
 import { useTranslation } from "react-i18next"
 
 import { PageHeader } from "@renderer/components/layout/page-header"
-import { Empty, EmptyDescription, EmptyHeader } from "@renderer/components/ui/empty"
+import { EmptyState } from "@renderer/components/ui-kit"
 import { useConnectionsStore } from "@renderer/store/connections"
 import { useCredentialsStore } from "@renderer/store/credentials"
 import { useAgentsStore } from "@renderer/store/agents"
@@ -127,13 +127,21 @@ export default function Connections({ showToast }: Props): React.JSX.Element {
         />
 
         {view.rows.length === 0 ? (
-          <Empty>
-            <EmptyHeader>
-              <EmptyDescription>
-                {t(emptyState.key, { query: emptyState.query })}
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
+          <EmptyState
+            icon={emptyState.searching ? <SearchX /> : <Plug />}
+            title={t(emptyState.titleKey)}
+            description={t(emptyState.key, { query: emptyState.query })}
+            action={
+              // Only a search can be undone from here; the other reasons are
+              // the data being what it is.
+              emptyState.searching
+                ? {
+                    label: t("common.clearSearch"),
+                    onClick: () => view.setSearch(""),
+                  }
+                : undefined
+            }
+          />
         ) : (
           <ConnectionsTable
             rows={view.rows}

--- a/packages/launcher/src/renderer/pages/credentials/index.tsx
+++ b/packages/launcher/src/renderer/pages/credentials/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react"
-import { Plus } from "lucide-react"
+import { FilterX, KeyRound, Plus, SearchX } from "lucide-react"
 import { useShallow } from "zustand/react/shallow"
 import { useTranslation } from "react-i18next"
 
@@ -8,12 +8,10 @@ import { Button } from "@renderer/components/ui/button"
 import { Card } from "@renderer/components/ui/card"
 import { Tabs, TabsList, TabsTrigger } from "@renderer/components/ui/tabs"
 import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-} from "@renderer/components/ui/empty"
-import { SearchInput } from "@renderer/components/ui-kit"
+  EmptyState,
+  PageToolbar,
+  SearchInput,
+} from "@renderer/components/ui-kit"
 import { CredentialCard } from "@renderer/components/credentials/CredentialCard"
 import { CredentialEditor } from "@renderer/components/credentials/CredentialEditor"
 import { CredentialApplyDialog } from "@renderer/components/credentials/CredentialApplyDialog"
@@ -182,7 +180,7 @@ export default function Credentials({ showToast }: Props): React.JSX.Element {
       />
 
       <div className="flex-1 overflow-y-auto px-9 py-6">
-        <div className="mb-5 flex flex-wrap items-center gap-2">
+        <PageToolbar>
           <SearchInput
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -202,25 +200,43 @@ export default function Credentials({ showToast }: Props): React.JSX.Element {
               ))}
             </TabsList>
           </Tabs>
-        </div>
+        </PageToolbar>
 
         {visible.length === 0 ? (
-          <Empty>
-            <EmptyHeader>
-              <EmptyDescription>
-                {credentials.length === 0
-                  ? t("credentials.empty.none")
-                  : search.trim()
-                    ? t("credentials.empty.noMatch", { query: search.trim() })
-                    : t("credentials.empty.noFilterMatch")}
-              </EmptyDescription>
-            </EmptyHeader>
-            {credentials.length === 0 && (
-              <EmptyContent>
-                <Button onClick={openAdd}>{t("credentials.empty.addFirst")}</Button>
-              </EmptyContent>
-            )}
-          </Empty>
+          credentials.length === 0 ? (
+            <EmptyState
+              icon={<KeyRound />}
+              title={t("credentials.empty.noneTitle")}
+              description={t("credentials.empty.none")}
+              action={{
+                label: t("credentials.addCredential"),
+                icon: <Plus />,
+                onClick: openAdd,
+              }}
+            />
+          ) : search.trim() ? (
+            <EmptyState
+              icon={<SearchX />}
+              title={t("credentials.empty.noMatchTitle")}
+              description={t("credentials.empty.noMatch", {
+                query: search.trim(),
+              })}
+              action={{
+                label: t("common.clearSearch"),
+                onClick: () => setSearch(""),
+              }}
+            />
+          ) : (
+            <EmptyState
+              icon={<FilterX />}
+              title={t("credentials.empty.noFilterMatchTitle")}
+              description={t("credentials.empty.noFilterMatch")}
+              action={{
+                label: t("common.showAll"),
+                onClick: () => setProviderFilter("all"),
+              }}
+            />
+          )
         ) : (
           <div className="flex flex-col gap-2.5">
             {visible.map((c) => (

--- a/packages/launcher/src/renderer/pages/dashboard/components/agents-card.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/components/agents-card.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import {
+  Cpu,
   MoreHorizontal,
+  Plus,
   Play,
   SlidersHorizontal,
   Square,
@@ -11,18 +13,13 @@ import { useTranslation } from "react-i18next"
 import AgentIcon from "@renderer/components/AgentIcon"
 import { Button } from "@renderer/components/ui/button"
 import { Card } from "@renderer/components/ui/card"
+import { EmptyState } from "@renderer/components/ui-kit"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@renderer/components/ui/dropdown-menu"
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-} from "@renderer/components/ui/empty"
 import { Skeleton } from "@renderer/components/ui/skeleton"
 import {
   Table,
@@ -61,7 +58,9 @@ interface Props {
   onOpenTerminal: (agent: Agent) => void
   onManage: (agent: Agent) => void
   onViewAll: () => void
-  onInstallFirst: () => void
+  onNewAgent: () => void
+  /** Agents in total, not just the rows shown — gates "View all". */
+  total: number
 }
 
 /**
@@ -77,7 +76,8 @@ export function AgentsCard({
   onOpenTerminal,
   onManage,
   onViewAll,
-  onInstallFirst,
+  onNewAgent,
+  total,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -87,9 +87,11 @@ export function AgentsCard({
         <h2 className="text-base font-semibold">{t("dashboard.agents.title")}</h2>
         {/* No refresh control: the list re-polls every few seconds on its own,
             so the button only ever raced the poll it was standing next to. */}
-        <Button variant="link" size="sm" onClick={onViewAll}>
-          {t("dashboard.agents.viewAll")}
-        </Button>
+        {total > agents.length && (
+          <Button variant="link" size="sm" onClick={onViewAll}>
+            {t("dashboard.agents.viewAll")}
+          </Button>
+        )}
       </div>
 
       {loading ? (
@@ -99,17 +101,17 @@ export function AgentsCard({
           <Skeleton className="h-8" />
         </div>
       ) : agents.length === 0 ? (
-        <div className="border-t px-4 py-4">
-          <Empty>
-            <EmptyHeader>
-              <EmptyDescription>{t("dashboard.agents.empty")}</EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent>
-              <Button onClick={onInstallFirst}>
-                {t("dashboard.agents.installFirst")}
-              </Button>
-            </EmptyContent>
-          </Empty>
+        <div className="border-t">
+          <EmptyState
+            icon={<Cpu />}
+            title={t("agents.list.emptyTitle")}
+            description={t("dashboard.agents.empty")}
+            action={{
+              label: t("common.actions.newAgent"),
+              icon: <Plus />,
+              onClick: onNewAgent,
+            }}
+          />
         </div>
       ) : (
         <div className="border-t">

--- a/packages/launcher/src/renderer/pages/dashboard/components/welcome-hero.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/components/welcome-hero.tsx
@@ -82,7 +82,7 @@ export function WelcomeHero({
               {t("dashboard.welcome.newAgent")}
             </Button>
             <Button variant="outline" onClick={onNewWorkspace}>
-              <Layers />
+              <Plus />
               {t("dashboard.welcome.newWorkspace")}
             </Button>
           </div>

--- a/packages/launcher/src/renderer/pages/dashboard/components/workspaces-card.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/components/workspaces-card.tsx
@@ -1,15 +1,10 @@
 import React from "react"
-import { ExternalLink, Layers } from "lucide-react"
+import { ExternalLink, Layers, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "@renderer/components/ui/button"
 import { Card } from "@renderer/components/ui/card"
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-} from "@renderer/components/ui/empty"
+import { EmptyState } from "@renderer/components/ui-kit"
 import {
   Table,
   TableBody,
@@ -33,6 +28,8 @@ interface Props {
   onOpen: (ws: Workspace) => void
   onViewAll: () => void
   onCreateFirst: () => void
+  /** Workspaces in total, not just the rows shown — gates "View all". */
+  total: number
 }
 
 export function WorkspacesCard({
@@ -42,6 +39,7 @@ export function WorkspacesCard({
   onOpen,
   onViewAll,
   onCreateFirst,
+  total,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -56,25 +54,25 @@ export function WorkspacesCard({
         <h2 className="text-base font-semibold">
           {t("dashboard.workspaces.title")}
         </h2>
-        <Button variant="link" size="sm" onClick={onViewAll}>
-          {t("dashboard.workspaces.viewAll")}
-        </Button>
+        {total > workspaces.length && (
+          <Button variant="link" size="sm" onClick={onViewAll}>
+            {t("dashboard.workspaces.viewAll")}
+          </Button>
+        )}
       </div>
 
       {workspaces.length === 0 ? (
-        <div className="border-t px-4 py-4">
-          <Empty>
-            <EmptyHeader>
-              <EmptyDescription>
-                {t("dashboard.workspaces.empty")}
-              </EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent>
-              <Button onClick={onCreateFirst}>
-                {t("dashboard.workspaces.createFirst")}
-              </Button>
-            </EmptyContent>
-          </Empty>
+        <div className="border-t">
+          <EmptyState
+            icon={<Layers />}
+            title={t("workspaces.emptyNoneTitle")}
+            description={t("dashboard.workspaces.empty")}
+            action={{
+              label: t("common.actions.addWorkspace"),
+              icon: <Plus />,
+              onClick: onCreateFirst,
+            }}
+          />
         </div>
       ) : (
         <div className="border-t">

--- a/packages/launcher/src/renderer/pages/dashboard/index.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/index.tsx
@@ -43,14 +43,12 @@ export default function Dashboard({
     activityLog,
     setCurrentTab,
     setInstallFocusAgent,
-    goToInstallList,
     requestCreate,
   } = useUiStore(
     useShallow((s) => ({
       activityLog: s.activityLog,
       setCurrentTab: s.setCurrentTab,
       setInstallFocusAgent: s.setInstallFocusAgent,
-      goToInstallList: s.goToInstallList,
       requestCreate: s.requestCreate,
     })),
   )
@@ -138,6 +136,7 @@ export default function Dashboard({
         <div className="grid grid-cols-1 gap-4 3xl:grid-cols-2">
           <AgentsCard
             agents={recentAgents}
+            total={agents.length}
             lastActive={activity}
             loading={data.loading}
             pending={pendingAgentActions}
@@ -145,11 +144,12 @@ export default function Dashboard({
             onOpenTerminal={(a) => actions.openTerminal(a)}
             onManage={() => manageAgent()}
             onViewAll={() => setCurrentTab("agents")}
-            onInstallFirst={() => goToInstallList()}
+            onNewAgent={() => requestCreate("agent")}
           />
 
           <WorkspacesCard
             workspaces={recentWorkspaces}
+            total={data.workspaces.length}
             agents={agents}
             lastUsedAt={lastUsedAt}
             onOpen={openWorkspace}

--- a/packages/launcher/src/renderer/pages/install/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/index.tsx
@@ -1,16 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { FilterX, SearchX } from "lucide-react"
 
 import { PageHeader } from "@renderer/components/layout/page-header"
 import { Button } from "@renderer/components/ui/button"
 import { Card } from "@renderer/components/ui/card"
 import { Skeleton } from "@renderer/components/ui/skeleton"
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-} from "@renderer/components/ui/empty"
+import { EmptyState } from "@renderer/components/ui-kit"
 import SetupWizard from "@renderer/components/setup-wizard"
 import AgentDetail from "./detail"
 import { InstallConfirmDialog } from "./detail/install-confirm-dialog"
@@ -194,31 +190,30 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
             ))}
           </div>
         ) : market.rows.length === 0 ? (
-          <Empty>
-            <EmptyHeader>
-              {/* Name what was searched for when there was a search; blaming
-                  "the current filter" for a typed query reads as a shrug. */}
-              <EmptyDescription>
-                {market.search.trim()
-                  ? t("install.empty.noQueryMatch", { query: market.search.trim() })
-                  : t("install.empty.noMatch")}
-              </EmptyDescription>
-            </EmptyHeader>
-            {(market.search || prefs.category !== "all") && (
-              <EmptyContent>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => {
-                    market.setSearch("")
-                    setCategory("all")
-                  }}
-                >
-                  {t("install.empty.resetFilters")}
-                </Button>
-              </EmptyContent>
-            )}
-          </Empty>
+          <EmptyState
+            icon={market.search.trim() ? <SearchX /> : <FilterX />}
+            title={
+              market.search.trim()
+                ? t("install.empty.noQueryMatchTitle")
+                : t("install.empty.noMatchTitle")
+            }
+            description={
+              market.search.trim()
+                ? t("install.empty.noQueryMatch", { query: market.search.trim() })
+                : t("install.empty.noMatch")
+            }
+            action={
+              market.search || prefs.category !== "all"
+                ? {
+                    label: t("install.empty.resetFilters"),
+                    onClick: () => {
+                      market.setSearch("")
+                      setCategory("all")
+                    },
+                  }
+                : undefined
+            }
+          />
         ) : prefs.view === "grid" ? (
           <MarketplaceGrid
             rows={market.rows}

--- a/packages/launcher/src/renderer/pages/settings/components/reset-summary.tsx
+++ b/packages/launcher/src/renderer/pages/settings/components/reset-summary.tsx
@@ -3,17 +3,28 @@ import { useTranslation } from "react-i18next"
 import { RotateCcw, ShieldCheck } from "lucide-react"
 
 /**
- * What "reset all settings" actually touches, shown inside the confirmation.
+ * What a reset actually touches, shown inside the confirmation.
  *
  * The prompt used to be one sentence — "back to defaults, cannot be undone" —
  * which is exactly the information a user already has and none of what they
  * are actually asking: does this wipe my agents? So both halves are spelled
  * out, and the answer to the scary half is the reassuring one.
+ *
+ * Two resets use this now (all settings, and the launcher's local state), so
+ * the strings come from a caller-supplied `settings.*Dialog` prefix.
  */
-const AFFECTED = ["startup", "agents", "network", "updates"] as const
-const KEPT = ["agents", "workspaces", "prefs"] as const
+export interface ResetSummaryProps {
+  /** i18n prefix holding `affectedTitle`, `affected.*`, `keptTitle`, `kept.*`. */
+  prefix: string
+  affected: readonly string[]
+  kept: readonly string[]
+}
 
-export function ResetSummary(): React.JSX.Element {
+export function ResetSummary({
+  prefix,
+  affected,
+  kept,
+}: ResetSummaryProps): React.JSX.Element {
   const { t } = useTranslation()
 
   return (
@@ -21,14 +32,14 @@ export function ResetSummary(): React.JSX.Element {
       <Column
         tone="text-destructive"
         icon={<RotateCcw className="size-3" />}
-        title={t("settings.resetDialog.affectedTitle")}
-        items={AFFECTED.map((id) => t(`settings.resetDialog.affected.${id}`))}
+        title={t(`${prefix}.affectedTitle`)}
+        items={affected.map((id) => t(`${prefix}.affected.${id}`))}
       />
       <Column
         tone="text-(--success-text)"
         icon={<ShieldCheck className="size-3" />}
-        title={t("settings.resetDialog.keptTitle")}
-        items={KEPT.map((id) => t(`settings.resetDialog.kept.${id}`))}
+        title={t(`${prefix}.keptTitle`)}
+        items={kept.map((id) => t(`${prefix}.kept.${id}`))}
       />
     </div>
   )

--- a/packages/launcher/src/renderer/pages/settings/index.tsx
+++ b/packages/launcher/src/renderer/pages/settings/index.tsx
@@ -28,6 +28,13 @@ import { UpdatesSection } from "./sections/updates-section"
 import { RuntimeSection } from "./sections/runtime-section"
 import { AboutSection } from "./sections/about-section"
 
+// Which lines each confirmation spells out; the copy lives under the matching
+// `settings.*Dialog.affected/kept` i18n prefix.
+const SETTINGS_RESET_AFFECTED = ["startup", "agents", "network", "updates"]
+const SETTINGS_RESET_KEPT = ["agents", "workspaces", "prefs"]
+const LOCAL_RESET_AFFECTED = ["appearance", "layout", "history", "marketplace"]
+const LOCAL_RESET_KEPT = ["settings", "language", "workspaces"]
+
 interface SettingsProps {
   showToast: (msg: string, type?: ToastType) => void
 }
@@ -81,6 +88,12 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
     closeReset,
     resetting,
     performReset,
+    clearingCache,
+    clearCache,
+    localResetOpen,
+    openLocalReset,
+    closeLocalReset,
+    performLocalReset,
   } = useSettingsIO(loadSettings, showToast)
 
   // Runtime and About both read the host snapshot; polling stays scoped to them.
@@ -130,6 +143,9 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
               exportSettings={exportSettings}
               importSettings={importSettings}
               openReset={openReset}
+              clearingCache={clearingCache}
+              clearCache={clearCache}
+              openLocalReset={openLocalReset}
             />
           )}
           {section === "language" && <LanguageSection />}
@@ -175,7 +191,27 @@ export default function Settings({ showToast }: SettingsProps): React.JSX.Elemen
         onCancel={closeReset}
         onConfirm={performReset}
       >
-        <ResetSummary />
+        <ResetSummary
+          prefix="settings.resetDialog"
+          affected={SETTINGS_RESET_AFFECTED}
+          kept={SETTINGS_RESET_KEPT}
+        />
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={localResetOpen}
+        title={t("settings.localResetDialog.title")}
+        description={t("settings.localResetDialog.description")}
+        confirmLabel={t("settings.localResetDialog.confirm")}
+        destructive
+        onCancel={closeLocalReset}
+        onConfirm={performLocalReset}
+      >
+        <ResetSummary
+          prefix="settings.localResetDialog"
+          affected={LOCAL_RESET_AFFECTED}
+          kept={LOCAL_RESET_KEPT}
+        />
       </ConfirmDialog>
     </section>
   )

--- a/packages/launcher/src/renderer/pages/settings/sections/data-section.tsx
+++ b/packages/launcher/src/renderer/pages/settings/sections/data-section.tsx
@@ -1,8 +1,16 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { ArrowDownToLine, ArrowUpFromLine, FolderOpen, RotateCcw } from "lucide-react"
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Eraser,
+  FolderOpen,
+  Palette,
+  RotateCcw,
+} from "lucide-react"
 
 import { Button } from "@renderer/components/ui/button"
+import { Spinner } from "@renderer/components/ui/spinner"
 import { SettingsCard, Row } from "../components/settings-card"
 import type { SettingsPaths } from "../use-settings-state"
 
@@ -11,6 +19,9 @@ interface Props {
   exportSettings: () => void | Promise<void>
   importSettings: () => void | Promise<void>
   openReset: () => void
+  clearingCache: boolean
+  clearCache: () => void | Promise<void>
+  openLocalReset: () => void
 }
 
 /** Order of the storage-location rows; labels come from `settings.data.*`. */
@@ -28,6 +39,9 @@ export function DataSection({
   exportSettings,
   importSettings,
   openReset,
+  clearingCache,
+  clearCache,
+  openLocalReset,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -77,6 +91,42 @@ export function DataSection({
           <Button size="sm" variant="outline" onClick={() => void importSettings()}>
             <ArrowUpFromLine />
             {t("common.import")}
+          </Button>
+        </Row>
+      </SettingsCard>
+
+      {/* The launcher's own state, as opposed to the settings file above.
+          Nothing here reaches the agents, the daemon or the workspace — it is
+          the app's cache and the window's own appearance, both of which used to
+          have no control at all and survived even a reinstall. */}
+      <SettingsCard
+        title={t("settings.data.localGroup")}
+        desc={t("settings.data.localGroupDesc")}
+      >
+        <Row
+          label={t("settings.data.clearCache")}
+          desc={t("settings.data.clearCacheDesc")}
+        >
+          {/* Clearing and resetting are destructive entry points, so they take
+              the destructive style like every other one in the app — the
+              neutral outline made them read as ordinary settings controls. */}
+          <Button
+            size="sm"
+            variant="destructive-ghost"
+            disabled={clearingCache}
+            onClick={() => void clearCache()}
+          >
+            {clearingCache ? <Spinner /> : <Eraser />}
+            {t("common.clear")}
+          </Button>
+        </Row>
+        <Row
+          label={t("settings.data.resetLocal")}
+          desc={t("settings.data.resetLocalDesc")}
+        >
+          <Button size="sm" variant="destructive-ghost" onClick={openLocalReset}>
+            <Palette />
+            {t("common.reset")}
           </Button>
         </Row>
       </SettingsCard>

--- a/packages/launcher/src/renderer/pages/settings/sections/runtime-section.tsx
+++ b/packages/launcher/src/renderer/pages/settings/sections/runtime-section.tsx
@@ -4,6 +4,7 @@ import { ClipboardCopy, FolderOpen, RefreshCw } from "lucide-react"
 
 import { Badge } from "@renderer/components/ui/badge"
 import { Button } from "@renderer/components/ui/button"
+import { formatBytes } from "@renderer/lib/format"
 import { SettingsCard, Row, InfoRow } from "../components/settings-card"
 import type { RuntimeInfo, SystemInfo } from "@renderer/types"
 import type { SettingsPaths } from "../use-settings-state"
@@ -225,19 +226,6 @@ function StatusChip({ ok }: { ok: boolean }): React.JSX.Element {
       {ok ? t("settings.runtime.ok") : t("common.notInstalled")}
     </Badge>
   )
-}
-
-const UNITS = ["B", "KB", "MB", "GB", "TB"]
-
-function formatBytes(bytes: number): string {
-  if (!bytes || bytes < 0) return "—"
-  let value = bytes
-  let unit = 0
-  while (value >= 1024 && unit < UNITS.length - 1) {
-    value /= 1024
-    unit += 1
-  }
-  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${UNITS[unit]}`
 }
 
 function formatUptime(seconds: number): string {

--- a/packages/launcher/src/renderer/pages/settings/sections/updates-section.tsx
+++ b/packages/launcher/src/renderer/pages/settings/sections/updates-section.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { Sparkles } from "lucide-react"
 
+import { Button } from "@renderer/components/ui/button"
 import { Switch } from "@renderer/components/ui/switch"
+import { WhatsNewDialog } from "@renderer/components/whats-new/whats-new-dialog"
+import { RELEASES } from "@renderer/lib/changelog"
 import { SettingsCard,
   Row,
   InfoRow,
@@ -30,6 +34,7 @@ export function UpdatesSection({
   installUpdate,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
+  const [notesOpen, setNotesOpen] = React.useState(false)
 
   return (
     <>
@@ -68,7 +73,29 @@ export function UpdatesSection({
           }
           mono
         />
+        {/* The same notes the app shows once after an update, kept reachable
+            afterwards — the dialog is easy to dismiss before reading it. */}
+        <Row
+          label={t("whatsNew.settingsRow")}
+          desc={t("whatsNew.settingsRowDesc")}
+        >
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={RELEASES.length === 0}
+            onClick={() => setNotesOpen(true)}
+          >
+            <Sparkles />
+            {t("whatsNew.settingsAction")}
+          </Button>
+        </Row>
       </SettingsCard>
+
+      <WhatsNewDialog
+        open={notesOpen}
+        releases={RELEASES}
+        onClose={() => setNotesOpen(false)}
+      />
     </>
   )
 }

--- a/packages/launcher/src/renderer/pages/settings/use-settings-io.ts
+++ b/packages/launcher/src/renderer/pages/settings/use-settings-io.ts
@@ -2,6 +2,8 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import type { ToastType } from "@renderer/hooks/useToast"
+import { formatBytes } from "@renderer/lib/format"
+import { resetLocalPreferences } from "@renderer/lib/local-data"
 
 interface SettingsIO {
   exportSettings: () => Promise<void>
@@ -11,9 +13,19 @@ interface SettingsIO {
   closeReset: () => void
   resetting: boolean
   performReset: () => Promise<void>
+  clearingCache: boolean
+  clearCache: () => Promise<void>
+  localResetOpen: boolean
+  openLocalReset: () => void
+  closeLocalReset: () => void
+  performLocalReset: () => void
 }
 
-/** Export / import / reset of the whole settings file. */
+/**
+ * Everything under Settings → Data: export / import / reset of the settings
+ * file, plus the two controls for the launcher's own local state (Chromium's
+ * cache and the renderer's localStorage).
+ */
 export function useSettingsIO(
   reload: () => Promise<void>,
   showToast: (msg: string, type?: ToastType) => void,
@@ -21,6 +33,8 @@ export function useSettingsIO(
   const { t } = useTranslation()
   const [resetOpen, setResetOpen] = useState(false)
   const [resetting, setResetting] = useState(false)
+  const [clearingCache, setClearingCache] = useState(false)
+  const [localResetOpen, setLocalResetOpen] = useState(false)
 
   const exportSettings = async (): Promise<void> => {
     try {
@@ -77,6 +91,39 @@ export function useSettingsIO(
     }
   }
 
+  const clearCache = async (): Promise<void> => {
+    setClearingCache(true)
+    try {
+      const res = await window.api.clearAppCache()
+      if (res.ok) {
+        // An already-empty cache reports nothing to free; "0 B freed" is noise.
+        showToast(
+          res.freed
+            ? t("settings.toasts.cacheCleared", {
+                size: formatBytes(res.freed),
+              })
+            : t("settings.toasts.cacheAlreadyEmpty"),
+          "success",
+        )
+      } else {
+        showToast(
+          t("settings.toasts.cacheClearFailed", { error: res.error || "" }),
+          "error",
+        )
+      }
+    } finally {
+      setClearingCache(false)
+    }
+  }
+
+  // Synchronous: this is localStorage plus a repaint, and the window is already
+  // wearing the result by the time the dialog closes.
+  const performLocalReset = (): void => {
+    resetLocalPreferences()
+    setLocalResetOpen(false)
+    showToast(t("settings.toasts.localDataReset"), "success")
+  }
+
   return {
     exportSettings,
     importSettings,
@@ -85,5 +132,11 @@ export function useSettingsIO(
     closeReset: () => setResetOpen(false),
     resetting,
     performReset,
+    clearingCache,
+    clearCache,
+    localResetOpen,
+    openLocalReset: () => setLocalResetOpen(true),
+    closeLocalReset: () => setLocalResetOpen(false),
+    performLocalReset,
   }
 }

--- a/packages/launcher/src/renderer/pages/workspaces/components/workspaces-toolbar.tsx
+++ b/packages/launcher/src/renderer/pages/workspaces/components/workspaces-toolbar.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@renderer/components/ui/select"
-import { FilterChips, SearchInput } from "@renderer/components/ui-kit"
+import { FilterChips, PageToolbar, SearchInput } from "@renderer/components/ui-kit"
 import { cn } from "@renderer/lib/utils"
 import {
   WORKSPACE_FILTERS,
@@ -54,7 +54,7 @@ export function WorkspacesToolbar({
   const { t } = useTranslation()
 
   return (
-    <div className="mb-5 flex items-center gap-2">
+    <PageToolbar>
       <SearchInput
         value={search}
         onChange={(e) => onSearch(e.target.value)}
@@ -92,6 +92,6 @@ export function WorkspacesToolbar({
         <RefreshCw className={cn(refreshing && "animate-spin")} />
         {t("workspaces.refresh")}
       </Button>
-    </div>
+    </PageToolbar>
   )
 }

--- a/packages/launcher/src/renderer/pages/workspaces/index.tsx
+++ b/packages/launcher/src/renderer/pages/workspaces/index.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from "react"
 import { useShallow } from "zustand/react/shallow"
 import { useTranslation } from "react-i18next"
-import { Link as LinkIcon } from "lucide-react"
+import { FilterX, Layers, Plus, SearchX } from "lucide-react"
 
 import { PageHeader } from "@renderer/components/layout/page-header"
 import { Button } from "@renderer/components/ui/button"
 import { Spinner } from "@renderer/components/ui/spinner"
 import {
   Empty,
-  EmptyContent,
   EmptyDescription,
   EmptyHeader,
 } from "@renderer/components/ui/empty"
+import { EmptyState } from "@renderer/components/ui-kit"
 import { WorkspaceCard } from "@renderer/components/workspaces/WorkspaceCard"
 import {
   WorkspaceQuickConnect,
@@ -77,12 +77,14 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
     refreshConnections()
   }, [refreshConnections])
 
-  // The dashboard's "Create workspace" button lands here with the dialog
-  // requested; clearing the flag keeps a later tab click from re-opening it.
+  // "Add workspace" from anywhere else — the dashboard, the command palette —
+  // lands here with the dialog requested. It opens on the same tab the header
+  // button uses, because it is the same button: one label, one door, and
+  // creating is the third tab inside it. Clearing the flag keeps a later tab
+  // click from re-opening it.
   React.useEffect(() => {
     if (pendingCreate !== "workspace") return
-    setQuickMode("create")
-    setQuickOpen(true)
+    openQuick("pair")
     clearPendingCreate()
   }, [pendingCreate, clearPendingCreate])
 
@@ -139,7 +141,7 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
           // header printed the same control twice. Creating a workspace is the
           // dialog's third tab, one click further in.
           <Button onClick={() => openQuick("pair")}>
-            <LinkIcon />
+            <Plus />
             {t("workspaces.join")}
           </Button>
         }
@@ -168,29 +170,45 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
             </EmptyHeader>
           </Empty>
         ) : filtered.length === 0 ? (
-          <Empty>
-            <EmptyHeader>
-              {/* Three distinct reasons a list can be empty, and each gets its
-                  own sentence: no workspaces at all, none matching what was
-                  typed, none matching the active filter. Folding the last two
-                  together used to print 没有匹配""的工作区 whenever a filter
-                  emptied the list with the search box untouched. */}
-              <EmptyDescription>
-                {workspaces.length === 0
-                  ? t("workspaces.emptyNone")
-                  : search.trim()
-                    ? t("workspaces.emptyNoMatch", { query: search.trim() })
-                    : t("workspaces.emptyNoFilterMatch")}
-              </EmptyDescription>
-            </EmptyHeader>
-            {workspaces.length === 0 && (
-              <EmptyContent>
-                <Button onClick={() => openQuick("pair")}>
-                  {t("workspaces.connectFirst")}
-                </Button>
-              </EmptyContent>
-            )}
-          </Empty>
+          // Three distinct reasons a list can be empty, each with its own way
+          // out: none at all (add one), none matching what was typed (drop the
+          // search), none matching the filter (widen it). Folding the last two
+          // together used to print 没有匹配""的工作区 whenever a filter emptied
+          // the list with the search box untouched.
+          workspaces.length === 0 ? (
+            <EmptyState
+              icon={<Layers />}
+              title={t("workspaces.emptyNoneTitle")}
+              description={t("workspaces.emptyNone")}
+              action={{
+                label: t("workspaces.join"),
+                icon: <Plus />,
+                onClick: () => openQuick("pair"),
+              }}
+            />
+          ) : search.trim() ? (
+            <EmptyState
+              icon={<SearchX />}
+              title={t("workspaces.emptyNoMatchTitle")}
+              description={t("workspaces.emptyNoMatch", {
+                query: search.trim(),
+              })}
+              action={{
+                label: t("common.clearSearch"),
+                onClick: () => setSearch(""),
+              }}
+            />
+          ) : (
+            <EmptyState
+              icon={<FilterX />}
+              title={t("workspaces.emptyNoFilterMatchTitle")}
+              description={t("workspaces.emptyNoFilterMatch")}
+              action={{
+                label: t("common.showAll"),
+                onClick: () => setFilter("all"),
+              }}
+            />
+          )
         ) : (
           // Two up from the start: the window is 1200px wide at its smallest,
           // so a breakpoint above that only ever produced a single column on

--- a/packages/launcher/src/renderer/store/appearance.ts
+++ b/packages/launcher/src/renderer/store/appearance.ts
@@ -133,21 +133,32 @@ function apply(state: Applied): void {
   else delete root.dataset.contrast
 }
 
+/** What a fresh install looks like; also what `reset()` restores. */
+export const DEFAULT_APPEARANCE: Applied = {
+  accent: 'indigo',
+  scale: 'md',
+  animations: true,
+  highContrast: false,
+  skin: DEFAULT_SKIN,
+}
+
 interface AppearanceState extends Applied {
   setAccent: (a: AccentColor) => void
   setScale: (s: UiScale) => void
   setAnimations: (on: boolean) => void
   setHighContrast: (on: boolean) => void
   setSkin: (s: Skin) => void
+  /** Back to DEFAULT_APPEARANCE, repainted and mirrored to main. */
+  reset: () => void
   init: () => void
 }
 
 export const useAppearanceStore = create<AppearanceState>((set, get) => ({
-  accent: readStored<AccentColor>(ACCENT_KEY, ACCENT_COLORS, 'indigo'),
-  scale: readStored<UiScale>(SCALE_KEY, UI_SCALES, 'md'),
-  animations: readFlag(ANIMATIONS_KEY, true),
-  highContrast: readFlag(CONTRAST_KEY, false),
-  skin: readStored<Skin>(SKIN_KEY, SKIN_IDS, DEFAULT_SKIN),
+  accent: readStored<AccentColor>(ACCENT_KEY, ACCENT_COLORS, DEFAULT_APPEARANCE.accent),
+  scale: readStored<UiScale>(SCALE_KEY, UI_SCALES, DEFAULT_APPEARANCE.scale),
+  animations: readFlag(ANIMATIONS_KEY, DEFAULT_APPEARANCE.animations),
+  highContrast: readFlag(CONTRAST_KEY, DEFAULT_APPEARANCE.highContrast),
+  skin: readStored<Skin>(SKIN_KEY, SKIN_IDS, DEFAULT_APPEARANCE.skin),
 
   setAccent: (accent) => {
     try {
@@ -189,6 +200,21 @@ export const useAppearanceStore = create<AppearanceState>((set, get) => ({
     apply(next)
     syncMain(effectiveAccent(next), next.skin)
     set({ skin })
+  },
+
+  // One write, one paint, one sync — going through the five setters would
+  // repaint five times and leave main holding an intermediate accent.
+  reset: () => {
+    try {
+      localStorage.setItem(ACCENT_KEY, DEFAULT_APPEARANCE.accent)
+      localStorage.setItem(SCALE_KEY, DEFAULT_APPEARANCE.scale)
+      localStorage.setItem(SKIN_KEY, DEFAULT_APPEARANCE.skin)
+    } catch {}
+    writeFlag(ANIMATIONS_KEY, DEFAULT_APPEARANCE.animations)
+    writeFlag(CONTRAST_KEY, DEFAULT_APPEARANCE.highContrast)
+    apply(DEFAULT_APPEARANCE)
+    syncMain(effectiveAccent(DEFAULT_APPEARANCE), DEFAULT_APPEARANCE.skin)
+    set({ ...DEFAULT_APPEARANCE })
   },
 
   // Re-asserted on every boot, not just on change: this is what gives main a

--- a/packages/launcher/src/renderer/store/theme.ts
+++ b/packages/launcher/src/renderer/store/theme.ts
@@ -5,12 +5,14 @@ export type ResolvedTheme = 'light' | 'dark'
 
 const STORAGE_KEY = 'launcher:theme-mode'
 
+export const DEFAULT_THEME_MODE: ThemeMode = 'system'
+
 function readStoredMode(): ThemeMode {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (raw === 'light' || raw === 'dark' || raw === 'system') return raw
   } catch {}
-  return 'system'
+  return DEFAULT_THEME_MODE
 }
 
 function systemPrefersDark(): boolean {
@@ -50,6 +52,8 @@ interface ThemeState {
   mode: ThemeMode
   resolved: ResolvedTheme
   setMode: (m: ThemeMode) => void
+  /** Back to the default mode, painted and mirrored like any other change. */
+  reset: () => void
   init: () => void
 }
 
@@ -63,6 +67,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     syncNativeFrame(mode)
     set({ mode, resolved })
   },
+  reset: () => get().setMode(DEFAULT_THEME_MODE),
   init: () => {
     const { mode } = get()
     const resolved = resolve(mode)

--- a/packages/launcher/src/renderer/styles/skin-openagents.css
+++ b/packages/launcher/src/renderer/styles/skin-openagents.css
@@ -402,8 +402,15 @@
 
    Ghost and link buttons are excluded — they are text, and framing them would
    turn every toolbar into a grid of boxes. The site does the same: its nav
-   items are bare `font-bold text-neutral-700`. */
-:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']),
+   items are bare `font-bold text-neutral-700`.
+
+   `destructive-ghost` is NOT excluded, though it is in the default skin. There
+   it is deliberately bare: red text among outlines already carries the weight.
+   Here every neighbouring control is framed and shadowed, so bare text read as
+   an unstyled button rather than a quiet one — Settings → Data put "Clear" and
+   "Reset" in ink next to a "Reset all settings" with no edges at all. It takes
+   the same frame and lift as the rest; see the danger fill further down. */
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']),
 :root[data-skin='openagents'] [data-slot='input'],
 :root[data-skin='openagents'] [data-slot='textarea'],
 :root[data-skin='openagents'] [data-slot='select-trigger'],
@@ -490,7 +497,7 @@
    the site has no pressed state to copy — a link navigates away. Landing at
    exactly `--skin-lift` with the shadow removed puts the control where its own
    shadow was, which is what reads as "pushed down" rather than "slid across". */
-:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']) {
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']) {
   box-shadow: var(--skin-lift) var(--skin-lift) 0 0 var(--skin-ink-shadow);
   transition:
     transform var(--skin-lift-duration) var(--ease),
@@ -498,13 +505,13 @@
     background-color var(--skin-lift-duration) var(--ease);
 }
 
-:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']):hover:not(:disabled) {
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):hover:not(:disabled) {
   transform: translateY(calc(var(--skin-lift) * -1));
   box-shadow: var(--skin-hover-shadow) var(--skin-hover-shadow) 0 0
     var(--skin-ink-shadow);
 }
 
-:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):not([data-variant='destructive-ghost']):active:not(:disabled) {
+:root[data-skin='openagents'] [data-slot='button']:not([data-variant='ghost']):not([data-variant='link']):active:not(:disabled) {
   transform: translate(var(--skin-lift), var(--skin-lift));
   box-shadow: 0 0 0 0 var(--skin-ink-shadow);
 }
@@ -513,6 +520,27 @@
 :root[data-skin='openagents'] [data-slot='button']:disabled {
   box-shadow: none;
   transform: none;
+}
+
+/* Destructive entry points — remove, uninstall, reset, clear, disconnect.
+   The frame comes from the shared rule above; what makes them read as danger
+   is the fill, exactly as this skin already does it for a danger badge or
+   toast (`--danger-border` here resolves to the ink, not to red). Red text on
+   a red tint inside a black frame, so it sits in the family and still stops
+   the eye. */
+:root[data-skin='openagents']
+  [data-slot='button'][data-variant='destructive-ghost'] {
+  background-color: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+/* The base variant hovers to `destructive/10`, a tint of the shadcn token that
+   this skin does not drive — it would wash the fill out on hover. Deepening
+   the skin's own tint keeps the gesture in the same colour. */
+:root[data-skin='openagents']
+  [data-slot='button'][data-variant='destructive-ghost']:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--danger) 18%, var(--bg-card));
+  color: var(--danger-text);
 }
 
 /* Icon-only buttons in toolbars and the title bar are chrome, not CTAs. At the

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -552,6 +552,10 @@ declare global {
       }>
       importSettings(json: string): Promise<{ ok: boolean; error?: string }>
       resetSettings(): Promise<boolean>
+      /** Empties Chromium's HTTP/image cache. `freed` is bytes reclaimed. */
+      clearAppCache(): Promise<{ ok: boolean; freed?: number; error?: string }>
+      /** The running app's version, e.g. "0.9.9" — cheap, unlike systemInfo. */
+      appVersion(): Promise<string>
       /** Quits and starts the app again — for launch-time settings like GPU. */
       relaunchApp(): Promise<boolean>
       /** Reachability probe for a workspace URL. `error` is a code, not prose. */


### PR DESCRIPTION
Four things the launcher was missing or getting wrong, plus the consistency work that fell out of fixing them. Bumps the launcher to 0.9.9.

## Release notes (What's new)

`packages/launcher/changelog/<version>.json`, one file per version, both languages per entry. The GitHub Release body is generated across the whole monorepo and is mostly other packages' PRs, so it can never be shown to launcher users; a shared `CHANGELOG.md` would conflict in every parallel PR. Format and rules are documented in `changelog/README.md`.

- Bundled at build time, so the notes work offline and can never describe a version other than the one running.
- Opens once on the first launch after an update. **A fresh install is recorded silently** — someone who has never run this app does not need to be told what changed in it. Held back while onboarding or the guided tour is on screen (the tour's spotlight paints above a dialog).
- Settings → Updates keeps them reachable afterwards.
- A new `check-release-notes` CI job fails a `launcher-v*` tag whose version has no notes, whose notes are malformed, or whose `package.json` version disagrees with the tag. Run locally with `npm run check:changelog`.

Remote distribution was considered and deliberately skipped; `changelog/README.md` records the one trap for whoever adds it later (the `stable/` prefix is an `aws s3 sync --delete` target, so history cannot live there).

## Reload is gone from shipped builds

macOS kept Electron's default menu, so View → Reload shipped with Cmd+R bound to it — one keystroke that throws away install progress, a half-finished agent login or an unsent message. Packaged macOS builds now get a menu without the developer items (Edit and Window stay; Cmd+C has to work), and `before-input-event` blocks Cmd/Ctrl+R, Cmd/Ctrl+Shift+R and F5 as well, so a future menu item cannot quietly bind them again. Development is untouched. `isReloadShortcut` is unit-tested per platform.

## A workspace created in the launcher now appears in the launcher

The core's `createWorkspace` only POSTs `/v1/workspaces` and returns the credentials — persisting is the caller's job, which is why the core's own CLI prints the token from `workspace create` and calls `addNetwork` from `workspace join`. The launcher never did the second half, so a created workspace existed on the server, showed its slug and token, and then failed to appear in the list the dialog had just promised to add it to. It now registers the result exactly like the paste and pairing paths (`addNetwork` is idempotent, so re-adding an existing one is a no-op).

Also in that dialog:
- Creating twice is no longer possible: the success state is terminal (primary becomes **Done**, name field locks), and a ref latch closes the double-click window that `disabled={busy}` leaves open for one render.
- An `AbortError` from the connector's own request deadline now reads as a timeout instead of "The operation was aborted".

## The launcher's own local data has controls

Theme, accent, skin and the rest live in localStorage because they must be read before the first paint — which meant they survived "Reset all settings" and even a reinstall, and the startup splash came back in a colour the user thought they had thrown away. Settings → Data can now clear the Chromium cache and reset appearance and interface state; the reset also repairs the accent mirror in `settings.json` that the splash reads. The UI language, workspace favourites and onboarding progress are deliberately left alone.

## Consistency work

All of it drift found while doing the above:

- **One action, one label, one icon.** "Add workspace", "New agent" and friends are single entries under `common.actions` that every entry point quotes; the "your first X" variants and their duplicate keys are gone. Entry points now open the door their label names — the command palette's "new workspace" only switched tabs and created nothing, and the dashboard's agents card went to the marketplace while the button beside it opened the new-agent dialog.
- **One empty state.** Seven of them, each previously a different subset of the shadcn primitives, are now `EmptyState`: icon, title, sentence, one action. Each of the three reasons a list can be empty gets its own way out (create / clear search / show all).
- **One toolbar layout.** Four list pages had four (`mb-4` vs `mb-5`, one row vs two, `size="sm"` controls vs default heights); `PageToolbar` holds it now.
- **Workspace menu names are translated.** The launcher quotes the workspace's own menu ("Connect Agent → Nodes") in six strings, and the workspace is bilingual too — those are now shared terms resolved per language. A test asserts every `$t()` reference points at a real key: a broken one renders the key name into the UI and throws nothing.
- **Pairing copy corrected.** It still said a second code moves the device between workspaces, which stopped being true when memberships became additive.
- Confirm dialogs that stack two blocks (an opt-in and the warning it unlocks) had no gap between them at all.
- Destructive entry points take the openagents skin's frame like every other control, in danger colours — bare red text among framed buttons read as unstyled rather than quiet.

## Verification

`npm run typecheck`, `npm test` (260 tests, 25 files — new coverage for the reload shortcut, changelog selection, local-data reset and i18n nesting), `npm run build`, and `npm run check:changelog` all pass.

Not self-tested in a running app: the visual changes need a look, in particular the four unified toolbars at the 1200px minimum window width, where the Agents page carries the most controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)