### PR TITLE
fix(launcher): window buttons that stay dim, and joining a workspace by link

### DIFF
--- a/packages/launcher/changelog/0.9.12.json
+++ b/packages/launcher/changelog/0.9.12.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.9.12",
+  "date": "2026-08-14",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "Window buttons dim behind the release notes too",
+        "zh": "更新公告弹出时，窗口按钮也会跟着变暗"
+      },
+      "description": {
+        "en": "On Windows the minimise/maximise/close buttons went back to full strength whenever a dialog opened while the app was still starting — and the notes you are reading are exactly that dialog. They now dim with the rest of the app, as they already did for every dialog opened later.",
+        "zh": "Windows 上，如果弹窗是在应用启动过程中出现的（更新后的这份公告就是），最小化/最大化/关闭三个按钮会恢复成高亮，看起来像是整屏唯一还亮着的东西。现在它们和之后打开的弹窗一样，会跟着一起被遮罩。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Where the workspace token actually is",
+        "zh": "加入工作区时，令牌到底在哪"
+      },
+      "description": {
+        "en": "The hint and the error both sent people to the top right of the workspace; the avatar menu is at the bottom left. Both now also say why a link copied from the address bar cannot join — it carries no token — and where to copy one that does.",
+        "zh": "提示和报错都指向工作区右上角，而头像菜单其实在左下角。现在还会说明：直接从地址栏复制的链接不带令牌，所以加入不了，以及去哪里复制一条带令牌的链接。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -521,14 +521,22 @@ function createWindow(): void {
   setNotificationsWindow(mainWindow)
   hardenWebContents(mainWindow.webContents)
 
-  // Repaint the window-controls overlay once the page is up. Two things it
-  // fixes, both of which leave the buttons wearing a colour nothing on screen
-  // explains: a window created before the stored theme took effect, and a
-  // reload that stranded main holding a dim state whose dialog is long gone.
-  mainWindow.webContents.on("did-finish-load", () => {
-    setChromeDimmed(mainWindow, false)
-    refreshTitleBarOverlay(mainWindow)
-  })
+  // Forget any dim state at the START of a load, not at the end of one. A
+  // reload can strand main holding a dim whose dialog is long gone, so it does
+  // have to be cleared — but the renderer reports its own the moment its entry
+  // script runs, which is long before `did-finish-load`. Clearing it there
+  // overwrote the report of any dialog opened during startup — the release
+  // notes are exactly that — and left the buttons bright over a scrimmed app.
+  mainWindow.webContents.on("did-start-loading", () =>
+    setChromeDimmed(mainWindow, false),
+  )
+
+  // Repaint the overlay once the page is up, for a window created before the
+  // stored theme took effect: its buttons wear a colour nothing on screen
+  // explains. Whatever the renderer has since said about a dialog is kept.
+  mainWindow.webContents.on("did-finish-load", () =>
+    refreshTitleBarOverlay(mainWindow),
+  )
 
   // Full screen hides the window buttons on every platform, which leaves the
   // strip the app reserves for them holding nothing. Tell the renderer so it

--- a/packages/launcher/src/renderer/i18n/locales/en/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agents.json
@@ -191,8 +191,8 @@
     "workspaceNamePlaceholder": "my-workspace",
     "create": "Create",
     "pasteUrlOrToken": "Paste workspace URL or token",
-    "pasteUrlPlaceholder": "https://workspace.openagents.org/team?token=… or http://localhost:8000/team?token=…",
-    "tokenHint": "No link with a token? In the workspace, open the avatar menu (top right) → Copy workspace token, and paste it here.",
+    "pasteUrlPlaceholder": "https://workspace.openagents.org/my-team?token=…",
+    "tokenHint": "A link copied from the address bar has no token in it, and cannot join on its own. In the workspace, click the avatar at the bottom left → Copy workspace token and paste the token here — or open the QR button beside it and click the code, which copies a link with the token in it.",
     "join": "Join",
     "toast": {
       "connecting": "Adding {{name}} to the workspace…",

--- a/packages/launcher/src/renderer/i18n/locales/en/workspaces.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/workspaces.json
@@ -101,7 +101,7 @@
     "pairError": "A pairing code is 8 characters, like XXXX-XXXX.",
     "pasteLabel": "Workspace URL or invitation token",
     "pastePlaceholder": "https://workspace.openagents.org/my-team?token=…",
-    "pasteHint": "Hosted URLs use remote token resolution. Custom URLs use the URL origin, first path segment, and token query parameter.",
+    "pasteHint": "The link has to carry ?token=, and one copied from the address bar does not. In the workspace, click the avatar at the bottom left → $t(common.workspaceMenu.copyToken) — or open the QR button beside it and click the code, which copies a link with the token in it.",
     "createLabel": "Workspace name",
     "createPlaceholder": "My Team",
     "createHint": "A new workspace is created on OpenAgents and added here. You get its address and token straight away, and agents on this device can join it.",
@@ -126,8 +126,8 @@
       "tls": "Workspace service is temporarily unreachable (TLS certificate mismatch). Please try again later or contact support.",
       "dns": "Cannot reach the workspace service. Check your internet connection and try again.",
       "timeout": "Workspace service didn't respond in time. Please try again in a moment.",
-      "linkMissingToken": "That workspace link carries no token. In the workspace, open the avatar menu (top right) → $t(common.workspaceMenu.copyToken), then paste the token here.",
-      "invalidToken": "That token is invalid or has expired. Copy a fresh one from the workspace: avatar menu (top right) → $t(common.workspaceMenu.copyToken)."
+      "linkMissingToken": "That workspace link carries no token, and one copied from the address bar never does. In the workspace, click the avatar at the bottom left → $t(common.workspaceMenu.copyToken), then paste the token here.",
+      "invalidToken": "That token is invalid or has expired. Copy a fresh one from the workspace: click the avatar at the bottom left → $t(common.workspaceMenu.copyToken)."
     }
   },
   "rename": {

--- a/packages/launcher/src/renderer/i18n/locales/zh/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agents.json
@@ -191,8 +191,8 @@
     "workspaceNamePlaceholder": "my-workspace",
     "create": "创建",
     "pasteUrlOrToken": "粘贴工作区 URL 或令牌",
-    "pasteUrlPlaceholder": "https://workspace.openagents.org/team?token=… 或 http://localhost:8000/team?token=…",
-    "tokenHint": "没有带令牌的链接？在工作区右上角点击头像 → 复制工作区令牌，粘贴到这里即可。",
+    "pasteUrlPlaceholder": "https://workspace.openagents.org/my-team?token=…",
+    "tokenHint": "从地址栏复制的链接不带令牌，单靠它加入不了。请在工作区左下角点击头像 →「复制工作区令牌」，把令牌粘贴到这里；也可以点开旁边的二维码按钮，点一下二维码，复制的就是带令牌的链接。",
     "join": "加入",
     "toast": {
       "connecting": "正在把 {{name}} 加入工作区…",

--- a/packages/launcher/src/renderer/i18n/locales/zh/workspaces.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/workspaces.json
@@ -101,7 +101,7 @@
     "pairError": "配对码是 8 位，形如 XXXX-XXXX。",
     "pasteLabel": "工作区链接或邀请令牌",
     "pastePlaceholder": "https://workspace.openagents.org/my-team?token=…",
-    "pasteHint": "托管链接使用远程令牌解析。自定义链接会使用链接来源、首段路径和 token 查询参数。",
+    "pasteHint": "链接必须带 ?token=，从地址栏复制的那条没有。请在工作区左下角点击头像 →「$t(common.workspaceMenu.copyToken)」；也可以点开旁边的二维码按钮，点一下二维码，复制的就是带令牌的链接。",
     "createLabel": "工作区名称",
     "createPlaceholder": "我的团队",
     "createHint": "会在 OpenAgents 上新建一个工作区并添加到这里，随即给出它的地址与令牌，这台设备上的智能体可以直接加入。",
@@ -126,8 +126,8 @@
       "tls": "工作区服务暂时无法访问（TLS 证书不匹配）。请稍后重试或联系支持。",
       "dns": "无法连接到工作区服务。请检查你的网络连接后重试。",
       "timeout": "工作区服务未能及时响应。请稍后重试。",
-      "linkMissingToken": "这个工作区链接里没有令牌。请在工作区右上角点击头像 →「$t(common.workspaceMenu.copyToken)」，然后粘贴令牌。",
-      "invalidToken": "令牌无效或已过期。请在工作区右上角点击头像 →「$t(common.workspaceMenu.copyToken)」重新获取后再试。"
+      "linkMissingToken": "这个工作区链接里没有令牌，从地址栏复制的链接都没有。请在工作区左下角点击头像 →「$t(common.workspaceMenu.copyToken)」，再把令牌粘贴到这里。",
+      "invalidToken": "令牌无效或已过期。请在工作区左下角点击头像 →「$t(common.workspaceMenu.copyToken)」重新获取后再试。"
     }
   },
   "rename": {


### PR DESCRIPTION
Three reports from testing 0.9.11 on Windows.

## Window buttons went bright behind the release notes

0.9.11 taught the Windows window-controls overlay to dim with a dialog's scrim, and it still came up bright behind the "What's new" dialog after updating — the one dialog every user sees.

Main cleared the dim state on `did-finish-load`. The renderer reports its own state the moment its entry script runs, which is long before the page's `load` event, so a dialog opened during startup reported `true` and then had it overwritten by that clear. Dialogs opened later were unaffected, which is why this only ever showed up on the release notes.

The clear now runs on `did-start-loading` — still ahead of a reload stranding main with a dim whose dialog is gone, but now also ahead of anything the renderer can say. `did-finish-load` keeps the repaint (for a window created before the stored theme took effect) and no longer contradicts the renderer.

## "Join a workspace" pointed at the wrong corner, and at a link that cannot work

The hint and both errors sent people to the top right of the workspace for the token. The avatar menu is at the bottom left.

They also did not explain the actual failure. `https://workspace.openagents.org/<slug>` is what the address bar gives you, and its first path segment is the workspace slug, not a token — `/v1/token/resolve` matches on the workspace token alone, so a slug can never resolve. The web app gets away with opening `/<slug>` because it exchanges the signed-in user's idToken for the workspace token; the launcher has no account session to do that with.

So the copy now says the link carries no token and names the two things that do work: **Copy workspace token** from the avatar menu, or the QR button beside it — clicking the code there copies `/<slug>?token=…`, which the launcher already accepts. (A slug-only URL also still works for a workspace this device has joined before; `connectWorkspace` matches it against the locally registered networks first.)

Six strings, en and zh.

## Placeholder truncated mid-token

The connect dialog's placeholder listed a hosted URL *and* a localhost one; at ~90 characters the field cut the second off mid-token. Trimmed to one example, matching what the workspace page's own placeholder was already reduced to. Self-hosted URLs are still accepted — the hint below is where that belongs.

## Also

- Version bumped to 0.9.12, `changelog/0.9.12.json` added.
- A fourth report, the update banner surviving its own "view progress" click, needed no change: that was fixed in d73fea3e and shipped in 0.9.11. The banner seen was the previous build's.

`npm run test` (268 passing), `check:changelog`, and both `tsc --noEmit` projects are clean. The overlay change is Windows/Linux-only and wants a look on a real Windows box.