### PR TITLE
feat: channel-agnostic workspace skill files (channelMode switch)

### DIFF
--- a/packages/agent-connector/src/adapters/workspace-prompt.js
+++ b/packages/agent-connector/src/adapters/workspace-prompt.js
@@ -121,11 +121,13 @@ function workspaceSkillName(agentName) {
  * - `'skills'` → points at the agent's workspace skill (Bash + curl),
  *   since no MCP server is spawned and that tool would not exist.
  */
-function buildWorkspaceIdentity(agentName, workspaceId, channelName, mode = 'execute', toolMode = 'mcp') {
+function buildWorkspaceIdentity(agentName, workspaceId, channelName, mode = 'execute', toolMode = 'mcp', channelMode = 'literal') {
+  const dynamic = channelMode === 'dynamic';
   const priorContext = toolMode === 'skills'
     ? (
       `When you need prior context, use the ${workspaceSkillName(agentName)} skill to ` +
-      `read this channel's recent messages (with \`channel="${channelName}"\`). ` +
+      `read this channel's recent messages (with \`channel="${dynamic ? 'CHANNEL_NAME' : channelName}"\`). ` +
+      (dynamic ? 'Replace CHANNEL_NAME with the channel you are currently in. ' : '') +
       'Always specify the channel — the default may be different from where ' +
       'you are.\n'
     )
@@ -141,7 +143,7 @@ function buildWorkspaceIdentity(agentName, workspaceId, channelName, mode = 'exe
     '— just write your answer naturally.\n\n' +
     '## Workspace Context\n' +
     `- Workspace ID: ${workspaceId}\n` +
-    `- Channel: ${channelName}  (this is the channel you are currently speaking in)\n` +
+    `- Channel: ${dynamic ? 'CHANNEL_NAME' : channelName}  (${dynamic ? 'substitute the channel you are currently in — see "Channel:" in your system prompt\'s Workspace Context' : 'this is the channel you are currently speaking in'})\n` +
     `- Mode: ${mode}\n\n` +
     priorContext
   );
@@ -209,11 +211,12 @@ function buildModePrompt(mode) {
  *
  * In plan mode, only read-only operations are documented.
  */
-function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channelName, disabledModules, mode = 'execute', isWindows = process.platform === 'win32' }) {
+function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channelName, disabledModules, mode = 'execute', channelMode = 'literal', isWindows = process.platform === 'win32' }) {
   const disabled = disabledModules || new Set();
   const baseUrl = endpoint.replace(/\/+$/, '');
   const isPlan = mode === 'plan';
   const h = `X-Workspace-Token: ${token}`;
+  const chan = channelMode === 'dynamic' ? 'CHANNEL_NAME' : channelName;
   const curl = isWindows ? 'curl.exe' : 'curl';
 
   const sections = [];
@@ -261,7 +264,7 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
           `\\"content_type\\":\\"text/markdown\\",` +
           `\\"network\\":\\"${workspaceId}\\",` +
           `\\"source\\":\\"openagents:${agentName}\\",` +
-          `\\"channel_name\\":\\"${channelName}\\"}"\n\n`
+          `\\"channel_name\\":\\"${chan}\\"}"\n\n`
         );
       } else {
         s += (
@@ -275,7 +278,7 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
           `"content_type":"text/markdown",` +
           `"network":"${workspaceId}",` +
           `"source":"openagents:${agentName}",` +
-          `"channel_name":"${channelName}"}'\n\n`
+          `"channel_name":"${chan}"}'\n\n`
         );
       }
     }
@@ -321,7 +324,7 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
         `${curl} -s -X POST ${baseUrl}/v1/files/from_url ` +
         `-H "${h}" -H "Content-Type: application/json" ` +
         `-d '{"url":"IMAGE_URL","network":"${workspaceId}",` +
-        `"channel_name":"${channelName}","source":"openagents:${agentName}",` +
+        `"channel_name":"${chan}","source":"openagents:${agentName}",` +
         `"post_to_channel":true,"caption":"optional message text"}'\n\n` +
         'Mention the source page when you share images, and never present a ' +
         'search result as license-free.\n'
@@ -432,7 +435,7 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
   sections.push(
     '\n### Message History\n\n' +
     '**Get recent messages in the current channel:**\n' +
-    `\`${curl} -s -H "${h}" "${baseUrl}/v1/events?network=${workspaceId}&channel=${channelName}&type=workspace.message&sort=desc&limit=20"\`\n\n` +
+    `\`${curl} -s -H "${h}" "${baseUrl}/v1/events?network=${workspaceId}&channel=${chan}&type=workspace.message&sort=desc&limit=20"\`\n\n` +
     '**Get messages from a specific channel:**\n' +
     `\`${curl} -s -H "${h}" "${baseUrl}/v1/events?network=${workspaceId}&channel=CHANNEL_NAME&type=workspace.message&sort=desc&limit=20"\`\n`
   );
@@ -444,7 +447,7 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
       'Post a status/thinking message (visible in the workspace UI as an intermediate step):\n' +
       `\`${curl} -s -X POST -H "${h}" -H "Content-Type: application/json" ` +
       `${baseUrl}/v1/events -d '{"type":"workspace.message.posted",` +
-      `"source":"openagents:${agentName}","target":"channel/${channelName}",` +
+      `"source":"openagents:${agentName}","target":"channel/${chan}",` +
       `"payload":{"content":"YOUR_STATUS","message_type":"status"}}'\`\n`
     );
   }
@@ -461,10 +464,10 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
       `${baseUrl}/v1/todos -d '{"todos":[` +
       `{"content":"First task","status":"in_progress"},` +
       `{"content":"Second task","status":"pending"}` +
-      `],"network":"${workspaceId}","channel":"${channelName}",` +
+      `],"network":"${workspaceId}","channel":"${chan}",` +
       `"source":"openagents:${agentName}"}'\`\n\n` +
       '**Get your to-do list:**\n' +
-      `\`${curl} -s -H "${h}" "${baseUrl}/v1/todos?network=${workspaceId}&channel=${channelName}"\`\n\n` +
+      `\`${curl} -s -H "${h}" "${baseUrl}/v1/todos?network=${workspaceId}&channel=${chan}"\`\n\n` +
       '**IMPORTANT:** When you receive a task with multiple steps or a list of things to do, ' +
       'ALWAYS create a to-do list first before starting work. This lets the user see your ' +
       'progress in real time. Update statuses as you work through each item.\n' +
@@ -484,10 +487,10 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
       '**Create a timer:**\n' +
       `\`${curl} -s -X POST -H "${h}" -H "Content-Type: application/json" ` +
       `${baseUrl}/v1/timers -d '{"delay":300,"message":"Check the build",` +
-      `"network":"${workspaceId}","channel":"${channelName}",` +
+      `"network":"${workspaceId}","channel":"${chan}",` +
       `"source":"openagents:${agentName}"}'\`\n\n` +
       '**List active timers:**\n' +
-      `\`${curl} -s -H "${h}" "${baseUrl}/v1/timers?network=${workspaceId}&channel=${channelName}"\`\n\n` +
+      `\`${curl} -s -H "${h}" "${baseUrl}/v1/timers?network=${workspaceId}&channel=${chan}"\`\n\n` +
       '**Cancel a timer:**\n' +
       `\`${curl} -s -X DELETE -H "${h}" ${baseUrl}/v1/timers/TIMER_ID\`\n`
     );
@@ -534,7 +537,7 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
       '**Send a notification:**\n' +
       `\`${curl} -s -X POST -H "${h}" -H "Content-Type: application/json" ` +
       `${baseUrl}/v1/notifications -d '{"title":"Task Complete","message":"The analysis is ready.",` +
-      `"priority":"normal","channel":"${channelName}",` +
+      `"priority":"normal","channel":"${chan}",` +
       `"network":"${workspaceId}",` +
       `"source":"openagents:${agentName}"}'\`\n\n` +
       '**Priority values:** `low`, `normal`, `high`\n\n' +
@@ -584,16 +587,25 @@ function buildApiSkillsPrompt({ endpoint, workspaceId, token, agentName, channel
     'an `address` `channel/<name>` and a `participants` list of agent names).\n\n' +
     '**To list the agents in THIS channel with their descriptions:** call ' +
     'discover, find the entry in `channels[]` whose `address` is ' +
-    `\`channel/${channelName}\`, then keep the \`agents[]\` whose name is in ` +
+    `\`channel/${chan}\`, then keep the \`agents[]\` whose name is in ` +
     'that channel\'s `participants`. Example:\n' +
     `\`${curl} -s -H "${h}" ${baseUrl}/v1/discover?network=${workspaceId} | ` +
-    'jq --arg ch "channel/' + channelName + '" \'' +
+    'jq --arg ch "channel/' + chan + '" \'' +
     '(.data.channels[]|select(.address==$ch).participants) as $p | ' +
     '.data.agents[]|select((.address|sub("openagents:";"")) as $n|$p|index($n))|' +
     '{name:(.address|sub("openagents:";"")),description,role,status}\'`\n' +
     '(Discovery is workspace-wide — there is no per-channel discover endpoint, ' +
     'so cross-reference `participants` yourself as shown.)\n'
   );
+
+  if (channelMode === 'dynamic') {
+    sections.splice(1, 0,
+      '\n**Current channel:** This skill is channel-agnostic and works from any channel. ' +
+      'In every command below, replace `CHANNEL_NAME` with the channel you are currently ' +
+      'speaking in — it is listed under "Channel:" in your system prompt\'s Workspace Context. ' +
+      'Always target the channel you are operating in, never a channel from an older session.\n'
+    );
+  }
 
   return sections.join('\n');
 }
@@ -833,10 +845,10 @@ function buildOpenclawSystemPrompt({ agentName, workspaceId, channelName, endpoi
  */
 function buildOpenclawSkillMd({ endpoint, workspaceId, token, agentName, channelName, disabledModules, browserEnabled = false }) {
   const body = buildApiSkillsPrompt({
-    endpoint, workspaceId, token, agentName, channelName, disabledModules, mode: 'execute',
+    endpoint, workspaceId, token, agentName, channelName, disabledModules, mode: 'execute', channelMode: 'dynamic',
   });
 
-  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute', 'skills');
+  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute', 'skills', 'dynamic');
   const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt('skills', workspaceSkillName(agentName));
 
@@ -898,6 +910,7 @@ function buildOpenCodeSkillMd({ endpoint, workspaceId, token, agentName, channel
     channelName: channelName || 'general',
     disabledModules,
     mode: 'execute',
+    channelMode: 'dynamic',
   });
 
   const frontmatter =
@@ -926,9 +939,10 @@ function buildClaudeSkillMd({ endpoint, workspaceId, token, agentName, channelNa
     channelName: channelName || 'general',
     disabledModules,
     mode: 'execute',
+    channelMode: 'dynamic',
   });
 
-  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute', 'skills');
+  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute', 'skills', 'dynamic');
   const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt('skills', workspaceSkillName(agentName));
 
@@ -957,9 +971,10 @@ function buildCursorSkillMd({ endpoint, workspaceId, token, agentName, channelNa
     channelName: channelName || 'general',
     disabledModules,
     mode: 'execute',
+    channelMode: 'dynamic',
   });
 
-  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute', 'skills');
+  const identity = buildWorkspaceIdentity(agentName, workspaceId, channelName, 'execute', 'skills', 'dynamic');
   const directive = buildBrowserDirective(browserEnabled);
   const collab = buildCollaborationPrompt('skills', workspaceSkillName(agentName));
 

--- a/sdk/src/openagents/adapters/workspace_prompt.py
+++ b/sdk/src/openagents/adapters/workspace_prompt.py
@@ -76,15 +76,21 @@ def build_workspace_identity(
     workspace_id: str,
     channel_name: str,
     mode: str = "execute",
+    channel_mode: str = "literal",
 ) -> str:
     """Build the identity section common to all adapters."""
+    channel_display = (
+        "CHANNEL_NAME  (substitute the channel you are currently in — see \"Channel:\" in your system prompt's Workspace Context)"
+        if channel_mode == "dynamic"
+        else channel_name
+    )
     return (
         f"You are agent '{agent_name}' connected to an OpenAgents workspace.\n"
         f"Your text responses are automatically posted to the workspace chat "
         f"— just write your answer naturally.\n\n"
         f"## Workspace Context\n"
         f"- Workspace ID: {workspace_id}\n"
-        f"- Channel: {channel_name}\n"
+        f"- Channel: {channel_display}\n"
         f"- Mode: {mode}\n"
     )
 
@@ -132,6 +138,7 @@ def build_api_skills_prompt(
     channel_name: str,
     disabled_modules: Optional[set] = None,
     mode: str = "execute",
+    channel_mode: str = "literal",
 ) -> str:
     """Build REST API skill instructions for non-MCP agents.
 
@@ -144,6 +151,7 @@ def build_api_skills_prompt(
     base_url = endpoint.rstrip("/")
     is_plan = mode == "plan"
     h = f"X-Workspace-Token: {token}"
+    chan = "CHANNEL_NAME" if channel_mode == "dynamic" else channel_name
 
     sections = []
 
@@ -191,7 +199,7 @@ def build_api_skills_prompt(
                 "\"content_type\":\"text/markdown\","
                 f"\"network\":\"{workspace_id}\","
                 f"\"source\":\"openagents:{agent_name}\","
-                f"\"channel_name\":\"{channel_name}\"}}'\n\n"
+                f"\"channel_name\":\"{chan}\"}}'\n\n"
             )
 
         s += (
@@ -230,7 +238,7 @@ def build_api_skills_prompt(
                 f"curl -s -X POST {base_url}/v1/files/from_url "
                 f'-H "{h}" -H "Content-Type: application/json" '
                 f'-d \'{{"url":"IMAGE_URL","network":"{workspace_id}",'
-                f'"channel_name":"{channel_name}","source":"openagents:{agent_name}",'
+                f'"channel_name":"{chan}","source":"openagents:{agent_name}",'
                 f'"post_to_channel":true,"caption":"optional message text"}}\'\n\n'
                 "Mention the source page when you share images, and never present a "
                 "search result as license-free.\n"
@@ -295,6 +303,15 @@ def build_api_skills_prompt(
         "\n### Discover Agents\n"
         f"`curl -s -H \"{h}\" {base_url}/v1/discover?network={workspace_id}`\n"
     )
+
+    if channel_mode == "dynamic":
+        sections.insert(
+            1,
+            "\n**Current channel:** This skill is channel-agnostic and works from any channel. "
+            "In every command below, replace `CHANNEL_NAME` with the channel you are currently "
+            'speaking in — it is listed under "Channel:" in your system prompt\'s Workspace Context. '
+            "Always target the channel you are operating in, never a channel from an older session.\n",
+        )
 
     return "\n".join(sections)
 
@@ -398,10 +415,11 @@ def build_openclaw_skill_md(
         channel_name=channel_name,
         disabled_modules=disabled_modules,
         mode="execute",
+        channel_mode="dynamic",
     )
 
     identity = build_workspace_identity(
-        agent_name, workspace_id, channel_name, "execute"
+        agent_name, workspace_id, channel_name, "execute", "dynamic"
     )
     directive = build_browser_directive(browser_enabled)
     collab = build_collaboration_prompt()
@@ -481,7 +499,7 @@ def _build_opencode_api_skills_prompt(
                 '"content_type":"text/markdown",'
                 f'"network":"{workspace_id}",'
                 f'"source":"openagents:{agent_name}",'
-                f'"channel_name":"{channel_name}"}}\'\n\n'
+                f'"channel_name":"{chan}"}}\'\n\n'
             )
 
         s += (
@@ -515,11 +533,11 @@ def _build_opencode_api_skills_prompt(
         )
         if not is_plan:
             s += (
-                "**To keep a copy in the workspace AND post it as an attachment:**\n"
+                "**To keep a copy in the workspace AND post it as an attachment** "
                 f"curl -s -X POST {base_url}/v1/files/from_url "
                 f'-H "{h}" -H "Content-Type: application/json" '
                 f'-d \'{{"url":"IMAGE_URL","network":"{workspace_id}",'
-                f'"channel_name":"{channel_name}","source":"openagents:{agent_name}",'
+                f'"channel_name":"{chan}","source":"openagents:{agent_name}",'
                 f'"post_to_channel":true,"caption":"optional message text"}}\'\n\n'
                 "Mention the source page when you share images, and never present a "
                 "search result as license-free.\n"
@@ -594,6 +612,15 @@ def _build_opencode_api_skills_prompt(
         f'`curl -s -H "{h}" {base_url}/v1/discover?network={workspace_id}`\n'
     )
 
+    if channel_mode == "dynamic":
+        sections.insert(
+            1,
+            "\n**Current channel:** This skill is channel-agnostic and works from any channel. "
+            "In every command below, replace `CHANNEL_NAME` with the channel you are currently "
+            'speaking in — it is listed under "Channel:" in your system prompt\'s Workspace Context. '
+            "Always target the channel you are operating in, never a channel from an older session.\n",
+        )
+
     return "\n".join(sections)
 
 
@@ -653,10 +680,11 @@ def build_opencode_skill_md(
         channel_name=channel_name,
         disabled_modules=disabled_modules,
         mode="execute",
+        channel_mode="dynamic",
     )
 
     identity = build_workspace_identity(
-        agent_name, workspace_id, channel_name, "execute"
+        agent_name, workspace_id, channel_name, "execute", "dynamic"
     )
     collab = build_collaboration_prompt()
 


### PR DESCRIPTION
## Summary

Adds a `channelMode` switch (`'literal'` | `'dynamic'`) to the workspace prompt builders in **agent-connector** (JS) and the **SDK** (Python). Default stays `'literal'` — fully backward compatible.

## Problem

When the launcher regenerates a workspace skill file, it bakes the **current channel** into the file (e.g. `channel="channel-abc123"` in every curl example, the `Channel:` line in the workspace context header, and the discover-jq example). Two failure modes:

1. A skill file copied or reused from another channel hardcodes the wrong channel.
2. Any regeneration while the daemon holds a stale template re-hardcodes files that were previously made channel-agnostic.

## Solution

In `dynamic` mode, generated skill files carry a `CHANNEL_NAME` placeholder plus an explicit substitution hint (`Replace CHANNEL_NAME with the channel you are currently in`), so the file is channel-agnostic and the agent substitutes the live channel at runtime. The four skill builders (Claude, Cursor, OpenCode, OpenClaw) are wired to `dynamic`; MCP-mode system prompts remain `literal`.

### JS — `packages/agent-connector/src/adapters/workspace-prompt.js`
- `buildWorkspaceIdentity(..., channelMode = 'literal')` — placeholder for `Channel:` line and prior-context hint
- `buildApiSkillsPrompt({ ..., channelMode = 'literal' })` — `chan` variable used across files/from_url/events/todos/timers/discover examples
- 4 builders pass `channelMode: 'dynamic'`

### Python — `sdk/src/openagents/adapters/workspace_prompt.py`
- `build_workspace_identity(..., channel_mode: str = "literal")` — placeholder for `Channel:` line
- `build_api_skills_prompt(..., channel_mode = "literal")` and `_build_opencode_api_skills_prompt` — `chan` scoping + "Current channel" note in dynamic mode
- `build_openclaw_skill_md` / `build_opencode_skill_md` pass `channel_mode="dynamic"`

## Verification
- `node --check` on JS, `python3 -m py_compile` on Python
- JS file byte-identical to the locally verified patched template (same version v0.2.166)
- Regenerated skill files: 0 hardcoded channel refs, 16 `CHANNEL_NAME` placeholders each

## Test plan
- Existing `test/workspace-prompt.test.js` still passes (default `literal` path unchanged)
- Manual: regenerate a skill in dynamic mode → grep for `channel-[0-9a-f]{8}` → 0 hits; `CHANNEL_NAME` present with substitution note