### PR TITLE
fix(launcher): Windows CLI sign-in — probe, login terminal, stale install state

### DIFF
--- a/packages/launcher/changelog/0.9.14.json
+++ b/packages/launcher/changelog/0.9.14.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.9.14",
+  "date": "2026-08-17",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "Windows: signing in to Codex now works, and the app can tell that it did",
+        "zh": "Windows：Codex 登录可用，登录状态也能正确识别"
+      },
+      "description": {
+        "en": "On Windows, an agent installed through npm could end up with no launchable shim, and the launcher then failed three ways at once: the sign-in check couldn't run at all — so a finished browser login still read as \"couldn't confirm your login\" and the agent stayed \"not signed in\" — and \"Sign in in a terminal\" opened a window that answered 'codex' is not recognized. The launcher now runs these CLIs the way Windows actually needs, and the terminal it opens uses the same PATH the agents themselves run with. Codex was the agent that hit all three, but the fix covers every agent that signs in through its CLI.",
+        "zh": "在 Windows 上，通过 npm 安装的智能体可能没有可直接启动的入口文件，于是启动器同时出现三个问题：登录状态检查根本无法执行——浏览器里明明登录成功，却仍提示「无法确认登录状态」，智能体也一直显示未登录；点「用终端登录」打开的窗口则报 'codex' 不是内部或外部命令。现在启动器会按 Windows 真正需要的方式调用这些命令行工具，打开的终端也与智能体运行时使用同一套 PATH。Codex 是三个问题全中的那个，但修复覆盖所有通过 CLI 登录的智能体。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "An agent whose files are gone no longer shows as installed",
+        "zh": "文件已丢失的智能体不再显示为「已安装」"
+      },
+      "description": {
+        "en": "If an agent's files disappeared — a failed update, an uninstall from outside the app, antivirus — the Install page kept showing it as installed, at whatever version it was when it last worked, offering Update and Uninstall. Everything you could do with it then failed, and the one button that would have fixed it (Install) was hidden. The page now checks the disk, and the version it shows is the one actually there rather than the one last recorded.",
+        "zh": "如果智能体的文件不见了——更新失败、在应用外被卸载、被杀毒软件清理——安装页仍会显示它已安装，版本号停留在最后一次正常工作时，并提供「更新」和「卸载」。此时对它做任何操作都会失败，而唯一能修好的按钮（安装）反而被隐藏了。现在安装页会核对磁盘上的实际情况，显示的版本号也以磁盘为准，而不是最后一次记录的版本。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -56,6 +56,8 @@ import {
   type InstalledAgentRecord,
 } from "./agents/install-service"
 import { LoginProbe } from "./agents/login-probe"
+import { buildBinaryTypeMap } from "./agents/binary-map"
+import { shellCommandFor } from "./win-exec"
 import { ChatService } from "./chat/service"
 import type {
   ChatMessage,
@@ -199,6 +201,7 @@ export class AgentManager extends EventEmitter {
       connector: () => this._connector,
       clearCatalogCache: () => this.clearCatalogCache(),
       getCatalog: () => this.getCatalog(),
+      resolveBinary: (type) => this.resolveBinary(type),
     })
     this._chat = new ChatService({
       getClient: () => this._getWorkspaceClient(),
@@ -394,12 +397,20 @@ export class AgentManager extends EventEmitter {
     tick()
   }
 
-  /** Install check matching the marketplace's "Installed" badge (getInstallInfo). */
+  /**
+   * Install check matching the marketplace's "Installed" badge (getInstallInfo),
+   * minus the installs that are only claimed by a marker — see
+   * `InstallService.installVanished`. Without that second half an agent whose
+   * package is gone reads as installed-but-broken everywhere: the Agents list
+   * says "Login required" for a CLI that isn't on the machine, and the only
+   * action that would actually fix it (install) is the one the UI hides.
+   */
   private _isInstalled(type: string): boolean {
     try {
       const isInstalled = this._connector?.isInstalled as
         ((t: string) => boolean) | undefined
-      return !!isInstalled?.call(this._connector, type)
+      if (!isInstalled?.call(this._connector, type)) return false
+      return !this._install.installVanished(type)
     } catch {
       return false
     }
@@ -416,26 +427,76 @@ export class AgentManager extends EventEmitter {
         Record<string, unknown> | undefined
       const which = installer?.which as
         ((t: string) => string | null) | undefined
-      return which?.call(installer, type) || null
+      const bin = which?.call(installer, type) || null
+      this._logUnshimmedBinary(type, bin)
+      return bin
     } catch {
       return null
     }
   }
 
+  /** Last path we logged as shim-less, per type — so a re-install re-reports. */
+  private _unshimmedLogged = new Map<string, string>()
+
   /**
-   * Rewrite a hosted-login command (e.g. "cursor-agent login", "hermes setup")
-   * so its leading binary token becomes the resolved ABSOLUTE path. This is the
-   * fix for the Windows "'cursor-agent' is not recognized as an internal or
-   * external command" failure: the native installer drops the CLI under
-   * %LOCALAPPDATA%\cursor-agent and only edits the *registry* PATH, which a
-   * freshly-spawned login terminal inherits stale — so a bare `cursor-agent
-   * login` dies. Resolving to an absolute path makes the login PATH-independent.
-   * Returns the original command unchanged when it isn't a known hosted-login
-   * binary or the binary can't be resolved (callers still inject PATH as a
-   * fallback). The returned binary path is quoted so spaces in the home dir
-   * (e.g. C:\Users\First Last\...) survive.
+   * Record when an agent's CLI resolves to something Windows can't execute
+   * directly — the package's own `bin\x.js`, or npm's extensionless Git-Bash
+   * script — because `where` found no `.cmd` shim for it.
+   *
+   * This is a diagnostic, not a failure: the launcher runs those shapes fine now
+   * (see win-exec.ts). It is logged because the DAEMON does not. Every npm
+   * adapter (claude, codex, gemini, cline, opencode, pi) resolves its binary
+   * with its own tiered search that only ever builds `<name>.cmd` on Windows and
+   * never falls back to the package bin — so an agent in this state looks
+   * installed and signs in from the launcher while every message to it fails.
+   * When that report comes in, this line in the log is the answer, and nobody
+   * has to go read directories over chat to find it.
    */
-  resolveLoginCommand(cmd: string): string {
+  private _logUnshimmedBinary(type: string, bin: string | null): void {
+    if (process.platform !== "win32" || !bin) return
+    if (/\.(cmd|bat|exe)$/i.test(bin)) return
+    if (this._unshimmedLogged.get(type) === bin) return
+    this._unshimmedLogged.set(type, bin)
+    appendDaemonLog(
+      `${type}: CLI resolved to "${bin}" — no Windows .cmd shim was found for it. ` +
+        `The launcher can run this, but the daemon's ${type} adapter only looks for ` +
+        `${type}.cmd, so agents of this type may fail to start. Reinstalling ${type} ` +
+        `from the marketplace should restore the shim.`,
+    )
+  }
+
+  /** Binary name → agent type, built once from the registry. See binary-map.ts. */
+  private _binaryTypeMap: Map<string, string> | null = null
+  private _binaryToType(): Map<string, string> {
+    if (!this._binaryTypeMap)
+      this._binaryTypeMap = buildBinaryTypeMap(
+        Array.isArray(BUNDLED_REGISTRY)
+          ? (BUNDLED_REGISTRY as Array<Record<string, unknown>>)
+          : [],
+      )
+    return this._binaryTypeMap
+  }
+
+  /**
+   * Rewrite a command (e.g. "codex login", "cursor-agent login", "hermes setup")
+   * so its leading binary token becomes something Windows can actually execute:
+   * the resolved ABSOLUTE path, quoted, and routed through `node` when the
+   * resolved bin is a plain `.js` (see win-exec.ts).
+   *
+   * This is the fix for the Windows "'x' is not recognized as an internal or
+   * external command" failure in the login terminal. A CLI's installer only
+   * edits the *registry* PATH (Cursor drops itself under
+   * %LOCALAPPDATA%\cursor-agent) or lands in a per-agent runtime prefix the
+   * fresh cmd window was never told about — so a bare command dies even though
+   * the launcher knows exactly where the binary is. An absolute path sidesteps
+   * PATH entirely.
+   *
+   * `agentType` is passed by callers that already know which agent they're
+   * launching; without it the type is traced from the binary name. Returns the
+   * command unchanged when neither resolves (callers still inject PATH as a
+   * fallback).
+   */
+  resolveLoginCommand(cmd: string, agentType?: string): string {
     if (!cmd || !cmd.trim()) return cmd
     const trimmed = cmd.trim()
     // First whitespace-delimited token, with any surrounding quotes stripped.
@@ -443,24 +504,39 @@ export class AgentManager extends EventEmitter {
     if (!m) return cmd
     const rawFirst = m[1].replace(/^["']|["']$/g, "")
     const rest = m[2] || ""
-    // Map the CLI binary name to its agent type so we can resolve via the core.
+    // `.js` is in the strip list because that is what the core hands back for an
+    // npm agent with no Windows shim on PATH (…\@openai\codex\bin\codex.js).
     const base = rawFirst
-      .replace(/\.(exe|cmd|ps1|bat)$/i, "")
+      .replace(/\.(exe|cmd|ps1|bat|js|cjs|mjs)$/i, "")
       .split(/[\\/]/)
       .pop()
-    const BINARY_TO_TYPE: Record<string, string> = {
-      "cursor-agent": "cursor",
-      agent: "cursor",
-      hermes: "hermes",
-      claude: "claude",
-      amp: "amp",
-      gemini: "gemini",
-    }
-    const type = base ? BINARY_TO_TYPE[base] : undefined
+    const type =
+      agentType ||
+      (base ? this._binaryToType().get(base.toLowerCase()) : undefined)
     if (!type) return cmd
     const abs = this.resolveBinary(type)
     if (!abs) return cmd
-    return `"${abs}"${rest}`
+    return `${shellCommandFor(abs)}${rest}`
+  }
+
+  /**
+   * The dirs the core prepends to PATH when it spawns an agent (npm's global
+   * prefix, the per-agent runtime bins, nvm/fnm/volta, the native Cursor/Amp/
+   * Hermes install dirs…). Exposed so the login terminal can hand a new cmd
+   * window the SAME PATH the daemon uses instead of maintaining a second,
+   * always-lagging copy of the list. Empty when the core isn't loaded.
+   */
+  extraBinDirs(): string[] {
+    try {
+      const paths = core?.paths as
+        { getExtraBinDirs?: () => string[] } | undefined
+      const dirs = paths?.getExtraBinDirs?.()
+      return Array.isArray(dirs)
+        ? dirs.filter((d) => typeof d === "string")
+        : []
+    } catch {
+      return []
+    }
   }
 
   /**
@@ -801,6 +877,20 @@ export class AgentManager extends EventEmitter {
       if (!spec) continue
       const checkReady = (e.check_ready as Record<string, unknown>) || {}
       e.check_ready = { ...checkReady, login_command: spec.loginCommand }
+    }
+    // Demote installs the core only knows about from a marker. getInstallInfo
+    // reports installed:true for an agent whose package has since disappeared,
+    // which is how the marketplace offered "Update to v0.147.0" and "Uninstall"
+    // for a Codex that wasn't on the disk at all. Cheap in the normal case: the
+    // check short-circuits on entries that aren't claimed as installed, and on
+    // the package.json of the ones that really are.
+    for (const entry of catalog) {
+      const e = entry as Record<string, unknown>
+      if (!e.installed) continue
+      if (!this._install.installVanished(e.name as string)) continue
+      e.installed = false
+      e.managed = false
+      e.location = null
     }
     // Stamp the supported-core flag + display order. Non-core agents become
     // "coming soon" (the UI sinks + disables them); core agents carry the

--- a/packages/launcher/src/main/agents/auth-specs.ts
+++ b/packages/launcher/src/main/agents/auth-specs.ts
@@ -306,12 +306,16 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
  * `apiKeyEnv` lets a power user skip the browser login by setting that env var
  * (Cursor accepts CURSOR_API_KEY); when present the agent is ready without a
  * `status` probe. `statusArgs` is run against the resolved binary; sign-in is
- * derived from its output via EXACTLY ONE of:
+ * derived from its output (see `loginVerdict`) via either or both of:
  *   • `loggedOutPattern` — match ⇒ signed OUT (for terse CLIs like Cursor whose
- *     status is just "Not logged in" vs an account line); or
+ *     status is just "Not logged in" vs an account line);
  *   • `loggedInPattern`  — match ⇒ signed IN (for verbose CLIs like Hermes whose
  *     status always lists "not logged in" for every unconfigured provider, so a
  *     negative match is useless — we look for a positive "✓ logged in" instead).
+ * One is enough for a CLI that exits 0 either way: "ran clean and matched
+ * nothing" then stands in for the pattern's opposite. Declare BOTH when the CLI
+ * exits non-zero while signed out (codex does), because that shortcut is gated
+ * on a clean exit and would otherwise leave the verdict permanently unknown.
  * The probe runs ASYNC (status can take seconds, e.g. Hermes ~2.5s) and the
  * result is cached; sync health reads the cache and never blocks the main loop.
  */
@@ -423,11 +427,20 @@ export const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
     // makes the ChatGPT sign-in the primary path with the key as a fallback.
     //
     // `codex login status` prints "Logged in using ChatGPT" / "Logged in using
-    // an API key" (exit 0) when authenticated and "Not logged in" otherwise;
-    // the pattern matches the positive form only (avoids "Not logged in").
+    // an API key" when authenticated and "Not logged in" otherwise; the
+    // positive pattern matches only the former (it does not match "Not logged
+    // in", which contains no "using").
+    //
+    // The signed-out wording is spelled out as well because codex exits **1**
+    // when signed out (verified on Windows, codex 0.147.0: `EXIT 1 | OUT: "Not
+    // logged in"`). Without it, loginVerdict's clean-exit shortcut can't fire
+    // and a signed-out codex reads as null/unknown — which health.ts treats
+    // optimistically, leaving the agent looking usable right up until every
+    // message to it fails.
     loginCommand: "codex login",
     statusArgs: ["login", "status"],
     loggedInPattern: /logged in using/i,
+    loggedOutPattern: /not logged in/i,
   },
   amp: {
     // Amp (Sourcegraph) authenticates against Sourcegraph's own service, two

--- a/packages/launcher/src/main/agents/binary-map.test.ts
+++ b/packages/launcher/src/main/agents/binary-map.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import BUNDLED_REGISTRY from "../../../../agent-connector/registry.json"
+import { buildBinaryTypeMap, firstToken } from "./binary-map"
+import { DUAL_LOGIN_AGENTS, HOSTED_LOGIN_AGENTS } from "./auth-specs"
+
+const entries = BUNDLED_REGISTRY as Array<Record<string, unknown>>
+const map = buildBinaryTypeMap(entries)
+
+describe("firstToken", () => {
+  it("takes the binary and drops the subcommands", () => {
+    expect(firstToken("claude auth login")).toBe("claude")
+    expect(firstToken("  codex login  ")).toBe("codex")
+    expect(firstToken("gemini")).toBe("gemini")
+  })
+
+  it("shrugs at anything that isn't a command string", () => {
+    expect(firstToken(undefined)).toBe("")
+    expect(firstToken(null)).toBe("")
+    expect(firstToken("")).toBe("")
+    expect(firstToken(42)).toBe("")
+  })
+})
+
+describe("buildBinaryTypeMap", () => {
+  // The regression this whole change exists for: a hand-written map covered six
+  // agents, and `codex login` was rewritten to an absolute path for none of
+  // them — so the Windows login terminal ran a bare command that PATH couldn't
+  // resolve. EVERY agent that can be signed in from a terminal must be here.
+  it("covers every agent with a login command — the codex regression", () => {
+    const withLogin = entries
+      .filter((e) => {
+        const type = String(e.name || "")
+        const cr = (e.check_ready || {}) as Record<string, unknown>
+        return (
+          !!cr.login_command ||
+          !!HOSTED_LOGIN_AGENTS[type] ||
+          !!DUAL_LOGIN_AGENTS[type]
+        )
+      })
+      .map((e) => String(e.name))
+    expect(withLogin).toContain("codex")
+    for (const type of withLogin) {
+      const cr = (entries.find((e) => e.name === type)?.check_ready ||
+        {}) as Record<string, unknown>
+      const commands = [
+        cr.login_command,
+        HOSTED_LOGIN_AGENTS[type]?.loginCommand,
+        DUAL_LOGIN_AGENTS[type]?.loginCommand,
+      ].filter(Boolean)
+      for (const cmd of commands)
+        expect([type, map.get(firstToken(cmd))]).toEqual([type, type])
+    }
+  })
+
+  it("maps each agent's own binary, including renamed ones", () => {
+    expect(map.get("codex")).toBe("codex")
+    expect(map.get("cursor-agent")).toBe("cursor")
+    expect(map.get("ncl")).toBe("nanoclaw")
+    expect(map.get("mini")).toBe("mini-swe-agent")
+  })
+
+  it("maps binary aliases", () => {
+    // Cursor installs both `cursor-agent` and a bare `agent`.
+    expect(map.get("agent")).toBe("cursor")
+  })
+
+  it("is case-insensitive — Windows paths are", () => {
+    expect(map.get("CODEX".toLowerCase())).toBe("codex")
+  })
+
+  it("lets a binary name win over another agent's alias", () => {
+    const collide = buildBinaryTypeMap([
+      { name: "beta", install: { binary: "shared" } },
+      {
+        name: "alpha",
+        install: { binary: "alpha", binary_aliases: ["shared"] },
+      },
+    ])
+    expect(collide.get("shared")).toBe("beta")
+    expect(collide.get("alpha")).toBe("alpha")
+  })
+
+  it("survives a junk registry", () => {
+    expect(buildBinaryTypeMap([]).size).toBeGreaterThan(0) // login specs still land
+    expect(() =>
+      buildBinaryTypeMap([{}, { name: 42 }, { name: "x", install: null }]),
+    ).not.toThrow()
+  })
+})

--- a/packages/launcher/src/main/agents/binary-map.ts
+++ b/packages/launcher/src/main/agents/binary-map.ts
@@ -1,0 +1,58 @@
+import { DUAL_LOGIN_AGENTS, HOSTED_LOGIN_AGENTS } from "./auth-specs"
+
+/** The binary token of a command string: "claude auth login" → "claude". */
+export function firstToken(cmd: unknown): string {
+  return typeof cmd === "string" ? cmd.trim().split(/\s+/)[0] || "" : ""
+}
+
+/**
+ * Every CLI binary name we know, mapped to the agent type that owns it.
+ *
+ * Derived from the registry — `install.binary`, its `binary_aliases`, and the
+ * leading token of `check_ready.login_command` — plus the launcher's own login
+ * specs, whose command can differ from the registry's (Claude is `claude auth
+ * login` here and `claude login` there).
+ *
+ * This replaced a hand-written six-entry object. That object covered
+ * cursor/hermes/claude/amp/gemini and silently did nothing for everything else,
+ * codex included — which is how `codex login` reached a Windows terminal as a
+ * bare command and died with "'codex' is not recognized", even though the
+ * launcher had the CLI's absolute path in hand at that exact moment. Deriving
+ * the map means an agent added to the registry is covered the day it lands.
+ *
+ * `install.binary` is registered for every entry BEFORE any alias or login
+ * token, so a name that is one agent's binary and another's alias resolves to
+ * the agent that owns it outright.
+ */
+export function buildBinaryTypeMap(
+  entries: Array<Record<string, unknown>>,
+): Map<string, string> {
+  const map = new Map<string, string>()
+  const add = (name: unknown, type: string): void => {
+    const key = String(name || "")
+      .trim()
+      .toLowerCase()
+    if (key && !map.has(key)) map.set(key, type)
+  }
+  const installOf = (entry: Record<string, unknown>): Record<string, unknown> =>
+    (entry.install || {}) as Record<string, unknown>
+
+  for (const entry of entries) {
+    const type = typeof entry.name === "string" ? entry.name : ""
+    if (type) add(installOf(entry).binary || type, type)
+  }
+  for (const entry of entries) {
+    const type = typeof entry.name === "string" ? entry.name : ""
+    if (!type) continue
+    const aliases = installOf(entry).binary_aliases
+    for (const alias of Array.isArray(aliases) ? aliases : []) add(alias, type)
+    const checkReady = (entry.check_ready || {}) as Record<string, unknown>
+    add(firstToken(checkReady.login_command), type)
+  }
+  for (const [type, spec] of [
+    ...Object.entries(HOSTED_LOGIN_AGENTS),
+    ...Object.entries(DUAL_LOGIN_AGENTS),
+  ])
+    add(firstToken(spec.loginCommand), type)
+  return map
+}

--- a/packages/launcher/src/main/agents/install-service.test.ts
+++ b/packages/launcher/src/main/agents/install-service.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// The whole point of these cases is what is and isn't on disk, so fs is the
+// thing under control. Only the two reads installVanished/getInstalledVersion
+// make are modelled: existsSync and readFileSync.
+const files = new Map<string, string>()
+vi.mock("fs", () => {
+  const api = {
+    existsSync: (p: string) => files.has(String(p)),
+    readFileSync: (p: string) => {
+      const v = files.get(String(p))
+      if (v === undefined) throw new Error(`ENOENT: ${p}`)
+      return v
+    },
+    mkdirSync: () => undefined,
+    writeFileSync: (p: string, data: string) => {
+      files.set(String(p), String(data))
+    },
+    // installVanished logs its verdict through appendDaemonLog.
+    appendFileSync: () => undefined,
+  }
+  return { ...api, default: api }
+})
+
+import path from "path"
+
+import { InstallService } from "./install-service"
+import { CONFIG_DIR, INSTALLED_HISTORY_FILE, PORTABLE_NODE_DIR } from "./paths"
+
+const npmInstall = "npm install -g @openai/codex"
+const script = "powershell -c irm cursor.com/install | iex"
+const REGISTRY: Record<string, Record<string, unknown>> = {
+  // npm-backed: has a package dir we can check.
+  codex: {
+    name: "codex",
+    install: {
+      binary: "codex",
+      macos: npmInstall,
+      linux: npmInstall,
+      windows: npmInstall,
+    },
+  },
+  // Script-installed: no package, so the records are all we have.
+  cursor: {
+    name: "cursor",
+    install: {
+      binary: "cursor-agent",
+      macos: script,
+      linux: script,
+      windows: script,
+    },
+  },
+}
+
+const pkgJson = (agent: string, pkg: string): string =>
+  path.join(CONFIG_DIR, "runtimes", agent, "node_modules", pkg, "package.json")
+const legacyPkgJson = (pkg: string): string =>
+  path.join(PORTABLE_NODE_DIR, "node_modules", pkg, "package.json")
+
+function makeService(resolveBinary: (t: string) => string | null) {
+  return new InstallService({
+    connector: () => ({
+      registry: { getEntry: (t: string) => REGISTRY[t] || null },
+    }),
+    clearCatalogCache: () => undefined,
+    getCatalog: async () => [],
+    resolveBinary,
+  })
+}
+
+const none = (): null => null
+
+beforeEach(() => {
+  files.clear()
+})
+
+/**
+ * The install history and the core's markers are write-once claims that nothing
+ * re-checks. On Windows, 2026-08-17, that showed a user "Codex, installed
+ * v0.133.0, update available" for a CLI that `where codex` could not find —
+ * every sign-in attempt failed and the marketplace hid the one button (Install)
+ * that would have fixed it.
+ */
+describe("installVanished", () => {
+  it("calls out an npm agent whose package is gone", () => {
+    const svc = makeService(none)
+    expect(svc.installVanished("codex")).toBe(true)
+  })
+
+  it("leaves it alone when the package is right there", () => {
+    files.set(
+      pkgJson("codex", "@openai/codex"),
+      JSON.stringify({ version: "0.147.0" }),
+    )
+    expect(makeService(none).installVanished("codex")).toBe(false)
+  })
+
+  it("accepts the legacy shared prefix too", () => {
+    files.set(
+      legacyPkgJson("@openai/codex"),
+      JSON.stringify({ version: "0.133.0" }),
+    )
+    expect(makeService(none).installVanished("codex")).toBe(false)
+  })
+
+  it("accepts a global install the launcher never made", () => {
+    const svc = makeService((t) =>
+      t === "codex" ? "C:\\npm\\codex.cmd" : null,
+    )
+    expect(svc.installVanished("codex")).toBe(false)
+  })
+
+  it("never judges a script-installed CLI — there is no package to look for", () => {
+    // Cursor's installer drops an exe and edits the registry PATH; nothing about
+    // it lives in node_modules, so an empty disk here proves nothing.
+    expect(makeService(none).installVanished("cursor")).toBe(false)
+  })
+
+  it("never judges an agent the registry doesn't know", () => {
+    expect(makeService(none).installVanished("nope")).toBe(false)
+  })
+})
+
+describe("listInstalledAgents", () => {
+  const history = (data: Record<string, unknown>): void => {
+    files.set(INSTALLED_HISTORY_FILE, JSON.stringify(data))
+  }
+
+  it("drops a record whose package no longer exists", () => {
+    history({
+      codex: { name: "codex", version: "0.133.0", installedAt: "2026-08-17" },
+    })
+    expect(makeService(none).listInstalledAgents()).toEqual([])
+  })
+
+  it("keeps it once the package is back, and reports the DISK version", () => {
+    history({
+      codex: { name: "codex", version: "0.133.0", installedAt: "2026-08-17" },
+    })
+    files.set(
+      pkgJson("codex", "@openai/codex"),
+      JSON.stringify({ version: "0.147.0" }),
+    )
+    const [rec] = makeService(none).listInstalledAgents()
+    // The record still says 0.133.0 — an update outside the launcher is exactly
+    // the case where believing the record misreports what is running.
+    expect(rec.version).toBe("0.147.0")
+  })
+
+  it("keeps a script-installed agent on its recorded version", () => {
+    history({
+      cursor: {
+        name: "cursor",
+        version: "2026.8.1",
+        installedAt: "2026-08-17",
+      },
+    })
+    const [rec] = makeService(none).listInstalledAgents()
+    expect([rec.name, rec.version]).toEqual(["cursor", "2026.8.1"])
+  })
+})

--- a/packages/launcher/src/main/agents/install-service.ts
+++ b/packages/launcher/src/main/agents/install-service.ts
@@ -18,6 +18,7 @@ import {
   resolveNpmPackage,
 } from "../../shared/npm-install-spec"
 import { CONFIG_DIR, INSTALLED_HISTORY_FILE, PORTABLE_NODE_DIR } from "./paths"
+import { appendDaemonLog } from "./daemon-process"
 import { platformKey, resolveNpmInvocation } from "./runtime"
 import {
   fetchNpmInfo,
@@ -46,6 +47,8 @@ export interface InstallServiceDeps {
   clearCatalogCache: () => void
   /** The marketplace catalog, used to find everything currently installed. */
   getCatalog: () => Promise<unknown[]>
+  /** Absolute path to an agent's CLI, or null — the global-install escape hatch. */
+  resolveBinary: (type: string) => string | null
 }
 
 export class InstallService {
@@ -343,12 +346,57 @@ export class InstallService {
     } catch {}
   }
 
+  /**
+   * An install this launcher recorded that is no longer on disk.
+   *
+   * The install history and the core's install markers are both WRITE-ONCE
+   * claims: "we installed this, at this version". Neither is re-checked against
+   * the filesystem, so an agent whose package went away — a failed update that
+   * wiped the old copy, an uninstall outside the app, antivirus, a wiped
+   * ~/.openagents — keeps reporting installed forever, at the version it was
+   * when it last worked. What the user then sees is an agent that is "installed
+   * v0.133.0" with an Update button, whose sign-in always fails, and no hint
+   * anywhere that the CLI simply isn't there. (Codex on Windows, 2026-08-17: the
+   * marketplace showed 0.133.0 while `where codex` found nothing at all.)
+   *
+   * Only npm-backed agents are judged — a script-installed CLI (Cursor, Hermes,
+   * Amp) has no package dir to check, and an API-only agent has no CLI at all,
+   * so for those the records stand. A globally-installed copy still counts, so
+   * the binary lookup gets the last word before we call an install gone.
+   */
+  installVanished(agentType: string): boolean {
+    try {
+      const npmPkg = this.resolveNpmPackage(this.getRegistryEntry(agentType))
+      if (!npmPkg) return false
+      if (this.getInstalledVersion(agentType)) return false
+      if (this.deps.resolveBinary(agentType)) return false
+      // Logged once per agent per session: this is the state where the UI used
+      // to say "installed v0.133.0" about a package that wasn't on the machine,
+      // and it is worth knowing whether an install went missing or never landed.
+      if (!this._vanishedLogged.has(agentType)) {
+        this._vanishedLogged.add(agentType)
+        appendDaemonLog(
+          `${agentType}: recorded as installed, but ${npmPkg} is not in either ` +
+            `runtime prefix and no binary resolves — treating it as not installed.`,
+        )
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
+  private _vanishedLogged = new Set<string>()
+
   listInstalledAgents(): InstalledAgentRecord[] {
     const data = this.getInstalledHistory()
     const out: InstalledAgentRecord[] = []
     for (const name of Object.keys(data)) {
       const r = data[name]
-      const version = r.version || this.getInstalledVersion(name)
+      if (this.installVanished(name)) continue
+      // Disk first: the record is what we installed, the package.json is what is
+      // actually there now, and they part ways the moment anything updates the
+      // CLI from outside the launcher.
+      const version = this.getInstalledVersion(name) || r.version
       // Auto-heal self-referential previousVersion / history entries written
       // by the pre-fix recordInstall code. Without this scrub, machines
       // upgraded from the buggy version keep seeing the Roll back button

--- a/packages/launcher/src/main/agents/login-probe.test.ts
+++ b/packages/launcher/src/main/agents/login-probe.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { loginVerdict } from "./login-probe"
+import { DUAL_LOGIN_AGENTS, HOSTED_LOGIN_AGENTS } from "./auth-specs"
+
+/**
+ * Verbatim `status` output, captured by running each CLI. The codex pair is the
+ * one that forced this function to exist: it exits **1** when signed out, so
+ * "clean run, matched nothing ⇒ signed out" never fired for it.
+ */
+const CODEX_OUT = "Not logged in"
+const CODEX_IN_CHATGPT = "Logged in using ChatGPT"
+const CODEX_IN_KEY = "Logged in using an API key"
+
+describe("loginVerdict", () => {
+  const codex = DUAL_LOGIN_AGENTS.codex
+  const claude = DUAL_LOGIN_AGENTS.claude
+  const cursor = HOSTED_LOGIN_AGENTS.cursor
+
+  it("reads codex as SIGNED OUT despite its non-zero exit", () => {
+    // The regression: this used to be null, and health.ts treats null
+    // optimistically, so a signed-out codex looked usable.
+    expect(loginVerdict(codex, CODEX_OUT, 1)).toBe(false)
+  })
+
+  it("reads both of codex's signed-in wordings", () => {
+    expect(loginVerdict(codex, CODEX_IN_CHATGPT, 0)).toBe(true)
+    expect(loginVerdict(codex, CODEX_IN_KEY, 0)).toBe(true)
+  })
+
+  it("never lets 'Not logged in' match the signed-in pattern", () => {
+    expect(codex.loggedInPattern?.test(CODEX_OUT)).toBe(false)
+  })
+
+  it("still treats a clean run that matched nothing as the opposite", () => {
+    // claude declares only a signed-in pattern and exits 0 either way.
+    expect(loginVerdict(claude, '{"loggedIn": false}', 0)).toBe(false)
+    expect(loginVerdict(claude, '{"loggedIn": true}', 0)).toBe(true)
+    // cursor declares only a signed-out pattern — the shortcut runs the other way.
+    expect(loginVerdict(cursor, "Logged in as ada@example.com", 0)).toBe(true)
+    expect(loginVerdict(cursor, "Not logged in", 0)).toBe(false)
+  })
+
+  it("stays unknown when the CLI fell over rather than answered", () => {
+    // Non-zero AND nothing a pattern recognises: a crash, not a verdict.
+    expect(loginVerdict(claude, "panic: runtime error", 3)).toBe(null)
+    expect(loginVerdict(codex, "", 1)).toBe(null)
+    expect(loginVerdict(codex, "   ", null)).toBe(null)
+  })
+
+  it("stays unknown for a spec that declares no pattern at all", () => {
+    expect(loginVerdict({}, "anything", 0)).toBe(null)
+  })
+})

--- a/packages/launcher/src/main/agents/login-probe.ts
+++ b/packages/launcher/src/main/agents/login-probe.ts
@@ -16,6 +16,40 @@ import {
   HOSTED_LOGIN_AGENTS,
   type HostedLoginSpec,
 } from "./auth-specs"
+import { windowsExecutable } from "../win-exec"
+
+/**
+ * Read a sign-in verdict out of a `status` command's output and exit code:
+ * true (signed in) / false (signed out) / null (couldn't tell).
+ *
+ * A spec may declare either direction, or BOTH. Both is what a CLI that exits
+ * NON-ZERO when signed out forces on us: `codex login status` prints
+ * "Not logged in" and exits 1, so the "clean run that matched nothing"
+ * shortcut below never fires and, with only a signed-in pattern to go on, the
+ * verdict was null forever. null is deliberately optimistic downstream —
+ * `health.ts` only reports "Not signed in" for an explicit `false` — so a codex
+ * that was merely signed out kept reading as usable, and every message to it
+ * failed. Naming the signed-out wording as well removes the guesswork.
+ *
+ * The exit code is still what separates "matched nothing because signed out"
+ * from "matched nothing because the CLI fell over": only a clean exit is
+ * allowed to stand in for the absent pattern.
+ */
+export function loginVerdict(
+  spec: Pick<HostedLoginSpec, "loggedInPattern" | "loggedOutPattern">,
+  out: string,
+  code: number | null,
+): boolean | null {
+  if (spec.loggedInPattern?.test(out)) return true
+  if (spec.loggedOutPattern?.test(out)) return false
+  const definitive = !!out.trim() && code === 0
+  if (!definitive) return null
+  // A clean run that matched nothing means the opposite of whichever direction
+  // the spec is written in.
+  if (spec.loggedInPattern) return false
+  if (spec.loggedOutPattern) return true
+  return null
+}
 
 export interface LoginProbeDeps {
   /** Absolute path to the agent's CLI, via the core's installer.which. */
@@ -111,25 +145,30 @@ export class LoginProbe {
   }
 
   /**
-   * Spawn an agent CLI for a short-lived probe (status / usage), the SAME way
-   * the daemon's adapter (_spawnAmp) does: shell:true for a Windows `.cmd`/`.bat`
-   * shim — Node cannot launch those directly via CreateProcess, so a bare
-   * spawn(bin) throws and the probe used to fall back to a misleading "Not
-   * installed". Enhanced PATH + windowsHide round it out. The shell rule mirrors
-   * the shared core helper (shouldUseShellForBinary) so launcher and daemon
-   * never diverge on `.cmd`.
+   * Spawn an agent CLI for a short-lived probe (status / usage).
+   *
+   * The launch shape comes from `windowsExecutable` — the same helper the in-app
+   * login uses — because a path from `installer.which()` is usually NOT
+   * spawnable on Windows. This probe used to test only for a `.cmd`/`.bat`
+   * suffix, which the two commonest shapes don't have: the extensionless
+   * Git-Bash script `where` lists first, and the package's own `bin\<x>.js` that
+   * the core falls back to when no shim is on PATH. Both made CreateProcess
+   * throw, `child.on("error")` settled the probe at null, and the UI read that
+   * as signed-out — so a Codex user who had just completed the browser sign-in
+   * was told "couldn't confirm your login", forever. Enhanced PATH + windowsHide
+   * round it out.
    */
   spawnAgentCli(
     bin: string,
     args: string[],
     extra?: Record<string, string>,
   ): ReturnType<typeof spawn> {
-    const useShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin)
-    return spawn(bin, args, {
+    const { command, shell } = windowsExecutable(bin)
+    return spawn(command, args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: this.childEnv(extra),
       windowsHide: true,
-      shell: useShell,
+      shell,
     })
   }
 
@@ -188,27 +227,7 @@ export class LoginProbe {
         child.stdout?.on("data", (c: Buffer) => (out += c.toString("utf-8")))
         child.stderr?.on("data", (c: Buffer) => (out += c.toString("utf-8")))
         child.on("error", () => finish(null))
-        child.on("close", (code) => {
-          // Decide via whichever direction the spec declares. A clean run with
-          // output but no match is "definitive" → the opposite of the pattern;
-          // anything else stays null (unknown) so a hiccup never reads as out.
-          const definitive = !!out.trim() && code === 0
-          let value: boolean | null = null
-          if (spec.loggedInPattern) {
-            value = spec.loggedInPattern.test(out)
-              ? true
-              : definitive
-                ? false
-                : null
-          } else if (spec.loggedOutPattern) {
-            value = spec.loggedOutPattern.test(out)
-              ? false
-              : definitive
-                ? true
-                : null
-          }
-          finish(value)
-        })
+        child.on("close", (code) => finish(loginVerdict(spec, out, code)))
       } catch {
         settle(null)
       }

--- a/packages/launcher/src/main/cli-login.test.ts
+++ b/packages/launcher/src/main/cli-login.test.ts
@@ -13,7 +13,6 @@ import {
   TERMINAL_ONLY_LOGIN,
   YES_NO_PROMPT,
 } from "./cli-login-patterns"
-import { windowsExecutable } from "./cli-login"
 
 /**
  * Verbatim output, captured by running each CLI under pipes. If a CLI changes
@@ -142,59 +141,3 @@ describe("needsRealTerminal", () => {
   })
 })
 
-// The in-app login shipped broken on Windows: `installer.which("claude")`
-// returns C:\...\claude with NO extension (npm writes an extensionless Git-Bash
-// script alongside claude.cmd and claude.ps1), CreateProcess can't run it, the
-// spawn failed instantly and every Windows user was handed the terminal window
-// this feature exists to avoid. These cases can't run on the machine the bug
-// appears on, so the platform and the file check are injected.
-describe("windowsExecutable", () => {
-  const win = (bin: string, present: string[] = []) =>
-    windowsExecutable(bin, "win32", (p) => present.includes(p))
-
-  it("leaves other platforms completely alone", () => {
-    expect(windowsExecutable("/usr/local/bin/claude", "darwin")).toEqual({
-      command: "/usr/local/bin/claude",
-      shell: false,
-    })
-  })
-
-  it("picks the .cmd shim sitting next to the extensionless script", () => {
-    expect(win("C:\\nvm4w\\nodejs\\claude", ["C:\\nvm4w\\nodejs\\claude.cmd"])).toEqual(
-      { command: '"C:\\nvm4w\\nodejs\\claude.cmd"', shell: true },
-    )
-  })
-
-  it("quotes the path, because plenty of people are C:\\Users\\First Last", () => {
-    const { command } = win("C:\\Users\\First Last\\bin\\claude", [
-      "C:\\Users\\First Last\\bin\\claude.cmd",
-    ])
-    expect(command).toBe('"C:\\Users\\First Last\\bin\\claude.cmd"')
-  })
-
-  it("runs a real .exe directly — no shell, no quoting needed", () => {
-    expect(win("C:\\tools\\cursor-agent.exe")).toEqual({
-      command: "C:\\tools\\cursor-agent.exe",
-      shell: false,
-    })
-  })
-
-  it("sends an already-.cmd path through the shell (Node won't spawn it directly)", () => {
-    expect(win("C:\\bin\\amp.cmd")).toEqual({
-      command: '"C:\\bin\\amp.cmd"',
-      shell: true,
-    })
-  })
-
-  it("prefers .cmd over .exe when both are present", () => {
-    const { command } = win("C:\\bin\\x", ["C:\\bin\\x.cmd", "C:\\bin\\x.exe"])
-    expect(command).toBe('"C:\\bin\\x.cmd"')
-  })
-
-  it("falls back to the shell rather than a spawn that cannot work", () => {
-    expect(win("C:\\bin\\mystery")).toEqual({
-      command: '"C:\\bin\\mystery"',
-      shell: true,
-    })
-  })
-})

--- a/packages/launcher/src/main/cli-login.ts
+++ b/packages/launcher/src/main/cli-login.ts
@@ -1,5 +1,4 @@
 import { execFile, spawn, type ChildProcess } from "child_process"
-import fs from "fs"
 
 import {
   BROWSER_CLAIMED,
@@ -13,6 +12,11 @@ import {
   stripAnsi,
   YES_NO_PROMPT,
 } from "./cli-login-patterns"
+import { windowsExecutable } from "./win-exec"
+
+// Re-exported because this module used to own it and the terminal/probe paths
+// now share it — see win-exec.ts for why a resolved path isn't spawnable.
+export { windowsExecutable }
 
 /**
  * In-app CLI sign-in: run `<cli> login` under PIPES inside the launcher and
@@ -62,7 +66,7 @@ export interface CliLoginDeps {
   /** A FRESH sign-in probe — the authority on whether the login worked. */
   verifyLogin(type: string): Promise<boolean>
   openExternal(url: string): void
-  openTerminal(cmd: string): void
+  openTerminal(cmd: string, agentType: string): void
   emit(ev: CliLoginEvent): void
 }
 
@@ -79,50 +83,6 @@ const TAIL_LIMIT = 8_000
 
 const delay = (ms: number): Promise<void> =>
   new Promise((r) => setTimeout(r, ms))
-
-/**
- * How to actually launch a resolved CLI path on this platform.
- *
- * This is where the in-app login died on Windows. `installer.which()` resolves
- * `claude` to something like `C:\nvm4w\nodejs\claude` — npm writes THREE files
- * into its global bin: an extensionless shell script (for Git Bash), a `.cmd`,
- * and a `.ps1`. CreateProcess can't run the extensionless one, so the spawn
- * failed instantly, the error handler opened a terminal, and every Windows user
- * got the exact experience this feature was built to remove. The old check only
- * looked for a `.cmd`/`.bat` suffix that was never there.
- *
- * So: keep `.exe` as-is, and for anything else prefer a real Windows shim next
- * to it. `.cmd`/`.bat` must go through the shell (Node refuses to spawn them
- * directly since the CVE-2024-27980 fix), which in turn means quoting the path
- * ourselves — with shell:true Node hands the string to cmd.exe verbatim, and
- * plenty of people have a space in `C:\Users\First Last\`.
- */
-export function windowsExecutable(
-  bin: string,
-  // Injected so the Windows branches are testable from any machine — the bug
-  // this function exists for could only ever be reproduced on Windows, so a
-  // test that can only run there is a test that never runs.
-  platform: string = process.platform,
-  exists: (p: string) => boolean = fs.existsSync,
-): { command: string; shell: boolean } {
-  if (platform !== "win32") return { command: bin, shell: false }
-  if (/\.exe$/i.test(bin)) return { command: bin, shell: false }
-  if (/\.(cmd|bat)$/i.test(bin)) return { command: `"${bin}"`, shell: true }
-  for (const ext of [".cmd", ".bat", ".exe"]) {
-    try {
-      if (exists(bin + ext))
-        return {
-          command: ext === ".exe" ? bin + ext : `"${bin + ext}"`,
-          shell: ext !== ".exe",
-        }
-    } catch {
-      /* unreadable path — fall through to the shell */
-    }
-  }
-  // No shim found: let the shell figure it out rather than handing
-  // CreateProcess something it will certainly reject.
-  return { command: `"${bin}"`, shell: true }
-}
 
 /** The first non-empty line of `text`, trimmed — used for error messages. */
 function firstLine(text: string): string {
@@ -351,7 +311,7 @@ class LoginSession {
     // a second copy of it runs in the terminal.
     this.killChild()
     try {
-      this.deps.openTerminal(this.cmd)
+      this.deps.openTerminal(this.cmd, this.type)
     } catch (e) {
       this.settle("failed", (e as Error).message)
       return

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -2095,17 +2095,24 @@ function setupIPC(): void {
   // Open a terminal running `cmd`, optionally cd'd into `cwd` first. Shared by
   // the CLI-login flow (no cwd) and the per-agent "Chat" button, which opens an
   // interactive CLI session inside the agent's working folder.
-  const runTerminal = (cmd: string, cwd?: string): void => {
+  const runTerminal = (cmd: string, cwd?: string, agentType?: string): void => {
     const { spawn } = require("child_process")
-    // Resolve hosted-login CLIs (Cursor/Hermes) to an ABSOLUTE binary path so
-    // the login terminal never depends on PATH. The Windows native installer
-    // drops cursor-agent under %LOCALAPPDATA%\cursor-agent and only edits the
-    // *registry* PATH — a freshly-spawned terminal inherits that stale, so a
-    // bare `cursor-agent login` dies with "'cursor-agent' is not recognized as
+    // Resolve the CLI to an ABSOLUTE binary path so the terminal never depends
+    // on PATH. A CLI's own installer only edits the *registry* PATH (Cursor
+    // drops itself under %LOCALAPPDATA%\cursor-agent) or lands in a per-agent
+    // runtime prefix — either way a freshly-spawned terminal inherits a PATH
+    // that can't see it, and a bare command dies with "'x' is not recognized as
     // an internal or external command". An absolute path sidesteps it entirely.
     const resolvedCmd = agentManager
-      ? agentManager.resolveLoginCommand(cmd)
+      ? agentManager.resolveLoginCommand(cmd, agentType)
       : cmd
+    // The dirs the core prepends to the daemon's PATH, so child tools the CLI
+    // spawns (node, git) and the fallback when abs-path resolution misses still
+    // resolve without a reboot. Taken from the core rather than rebuilt here:
+    // the local copy of this list was missing npm's configured global prefix,
+    // among others, so a CLI installed to a custom prefix was invisible in the
+    // terminal while the daemon found it fine.
+    const coreBins = agentManager?.extraBinDirs() ?? []
     if (process.platform === "win32") {
       const { execSync: exec } = require("child_process")
       const home = process.env.USERPROFILE || os.homedir()
@@ -2119,10 +2126,8 @@ function setupIPC(): void {
             runtimeBins.push(path.join(rd, d.name, "node_modules", ".bin"))
         }
       } catch {}
-      // Mirror the dirs the core adds to its own enhanced PATH so child tools
-      // the CLI spawns (and the fallback when abs-path resolution misses) still
-      // resolve without a reboot. Kept as a PATH fallback only — the command
-      // itself is already an absolute path via resolveLoginCommand above.
+      // Kept as a second layer under coreBins for the case the core failed to
+      // load (its own install is what the launcher is often busy repairing).
       const localAppData =
         process.env.LOCALAPPDATA || path.join(home, "AppData", "Local")
       const cliBins = [
@@ -2138,15 +2143,19 @@ function setupIPC(): void {
         path.join(localAppData, "hermes", "bin"),
       ]
       const allBins = [
+        ...coreBins,
         ...runtimeBins,
         path.join(portableNode, "node_modules", ".bin"),
         portableNode,
         npmBin,
         ...cliBins,
       ]
-        .filter((d) => {
+        .filter((d, i, all) => {
+          if (!d) return false
+          const first = all.findIndex((o) => o.toLowerCase() === d.toLowerCase())
+          if (first !== i) return false
           try {
-            return !!d && fs.existsSync(d)
+            return fs.existsSync(d)
           } catch {
             return false
           }
@@ -2198,12 +2207,15 @@ function setupIPC(): void {
         }
       } catch {}
       const allBins = [
+        ...coreBins,
         ...runtimeBins,
         path.join(portableNode, "node_modules", ".bin"),
         portableNodeBin,
         portableNode,
         "/usr/local/bin",
-      ].join(":")
+      ]
+        .filter((d, i, all) => !!d && all.indexOf(d) === i)
+        .join(":")
       const setPath = `export PATH=${allBins}:$PATH`
       const cdPart = cwd ? `cd "${cwd}" && ` : ""
       const fullCmd = `${setPath} && ${cdPart}${resolvedCmd}`.replace(
@@ -2255,7 +2267,10 @@ function setupIPC(): void {
     openExternal: (url) => {
       void shell.openExternal(url)
     },
-    openTerminal: (cmd) => runTerminal(cmd),
+    // The type is passed explicitly: the fallback terminal must resolve the
+    // SAME binary the piped attempt just used, not re-guess it from the
+    // command's first word.
+    openTerminal: (cmd, type) => runTerminal(cmd, undefined, type),
     emit: (ev) => {
       if (mainWindow && !mainWindow.isDestroyed())
         mainWindow.webContents.send("cli-login:event", ev)
@@ -2300,8 +2315,10 @@ function setupIPC(): void {
     try {
       fs.mkdirSync(cwd, { recursive: true })
     } catch {}
-    // Quote the binary so a space in its path survives the shell.
-    runTerminal(/\s/.test(binary) ? `"${binary}"` : binary, cwd)
+    // Quote the binary so a space in its path survives the shell; runTerminal
+    // re-resolves it through the type, which also routes a `.js` bin (an npm
+    // agent with no Windows shim) through node instead of Windows Script Host.
+    runTerminal(/\s/.test(binary) ? `"${binary}"` : binary, cwd, type)
   })
 
   ipcMain.handle("icons:get-dir", () => {

--- a/packages/launcher/src/main/win-exec.test.ts
+++ b/packages/launcher/src/main/win-exec.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+
+import { shellCommandFor, windowsExecutable } from "./win-exec"
+
+/**
+ * Two Windows shapes have each shipped a broken login, and both come out of the
+ * same call:
+ *
+ *   `installer.which("claude")` → C:\...\claude with NO extension (npm writes an
+ *   extensionless Git-Bash script alongside claude.cmd and claude.ps1, and
+ *   `where` lists it first). CreateProcess can't run it, the spawn failed
+ *   instantly, and every Windows user was handed the terminal window the in-app
+ *   login exists to avoid.
+ *
+ *   `installer.which("codex")` → ...\@openai\codex\bin\codex.js, the core's
+ *   package-bin fallback for an npm agent with no .bin shim on PATH. cmd.exe
+ *   hands a .js to Windows Script Host; the sign-in probe, which didn't use a
+ *   shell at all, just got ENOENT and reported the user signed out.
+ *
+ * These cases can't run on the machine the bugs appear on, so the platform and
+ * the file check are injected.
+ */
+describe("windowsExecutable", () => {
+  const win = (bin: string, present: string[] = []) =>
+    windowsExecutable(bin, "win32", (p) => present.includes(p))
+
+  it("leaves other platforms completely alone", () => {
+    expect(windowsExecutable("/usr/local/bin/claude", "darwin")).toEqual({
+      command: "/usr/local/bin/claude",
+      shell: false,
+    })
+  })
+
+  it("picks the .cmd shim sitting next to the extensionless script", () => {
+    expect(
+      win("C:\\nvm4w\\nodejs\\claude", ["C:\\nvm4w\\nodejs\\claude.cmd"]),
+    ).toEqual({ command: '"C:\\nvm4w\\nodejs\\claude.cmd"', shell: true })
+  })
+
+  it("quotes the path, because plenty of people are C:\\Users\\First Last", () => {
+    const { command } = win("C:\\Users\\First Last\\bin\\claude", [
+      "C:\\Users\\First Last\\bin\\claude.cmd",
+    ])
+    expect(command).toBe('"C:\\Users\\First Last\\bin\\claude.cmd"')
+  })
+
+  it("runs a real .exe directly — no shell, no quoting needed", () => {
+    expect(win("C:\\tools\\cursor-agent.exe")).toEqual({
+      command: "C:\\tools\\cursor-agent.exe",
+      shell: false,
+    })
+  })
+
+  it("sends an already-.cmd path through the shell (Node won't spawn it directly)", () => {
+    expect(win("C:\\bin\\amp.cmd")).toEqual({
+      command: '"C:\\bin\\amp.cmd"',
+      shell: true,
+    })
+  })
+
+  it("prefers .cmd over .exe when both are present", () => {
+    const { command } = win("C:\\bin\\x", ["C:\\bin\\x.cmd", "C:\\bin\\x.exe"])
+    expect(command).toBe('"C:\\bin\\x.cmd"')
+  })
+
+  it("runs a bare .js bin through node, not Windows Script Host", () => {
+    expect(
+      win(
+        "C:\\Users\\q\\.openagents\\nodejs\\node_modules\\@openai\\codex\\bin\\codex.js",
+      ),
+    ).toEqual({
+      command:
+        'node "C:\\Users\\q\\.openagents\\nodejs\\node_modules\\@openai\\codex\\bin\\codex.js"',
+      shell: true,
+    })
+  })
+
+  it("prefers a .js bin's real shim — named for the command, not the file", () => {
+    // The sibling of `codex.js` is `codex.cmd`; `codex.js.cmd` never exists.
+    const { command } = win("C:\\p\\node_modules\\.bin\\codex.js", [
+      "C:\\p\\node_modules\\.bin\\codex.cmd",
+    ])
+    expect(command).toBe('"C:\\p\\node_modules\\.bin\\codex.cmd"')
+  })
+
+  it("leaves a .js alone off Windows — it has a shebang and the +x bit there", () => {
+    expect(windowsExecutable("/home/q/.bin/codex.js", "linux")).toEqual({
+      command: "/home/q/.bin/codex.js",
+      shell: false,
+    })
+  })
+
+  it("falls back to the shell rather than a spawn that cannot work", () => {
+    expect(win("C:\\bin\\mystery")).toEqual({
+      command: '"C:\\bin\\mystery"',
+      shell: true,
+    })
+  })
+})
+
+// A command line is not an argv[0]: everything windowsExecutable leaves bare
+// for spawn has to be quoted before it goes near a shell.
+describe("shellCommandFor", () => {
+  const win = (bin: string, present: string[] = []) =>
+    shellCommandFor(bin, "win32", (p) => present.includes(p))
+
+  it("quotes an .exe that spawn would take unquoted", () => {
+    expect(win("C:\\Program Files\\cursor\\cursor-agent.exe")).toBe(
+      '"C:\\Program Files\\cursor\\cursor-agent.exe"',
+    )
+  })
+
+  it("quotes a plain unix path", () => {
+    expect(
+      shellCommandFor("/Users/First Last/.local/bin/claude", "darwin"),
+    ).toBe('"/Users/First Last/.local/bin/claude"')
+  })
+
+  it("keeps the node prefix for a .js bin", () => {
+    expect(win("C:\\p\\@openai\\codex\\bin\\codex.js")).toBe(
+      'node "C:\\p\\@openai\\codex\\bin\\codex.js"',
+    )
+  })
+
+  it("doesn't double-quote what is already quoted", () => {
+    expect(win("C:\\bin\\amp.cmd")).toBe('"C:\\bin\\amp.cmd"')
+  })
+})

--- a/packages/launcher/src/main/win-exec.ts
+++ b/packages/launcher/src/main/win-exec.ts
@@ -1,0 +1,85 @@
+import fs from "fs"
+
+/**
+ * How to actually launch a CLI path the core resolved for us.
+ *
+ * Everything here exists because `installer.which()` does NOT hand back
+ * something Windows can execute. It hands back whatever `where` printed first,
+ * or — when PATH misses entirely — the package's own bin file. Three shapes
+ * reach us, and only one of them is directly spawnable:
+ *
+ *   C:\nvm4w\nodejs\claude          extensionless Git-Bash script; npm writes it
+ *                                   alongside claude.cmd and claude.ps1, and
+ *                                   `where claude` lists it FIRST. CreateProcess
+ *                                   refuses it.
+ *   …\@openai\codex\bin\codex.js    the package's declared bin, returned by the
+ *                                   core's _resolvePackageBin fallback when no
+ *                                   .bin shim is on PATH. cmd.exe hands a .js to
+ *                                   Windows Script Host, which is not node.
+ *   C:\bin\amp.cmd                  spawnable, but only through a shell (Node
+ *                                   refuses .cmd directly since CVE-2024-27980).
+ *
+ * So: keep `.exe` as-is, prefer a real Windows shim sitting next to whatever we
+ * were given, and run a bare .js through `node` rather than letting the shell
+ * guess. Paths are quoted — with shell:true Node hands the string to cmd.exe
+ * verbatim and plenty of people are `C:\Users\First Last\`.
+ *
+ * Shared by every launcher-side spawn of an agent CLI (the in-app login, the
+ * sign-in probe, the login terminal) so they can't disagree about what "the
+ * binary" means — they used to, and the probe's disagreement read as "not
+ * signed in" for every npm-installed agent on Windows.
+ */
+export function windowsExecutable(
+  bin: string,
+  // Injected so the Windows branches are testable from any machine — the bugs
+  // this function exists for could only ever be reproduced on Windows, so a
+  // test that can only run there is a test that never runs.
+  platform: string = process.platform,
+  exists: (p: string) => boolean = fs.existsSync,
+): { command: string; shell: boolean } {
+  if (platform !== "win32") return { command: bin, shell: false }
+  if (/\.exe$/i.test(bin)) return { command: bin, shell: false }
+  if (/\.(cmd|bat)$/i.test(bin)) return { command: `"${bin}"`, shell: true }
+  // A script's Windows shim is named for the COMMAND, not the file: the sibling
+  // of `…\bin\codex.js` is `codex.cmd`, never `codex.js.cmd`. For the
+  // extensionless case the stem is the path itself, so this is a no-op there.
+  const stem = bin.replace(/\.(js|cjs|mjs)$/i, "")
+  for (const ext of [".cmd", ".bat", ".exe"]) {
+    try {
+      if (exists(stem + ext))
+        return {
+          command: ext === ".exe" ? stem + ext : `"${stem + ext}"`,
+          shell: ext !== ".exe",
+        }
+    } catch {
+      /* unreadable path — fall through */
+    }
+  }
+  // No shim: a JS bin is node's job. `node` rather than an absolute path
+  // because every caller spawns with the core's enhanced PATH (which carries
+  // the portable ~/.openagents/nodejs), and the login terminal injects the same
+  // dirs — while process.execPath here is Electron, not node.
+  if (/\.(js|cjs|mjs)$/i.test(bin))
+    return { command: `node "${bin}"`, shell: true }
+  // Let the shell figure it out rather than handing CreateProcess something it
+  // will certainly reject.
+  return { command: `"${bin}"`, shell: true }
+}
+
+/**
+ * The same resolution, as a string to drop into a shell command line (the login
+ * terminal) rather than a spawn's argv[0].
+ *
+ * `windowsExecutable` leaves a directly-spawnable path UNQUOTED — a `.exe`, and
+ * every non-Windows path — because spawn passes argv[0] through untouched. On a
+ * command line that same path breaks at the first space, and `C:\Program
+ * Files\…` / `/Users/First Last/…` are not hypothetical.
+ */
+export function shellCommandFor(
+  bin: string,
+  platform: string = process.platform,
+  exists: (p: string) => boolean = fs.existsSync,
+): string {
+  const { command } = windowsExecutable(bin, platform, exists)
+  return command === bin ? `"${bin}"` : command
+}


### PR DESCRIPTION
## What was broken

On Windows, Codex could not be signed in from the launcher, and once signed in the launcher could not tell:

- the browser completed the sign-in (`Signed in to Codex`), but the launcher showed **"couldn't confirm your login"** and the Configure dialog stayed on **"not signed in"** — permanently
- **"Sign in in a terminal"** opened a window that answered `'codex' is not recognized as an internal or external command`
- the marketplace offered **"Update to v0.147.0" / "Uninstall"** for a codex whose package was not on the machine at all

Four independent defects, none of them codex-specific. Every one of them was reproduced on a **clean Windows install**.

## The defects

### 1. The sign-in probe could never spawn the CLI

`LoginProbe.spawnAgentCli` decided how to launch by testing for a `.cmd`/`.bat` suffix:

```ts
const useShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin)
```

But `installer.which()` returns whatever `where` printed **first**, and npm writes three files into `.bin`: an extensionless Git-Bash script, a `.cmd`, and a `.ps1` — with the extensionless one listed first. CreateProcess refuses it, `child.on("error")` settled the probe at `null`, and the UI read `null` as signed-out. **Every npm-installed agent was affected** (claude, codex, gemini, cline, opencode, pi).

Measured on a clean Windows box, replicating both call shapes exactly:

```
where.exe codex
  C:\Users\…\runtimes\codex\node_modules\.bin\codex        ← what which() returns
  C:\Users\…\runtimes\codex\node_modules\.bin\codex.cmd

BEFORE (extensionless, shell:false) → ERROR: ENOENT | EXIT -4058 | OUT: ""
AFTER  (.cmd, shell:true)           → EXIT 1 | OUT: "Not logged in"
```

The probe and the in-app login now share one `windowsExecutable` helper (moved to `win-exec.ts`), which prefers the `.cmd` shim next to whatever it was given and routes a bare `.js` bin through `node`.

### 2. The login terminal ran a bare command

`resolveLoginCommand` rewrote a login command to its absolute path using a hand-listed map of six binaries. `codex` was not in it, so the command reached the terminal unchanged and died on PATH.

The map is now derived from the registry (`install.binary`, `binary_aliases`, and each `login_command`'s leading token) plus the launcher's own login specs. **12 agents were silently uncovered** — 4 with a login command:

| agent | login command | before |
|---|---|---|
| **codex** | `codex login` | ❌ |
| **cline** | `cline auth` | ❌ |
| **copilot** | `copilot` | ❌ |
| **pi** | `pi` | ❌ |
| claude / cursor / hermes / amp / gemini | | ✅ |

plus 8 reachable from the chat terminal: aider, goose, kimi, openclaw, opencode, deepseek (`dsh`), nanoclaw (`ncl`), mini-swe-agent (`mini`).

`copilot` and `pi` are worth calling out: their login commands have no subcommand, so `needsRealTerminal()` sends them straight to a terminal — they were **guaranteed** to hit the same failure, just unreported.

A test asserts that every agent with a login command resolves through the map, so a newly added agent that slips through fails CI rather than a user's login.

### 3. The login terminal built its own PATH

`runTerminal` maintained a second, hand-written copy of the core's PATH prefix — missing npm's configured global prefix, `~/.openagents/core/node_modules/.bin`, and the Amp dirs. It now takes the core's `getExtraBinDirs()`, with the old list kept underneath for the case where the core itself failed to load.

### 4. An agent whose files vanished still reported installed

Neither the install history nor the core's install markers are ever re-checked against disk, so an agent whose package disappeared — failed update, uninstall outside the app, antivirus — kept reporting installed at the version it was when it last worked. The user got Update/Uninstall buttons for a CLI that wasn't there, every action failed, and **Install — the one button that would have fixed it — was hidden.**

`InstallService.installVanished()` now judges npm-backed agents against the disk, and the marketplace badge, the Agents list health, and the install records all honour it. Reported versions come from the package on disk first, so a CLI updated outside the launcher no longer reports a stale version.

Deliberately **not** applied to script-installed CLIs (Cursor, Hermes, Amp): they have no package dir to check, and the core's own comments document that a binary lookup misjudges them on Windows because their installers only edit the registry PATH. Misreporting a working install as missing is worse than the bug being fixed.

### Bonus: codex exits non-zero when signed out

`EXIT 1 | OUT: "Not logged in"` (above) means the "clean run that matched nothing ⇒ signed out" shortcut could never fire for codex, leaving its verdict permanently `null`/unknown. `loginVerdict` is now an extracted pure function that honours an explicit `loggedOutPattern`, and codex declares one. No user-visible behaviour changes today (codex goes through `dualLoginHealth`, where `null` and `false` both yield `ready: false`) — this closes the semantic gap while there is measured data to close it with.

## Diagnostics

Two lines now go to the daemon log, so the next report of this shape doesn't need directory listings collected over chat:

- a CLI resolving to a path with **no Windows shim** — worth knowing because the daemon's adapters (`claude`, `codex`, `gemini`, `cline`, `opencode`, `pi`) each run their own tiered lookup that only ever builds `<name>.cmd` and never falls back to the package bin
- a **recorded install that is no longer on disk**

## The core needs no changes

The clean-install evidence rules it out: `.bin` held all three files (`codex` 401B, `codex.cmd` 331B, `codex.ps1` 829B), so npm's shim generation is fine and `installer.which()`'s `.js` fallback is never reached. Everything above is fixed launcher-side.

## Verification

- **Defect 1** — measured on a clean Windows install (the ENOENT / `"Not logged in"` output above)
- **Defect 2** — confirmed on a clean Windows install: the terminal now runs `"C:\Users\…\.bin\codex.cmd" login` instead of a bare `codex login`
- **Defects 3–5** — unit tests; 3 takes effect with 2, and 4/5 are pure logic with no platform dependence
- 32 test files / 304 tests, `tsc -b`, and `check:changelog` all pass

The one path still unwalked by a human is "UI flips to signed-in after a successful login" — it needs a Codex account. Both things it depends on are closed: the spawn works (measured), and the output matches `/logged in using/i` (unit-tested against the wording recorded in `auth-specs.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
