### PR TITLE
feat(launcher): read model lists from the account/endpoint instead of pinning ids

### DIFF
--- a/packages/launcher/changelog/0.9.15.json
+++ b/packages/launcher/changelog/0.9.15.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.9.15",
+  "date": "2026-08-18",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "Agents you sign in to with an account can be given a model too",
+        "zh": "用账号登录的智能体现在也能设置模型"
+      },
+      "description": {
+        "en": "The model setting only ever appeared in the API-key form. So every agent that authenticates through its own sign-in instead — Codex with a ChatGPT account, Claude with a Pro/Max subscription, Gemini with a Google account, Cursor — had no model setting anywhere in the app, and ran on whatever its CLI happens to default to. With Codex that default is a model OpenAI has since retired, so every message failed and there was nothing on screen to change. The model now sits on both sign-in paths in the setup wizard and in Configure, and what it offers comes from the sign-in itself — for Codex, the line-up it keeps for your account. Leaving it empty still means \"whatever the CLI defaults to\".",
+        "zh": "模型设置一直只出现在 API Key 表单里。于是所有改用自身账号登录的智能体——用 ChatGPT 账号的 Codex、用 Pro/Max 订阅的 Claude、用 Google 账号的 Gemini，以及 Cursor——在应用里根本没有地方能设置模型，只能沿用命令行工具自带的默认模型。Codex 的那个默认模型已被 OpenAI 下线，于是每条消息都调用失败，界面上却没有任何地方可以改。现在设置向导和配置对话框的两种登录方式下都能设置模型，可选项来自登录本身——Codex 用的就是它为你账号维护的那份清单。留空仍然表示「用命令行工具自己的默认模型」。"
+      }
+    },
+    {
+      "type": "improvement",
+      "title": {
+        "en": "Model fields now offer a real list instead of a hardcoded name",
+        "zh": "模型输入框改为从服务商拉取真实列表，不再写死型号"
+      },
+      "description": {
+        "en": "Every agent shipped with one model name baked in, and those names age out — the agent kept calling a model the provider no longer serves, and finding the right replacement meant reading someone's docs. Model fields now have a picker: with an API key and base URL it lists what that endpoint actually serves (a relay answers for its own channels), and for CLI sign-ins it reads the list the agent's own tool keeps — Codex's cached line-up for your account, Cursor's `--list-models`. You can still type any id by hand, and the field says where its list came from. The list follows the form you are filling in: the API-key form lists what that endpoint serves, even on a machine where the same agent is also signed in through its CLI — the account's line-up is the wrong answer for a relay, and a convincing one.",
+        "zh": "过去每个智能体都内置了一个写死的模型名，而这些名字会过时——智能体一直在调用服务商已经下线的模型，想换还得自己去翻文档。现在模型输入框带有下拉选择：填了 API Key 和接口地址时，列表来自该地址真正提供的模型（中转站会返回它自己的渠道名）；使用命令行登录时，则读取工具自己维护的模型列表——Codex 是它为你账号缓存的清单，Cursor 是 `--list-models`。你依然可以手动填写任意模型 id，输入框也会标明列表的来源。列表跟随你正在填写的那种登录方式：在 API Key 表单里，列出的就是该接口地址提供的模型——哪怕这台机器上同一个智能体还通过命令行登录着，也不会拿账号的模型清单来冒充，因为那对中转地址来说是个看起来很可信的错误答案。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "The marketplace page no longer claims you're signed out after installing",
+        "zh": "应用市场页不再在安装后误报「未登录」"
+      },
+      "description": {
+        "en": "An agent's page checked the sign-in once, when the page opened — which is usually before the agent is even installed, so the check couldn't run and the card settled on \"Not signed in\" for the rest of the visit. Opening the setup wizard from that same page then showed \"Signed in\", one panel above a card saying the opposite. The card now checks once the install finishes and again after the setup wizard closes.",
+        "zh": "智能体页面只在打开时检查过一次登录状态，而那通常是在智能体还没装好之前，检查根本跑不起来，于是这张卡片就一直停在「未登录」。此时从同一个页面打开设置向导，向导显示「已连接」，正上方的卡片却写着相反的结论。现在安装完成后、以及设置向导关闭后，都会重新读取登录状态。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -43,6 +43,11 @@ import {
   normalizeWorkspaceEndpoint,
 } from "./agents/env-normalize"
 import { testLLMConnection, type LLMTestResult } from "./agents/llm-test"
+import {
+  listAgentModels,
+  type ModelListPath,
+  type ModelListResult,
+} from "./agents/model-catalog"
 import { clearLogsInRange as clearDaemonLogsInRange } from "./agents/daemon-logs"
 import {
   appendDaemonLog,
@@ -1055,6 +1060,76 @@ export class AgentManager extends EventEmitter {
     // "No API key provided". testLLMConnection covers every provider and works
     // even before the core is installed.
     return testLLMConnection(env)
+  }
+
+  /**
+   * The models this agent can be pointed at, given the credentials currently in
+   * the form. Read from the agent's own CLI cache or the provider endpoint —
+   * see agents/model-catalog. Kept in the launcher (not the installed core) for
+   * the same reason testLLM is: an older core on the user's machine knows
+   * nothing about it.
+   */
+  async listModels(
+    agentType: string,
+    env: Record<string, string>,
+    path?: ModelListPath,
+  ): Promise<ModelListResult> {
+    return listAgentModels(
+      agentType,
+      env || {},
+      {
+        runCli: (type, args, extra) => this._runCliForModels(type, args, extra),
+      },
+      path,
+    )
+  }
+
+  /**
+   * Run an agent's CLI for its model list (today: `cursor-agent --list-models`).
+   * Goes through LoginProbe.spawnAgentCli so it inherits the one launch shape
+   * that survives Windows npm shims and the enhanced PATH — the same reasons
+   * the sign-in probe can't just call spawn() itself. Returns null on anything
+   * that isn't a clean run; the caller then falls back or says it has no list.
+   *
+   * `extra` carries the credentials being configured (e.g. the CURSOR_API_KEY
+   * typed into the key form) so the CLI answers for THEM rather than for the
+   * sign-in this machine happens to hold. It goes in the child's env, never on
+   * the command line, where it would show up in the process list.
+   */
+  private _runCliForModels(
+    agentType: string,
+    args: string[],
+    extra?: Record<string, string>,
+  ): Promise<string | null> {
+    return new Promise((resolve) => {
+      const bin = this.resolveBinary(agentType)
+      if (!bin) return resolve(null)
+      try {
+        const child = this._login.spawnAgentCli(bin, args, {
+          ...this._savedTypeEnvForProbe(agentType),
+          ...(extra || {}),
+        })
+        let out = ""
+        let settled = false
+        const finish = (value: string | null): void => {
+          if (settled) return
+          settled = true
+          clearTimeout(timer)
+          resolve(value)
+        }
+        const timer = setTimeout(() => {
+          try {
+            child.kill()
+          } catch {}
+          finish(null)
+        }, 15000)
+        child.stdout?.on("data", (c: Buffer) => (out += c.toString("utf-8")))
+        child.on("error", () => finish(null))
+        child.on("close", (code) => finish(code === 0 ? out : null))
+      } catch {
+        resolve(null)
+      }
+    })
   }
 
   /**

--- a/packages/launcher/src/main/agents/auth-specs.ts
+++ b/packages/launcher/src/main/agents/auth-specs.ts
@@ -42,13 +42,17 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       default: "https://api.anthropic.com",
       placeholder: "https://api.anthropic.com",
     },
+    // No `default`: a pinned model id ages out (and a pre-filled one gets saved
+    // whether or not the user meant it), which is exactly how agents ended up
+    // calling models their account no longer serves. Empty means "the CLI's own
+    // default"; the launcher's model picker fills this from the live list —
+    // Anthropic's /v1/models for a key or relay. See main/agents/model-catalog.
     {
       name: "ANTHROPIC_MODEL",
       description:
-        "Model name (change it when using a relay/proxy — its channels rarely match the default)",
+        "Model name — leave empty to use Claude Code's default, or pick one from the list (a relay's channels rarely match the official ids)",
       required: true,
-      default: "claude-sonnet-4-6",
-      placeholder: "claude-sonnet-4-6",
+      placeholder: "claude-opus-5",
     },
     // A long-lived subscription token, produced by `claude setup-token` on a
     // machine that IS signed in. It is the third auth path, and the only one
@@ -90,9 +94,8 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
     {
       name: "GEMINI_MODEL",
       description:
-        "Model name (change it when using a relay/proxy — its channels rarely match the default)",
+        "Model name — leave empty to use the Gemini CLI's default, or pick one from the list (loaded from your key's own /models response)",
       required: false,
-      default: "gemini-2.5-pro",
       placeholder: "gemini-2.5-pro",
     },
   ],
@@ -111,13 +114,16 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       default: "https://api.openai.com/v1",
       placeholder: "https://api.openai.com/v1",
     },
+    // `gpt-5-codex` used to be the default here. OpenAI has since retired it,
+    // so every ChatGPT-login codex agent that inherited it — or fell through to
+    // the CLI's own build-time default — failed on the first message. The list
+    // now comes from codex's own `models_cache.json`, which is written for the
+    // signed-in account; empty means whatever the CLI picks.
     {
       name: "CODEX_MODEL",
       description:
-        "Model name (change it when using a relay/proxy — its channels rarely match the default)",
+        "Model name — leave empty to use the Codex CLI's default, or pick one from the list (which is loaded from your signed-in account or your relay)",
       required: true,
-      default: "gpt-5-codex",
-      placeholder: "gpt-5-codex",
     },
   ],
   pi: [
@@ -140,9 +146,9 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
     {
       name: "PI_MODEL",
       description:
-        "Exact model id exposed by the provider or relay (for example claude-sonnet-4-6, gpt-5-codex, or deepseek-v4-flash).",
+        "Exact model id exposed by the provider or relay — pick one from the list, which is loaded from the provider you selected above.",
       required: false,
-      placeholder: "claude-sonnet-4-6",
+      placeholder: "claude-opus-5",
     },
     {
       name: "PI_API_FORMAT",
@@ -226,10 +232,9 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
     },
     {
       name: "LLM_MODEL",
-      description: "Model name",
+      description:
+        "Model name — pick one from the list, which is loaded from the base URL above",
       required: true,
-      default: "gpt-4o",
-      placeholder: "gpt-4o, claude-sonnet-4-6, deepseek-chat, etc.",
     },
   ],
   opencode: [
@@ -248,10 +253,9 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
     },
     {
       name: "LLM_MODEL",
-      description: "Model name",
+      description:
+        "Model name — pick one from the list, which is loaded from the base URL above",
       required: true,
-      default: "gpt-4o",
-      placeholder: "gpt-4o, claude-sonnet-4-6, etc.",
     },
   ],
   // Cline supports many providers (its own account, Anthropic, OpenAI,
@@ -372,7 +376,13 @@ export const HOSTED_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
     statusArgs: ["status"],
     loggedOutPattern: /not logged in|logged out|signed out/i,
     apiKeyEnv: "CURSOR_API_KEY",
-    loginClearsEnv: ["CURSOR_API_KEY", "CURSOR_MODEL"],
+    // Only the KEY. CURSOR_MODEL used to be wiped alongside it, from back when
+    // the setup wizard could save a model Cursor no longer served and the CLI
+    // preferred that dead value over its account default. The model now comes
+    // from `cursor-agent --list-models` (the account's own list), so a chosen
+    // model is a deliberate setting — clearing it on every sign-in check meant
+    // the picker could never stick.
+    loginClearsEnv: ["CURSOR_API_KEY"],
   },
   hermes: {
     // `hermes setup` is the interactive wizard; `hermes status` prints a rich

--- a/packages/launcher/src/main/agents/llm-test.ts
+++ b/packages/launcher/src/main/agents/llm-test.ts
@@ -138,7 +138,11 @@ export async function testLLMConnection(
         openai: {
           base: "https://api.openai.com/v1",
           api: "openai-responses",
-          model: "gpt-5-codex",
+          // Only the probe's model, for a form that left PI_MODEL empty. It was
+          // `gpt-5-codex`, which OpenAI has retired — so the test 404'd on a
+          // perfectly good key. Same small, long-lived model the generic
+          // OpenAI-compatible branch below probes with.
+          model: "gpt-4o-mini",
         },
         deepseek: {
           base: "https://api.deepseek.com/v1",

--- a/packages/launcher/src/main/agents/model-catalog.test.ts
+++ b/packages/launcher/src/main/agents/model-catalog.test.ts
@@ -1,0 +1,250 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+
+// llm-test pulls in electron's `net`, which does not exist under vitest — and
+// the HTTP shape is what we want to control here anyway. `vi.hoisted` is what
+// lets the mock factory (hoisted above the imports) see this spy.
+const { httpRequestJson } = vi.hoisted(() => ({ httpRequestJson: vi.fn() }))
+vi.mock("./llm-test", () => ({ httpRequestJson }))
+
+import { listAgentModels } from "./model-catalog"
+
+/** Trimmed to the fields we read, in the shape codex 0.148 writes. */
+const CODEX_CACHE = {
+  fetched_at: "2026-08-18T03:06:54.783590Z",
+  client_version: "0.148.0",
+  models: [
+    {
+      slug: "gpt-5.4",
+      display_name: "GPT-5.4",
+      visibility: "list",
+      priority: 16,
+      upgrade: { model: "gpt-5.6-terra" },
+    },
+    {
+      slug: "codex-auto-review",
+      display_name: "Codex Auto Review",
+      visibility: "hide",
+      priority: 43,
+    },
+    {
+      slug: "gpt-5.6-sol",
+      display_name: "GPT-5.6-Sol",
+      description: "Latest frontier agentic coding model.",
+      visibility: "list",
+      priority: 1,
+    },
+  ],
+}
+
+let home: string
+
+beforeAll(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "codex-home-"))
+  fs.writeFileSync(
+    path.join(home, "models_cache.json"),
+    JSON.stringify(CODEX_CACHE),
+  )
+})
+
+afterAll(() => {
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+describe("listAgentModels — codex signed in with ChatGPT (no API key)", () => {
+  it("reads the account's own line-up from the CLI's cache", async () => {
+    const r = await listAgentModels("codex", { CODEX_HOME: home })
+    expect(r.source).toBe("cli")
+    // Priority order, internal models dropped.
+    expect(r.models.map((m) => m.id)).toEqual(["gpt-5.6-sol", "gpt-5.4"])
+    expect(httpRequestJson).not.toHaveBeenCalled()
+  })
+
+  it("keeps a model the backend is retiring, but flags it", async () => {
+    const r = await listAgentModels("codex", { CODEX_HOME: home })
+    const retiring = r.models.find((m) => m.id === "gpt-5.4")
+    expect(retiring?.deprecated).toBe(true)
+    expect(retiring?.note).toContain("gpt-5.6-terra")
+  })
+
+  it("says what to do when there is no cache and no key", async () => {
+    const r = await listAgentModels("codex", {
+      CODEX_HOME: path.join(home, "nope"),
+    })
+    expect(r.source).toBe("none")
+    expect(r.models).toEqual([])
+    expect(r.error).toBeTruthy()
+  })
+})
+
+describe("listAgentModels — the form's auth path decides the source", () => {
+  it("never answers the API-key form from the CLI's signed-in account", async () => {
+    // The regression: a machine signed in to Codex with ChatGPT showed that
+    // account's models under an API-key form pointed at a relay.
+    const r = await listAgentModels(
+      "codex",
+      { CODEX_HOME: home, OPENAI_BASE_URL: "https://relay.example.com/v1" },
+      {},
+      "key",
+    )
+    expect(r.models).toEqual([])
+    expect(r.code).toBe("need_key")
+    expect(httpRequestJson).not.toHaveBeenCalled()
+  })
+
+  it("ignores a key that is present when the sign-in path is the one being set up", async () => {
+    const r = await listAgentModels(
+      "codex",
+      { CODEX_HOME: home, OPENAI_API_KEY: "sk-test" },
+      {},
+      "login",
+    )
+    expect(r.source).toBe("cli")
+    expect(httpRequestJson).not.toHaveBeenCalled()
+  })
+
+  it("does not paper over an endpoint's failure with the CLI's list", async () => {
+    httpRequestJson.mockResolvedValueOnce({ status: 401, text: "bad key" })
+    const r = await listAgentModels(
+      "codex",
+      { CODEX_HOME: home, OPENAI_API_KEY: "sk-bad" },
+      {},
+      "key",
+    )
+    expect(r.models).toEqual([])
+    expect(r.error).toContain("401")
+  })
+
+  it("runs cursor's CLI with the key being configured, not the local login", async () => {
+    const runCli = vi.fn().mockResolvedValue("auto - Auto (default)")
+    await listAgentModels(
+      "cursor",
+      { CURSOR_API_KEY: "key-from-form" },
+      { runCli },
+      "key",
+    )
+    expect(runCli).toHaveBeenCalledWith("cursor", ["--list-models"], {
+      CURSOR_API_KEY: "key-from-form",
+    })
+  })
+
+  it("runs cursor's CLI with no credentials on the sign-in path", async () => {
+    const runCli = vi.fn().mockResolvedValue("auto - Auto (default)")
+    await listAgentModels(
+      "cursor",
+      { CURSOR_API_KEY: "key-from-form" },
+      { runCli },
+      "login",
+    )
+    expect(runCli).toHaveBeenCalledWith("cursor", ["--list-models"], undefined)
+  })
+})
+
+describe("listAgentModels — key present", () => {
+  it("asks the relay the agent will actually talk to, not api.openai.com", async () => {
+    httpRequestJson.mockResolvedValueOnce({
+      status: 200,
+      text: JSON.stringify({ data: [{ id: "sonnet-relay" }, { id: "gpt-x" }] }),
+    })
+    const r = await listAgentModels("codex", {
+      CODEX_HOME: home,
+      OPENAI_API_KEY: "sk-test",
+      OPENAI_BASE_URL: "https://relay.example.com/v1",
+    })
+    expect(httpRequestJson).toHaveBeenCalledWith(
+      "https://relay.example.com/v1/models",
+      "GET",
+      expect.objectContaining({ Authorization: "Bearer sk-test" }),
+      null,
+    )
+    expect(r.source).toBe("api")
+    expect(r.models.map((m) => m.id)).toEqual(["gpt-x", "sonnet-relay"])
+  })
+
+  it("falls back to the CLI cache when the endpoint refuses", async () => {
+    httpRequestJson.mockResolvedValueOnce({ status: 401, text: "nope" })
+    const r = await listAgentModels("codex", {
+      CODEX_HOME: home,
+      OPENAI_API_KEY: "sk-bad",
+    })
+    expect(r.source).toBe("cli")
+    expect(r.models.length).toBeGreaterThan(0)
+  })
+
+  it("sends a relay Bearer and the official endpoint x-api-key (Anthropic)", async () => {
+    httpRequestJson.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({ data: [{ id: "claude-opus-5" }] }),
+    })
+    await listAgentModels("claude", { ANTHROPIC_API_KEY: "sk-ant" })
+    expect(httpRequestJson).toHaveBeenLastCalledWith(
+      "https://api.anthropic.com/v1/models?limit=100",
+      "GET",
+      expect.objectContaining({ "x-api-key": "sk-ant" }),
+      null,
+    )
+    await listAgentModels("claude", {
+      ANTHROPIC_API_KEY: "sk-ant",
+      ANTHROPIC_BASE_URL: "https://relay.example.com",
+    })
+    expect(httpRequestJson).toHaveBeenLastCalledWith(
+      "https://relay.example.com/v1/models?limit=100",
+      "GET",
+      expect.objectContaining({ Authorization: "Bearer sk-ant" }),
+      null,
+    )
+  })
+})
+
+describe("listAgentModels — cursor, via its own CLI", () => {
+  /** Verbatim `cursor-agent --list-models` output. */
+  const OUT = [
+    "Available models",
+    "",
+    "auto - Auto (default)",
+    "gpt-5.3-codex - Codex 5.3",
+    "composer-2.5 - Composer 2.5 (current)",
+  ].join("\n")
+
+  it("asks the CLI, since Cursor has no endpoint to list from", async () => {
+    const runCli = vi.fn().mockResolvedValue(OUT)
+    const r = await listAgentModels("cursor", {}, { runCli })
+    expect(runCli).toHaveBeenCalledWith("cursor", ["--list-models"], {})
+    expect(r.source).toBe("cli")
+    expect(r.models.map((m) => m.id)).toEqual([
+      "auto",
+      "gpt-5.3-codex",
+      "composer-2.5",
+    ])
+    // The "(current)" marker is a state, not part of the name.
+    expect(r.models[2].label).toBe("Composer 2.5")
+  })
+
+  it("says it has no list when the CLI can't be run", async () => {
+    const r = await listAgentModels(
+      "cursor",
+      {},
+      {
+        runCli: vi.fn().mockResolvedValue(null),
+      },
+    )
+    expect(r.models).toEqual([])
+    expect(r.source).toBe("none")
+  })
+})
+
+describe("listAgentModels — nothing to probe", () => {
+  it("offers the built-in Anthropic list for a subscription sign-in", async () => {
+    const r = await listAgentModels("claude", {})
+    expect(r.source).toBe("builtin")
+    expect(r.models.map((m) => m.id)).toContain("claude-opus-5")
+  })
+
+  it("returns nothing for an agent with no model setting", async () => {
+    const r = await listAgentModels("cursor", {})
+    expect(r.source).toBe("none")
+    expect(r.models).toEqual([])
+  })
+})

--- a/packages/launcher/src/main/agents/model-catalog.ts
+++ b/packages/launcher/src/main/agents/model-catalog.ts
@@ -1,0 +1,617 @@
+/**
+ * Where an agent's MODEL field gets its choices.
+ *
+ * Every agent the launcher ships used to carry ONE hardcoded model id as the
+ * default of its `*_MODEL` env field. That id ages out: `gpt-5-codex` is no
+ * longer in OpenAI's Codex line-up at all, so a codex agent signed in with a
+ * ChatGPT account — the path where the launcher shows no model input — ran
+ * every message against a model its account cannot serve, and the run failed
+ * with nothing in the UI to change. Relays are the same story from the other
+ * side: their channel names never match whatever we baked in.
+ *
+ * So the list is READ, not declared. In order of trustworthiness:
+ *
+ *   • the CLI's own cache — codex writes the exact model line-up its account
+ *     may use to `~/.codex/models_cache.json` (slug, display name, deprecation
+ *     notice) after `codex login`. This is the ONLY honest source for a
+ *     subscription sign-in: no API key exists to ask a server with.
+ *   • the provider, over HTTP — with a key + base URL in hand we ask the
+ *     endpoint the agent will actually talk to (`/v1/models` and friends), so
+ *     a relay answers for its own channels rather than us guessing.
+ *   • a small built-in list — last resort, and flagged as such to the UI so it
+ *     can say the list may be stale instead of presenting it as truth.
+ *
+ * Nothing here is authoritative over what the user types: the model field stays
+ * free-form everywhere (a private deployment name is still a valid answer), and
+ * an empty value keeps meaning "whatever the CLI/provider defaults to".
+ */
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+import { isOfficialAnthropicBase } from "./env-normalize"
+import { httpRequestJson } from "./llm-test"
+
+export type ModelChoice = {
+  /** The exact value written to the env var. */
+  id: string
+  /** Human name from the provider, when it gives one. */
+  label?: string
+  /** One line of provider-supplied context (deprecation, description). */
+  note?: string
+  /** The provider says this one is going away — the UI sinks/marks it. */
+  deprecated?: boolean
+}
+
+export type ModelListResult = {
+  models: ModelChoice[]
+  /** Where the list came from, so the UI can be honest about it. */
+  source: "cli" | "api" | "builtin" | "none"
+  /** Why the list is empty / fell back. Never carries the key. */
+  error?: string
+  /**
+   * Machine-readable reason, when there is one worth phrasing in the user's
+   * language. `need_key` — the API-key path has no key yet; `need_login` — the
+   * CLI path has a list to read but nobody is signed in; `no_list` — this agent
+   * publishes no list on the CLI path at all, so the id has to be typed.
+   */
+  code?: "need_key" | "need_login" | "no_list"
+}
+
+/**
+ * Which auth path the user is configuring. The list has to follow it: someone
+ * filling in the API-key form wants the models THAT endpoint serves, even on a
+ * machine where the same agent happens to be signed in through its CLI — the
+ * account's line-up is the wrong answer there, and a convincing one.
+ */
+export type ModelListPath = "key" | "login"
+
+type Provider = "openai" | "anthropic" | "gemini" | "none"
+
+type ModelSource = {
+  /** The env var this agent's model lives in. */
+  envVar: string
+  provider: Provider
+  /** Candidate key vars, in precedence order. */
+  keyVars: string[]
+  /** Candidate base-URL vars, in precedence order. */
+  baseVars: string[]
+  /** Reads a list the agent's own CLI maintains (no API key involved). */
+  cliCache?: (env: Record<string, string>) => ModelListResult | null
+  /**
+   * Asks the agent's CLI for its list (needs `deps.runCli`). `credVars` are the
+   * form values handed to the child process, so a CLI that can authenticate
+   * either way answers for the credentials being configured rather than for
+   * whatever session the machine happens to hold.
+   */
+  cliCommand?: {
+    args: string[]
+    parse: (out: string) => ModelChoice[]
+    credVars?: string[]
+  }
+  /** Used only when nothing can be probed. */
+  builtin?: ModelChoice[]
+}
+
+/**
+ * Anthropic's current line-up, for a Claude agent signed in with a Pro/Max
+ * subscription — there is no key to list models with, and Claude Code has no
+ * on-disk cache like codex's. Deliberately ids only (no dated snapshots): the
+ * UI labels this source "built-in", and a key/relay replaces it with the live
+ * list the moment one is entered.
+ */
+const ANTHROPIC_BUILTIN: ModelChoice[] = [
+  { id: "claude-opus-5", label: "Claude Opus 5" },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+]
+
+/** `~/.codex` unless the CLI was pointed elsewhere. */
+function codexHome(env: Record<string, string>): string {
+  return (env.CODEX_HOME || "").trim() || path.join(os.homedir(), ".codex")
+}
+
+/**
+ * The line-up codex itself last fetched for the signed-in account.
+ *
+ * Codex refreshes this file on its own (it carries the fetch time, an ETag and
+ * the client version) and it is written for BOTH auth paths, so it answers the
+ * question the launcher could not answer before: which models may this ChatGPT
+ * account actually run? `visibility: "hide"` entries are internal (e.g. the
+ * auto-review model) and are dropped; `upgrade` marks a model the backend is
+ * retiring, which we keep but flag — it is still selectable today, and the note
+ * tells the user what replaces it.
+ */
+function codexCliModels(env: Record<string, string>): ModelListResult | null {
+  const file = path.join(codexHome(env), "models_cache.json")
+  let raw: string
+  try {
+    raw = fs.readFileSync(file, "utf-8")
+  } catch {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as {
+      models?: Array<Record<string, unknown>>
+    }
+    const list = Array.isArray(parsed.models) ? parsed.models : []
+    const models = list
+      .filter((m) => (m.visibility as string) !== "hide")
+      .filter((m) => typeof m.slug === "string" && (m.slug as string).trim())
+      .sort(
+        (a, b) =>
+          (typeof a.priority === "number" ? a.priority : 999) -
+          (typeof b.priority === "number" ? b.priority : 999),
+      )
+      .map((m) => {
+        const upgrade = m.upgrade as { model?: string } | null | undefined
+        return {
+          id: (m.slug as string).trim(),
+          label: (m.display_name as string) || undefined,
+          note: upgrade?.model
+            ? `Being retired — use ${upgrade.model}`
+            : (m.description as string) || undefined,
+          deprecated: !!upgrade?.model,
+        }
+      })
+    if (!models.length) return null
+    return { models, source: "cli" }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `cursor-agent --list-models`, which prints one `slug - Display Name` per line
+ * under an "Available models" header and marks the CLI's current pick with a
+ * trailing "(current)". Cursor authenticates entirely through its own service,
+ * so there is no endpoint the launcher may ask — but the CLI will answer for
+ * the signed-in account, which is the same deal codex's cache gives us.
+ */
+function parseCursorModels(out: string): ModelChoice[] {
+  const models: ModelChoice[] = []
+  const seen = new Set<string>()
+  for (const line of out.split(/\r?\n/)) {
+    const m = /^\s*(\S+)\s+-\s+(.+?)\s*$/.exec(line)
+    if (!m) continue
+    const id = m[1]
+    if (seen.has(id)) continue
+    seen.add(id)
+    models.push({ id, label: m[2].replace(/\s*\(current\)\s*$/i, "") })
+  }
+  return models
+}
+
+const MODEL_SOURCES: Record<string, ModelSource> = {
+  codex: {
+    envVar: "CODEX_MODEL",
+    provider: "openai",
+    keyVars: ["OPENAI_API_KEY"],
+    baseVars: ["OPENAI_BASE_URL"],
+    cliCache: codexCliModels,
+  },
+  cursor: {
+    envVar: "CURSOR_MODEL",
+    // Cursor's key is for Cursor's own service, not an OpenAI-compatible
+    // endpoint — there is nothing to GET /models from, so the CLI is the source
+    // on both paths. The key is still declared: it is what tells the key path
+    // apart from the sign-in path, and what the CLI is handed below.
+    provider: "none",
+    keyVars: ["CURSOR_API_KEY"],
+    baseVars: ["CURSOR_API_ENDPOINT"],
+    cliCommand: {
+      args: ["--list-models"],
+      parse: parseCursorModels,
+      // `cursor-agent` reads CURSOR_API_KEY / CURSOR_API_ENDPOINT from the env
+      // (its --api-key flag would put the secret in the process list). Passing
+      // the form's values makes the key tab list that key's models instead of
+      // the local login's.
+      credVars: ["CURSOR_API_KEY", "CURSOR_API_ENDPOINT"],
+    },
+  },
+  claude: {
+    envVar: "ANTHROPIC_MODEL",
+    provider: "anthropic",
+    keyVars: ["ANTHROPIC_API_KEY"],
+    baseVars: ["ANTHROPIC_BASE_URL"],
+    builtin: ANTHROPIC_BUILTIN,
+  },
+  gemini: {
+    envVar: "GEMINI_MODEL",
+    provider: "gemini",
+    keyVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    baseVars: ["GOOGLE_GEMINI_BASE_URL"],
+  },
+  kimi: {
+    envVar: "KIMI_MODEL",
+    provider: "openai",
+    keyVars: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+    baseVars: ["KIMI_BASE_URL"],
+  },
+  deepseek: {
+    envVar: "DEEPSEEK_MODEL",
+    provider: "openai",
+    keyVars: ["DEEPSEEK_API_KEY"],
+    baseVars: ["DEEPSEEK_BASE_URL"],
+  },
+  openclaw: {
+    envVar: "LLM_MODEL",
+    provider: "openai",
+    keyVars: ["LLM_API_KEY"],
+    baseVars: ["LLM_BASE_URL"],
+  },
+  opencode: {
+    envVar: "LLM_MODEL",
+    provider: "openai",
+    keyVars: ["LLM_API_KEY"],
+    baseVars: ["LLM_BASE_URL"],
+  },
+}
+
+/**
+ * Pi carries the provider in its own field, so its model source is resolved per
+ * value rather than per agent. `openai-codex` means "reuse the Codex
+ * subscription login" — same cache file, no key.
+ */
+function piSource(env: Record<string, string>): ModelSource {
+  const provider = (env.PI_PROVIDER || "").trim().toLowerCase()
+  const base: ModelSource = {
+    envVar: "PI_MODEL",
+    provider: "openai",
+    keyVars: ["PI_API_KEY"],
+    baseVars: ["PI_BASE_URL"],
+  }
+  switch (provider) {
+    case "anthropic":
+      return {
+        ...base,
+        provider: "anthropic",
+        keyVars: ["PI_API_KEY", "ANTHROPIC_API_KEY"],
+        builtin: ANTHROPIC_BUILTIN,
+      }
+    case "google":
+      return {
+        ...base,
+        provider: "gemini",
+        keyVars: ["PI_API_KEY", "GEMINI_API_KEY"],
+      }
+    case "deepseek":
+      return { ...base, keyVars: ["PI_API_KEY", "DEEPSEEK_API_KEY"] }
+    case "openrouter":
+      return { ...base, keyVars: ["PI_API_KEY", "OPENROUTER_API_KEY"] }
+    case "openai-codex":
+      return {
+        ...base,
+        keyVars: ["PI_API_KEY", "OPENAI_API_KEY"],
+        cliCache: codexCliModels,
+      }
+    default:
+      return { ...base, keyVars: ["PI_API_KEY", "OPENAI_API_KEY"] }
+  }
+}
+
+function resolveSource(
+  agentType: string,
+  env: Record<string, string>,
+): ModelSource | null {
+  if (agentType === "pi") return piSource(env)
+  return MODEL_SOURCES[agentType] || null
+}
+
+/** The model env var an agent's list applies to, or null if it has none. */
+export function modelEnvVar(
+  agentType: string,
+  env: Record<string, string> = {},
+): string | null {
+  return resolveSource(agentType, env)?.envVar || null
+}
+
+function pick(env: Record<string, string>, names: string[]): string {
+  for (const n of names) {
+    const v = (env[n] || "").trim()
+    if (v) return v
+  }
+  return ""
+}
+
+const trimSlash = (u: string): string => u.replace(/\/+$/, "")
+
+/** `data: [{ id }]`, an array, or a relay's `{ models: [...] }` shape. */
+function parseOpenAiModels(text: string): ModelChoice[] {
+  const parsed: unknown = JSON.parse(text)
+  const list = Array.isArray(parsed)
+    ? parsed
+    : ((parsed as { data?: unknown[] })?.data ??
+      (parsed as { models?: unknown[] })?.models ??
+      [])
+  if (!Array.isArray(list)) return []
+  const seen = new Set<string>()
+  const out: ModelChoice[] = []
+  for (const entry of list) {
+    const id =
+      typeof entry === "string"
+        ? entry
+        : String((entry as { id?: unknown })?.id ?? "")
+    const trimmed = id.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    out.push({ id: trimmed })
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+async function listOpenAiModels(
+  key: string,
+  baseInput: string,
+): Promise<ModelListResult> {
+  let base = trimSlash(baseInput || "https://api.openai.com/v1")
+  if (!/\/v\d+$/.test(base)) base += "/v1"
+  const { status, text } = await httpRequestJson(
+    `${base}/models`,
+    "GET",
+    { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    null,
+  )
+  if (status >= 400)
+    return {
+      models: [],
+      source: "none",
+      error: `HTTP ${status}: ${text.slice(0, 160)}`,
+    }
+  const models = parseOpenAiModels(text)
+  return models.length
+    ? { models, source: "api" }
+    : { models: [], source: "none", error: "The endpoint listed no models." }
+}
+
+async function listAnthropicModels(
+  key: string,
+  baseInput: string,
+): Promise<ModelListResult> {
+  const base = trimSlash(baseInput || "https://api.anthropic.com").replace(
+    /\/v1$/,
+    "",
+  )
+  // Same header choice as the connection test: official takes `x-api-key`, a
+  // relay only ever honors `Authorization: Bearer` (see llm-test).
+  const auth: Record<string, string> = isOfficialAnthropicBase(base)
+    ? { "x-api-key": key }
+    : { Authorization: `Bearer ${key}` }
+  const { status, text } = await httpRequestJson(
+    `${base}/v1/models?limit=100`,
+    "GET",
+    { ...auth, "anthropic-version": "2023-06-01" },
+    null,
+  )
+  if (status >= 400)
+    return {
+      models: [],
+      source: "none",
+      error: `HTTP ${status}: ${text.slice(0, 160)}`,
+    }
+  try {
+    const parsed = JSON.parse(text) as {
+      data?: Array<{ id?: string; display_name?: string }>
+    }
+    const models = (parsed.data || [])
+      .filter((m) => typeof m.id === "string" && m.id.trim())
+      .map((m) => ({ id: (m.id as string).trim(), label: m.display_name }))
+    if (models.length) return { models, source: "api" }
+  } catch {
+    // fall through — a relay that answers /v1/models with HTML is not a list
+  }
+  return { models: [], source: "none", error: "The endpoint listed no models." }
+}
+
+async function listGeminiModels(
+  key: string,
+  baseInput: string,
+): Promise<ModelListResult> {
+  const base = trimSlash(
+    baseInput || "https://generativelanguage.googleapis.com",
+  )
+  // Relays are usually entered WITH the version segment already in the base
+  // URL, so only add one when it isn't there (mirrors llm-test's Gemini path).
+  const url = /\/v\d+(beta)?$/.test(base)
+    ? `${base}/models`
+    : `${base}/v1beta/models`
+  const { status, text } = await httpRequestJson(
+    `${url}?key=${encodeURIComponent(key)}&pageSize=200`,
+    "GET",
+    { "x-goog-api-key": key },
+    null,
+  )
+  if (status >= 400)
+    return {
+      models: [],
+      source: "none",
+      error: `HTTP ${status}: ${text.slice(0, 160)}`,
+    }
+  try {
+    const parsed = JSON.parse(text) as {
+      models?: Array<{
+        name?: string
+        displayName?: string
+        supportedGenerationMethods?: string[]
+      }>
+    }
+    const models = (parsed.models || [])
+      .filter(
+        (m) =>
+          !m.supportedGenerationMethods ||
+          m.supportedGenerationMethods.includes("generateContent"),
+      )
+      .map((m) => ({
+        // The API returns `models/gemini-…`; the CLI's -m wants the bare id.
+        id: String(m.name || "").replace(/^models\//, ""),
+        label: m.displayName,
+      }))
+      .filter((m) => m.id)
+    if (models.length) return { models, source: "api" }
+  } catch {
+    // fall through
+  }
+  return { models: [], source: "none", error: "The endpoint listed no models." }
+}
+
+export type ModelCatalogDeps = {
+  /**
+   * Runs the agent's own CLI and returns its output, or null when the binary
+   * isn't installed / the run fails. Injected (rather than spawned here) so the
+   * launcher's one Windows-safe spawn path is reused — see LoginProbe.
+   */
+  runCli?: (
+    agentType: string,
+    args: string[],
+    env?: Record<string, string>,
+  ) => Promise<string | null>
+}
+
+/**
+ * The CLI's answer, from whichever of the two CLI sources this agent has.
+ * `creds` are handed to the child when the caller is configuring the API-key
+ * path — see cliCommand.credVars.
+ */
+async function fromCli(
+  agentType: string,
+  source: ModelSource,
+  env: Record<string, string>,
+  deps: ModelCatalogDeps,
+  creds?: Record<string, string>,
+): Promise<ModelListResult | null> {
+  const cached = source.cliCache?.(env) || null
+  if (cached) return cached
+  if (!source.cliCommand || !deps.runCli) return null
+  const out = await deps.runCli(agentType, source.cliCommand.args, creds)
+  if (!out) return null
+  const models = source.cliCommand.parse(out)
+  return models.length ? { models, source: "cli" } : null
+}
+
+/** The form values a CLI needs to answer for the key being configured. */
+function credEnv(
+  source: ModelSource,
+  env: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const name of source.cliCommand?.credVars || []) {
+    const v = (env[name] || "").trim()
+    if (v) out[name] = v
+  }
+  return out
+}
+
+/**
+ * The models an agent can be pointed at right now, given the credentials
+ * currently in the form (which may not be saved yet — that is the point: the
+ * list has to follow the base URL the user is typing).
+ *
+ * `path` says which half of a dual-auth agent the user is filling in, and it
+ * decides the source outright rather than being a hint:
+ *
+ *   • "key"   — the endpoint in the form, and only that. A machine that also
+ *     has the CLI signed in must NOT answer here: someone pointing codex at a
+ *     relay was shown their ChatGPT account's line-up, which looks authoritative
+ *     and is wrong for that endpoint. With no key yet we say so (`need_key`)
+ *     instead of substituting a list from somewhere else. For a CLI that owns
+ *     its own service (cursor) the CLI is still the only place a list exists —
+ *     so it is run WITH the form's key, answering for that key.
+ *   • "login" — the CLI's own list (cache or command), for the session the
+ *     agent will actually run under. Any key in the form is ignored.
+ *
+ * Left unset (a form with no tabs) it keeps the old order: a key means the
+ * endpoint, otherwise the CLI, otherwise the built-in list.
+ */
+export async function listAgentModels(
+  agentType: string,
+  env: Record<string, string> = {},
+  deps: ModelCatalogDeps = {},
+  path?: ModelListPath,
+): Promise<ModelListResult> {
+  const source = resolveSource(agentType, env)
+  if (!source)
+    return {
+      models: [],
+      source: "none",
+      error: "This agent has no model setting.",
+    }
+
+  const key = pick(env, source.keyVars)
+  const base = pick(env, source.baseVars)
+  // A CLI-only agent (cursor) has no endpoint to query, so the CLI serves both
+  // paths — with the form's key on the key path.
+  const httpOnlyPath = path === "key" && source.provider !== "none"
+
+  if (path === "key" && !key)
+    return {
+      models: [],
+      source: "none",
+      code: "need_key",
+      error: "Enter an API key to load this endpoint's models.",
+    }
+
+  if ((key || httpOnlyPath) && source.provider !== "none" && path !== "login") {
+    try {
+      const viaApi =
+        source.provider === "anthropic"
+          ? await listAnthropicModels(key, base)
+          : source.provider === "gemini"
+            ? await listGeminiModels(key, base)
+            : await listOpenAiModels(key, base)
+      if (viaApi.models.length) return viaApi
+      // On the key path the endpoint is the only honest source — report why it
+      // came back empty rather than quietly showing another account's models.
+      if (httpOnlyPath) return viaApi
+      const fallback = await fromCli(agentType, source, env, deps)
+      if (fallback) return fallback
+      if (source.builtin?.length)
+        return {
+          models: source.builtin,
+          source: "builtin",
+          error: viaApi.error,
+        }
+      return viaApi
+    } catch (e) {
+      const failed = (e as Error)?.message || "Request failed"
+      if (httpOnlyPath) return { models: [], source: "none", error: failed }
+      const fallback = await fromCli(agentType, source, env, deps)
+      if (fallback) return fallback
+      if (source.builtin?.length)
+        return { models: source.builtin, source: "builtin", error: failed }
+      return { models: [], source: "none", error: failed }
+    }
+  }
+
+  const cli = await fromCli(
+    agentType,
+    source,
+    env,
+    deps,
+    path === "login" ? undefined : credEnv(source, env),
+  )
+  if (cli) return cli
+
+  // Nothing answered. Say which kind of "nothing" it was, so the picker can ask
+  // for the one thing that would fix it.
+  const hasCliSource = !!(source.cliCache || source.cliCommand)
+  if (path === "key")
+    return {
+      models: [],
+      source: "none",
+      error: hasCliSource
+        ? "Couldn't read a model list for this key."
+        : "This endpoint returned no model list.",
+    }
+  if (source.builtin?.length)
+    return { models: source.builtin, source: "builtin" }
+  return {
+    models: [],
+    source: "none",
+    // An agent with a CLI list just isn't signed in yet; one without (Gemini)
+    // never had a list to offer — don't send the user off to sign in again.
+    code: hasCliSource ? "need_login" : "no_list",
+    error: hasCliSource
+      ? "Sign in to load the model list."
+      : "This sign-in doesn't publish a model list — type the model id.",
+  }
+}

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1255,6 +1255,9 @@ function setupIPC(): void {
     requireManager().saveAgentInstanceEnv(agentName, env),
   )
   ipcMain.handle("agents:test-llm", (_e, env) => requireManager().testLLM(env))
+  ipcMain.handle("agents:list-models", (_e, agentType, env, path) =>
+    requireManager().listModels(agentType, env, path),
+  )
   ipcMain.handle("agents:signal-reload", () => requireManager().signalReload())
 
   // ── Chat IPC (Stage 3.1) ──

--- a/packages/launcher/src/preload/index.ts
+++ b/packages/launcher/src/preload/index.ts
@@ -54,6 +54,8 @@ contextBridge.exposeInMainWorld('api', {
   getAgentInstanceEnv: (name: string) => ipcRenderer.invoke('agents:get-instance-env', name),
   saveAgentInstanceEnv: (name: string, env: unknown) => ipcRenderer.invoke('agents:save-instance-env', name, env),
   testLLM: (env: unknown) => ipcRenderer.invoke('agents:test-llm', env),
+  listModels: (agentType: string, env: Record<string, string>, path?: 'key' | 'login') =>
+    ipcRenderer.invoke('agents:list-models', agentType, env, path),
   signalReload: () => ipcRenderer.invoke('agents:signal-reload'),
 
   connectWorkspace: (agentName: string, slug: string) => ipcRenderer.invoke('workspace:connect', agentName, slug),

--- a/packages/launcher/src/renderer/components/agent-env-fields.tsx
+++ b/packages/launcher/src/renderer/components/agent-env-fields.tsx
@@ -15,11 +15,21 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select"
 import { PasswordInput } from "@renderer/components/ui-kit"
+import { ModelField } from "@renderer/components/model-field"
 import { envFieldHint } from "@renderer/lib/agent-meta"
+import { hasModelPicker } from "@renderer/lib/model-fields"
 import { cn } from "@renderer/lib/utils"
-import type { EnvField } from "@renderer/types"
+import type { EnvField, ModelListPath } from "@renderer/types"
 
 interface Props {
+  /** Agent type id — decides which model list the `*_MODEL` picker loads. */
+  agentType?: string
+  /**
+   * Which auth path this form is: the model picker lists what the endpoint in
+   * THIS form serves ("key") or what the CLI sign-in offers ("login"). Defaults
+   * to "key", since every form that carries key fields is the key path.
+   */
+  modelPath?: ModelListPath
   fields: EnvField[]
   values: Record<string, string>
   onChange: (name: string, value: string) => void
@@ -45,6 +55,8 @@ interface Props {
  * DOM (stage.md §2.2).
  */
 export function AgentEnvFields({
+  agentType,
+  modelPath = "key",
   fields,
   values,
   onChange,
@@ -67,7 +79,17 @@ export function AgentEnvFields({
                   distinct element rather than folding it into the label text. */}
               {f.required && <span className="required"> *</span>}
             </FieldLabel>
-            {f.options?.length ? (
+            {agentType && hasModelPicker(agentType, f.name) ? (
+              <ModelField
+                id={id}
+                agentType={agentType}
+                value={value}
+                env={values}
+                path={modelPath}
+                placeholder={f.placeholder}
+                onChange={(next) => onChange(f.name, next)}
+              />
+            ) : f.options?.length ? (
               <Select
                 value={value}
                 onValueChange={(next: string) => onChange(f.name, next)}
@@ -75,7 +97,8 @@ export function AgentEnvFields({
                 <SelectTrigger id={id} className="w-full">
                   <SelectValue
                     placeholder={
-                      f.placeholder || t("agents.envFields.enterField", { name: f.name })
+                      f.placeholder ||
+                      t("agents.envFields.enterField", { name: f.name })
                     }
                   />
                 </SelectTrigger>
@@ -93,7 +116,8 @@ export function AgentEnvFields({
                 value={value}
                 onChange={(e) => onChange(f.name, e.target.value)}
                 placeholder={
-                  f.placeholder || t("agents.envFields.enterField", { name: f.name })
+                  f.placeholder ||
+                  t("agents.envFields.enterField", { name: f.name })
                 }
               />
             )}

--- a/packages/launcher/src/renderer/components/model-field.test.tsx
+++ b/packages/launcher/src/renderer/components/model-field.test.tsx
@@ -1,0 +1,97 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ModelField } from "./model-field"
+
+type Api = Record<string, ReturnType<typeof vi.fn>>
+
+// cmdk measures its list on mount; jsdom ships no ResizeObserver.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??=
+  ResizeObserverStub as unknown as typeof ResizeObserver
+// …and no scrollIntoView, which cmdk calls to reveal the highlighted item.
+Element.prototype.scrollIntoView ??= function scrollIntoView(): void {}
+
+/**
+ * The list is an offer, never a constraint. A relay that doesn't publish
+ * `/models`, a private deployment name, a model newer than whatever the CLI
+ * cached — all of those have to remain typeable, or the picker becomes a
+ * narrower field than the plain text box it replaced.
+ */
+function installApi(models: Array<{ id: string }> = []): Api {
+  const api: Api = {
+    listModels: vi.fn().mockResolvedValue({ models, source: "api" }),
+  }
+  ;(window as unknown as { api: Api }).api = api
+  return api
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("ModelField", () => {
+  it("keeps an id that is in no list", async () => {
+    installApi([{ id: "gpt-5.6-sol" }])
+    const onChange = vi.fn()
+    render(
+      <ModelField
+        id="m"
+        agentType="codex"
+        value=""
+        env={{}}
+        onChange={onChange}
+      />,
+    )
+    await userEvent.type(screen.getByRole("textbox"), "my-private-deploy")
+    // Controlled input: every keystroke is reported, the last one carries the
+    // final character — nothing filters or rewrites it.
+    expect(onChange).toHaveBeenCalled()
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("y")
+    expect(onChange.mock.calls[0][0]).toBe("m")
+  })
+
+  it("does not fetch a list until the picker is opened", async () => {
+    const api = installApi([{ id: "gpt-5.6-sol" }])
+    render(
+      <ModelField
+        id="m"
+        agentType="codex"
+        value="something-custom"
+        env={{}}
+        onChange={vi.fn()}
+      />,
+    )
+    expect(api.listModels).not.toHaveBeenCalled()
+    expect(screen.getByRole("textbox")).toHaveValue("something-custom")
+  })
+
+  it("passes the auth path through, and writes a picked id back", async () => {
+    const api = installApi([{ id: "gpt-5.6-sol" }])
+    const onChange = vi.fn()
+    render(
+      <ModelField
+        id="m"
+        agentType="codex"
+        value=""
+        env={{ OPENAI_API_KEY: "sk-x" }}
+        path="key"
+        onChange={onChange}
+      />,
+    )
+    await userEvent.click(screen.getByRole("button"))
+    await waitFor(() =>
+      expect(api.listModels).toHaveBeenCalledWith(
+        "codex",
+        { OPENAI_API_KEY: "sk-x" },
+        "key",
+      ),
+    )
+    await userEvent.click(await screen.findByText("gpt-5.6-sol"))
+    expect(onChange).toHaveBeenCalledWith("gpt-5.6-sol")
+  })
+})

--- a/packages/launcher/src/renderer/components/model-field.tsx
+++ b/packages/launcher/src/renderer/components/model-field.tsx
@@ -1,0 +1,214 @@
+import React, { useCallback, useState } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Check,
+  ChevronsUpDown,
+  CircleAlert,
+  KeyRound,
+  PencilLine,
+  RefreshCw,
+  Terminal,
+} from "lucide-react"
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@renderer/components/ui/command"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@renderer/components/ui/input-group"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@renderer/components/ui/popover"
+import { Spinner } from "@renderer/components/ui/spinner"
+import { cn } from "@renderer/lib/utils"
+import type { ModelListPath, ModelListResult } from "@renderer/types"
+
+/**
+ * The model input, with the agent's REAL model list behind it.
+ *
+ * A pinned default in the field spec is how a codex agent ended up calling a
+ * model OpenAI had retired, with no input on screen to change it. So the value
+ * stays free-form (private deployments, relay channels, empty = the CLI's own
+ * default) and the picker offers what the account/endpoint actually serves.
+ * The list is fetched on demand — one request when the user opens the picker,
+ * not on every render of the form.
+ *
+ * `env` is the LIVE form values, not what was saved: the point is that typing a
+ * relay's base URL and key then opening the picker lists that relay's channels.
+ * `path` is which auth form this input sits in, and it decides the source —
+ * without it, a key form on a machine with the CLI signed in was answered by
+ * the CLI's account, which is a confident wrong answer for that endpoint.
+ */
+export function ModelField({
+  id,
+  agentType,
+  value,
+  env,
+  path,
+  placeholder,
+  onChange,
+}: {
+  id: string
+  agentType: string
+  value: string
+  env: Record<string, string>
+  path?: ModelListPath
+  placeholder?: string
+  onChange: (value: string) => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<ModelListResult | null>(null)
+
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      setResult(await window.api.listModels(agentType, env, path))
+    } catch (err: unknown) {
+      setResult({ models: [], source: "none", error: (err as Error).message })
+    } finally {
+      setLoading(false)
+    }
+  }, [agentType, env, path])
+
+  // Fetch on open, and only the first time: reopening the picker to pick a
+  // different model shouldn't re-hit the provider. Refresh is explicit.
+  const onOpenChange = (next: boolean): void => {
+    setOpen(next)
+    if (next && !result && !loading) void load()
+  }
+
+  const hasModels = !!result?.models.length
+  const sourceLabel = result
+    ? t(`agents.envFields.model.source.${result.source}`)
+    : ""
+  // A known reason gets the user's language and names the one thing that would
+  // fix it; anything else falls back to what the provider actually said.
+  const emptyMessage = loading
+    ? t("agents.envFields.model.loading")
+    : result?.code
+      ? t(`agents.envFields.model.${result.code}`)
+      : result?.error || t("agents.envFields.model.empty")
+  // The icon says which kind of "no list" this is at a glance: something to
+  // fill in, somewhere to sign in, or nothing to expect at all.
+  const EmptyIcon =
+    result?.code === "need_key"
+      ? KeyRound
+      : result?.code === "need_login"
+        ? Terminal
+        : result?.code === "no_list"
+          ? PencilLine
+          : CircleAlert
+
+  return (
+    <InputGroup>
+      <InputGroupInput
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder || t("agents.envFields.model.placeholder")}
+      />
+      <InputGroupAddon align="inline-end">
+        <Popover open={open} onOpenChange={onOpenChange}>
+          <PopoverTrigger asChild>
+            <InputGroupButton
+              size="icon-xs"
+              aria-label={t("agents.envFields.model.browse")}
+            >
+              {loading ? <Spinner /> : <ChevronsUpDown />}
+            </InputGroupButton>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-80 p-0">
+            {/* A search box over nothing, and a full-width sentence set in the
+                list's own type, is what an empty picker used to look like. When
+                there is no list there is nothing to search — so the popover
+                becomes one quiet line saying what would produce one. */}
+            {hasModels ? (
+              <Command>
+                <CommandInput
+                  placeholder={t("agents.envFields.model.search")}
+                />
+                <CommandList>
+                  <CommandEmpty>
+                    {t("agents.envFields.model.noMatch")}
+                  </CommandEmpty>
+                  <CommandGroup heading={sourceLabel}>
+                    {result!.models.map((m) => (
+                      <CommandItem
+                        key={m.id}
+                        value={`${m.id} ${m.label || ""}`}
+                        onSelect={() => {
+                          onChange(m.id)
+                          setOpen(false)
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "size-3.5",
+                            m.id === value ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span className="flex min-w-0 flex-col">
+                          <span className="truncate font-mono text-xs">
+                            {m.id}
+                          </span>
+                          {(m.label || m.note) && (
+                            <span
+                              className={cn(
+                                "truncate text-2xs",
+                                m.deprecated
+                                  ? "text-(--warning-text)"
+                                  : "text-(--text-tertiary)",
+                              )}
+                            >
+                              {[m.label, m.note].filter(Boolean).join(" — ")}
+                            </span>
+                          )}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            ) : (
+              <div className="flex items-start gap-2 px-3 py-3 text-xs leading-relaxed text-(--text-tertiary)">
+                {loading ? (
+                  <Spinner className="mt-px size-3.5 shrink-0" />
+                ) : (
+                  <EmptyIcon className="mt-px size-3.5 shrink-0" />
+                )}
+                <span className="min-w-0">{emptyMessage}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-between gap-2 border-t px-2 py-1.5">
+              <span className="truncate text-2xs text-(--text-tertiary)">
+                {loading
+                  ? t("agents.envFields.model.loading")
+                  : t("agents.envFields.model.freeform")}
+              </span>
+              <InputGroupButton
+                size="xs"
+                disabled={loading}
+                onClick={() => void load()}
+              >
+                <RefreshCw />
+                {t("agents.envFields.model.refresh")}
+              </InputGroupButton>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}

--- a/packages/launcher/src/renderer/components/onboarding/steps/api-key-step.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/steps/api-key-step.tsx
@@ -3,10 +3,12 @@ import { Check, Loader2, X } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { CliLoginPanel } from "@renderer/components/agent-auth/cli-login-panel"
+import { ModelField } from "@renderer/components/model-field"
 import { Button } from "@renderer/components/ui/button"
 import { Input } from "@renderer/components/ui/input"
 import { PasswordInput } from "@renderer/components/ui-kit"
 import { envFieldHint, envFieldLabel } from "@renderer/lib/agent-meta"
+import { hasModelPicker } from "@renderer/lib/model-fields"
 import { cn } from "@renderer/lib/utils"
 import type { EnvField, OnboardingAgent } from "@renderer/types"
 
@@ -55,12 +57,22 @@ export function ApiKeyStep({
 
               <div className="flex flex-col gap-5">
                 {secrets.map((field) => (
-                  <EnvRow key={field.name} field={field} auth={auth} />
+                  <EnvRow
+                    key={field.name}
+                    agentType={entry.name}
+                    field={field}
+                    auth={auth}
+                  />
                 ))}
                 {options.length > 0 && (
                   <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
                     {options.map((field) => (
-                      <EnvRow key={field.name} field={field} auth={auth} />
+                      <EnvRow
+                        key={field.name}
+                        agentType={entry.name}
+                        field={field}
+                        auth={auth}
+                      />
                     ))}
                   </div>
                 )}
@@ -127,15 +139,23 @@ export function ApiKeyStep({
 }
 
 function EnvRow({
+  agentType,
   field,
   auth,
 }: {
+  agentType: string
   field: EnvField
   auth: OnboardingAuthApi
 }): React.JSX.Element {
   const { t } = useTranslation()
   const Control = field.password ? PasswordInput : Input
   const id = `onboarding-env-${field.name}`
+  // Model fields get the live picker (the account's / endpoint's own list)
+  // rather than a text box the user has to know the right id for.
+  const model = hasModelPicker(agentType, field.name)
+  // One form here, not tabs: the user is on the key path the moment they type a
+  // key, and on the sign-in path until then. Same rule the save uses.
+  const modelPath = auth.usingApiKeyPath ? "key" : "login"
   // The registry's own `description` is a full sentence written for docs, not
   // a label — it belongs under the input as a hint, with a short translated
   // name up top. See lib/agent-meta.
@@ -148,16 +168,28 @@ function EnvRow({
         token={field.name}
         required={field.required}
       />
-      <Control
-        id={id}
-        value={auth.values[field.name] ?? ""}
-        onChange={(e) => auth.setValue(field.name, e.target.value)}
-        placeholder={
-          field.placeholder ||
-          field.default ||
-          t("onboarding.flow.apiKey.fieldPlaceholder", { name: field.name })
-        }
-      />
+      {model ? (
+        <ModelField
+          id={id}
+          agentType={agentType}
+          value={auth.values[field.name] ?? ""}
+          env={auth.values}
+          path={modelPath}
+          placeholder={field.placeholder}
+          onChange={(next) => auth.setValue(field.name, next)}
+        />
+      ) : (
+        <Control
+          id={id}
+          value={auth.values[field.name] ?? ""}
+          onChange={(e) => auth.setValue(field.name, e.target.value)}
+          placeholder={
+            field.placeholder ||
+            field.default ||
+            t("onboarding.flow.apiKey.fieldPlaceholder", { name: field.name })
+          }
+        />
+      )}
       {hint && (
         <p className="mt-1.5 mb-0 text-2xs leading-relaxed text-(--text-tertiary)">
           {hint}
@@ -200,7 +232,9 @@ function TestStatus({ auth }: { auth: OnboardingAuthApi }): React.JSX.Element {
           )}
         </>
       ) : (
-        <span className="truncate">{t("onboarding.flow.apiKey.notTested")}</span>
+        <span className="truncate">
+          {t("onboarding.flow.apiKey.notTested")}
+        </span>
       )}
     </div>
   )

--- a/packages/launcher/src/renderer/components/onboarding/use-onboarding-auth.ts
+++ b/packages/launcher/src/renderer/components/onboarding/use-onboarding-auth.ts
@@ -7,6 +7,7 @@ import {
 } from "@renderer/components/agent-auth/use-cli-login"
 import type { ToastType } from "@renderer/hooks/useToast"
 import { capture } from "@renderer/lib/analytics"
+import { hasModelPicker } from "@renderer/lib/model-fields"
 import type { EnvField, OnboardingAgent } from "@renderer/types"
 
 export interface TestResult {
@@ -188,6 +189,23 @@ export function useOnboardingAuth({
     if (!usingApiKeyPath) {
       // login / none modes (no key entered): never block. If the agent isn't
       // actually authed yet, it'll surface when the agent is started later.
+      // The model is NOT a credential though — someone signing in through the
+      // CLI can still pick one, and dropping it here is how a codex agent ended
+      // up on the CLI's own (retired) default with no way to change it. Save
+      // just that field; saveAgentEnv merges, so nothing else is touched.
+      const models: Record<string, string> = {}
+      for (const f of entry.envFields) {
+        if (!hasModelPicker(entry.name, f.name)) continue
+        const v = (values[f.name] || "").trim()
+        if (v) models[f.name] = v
+      }
+      if (Object.keys(models).length) {
+        try {
+          await window.api.saveAgentEnv(entry.name, models)
+        } catch (e) {
+          showToast((e as Error).message, "error")
+        }
+      }
       onSaved()
       return
     }

--- a/packages/launcher/src/renderer/components/setup-wizard/setup-auth-step.tsx
+++ b/packages/launcher/src/renderer/components/setup-wizard/setup-auth-step.tsx
@@ -4,7 +4,13 @@ import { useTranslation } from "react-i18next"
 
 import { AgentEnvFields } from "@renderer/components/agent-env-fields"
 import type { CliLoginApi } from "@renderer/components/agent-auth/use-cli-login"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@renderer/components/ui/tabs"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@renderer/components/ui/tabs"
+import { hasModelPicker } from "@renderer/lib/model-fields"
 import type { EnvField } from "@renderer/types"
 
 import { WizardCliCard } from "./wizard-cli-card"
@@ -73,10 +79,38 @@ export function SetupAuthStep({
     />
   ) : null
 
+  // The model is a setting of both paths, not of the key — an agent signed in
+  // through its CLI still has to be told which model to run. Its list here comes
+  // from the sign-in, not from the (empty) key form beside it.
+  const modelFields = fields.filter((f) => hasModelPicker(agentType, f.name))
+  const cliBlock =
+    cli && modelFields.length > 0 ? (
+      <div className="flex flex-col gap-4">
+        {cli}
+        <div className="border-t pt-4">
+          <AgentEnvFields
+            agentType={agentType}
+            modelPath="login"
+            fields={modelFields}
+            values={values}
+            onChange={(name, value) => onChange({ ...values, [name]: value })}
+            idPrefix="setup-env-cli"
+          />
+          <p className="mt-2 mb-0 text-2xs text-muted-foreground">
+            {t("agents.configureDialog.modelWithLogin")}
+          </p>
+        </div>
+      </div>
+    ) : (
+      cli
+    )
+
   const keyForm =
     fields.length > 0 ? (
       <div className="flex flex-col gap-4">
         <AgentEnvFields
+          agentType={agentType}
+          modelPath="key"
           fields={fields}
           values={values}
           onChange={(name, value) => onChange({ ...values, [name]: value })}
@@ -115,7 +149,7 @@ export function SetupAuthStep({
       </div>
 
       {!dual ? (
-        (cli ?? keyForm)
+        (cliBlock ?? keyForm)
       ) : (
         <Tabs value={tab} onValueChange={(v) => onTabChange(v as AuthTab)}>
           <TabsList className="grid w-full grid-cols-2">
@@ -129,7 +163,7 @@ export function SetupAuthStep({
             </TabsTrigger>
           </TabsList>
           <TabsContent value="cli" className="pt-2">
-            {cli}
+            {cliBlock}
           </TabsContent>
           <TabsContent value="key" className="pt-2">
             {keyForm}

--- a/packages/launcher/src/renderer/i18n/locales/en/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agents.json
@@ -162,7 +162,8 @@
     "test": {
       "okResult": "OK — model: {{model}}, response: \"{{response}}\"",
       "unknownError": "Unknown error"
-    }
+    },
+    "modelWithLogin": "Optional — leave empty to use the CLI's own default model."
   },
   "loginStatus": {
     "checking": "Checking sign-in…",
@@ -324,7 +325,26 @@
     "cancel": "Cancel"
   },
   "envFields": {
-    "enterField": "Enter {{name}}"
+    "enterField": "Enter {{name}}",
+    "model": {
+      "placeholder": "Default model",
+      "browse": "Choose a model",
+      "search": "Search models…",
+      "loading": "Loading models…",
+      "empty": "No models to show.",
+      "noMatch": "No model matches that.",
+      "refresh": "Refresh",
+      "freeform": "Or type any id your provider serves",
+      "source": {
+        "cli": "From your signed-in account",
+        "api": "From this endpoint",
+        "builtin": "Built-in list — may be out of date",
+        "none": "No list available"
+      },
+      "need_key": "Enter an API key above to load this endpoint's models.",
+      "need_login": "Sign in above to load the models your account can run.",
+      "no_list": "This sign-in publishes no model list — type the model id."
+    }
   },
   "unmanaged": {
     "title": "Installed outside the launcher",

--- a/packages/launcher/src/renderer/i18n/locales/zh/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agents.json
@@ -162,7 +162,8 @@
     "test": {
       "okResult": "成功 — 模型：{{model}}，响应：\"{{response}}\"",
       "unknownError": "未知错误"
-    }
+    },
+    "modelWithLogin": "可留空，留空时使用命令行工具自带的默认模型。"
   },
   "loginStatus": {
     "checking": "正在检查登录状态…",
@@ -324,7 +325,26 @@
     "cancel": "取消"
   },
   "envFields": {
-    "enterField": "请输入 {{name}}"
+    "enterField": "请输入 {{name}}",
+    "model": {
+      "placeholder": "默认模型",
+      "browse": "选择模型",
+      "search": "搜索模型…",
+      "loading": "正在获取模型…",
+      "empty": "没有可显示的模型。",
+      "noMatch": "没有匹配的模型。",
+      "refresh": "刷新",
+      "freeform": "也可直接填写服务商支持的任意模型 id",
+      "source": {
+        "cli": "来自你已登录的账号",
+        "api": "来自当前接口地址",
+        "builtin": "内置列表，可能已过时",
+        "none": "暂无可用列表"
+      },
+      "need_key": "先在上方填写 API Key，即可加载该接口地址提供的模型。",
+      "need_login": "先在上方登录，即可加载你的账号可用的模型。",
+      "no_list": "这种登录方式不提供模型列表，请直接填写模型 id。"
+    }
   },
   "unmanaged": {
     "title": "安装在 launcher 管理范围之外",

--- a/packages/launcher/src/renderer/lib/model-fields.ts
+++ b/packages/launcher/src/renderer/lib/model-fields.ts
@@ -1,0 +1,30 @@
+/**
+ * Which env fields hold a model id, and which agents the launcher can list
+ * models for.
+ *
+ * The list itself is resolved in the main process (main/agents/model-catalog) —
+ * this is only the renderer's answer to "should this input get a model picker".
+ * Keep MODEL_LIST_AGENTS in step with MODEL_SOURCES over there: an agent
+ * missing here simply gets the plain text input it had before.
+ */
+
+/** Every model field we ship is named `<PROVIDER>_MODEL`. */
+export function isModelField(name: string): boolean {
+  return /_MODEL$/.test(name)
+}
+
+const MODEL_LIST_AGENTS = new Set([
+  "codex",
+  "cursor",
+  "claude",
+  "gemini",
+  "kimi",
+  "deepseek",
+  "openclaw",
+  "opencode",
+  "pi",
+])
+
+export function hasModelPicker(agentType: string, fieldName: string): boolean {
+  return isModelField(fieldName) && MODEL_LIST_AGENTS.has(agentType)
+}

--- a/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
@@ -26,6 +26,7 @@ import { useCliLogin } from "@renderer/components/agent-auth/use-cli-login"
 import { ConfigureWorkDir } from "./configure-workdir"
 import { AgentEnvFields } from "@renderer/components/agent-env-fields"
 import { isCliLoginDetected } from "@renderer/lib/agent-auth"
+import { hasModelPicker } from "@renderer/lib/model-fields"
 import { capture } from "@renderer/lib/analytics"
 import type { EnvField } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
@@ -351,6 +352,13 @@ export function ConfigureDialog({
     }
   }
 
+  // The model belongs to BOTH auth paths. It used to live only in the API-key
+  // form, so a codex agent signed in with a ChatGPT account had no model input
+  // anywhere — it ran on the CLI's built-in default (`gpt-5-codex`, since
+  // retired) and every message failed with nothing on screen to change. The
+  // picker reads the account's own model list, so the CLI tab can offer it too.
+  const modelFields = fields.filter((f) => hasModelPicker(agentType, f.name))
+
   // Shared by the tabbed (dual-auth) and the login-only layouts below.
   const cliLoginBlock = loginCmd ? (
     <CliLoginBlock
@@ -446,9 +454,25 @@ export function ConfigureDialog({
                 </TabsList>
                 <TabsContent value="cli" className="pt-1">
                   {cliLoginBlock}
+                  {modelFields.length > 0 && (
+                    <div className="mt-4 border-t pt-4">
+                      <AgentEnvFields
+                        agentType={agentType}
+                        modelPath="login"
+                        fields={modelFields}
+                        values={values}
+                        onChange={setFieldValue}
+                        idPrefix="agent-config-cli"
+                      />
+                      <p className="hint mt-2 mb-0">
+                        {t("agents.configureDialog.modelWithLogin")}
+                      </p>
+                    </div>
+                  )}
                 </TabsContent>
                 <TabsContent value="key" className="pt-1">
                   <AgentEnvFields
+                    agentType={agentType}
                     fields={fields}
                     values={values}
                     onChange={setFieldValue}
@@ -460,6 +484,7 @@ export function ConfigureDialog({
               cliLoginBlock
             ) : (
               <AgentEnvFields
+                agentType={agentType}
                 fields={fields}
                 values={values}
                 onChange={setFieldValue}

--- a/packages/launcher/src/renderer/pages/install/detail/detail-config.test.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-config.test.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+
+import { DetailConfig } from "./detail-config"
+
+type Api = Record<string, ReturnType<typeof vi.fn>>
+
+/**
+ * The marketplace page is where the install happens, so its auth card mounts
+ * BEFORE the CLI exists. These cover the two ways its verdict used to get
+ * stuck: probing a CLI that isn't there yet, and never looking again once it
+ * is.
+ */
+function installApi(overrides: Partial<Api> = {}): Api {
+  const api: Api = {
+    refreshLogin: vi.fn().mockResolvedValue({ logged_in: true, ready: true }),
+    // useCliLogin registers a listener on mount and unsubscribes on unmount.
+    onCliLoginEvent: vi.fn().mockReturnValue(() => {}),
+    cancelCliLogin: vi.fn().mockResolvedValue(undefined),
+    saveAgentEnv: vi.fn().mockResolvedValue(undefined),
+    testLLM: vi.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  }
+  ;(window as unknown as { api: Api }).api = api
+  return api
+}
+
+const props = {
+  agentName: "codex",
+  fields: [],
+  values: {},
+  onChange: vi.fn(),
+  loginCommand: "codex login",
+  showToast: vi.fn(),
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("DetailConfig sign-in card", () => {
+  it("does not probe a CLI that is not installed yet", async () => {
+    const api = installApi()
+    render(<DetailConfig {...props} installed={false} />)
+    await screen.findByText("Not signed in")
+    expect(api.refreshLogin).not.toHaveBeenCalled()
+  })
+
+  it("probes once the install finishes, instead of keeping the old verdict", async () => {
+    const api = installApi()
+    const { rerender } = render(<DetailConfig {...props} installed={false} />)
+    await screen.findByText("Not signed in")
+
+    rerender(<DetailConfig {...props} installed={true} />)
+    await waitFor(() => expect(api.refreshLogin).toHaveBeenCalledWith("codex"))
+    expect(await screen.findByText("Signed in")).toBeInTheDocument()
+  })
+
+  it("re-reads the sign-in when the setup wizard closes", async () => {
+    const api = installApi({
+      refreshLogin: vi
+        .fn()
+        .mockResolvedValue({ logged_in: false, ready: false }),
+    })
+    const { rerender } = render(
+      <DetailConfig {...props} installed={true} authRefresh={0} />,
+    )
+    await waitFor(() => expect(api.refreshLogin).toHaveBeenCalledTimes(1))
+
+    // The wizard's terminal login reports nothing back, so the close is the
+    // only signal this card gets.
+    api.refreshLogin.mockResolvedValue({ logged_in: true, ready: true })
+    rerender(<DetailConfig {...props} installed={true} authRefresh={1} />)
+    await waitFor(() => expect(api.refreshLogin).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText("Signed in")).toBeInTheDocument()
+  })
+})

--- a/packages/launcher/src/renderer/pages/install/detail/detail-config.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-config.tsx
@@ -23,6 +23,14 @@ interface Props {
   onChange: (next: Record<string, string>) => void
   /** Non-null when the agent can sign in through its own CLI. */
   loginCommand: string | null
+  /** Whether the CLI is on disk — a sign-in probe is only answerable if it is. */
+  installed: boolean
+  /**
+   * Bumped whenever something outside this card may have changed the sign-in
+   * (today: the setup wizard closing). The in-app login broadcasts its own
+   * success to every card, but the terminal fallback reports nothing back.
+   */
+  authRefresh?: number
   showToast: (msg: string, type?: ToastType) => void
 }
 
@@ -43,13 +51,15 @@ export function DetailConfig({
   values,
   onChange,
   loginCommand,
+  installed,
+  authRefresh = 0,
   showToast,
 }: Props): React.JSX.Element | null {
   const { t } = useTranslation()
   const [loggedIn, setLoggedIn] = useState<boolean | null>(null)
-  const [loginPhase, setLoginPhase] = useState<"idle" | "awaiting" | "checking">(
-    "idle",
-  )
+  const [loginPhase, setLoginPhase] = useState<
+    "idle" | "awaiting" | "checking"
+  >("idle")
   const [tab, setTab] = useState<"cli" | "key">(loginCommand ? "cli" : "key")
 
   const login = useCliLogin({
@@ -63,9 +73,27 @@ export function DetailConfig({
     if (login.phase === "terminal") setLoginPhase("awaiting")
   }, [login.phase])
 
-  // Probe once so the card opens on the truth rather than "not signed in".
+  // Probe so the card opens on the truth rather than "not signed in" — and
+  // probe AGAIN whenever the answer could have changed.
+  //
+  // This is the page the install happens on, so the first probe usually runs
+  // while the CLI is not on disk yet: `codex login status` can't be spawned,
+  // the verdict comes back unknown, and `?? ready` turns that into a flat "not
+  // signed in". With the old mount-only effect that verdict then stood for the
+  // rest of the visit — the setup wizard on top of this very page would read
+  // "signed in" from a fresh probe while the card underneath still said the
+  // opposite. Re-running on `installed` covers the install; `authRefresh`
+  // covers a sign-in that finished somewhere this card can't hear about (the
+  // terminal fallback reports nothing back, unlike the in-app login, whose
+  // success event every card receives).
   useEffect(() => {
     if (!loginCommand) return
+    // Not on disk ⇒ there is nothing to be signed in to, and spawning a probe
+    // would only burn its timeout. Say so instead of spinning.
+    if (!installed) {
+      setLoggedIn(false)
+      return
+    }
     let cancelled = false
     window.api
       .refreshLogin(agentName)
@@ -78,7 +106,7 @@ export function DetailConfig({
     return () => {
       cancelled = true
     }
-  }, [agentName, loginCommand])
+  }, [agentName, loginCommand, installed, authRefresh])
 
   async function confirmLogin(): Promise<void> {
     setLoginPhase("checking")

--- a/packages/launcher/src/renderer/pages/install/detail/detail-key-form.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-key-form.tsx
@@ -97,6 +97,8 @@ export function DetailKeyForm({
   return (
     <div className="flex flex-col gap-4">
       <AgentEnvFields
+        agentType={agentName}
+        modelPath="key"
         fields={fields}
         values={values}
         onChange={(name, value) => onChange({ ...values, [name]: value })}

--- a/packages/launcher/src/renderer/pages/install/detail/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/index.tsx
@@ -26,6 +26,8 @@ interface Props {
   onBack: () => void
   onAfterInstall: (entry: CatalogEntry) => void
   onOpenWizard?: (entry: CatalogEntry) => void
+  /** Bumped when the setup wizard closes — see DetailConfig.authRefresh. */
+  authRefresh?: number
   showToast: (msg: string, type?: ToastType) => void
 }
 
@@ -39,6 +41,7 @@ export default function AgentDetail({
   onBack,
   onAfterInstall,
   onOpenWizard,
+  authRefresh,
   showToast,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
@@ -146,6 +149,8 @@ export default function AgentDetail({
                 values={detail.envValues}
                 onChange={detail.setEnvValues}
                 loginCommand={entry.check_ready?.login_command || null}
+                installed={!!entry.installed}
+                authRefresh={authRefresh}
                 showToast={showToast}
               />
             </DetailSection>

--- a/packages/launcher/src/renderer/pages/install/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/index.tsx
@@ -37,6 +37,8 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
   const { t } = useTranslation()
   const [selectedName, setSelectedName] = useState<string | null>(null)
   const [wizardEntry, setWizardEntry] = useState<CatalogEntry | null>(null)
+  // Bumped when the wizard closes, so the detail page re-reads the sign-in.
+  const [authRefresh, setAuthRefresh] = useState(0)
 
   const market = useMarketplace()
   const { prefs, setView, setSort, setCategory } = market.prefs
@@ -127,6 +129,7 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
                 actions.maybeOpenWizard(e)
             }}
             onOpenWizard={setWizardEntry}
+            authRefresh={authRefresh}
             showToast={showToast}
           />
         </div>
@@ -136,6 +139,10 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
           onClose={() => {
             setWizardEntry(null)
             market.refreshAgentsStore()
+            // The wizard is where a sign-in usually happens, and its terminal
+            // fallback reports nothing back — so tell the page underneath to
+            // re-read the sign-in instead of leaving it on a stale verdict.
+            setAuthRefresh((n) => n + 1)
           }}
           showToast={showToast}
         />

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -61,6 +61,30 @@ export interface Agent {
   hasCli?: boolean
 }
 
+/** One model an agent can be pointed at (main: agents/model-catalog). */
+export interface ModelChoice {
+  id: string
+  label?: string
+  note?: string
+  deprecated?: boolean
+}
+
+/** Where the model list came from — the UI says so rather than implying truth. */
+export interface ModelListResult {
+  models: ModelChoice[]
+  source: "cli" | "api" | "builtin" | "none"
+  error?: string
+  /** Translatable reason for an empty list; `error` is the raw fallback. */
+  code?: "need_key" | "need_login" | "no_list"
+}
+
+/**
+ * Which auth path a model picker is attached to. The list follows the path: the
+ * API-key form lists what that endpoint serves even when the same agent is
+ * signed in through its CLI on this machine.
+ */
+export type ModelListPath = "key" | "login"
+
 export interface EnvField {
   name: string
   description: string
@@ -492,6 +516,11 @@ declare global {
       getAgentInstanceEnv(name: string): Promise<Record<string, string>>
       saveAgentInstanceEnv(name: string, env: Record<string, string>): Promise<unknown>
       testLLM(env: Record<string, string>): Promise<{ success: boolean; model?: string; response?: string; error?: string }>
+      listModels(
+        agentType: string,
+        env: Record<string, string>,
+        path?: ModelListPath,
+      ): Promise<ModelListResult>
       signalReload(): Promise<unknown>
       connectWorkspace(agentName: string, slug: string): Promise<unknown>
       disconnectWorkspace(agentName: string): Promise<unknown>


### PR DESCRIPTION
## Why

Every agent shipped one model id baked into its env field as a `default`, and those ids age out. `gpt-5-codex` is no longer in OpenAI's line-up, so a codex agent signed in with a ChatGPT account ran every message against a model its account cannot serve — and the model field only existed in the **API-key** form, so a user on the sign-in path had nothing on screen to change.

## What

Model lists are now **read**, per agent, from whichever source can actually answer (`src/main/agents/model-catalog.ts`):

| Source | Used for |
|---|---|
| The CLI's own list | codex's `~/.codex/models_cache.json` (account line-up, carrying the backend's own "being retired, use X" notices); `cursor-agent --list-models` |
| The provider endpoint | `/v1/models` (OpenAI-compatible), Anthropic `/v1/models` (official → `x-api-key`, relay → `Bearer`), Gemini `/v1beta/models` — against the base URL **in the form**, so a relay answers for its own channels |
| A built-in list | Only where nothing can be probed (Claude subscription sign-in), and labelled as such in the UI |

Covered agents: codex, cursor, claude, gemini, kimi, deepseek, openclaw, opencode, pi.

**The auth path decides the source, outright.** The API-key form never answers from the CLI's signed-in account — that is a convincing wrong answer for a relay — and the sign-in form ignores a key sitting in the form. Cursor has no endpoint to query, so its CLI serves both paths: on the key path it is run with the form's key, passed through the child env rather than argv (no secret in the process list).

**The input stays free-form.** A private deployment name, or a channel a relay does not publish, is still typeable; empty still means "the CLI's own default". Nothing validates the typed value against the list.

Pinned `default:` ids are dropped from codex/claude/gemini (dual-auth, so the model is optional) and openclaw/opencode (whose base URL can point anywhere, making `gpt-4o` a guess). The stale `gpt-5-codex` probe model in Pi's connection test goes with them.

## Also in here

- **The marketplace page no longer claims you're signed out.** `DetailConfig` probed the sign-in once at mount — which on that page is usually *before* the agent is installed, so the probe could not run and the verdict stuck for the rest of the visit. The setup wizard opened from the same page would then say "Signed in" one panel above a card saying the opposite. It now re-reads when the install finishes and when the wizard closes.
- Cursor's sign-in no longer wipes `CURSOR_MODEL` along with the key (only the key conflicts with the login session); otherwise a picked model could never stick.
- Empty-picker states are a single quiet line with a reason-specific icon instead of a search box over nothing.

## Testing

- `npm run typecheck`, `npm test` (325 passing), `npm run build`, `npm run check:changelog` — all green.
- New: `model-catalog.test.ts` (source selection per auth path, codex cache parsing incl. deprecation flags, cursor credential passthrough, relay vs official Anthropic headers), `model-field.test.tsx` (free-form input is never constrained by the list; no fetch until the picker opens), `detail-config.test.tsx` (re-probe after install / after the wizard closes).
- UI not self-verified — please exercise the codex Configure dialog and the marketplace page.

Ships as launcher 0.9.15 with release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
