### PR TITLE
fix(launcher): terminal sign-in on macOS, and Gemini's model list + sign-in state

### DIFF
--- a/packages/launcher/changelog/0.9.16.json
+++ b/packages/launcher/changelog/0.9.16.json
@@ -1,0 +1,50 @@
+{
+  "version": "0.9.16",
+  "date": "2026-08-19",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "Signing in through the terminal works again on macOS",
+        "zh": "macOS 上通过终端登录恢复正常"
+      },
+      "description": {
+        "en": "Every agent that signs in through a terminal window opened one that refused the command outright: the shell answered \"export: not valid in this context\" and stopped, so no sign-in ever started. The launcher was handing the terminal a list of program folders without quoting it, and one of those folders — the launcher's own, inside \"OpenAgents Launcher.app\" — has a space in its name, which the shell read as the end of the list. It also kept the truncated half, leaving that terminal window unable to find ordinary commands for the rest of its life. The command is now quoted properly, the terminal comes to the front on its own, and the folders it needs stay set in that window after the sign-in finishes.",
+        "zh": "所有需要打开终端登录的智能体，打开的终端都会直接拒绝执行命令：shell 报出「export: not valid in this context」后中止，登录根本无法开始。原因是启动器把一串程序目录交给终端时没有加引号，而其中一个目录——启动器自身所在的「OpenAgents Launcher.app」——名字里带空格，shell 就把空格当成了这串目录的结尾；更糟的是它还保留了被截断的前半段，导致那个终端窗口此后连普通命令都找不到。现在命令已正确加引号，终端会自动切到前台，登录结束后这些目录也仍然保留在该窗口中，可以继续使用命令行工具。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "The model picker works on relays that passed Test connection",
+        "zh": "能通过「测试连接」的中转地址，模型列表也能拉出来了"
+      },
+      "description": {
+        "en": "Configuring Gemini against a relay produced two answers at once: Test connection said the model replied, while the model picker right above it said HTTP 401, invalid token. Both were true. A relay serves the chat call the way Google does — the key rides in the URL — but guards its model list the way OpenAI does, behind an Authorization header, and the launcher only ever asked the Google way. It now asks again the other way when the first attempt is refused, so the relay's own channel names show up in the list. Google's own endpoint is never asked that way: it reads that header as a different kind of credential and would reject a normal API key.",
+        "zh": "把 Gemini 配到中转地址时，界面同时给出两个相反的答案：「测试连接」说模型已响应，正上方的模型列表却报 HTTP 401「无效的令牌」。两边都没说错——中转站的对话接口沿用 Google 的方式（密钥放在网址里），模型列表却沿用 OpenAI 的方式（密钥放在请求头里），而启动器一直只按 Google 的方式去问。现在第一次被拒后会换另一种方式再问一次，中转站自己的渠道名就能出现在列表里了。对 Google 官方地址不会这样重试：它会把那个请求头当成另一种凭证，反而拒绝正常的 API 密钥。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "The model list scrolls with the mouse wheel again",
+        "zh": "模型列表恢复用滚轮滚动"
+      },
+      "description": {
+        "en": "The list could only be moved by dragging its scrollbar — the wheel did nothing while the pointer was over the models themselves. And when the provider refused the request, its error was printed as one unbroken line that ran out past the edge of the panel and over the page behind it. The list takes the wheel now, and a provider's error is trimmed to the sentence it actually contains, wrapped, and kept inside the panel.",
+        "zh": "模型列表只能靠拖动滚动条移动——鼠标停在模型上滚滚轮毫无反应。另外服务商拒绝请求时，报错会被原样打印成不换行的一长串，直接冲出面板压到后面的页面上。现在列表可以用滚轮滚动，服务商的报错也只保留其中真正的那句话，并且会换行、留在面板内。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Signing in to Gemini with a Google account is finally recognised",
+        "zh": "Gemini 用 Google 账号登录后终于能被识别"
+      },
+      "description": {
+        "en": "The Gemini panel said \"Not signed in\" no matter how many times you signed in. It was watching for a token file that current versions of the CLI no longer write — they keep the token in the system keychain instead — so the answer was always the same. It now reads the account the CLI records for the signed-in address, which is written on every sign-in and cleared on sign-out, and falls back to the old file for older versions. And because the CLI remembers the last auth method it was given — going straight to chat when that was an API key, with the Google sign-in nowhere in sight — the terminal it opens now says up front to type /auth and pick the Google option.",
+        "zh": "Gemini 面板无论登录多少次都显示「未登录」。它一直在等一个当前版本的命令行工具已经不再写入的令牌文件——新版把令牌存进了系统钥匙串——所以答案永远不变。现在改为读取命令行工具记录的已登录账号，这份记录每次登录都会写入、退出登录时会清空，旧版本则仍回退到原来那个文件。另外，命令行工具会记住上次使用的认证方式——如果那次是 API 密钥，它就直接进入对话界面，根本看不到 Google 登录的入口——所以现在打开的终端会先说明：输入 /auth 并选择 Google 登录。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.8",
+  "version": "0.9.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.9.8",
+      "version": "0.9.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
-        "@openagents-org/agent-launcher": "0.2.166",
+        "@openagents-org/agent-launcher": "0.2.169",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -1744,9 +1744,9 @@
       }
     },
     "node_modules/@openagents-org/agent-launcher": {
-      "version": "0.2.166",
-      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.166.tgz",
-      "integrity": "sha512-63lYbJaX29FvUQgu2NG7k2xLz56FuDttSHYyJn4YUYbwIMsXZaUHPVekI6ZGMtjlk7xOrO9bJ6BrkWO6iYv+Ug==",
+      "version": "0.2.169",
+      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.169.tgz",
+      "integrity": "sha512-X9IlMbgDbY2A+DSRSlMMjqmJulCLQ9kSmCUl56txsCdeVaP16nhKDSSXyOTNX/1spnb+DG3olhVhLwoL85SSwg==",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
-    "@openagents-org/agent-launcher": "0.2.166",
+    "@openagents-org/agent-launcher": "0.2.169",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -549,6 +549,15 @@ export class AgentManager extends EventEmitter {
    * when it has none. Both login paths read it from here so the in-app flow and
    * the terminal fallback can never drift apart.
    */
+  /**
+   * A line to print in the login terminal before the command, when this CLI's
+   * sign-in isn't where the user would look for it (Gemini's `/auth`). Null for
+   * everything else.
+   */
+  loginHintFor(type: string): string | null {
+    return this._login.specFor(type)?.terminalHint || null
+  }
+
   loginCommandFor(type: string): string | null {
     const spec = this._login.specFor(type)
     if (spec) return spec.loginCommand

--- a/packages/launcher/src/main/agents/auth-specs.ts
+++ b/packages/launcher/src/main/agents/auth-specs.ts
@@ -330,10 +330,12 @@ export interface HostedLoginSpec {
   loggedInPattern?: RegExp
   apiKeyEnv?: string
   // Some CLIs (Gemini) have no non-interactive `status` command — auth is an
-  // interactive TUI flow that just writes a credentials file. When set, sign-in
-  // is detected by this file's existence (relative to the home dir) INSTEAD of
-  // spawning `statusArgs` (which for those CLIs would launch the TUI and hang).
-  credsFile?: string
+  // interactive TUI flow that just leaves evidence on disk. When set, sign-in is
+  // read from these files INSTEAD of spawning `statusArgs` (which for those CLIs
+  // would launch the TUI and hang). Paths are relative to the home dir and are
+  // tried in order; the first hit wins. `key` names a JSON field that has to
+  // hold a value — without it the file only has to exist.
+  credsFiles?: Array<{ path: string; key?: string }>
   // Env vars wiped when the user signs in via the browser flow. Hosted-login
   // agents have no env UI (getEnvFields → []), so any saved value is stale
   // leftover that overrides the login session — e.g. an invalid CURSOR_API_KEY
@@ -341,6 +343,12 @@ export interface HostedLoginSpec {
   // chat ("API key is invalid"). Clearing them lets the CLI use its own login +
   // account defaults.
   loginClearsEnv?: string[]
+  /**
+   * One line printed in the terminal above the login command, for a CLI whose
+   * sign-in isn't where the user would look for it. Plain ASCII — it is echoed
+   * by a shell script, not rendered by the app.
+   */
+  terminalHint?: string
 }
 
 /**
@@ -468,18 +476,34 @@ export const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
     loggedOutPattern: AMP_LOGGED_OUT,
   },
   gemini: {
-    // Gemini CLI (v0.46) has NO `login`/`auth`/`status` subcommand — auth is the
+    // Gemini CLI has NO `login`/`auth`/`status` subcommand — auth is the
     // interactive "Login with Google" OAuth flow reached by launching the CLI
     // (its `/auth` picker), or a GEMINI_API_KEY. So the login command is bare
-    // `gemini` (on first run it prompts for the auth method and opens the browser
-    // sign-in), and sign-in is detected by the OAuth token cache it writes at
-    // ~/.gemini/oauth_creds.json — there is no status command to spawn, and
-    // spawning bare `gemini` for a probe would launch its TUI and hang. A saved
-    // GEMINI_API_KEY counts as configured credentials separately, so readiness is
-    // "installed AND (signed in OR has a key)" like the other dual-login agents.
+    // `gemini`, and sign-in has to be read off disk: there is no status command
+    // to spawn, and spawning bare `gemini` for a probe would launch its TUI and
+    // hang. A saved GEMINI_API_KEY counts as configured credentials separately,
+    // so readiness is "installed AND (signed in OR has a key)" like the other
+    // dual-login agents.
+    //
+    // The evidence is `google_accounts.json`, which the CLI writes with the
+    // signed-in address on every successful OAuth flow and nulls on sign-out.
+    // It used to be `oauth_creds.json`, and that is the bug this replaces:
+    // current builds keep the token in the OS keychain and never write that
+    // file, so the panel said "not signed in" no matter how many times the user
+    // signed in. It stays as the fallback for older CLIs, which do write it.
     loginCommand: "gemini",
     statusArgs: [],
-    credsFile: ".gemini/oauth_creds.json",
+    credsFiles: [
+      { path: ".gemini/google_accounts.json", key: "active" },
+      { path: ".gemini/oauth_creds.json" },
+    ],
+    // Gemini remembers the auth method it was last given in its own settings
+    // file, and when that says "gemini-api-key" it goes straight to the chat
+    // screen — the Google sign-in never runs and nothing on this panel ever
+    // changes. There is no flag to force it (no `login` subcommand, no
+    // --auth-type), so the terminal says the one thing that gets there.
+    terminalHint:
+      "To sign in with your Google account, type /auth in Gemini and pick the Google option.",
   },
 }
 

--- a/packages/launcher/src/main/agents/login-probe.test.ts
+++ b/packages/launcher/src/main/agents/login-probe.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
-import { loginVerdict } from "./login-probe"
+import { credsVerdict, loginVerdict } from "./login-probe"
 import { DUAL_LOGIN_AGENTS, HOSTED_LOGIN_AGENTS } from "./auth-specs"
 
 /**
@@ -50,5 +53,58 @@ describe("loginVerdict", () => {
 
   it("stays unknown for a spec that declares no pattern at all", () => {
     expect(loginVerdict({}, "anything", 0)).toBe(null)
+  })
+})
+
+describe("credsVerdict — Gemini's sign-in, read off disk", () => {
+  const gemini = DUAL_LOGIN_AGENTS.gemini
+  let home: string
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-home-"))
+    fs.mkdirSync(path.join(home, ".gemini"))
+  })
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true })
+  })
+
+  const accounts = (body: unknown): void =>
+    fs.writeFileSync(
+      path.join(home, ".gemini", "google_accounts.json"),
+      JSON.stringify(body),
+    )
+
+  it("reads the signed-in Google address as signed in", () => {
+    accounts({ active: "ada@example.com", old: [] })
+    expect(credsVerdict(gemini, home)).toBe(true)
+  })
+
+  it("does not count the file's existence — a signed-out account nulls it", () => {
+    // The exact shape the CLI leaves behind after a sign-out, and what a
+    // never-signed-in install has sat at the whole time.
+    accounts({ active: null, old: [] })
+    expect(credsVerdict(gemini, home)).toBe(false)
+  })
+
+  it("still recognises an older CLI's token file", () => {
+    // Current builds keep the token in the OS keychain and never write this,
+    // which is the regression the accounts file replaces.
+    fs.writeFileSync(
+      path.join(home, ".gemini", "oauth_creds.json"),
+      '{"access_token":"x"}',
+    )
+    expect(credsVerdict(gemini, home)).toBe(true)
+  })
+
+  it("says signed out when the CLI has left nothing at all", () => {
+    expect(credsVerdict(gemini, home)).toBe(false)
+  })
+
+  it("stays unknown when the evidence is there but unreadable", () => {
+    fs.writeFileSync(
+      path.join(home, ".gemini", "google_accounts.json"),
+      "{ this is not json",
+    )
+    expect(credsVerdict(gemini, home)).toBe(null)
   })
 })

--- a/packages/launcher/src/main/agents/login-probe.ts
+++ b/packages/launcher/src/main/agents/login-probe.ts
@@ -35,6 +35,37 @@ import { windowsExecutable } from "../win-exec"
  * from "matched nothing because the CLI fell over": only a clean exit is
  * allowed to stand in for the absent pattern.
  */
+/**
+ * Sign-in read off disk, for a CLI whose auth is an interactive TUI flow with
+ * no status command to spawn (Gemini — spawning bare `gemini` for a probe would
+ * launch its TUI and hang). Each entry is tried in order and the first hit wins.
+ *
+ * Absent evidence is a real "signed out", not an unknown: only a file we can
+ * see but cannot read leaves the verdict null, because that is the one case
+ * where the user may well be signed in and we simply cannot tell.
+ */
+export function credsVerdict(
+  spec: HostedLoginSpec,
+  homeDir: string = os.homedir(),
+): boolean | null {
+  let value: boolean | null = false
+  for (const c of spec.credsFiles || []) {
+    const file = path.join(homeDir, c.path)
+    try {
+      if (!fs.existsSync(file)) continue
+      if (!c.key) return true
+      const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf-8"))
+      const field = (parsed as Record<string, unknown> | null)?.[c.key]
+      // `active: null` is how Gemini records a signed-OUT account, so the field
+      // has to carry a value — the file's existence proves nothing.
+      if (typeof field === "string" ? !!field.trim() : !!field) return true
+    } catch {
+      value = null
+    }
+  }
+  return value
+}
+
 export function loginVerdict(
   spec: Pick<HostedLoginSpec, "loggedInPattern" | "loggedOutPattern">,
   out: string,
@@ -183,17 +214,9 @@ export class LoginProbe {
         resolve(value)
       }
 
-      // File-based sign-in detection for CLIs with no status command (Gemini):
-      // the OAuth login just writes a creds file. Check it instead of spawning
-      // `statusArgs` — spawning bare `gemini` would launch its TUI and hang.
-      if (spec.credsFile) {
-        let value: boolean | null = null
-        try {
-          value = fs.existsSync(path.join(os.homedir(), spec.credsFile))
-        } catch {
-          value = null
-        }
-        settle(value)
+      // Sign-in read off disk, for a CLI with no status command (Gemini).
+      if (spec.credsFiles?.length) {
+        settle(credsVerdict(spec))
         return
       }
 

--- a/packages/launcher/src/main/agents/model-catalog.test.ts
+++ b/packages/launcher/src/main/agents/model-catalog.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 // llm-test pulls in electron's `net`, which does not exist under vitest — and
 // the HTTP shape is what we want to control here anyway. `vi.hoisted` is what
@@ -195,6 +195,69 @@ describe("listAgentModels — key present", () => {
       expect.objectContaining({ Authorization: "Bearer sk-ant" }),
       null,
     )
+  })
+})
+
+describe("listAgentModels — Gemini through a relay", () => {
+  // The bug: Test connection passed while the picker said 401. A relay proxies
+  // `:generateContent` off the `?key=` query but guards `/v1/models` with
+  // `Authorization: Bearer`, so the Google-style list call is the one call that
+  // fails — and it failed with the relay's own "invalid token" wording, which
+  // reads as a bad key rather than as the wrong header.
+  beforeEach(() => {
+    httpRequestJson.mockReset()
+  })
+
+  it("retries the relay's models endpoint with Bearer after the Google-style 401", async () => {
+    httpRequestJson
+      .mockResolvedValueOnce({
+        status: 401,
+        text: JSON.stringify({
+          error: { code: "", message: "无效的令牌", type: "new_api_error" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        text: JSON.stringify({ data: [{ id: "gemini-3.5-flash" }] }),
+      })
+    const r = await listAgentModels("gemini", {
+      GEMINI_API_KEY: "sk-relay",
+      GOOGLE_GEMINI_BASE_URL: "https://relay.example.com/v1",
+    })
+    expect(httpRequestJson).toHaveBeenLastCalledWith(
+      "https://relay.example.com/v1/models?pageSize=200",
+      "GET",
+      { Authorization: "Bearer sk-relay" },
+      null,
+    )
+    expect(r.source).toBe("api")
+    expect(r.models.map((m) => m.id)).toEqual(["gemini-3.5-flash"])
+  })
+
+  it("never sends Bearer to Google itself — it reads one as an OAuth token", async () => {
+    httpRequestJson.mockResolvedValueOnce({ status: 401, text: "nope" })
+    const r = await listAgentModels("gemini", { GEMINI_API_KEY: "AIza-test" })
+    expect(httpRequestJson).toHaveBeenCalledTimes(1)
+    expect(r.models).toEqual([])
+  })
+
+  it("shows the relay's message, not the whole JSON envelope", async () => {
+    httpRequestJson.mockResolvedValue({
+      status: 401,
+      text: JSON.stringify({
+        error: {
+          code: "",
+          message: "无效的令牌 (request id: 2026081911453639908)",
+          type: "new_api_error",
+        },
+      }),
+    })
+    const r = await listAgentModels("gemini", {
+      GEMINI_API_KEY: "sk-bad",
+      GOOGLE_GEMINI_BASE_URL: "https://relay.example.com/v1",
+    })
+    expect(r.error).toBe("HTTP 401: 无效的令牌 (request id: 2026081911453639908)")
+    expect(r.error).not.toContain("new_api_error")
   })
 })
 

--- a/packages/launcher/src/main/agents/model-catalog.ts
+++ b/packages/launcher/src/main/agents/model-catalog.ts
@@ -316,6 +316,38 @@ function pick(env: Record<string, string>, names: string[]): string {
 
 const trimSlash = (u: string): string => u.replace(/\/+$/, "")
 
+/**
+ * The one line worth showing from an error body.
+ *
+ * Relays answer with a nested JSON envelope — `{"error":{"code":"","message":
+ * "无效的令牌 (request id: …)","type":"new_api_error"}}` — and pasting that in
+ * raw is how a 401 became an unbroken 120-character string that overflowed the
+ * model picker. Anything that isn't JSON is passed through, still trimmed.
+ */
+function briefHttpError(text: string): string {
+  try {
+    const j = JSON.parse(text) as {
+      error?: { message?: string } | string
+      message?: string
+    }
+    const msg = typeof j.error === "string" ? j.error : j.error?.message
+    const line = (msg || j.message || "").trim()
+    if (line) return line.slice(0, 160)
+  } catch {
+    // not JSON — fall through to the raw body
+  }
+  return text.trim().slice(0, 160)
+}
+
+/** `parseOpenAiModels` for bodies that may not be JSON at all. */
+function safeParseOpenAiModels(text: string): ModelChoice[] {
+  try {
+    return parseOpenAiModels(text)
+  } catch {
+    return []
+  }
+}
+
 /** `data: [{ id }]`, an array, or a relay's `{ models: [...] }` shape. */
 function parseOpenAiModels(text: string): ModelChoice[] {
   const parsed: unknown = JSON.parse(text)
@@ -356,7 +388,7 @@ async function listOpenAiModels(
     return {
       models: [],
       source: "none",
-      error: `HTTP ${status}: ${text.slice(0, 160)}`,
+      error: `HTTP ${status}: ${briefHttpError(text)}`,
     }
   const models = parseOpenAiModels(text)
   return models.length
@@ -387,7 +419,7 @@ async function listAnthropicModels(
     return {
       models: [],
       source: "none",
-      error: `HTTP ${status}: ${text.slice(0, 160)}`,
+      error: `HTTP ${status}: ${briefHttpError(text)}`,
     }
   try {
     const parsed = JSON.parse(text) as {
@@ -403,6 +435,42 @@ async function listAnthropicModels(
   return { models: [], source: "none", error: "The endpoint listed no models." }
 }
 
+/** Google's own endpoint, as opposed to a relay or self-hosted gateway. */
+function isOfficialGeminiBase(base: string): boolean {
+  try {
+    return /(^|\.)googleapis\.com$/i.test(new URL(base).hostname)
+  } catch {
+    return false
+  }
+}
+
+/** Google's `{ models: [{ name: "models/…" }] }`, or [] for anything else. */
+function parseGeminiModels(text: string): ModelChoice[] {
+  try {
+    const parsed = JSON.parse(text) as {
+      models?: Array<{
+        name?: string
+        displayName?: string
+        supportedGenerationMethods?: string[]
+      }>
+    }
+    return (parsed.models || [])
+      .filter(
+        (m) =>
+          !m.supportedGenerationMethods ||
+          m.supportedGenerationMethods.includes("generateContent"),
+      )
+      .map((m) => ({
+        // The API returns `models/gemini-…`; the CLI's -m wants the bare id.
+        id: String(m.name || "").replace(/^models\//, ""),
+        label: m.displayName,
+      }))
+      .filter((m) => m.id)
+  } catch {
+    return []
+  }
+}
+
 async function listGeminiModels(
   key: string,
   baseInput: string,
@@ -415,42 +483,54 @@ async function listGeminiModels(
   const url = /\/v\d+(beta)?$/.test(base)
     ? `${base}/models`
     : `${base}/v1beta/models`
-  const { status, text } = await httpRequestJson(
+  const native = await httpRequestJson(
     `${url}?key=${encodeURIComponent(key)}&pageSize=200`,
     "GET",
     { "x-goog-api-key": key },
     null,
   )
-  if (status >= 400)
+  if (native.status < 400) {
+    const models = parseGeminiModels(native.text)
+    if (models.length) return { models, source: "api" }
+    // A gateway may answer this path in the OpenAI dialect regardless of how
+    // it was asked, so read the body both ways before calling it empty.
+    const compat = safeParseOpenAiModels(native.text)
+    if (compat.length) return { models: compat, source: "api" }
+  }
+  // A relay's `/v1` is an OpenAI-compatible surface. It proxies
+  // `:generateContent` off the `?key=` query — which is why Test connection
+  // passes — but guards `/v1/models` with `Authorization: Bearer` and answers
+  // the Google-style call with 401 "invalid token". So ask again the way that
+  // surface expects. Never against Google itself: it reads a Bearer as an
+  // OAuth token and rejects a plain API key with the same 401.
+  if (!isOfficialGeminiBase(base)) {
+    const bearer = await httpRequestJson(
+      `${url}?pageSize=200`,
+      "GET",
+      { Authorization: `Bearer ${key}` },
+      null,
+    )
+    if (bearer.status < 400) {
+      const models = safeParseOpenAiModels(bearer.text)
+      if (models.length) return { models, source: "api" }
+      const google = parseGeminiModels(bearer.text)
+      if (google.length) return { models: google, source: "api" }
+    }
+    if (native.status >= 400)
+      return {
+        models: [],
+        source: "none",
+        // Report whichever attempt got furthest — a 401 on both is the
+        // relay's verdict on the key, and that is what the user has to act on.
+        error: `HTTP ${bearer.status}: ${briefHttpError(bearer.text)}`,
+      }
+  }
+  if (native.status >= 400)
     return {
       models: [],
       source: "none",
-      error: `HTTP ${status}: ${text.slice(0, 160)}`,
+      error: `HTTP ${native.status}: ${briefHttpError(native.text)}`,
     }
-  try {
-    const parsed = JSON.parse(text) as {
-      models?: Array<{
-        name?: string
-        displayName?: string
-        supportedGenerationMethods?: string[]
-      }>
-    }
-    const models = (parsed.models || [])
-      .filter(
-        (m) =>
-          !m.supportedGenerationMethods ||
-          m.supportedGenerationMethods.includes("generateContent"),
-      )
-      .map((m) => ({
-        // The API returns `models/gemini-…`; the CLI's -m wants the bare id.
-        id: String(m.name || "").replace(/^models\//, ""),
-        label: m.displayName,
-      }))
-      .filter((m) => m.id)
-    if (models.length) return { models, source: "api" }
-  } catch {
-    // fall through
-  }
   return { models: [], source: "none", error: "The endpoint listed no models." }
 }
 

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -2116,6 +2116,10 @@ function setupIPC(): void {
     // among others, so a CLI installed to a custom prefix was invisible in the
     // terminal while the daemon found it fine.
     const coreBins = agentManager?.extraBinDirs() ?? []
+    // One line above the command for a CLI whose sign-in isn't where the user
+    // would look for it — Gemini opens straight into chat when it remembers an
+    // API key, and the Google sign-in is behind its `/auth` command.
+    const hint = agentType ? agentManager?.loginHintFor(agentType) || "" : ""
     if (process.platform === "win32") {
       const { execSync: exec } = require("child_process")
       const home = process.env.USERPROFILE || os.homedir()
@@ -2176,6 +2180,7 @@ function setupIPC(): void {
           "chcp 65001 >nul",
           `set "PATH=${allBins};%PATH%"`,
           ...(cwd ? [`cd /d "${cwd}"`] : []),
+          ...(hint ? [`echo ${hint.replace(/[&<>|^]/g, " ")}`, "echo."] : []),
           resolvedCmd,
         ]
         const tmpCmd = path.join(
@@ -2219,17 +2224,42 @@ function setupIPC(): void {
       ]
         .filter((d, i, all) => !!d && all.indexOf(d) === i)
         .join(":")
-      const setPath = `export PATH=${allBins}:$PATH`
-      const cdPart = cwd ? `cd "${cwd}" && ` : ""
-      const fullCmd = `${setPath} && ${cdPart}${resolvedCmd}`.replace(
-        /"/g,
-        '\\"',
-      )
-      spawn(
-        "osascript",
-        ["-e", `tell app "Terminal" to do script "${fullCmd}"`],
-        { detached: true, stdio: "ignore" },
-      )
+      // Quote every part for the shell. The launcher's own bundle dir
+      // ("/Applications/OpenAgents Launcher.app/Contents/MacOS") is on this
+      // list and contains a space: unquoted, zsh read the tail as a second
+      // assignment and failed with "export: not valid in this context" — and
+      // worse, it kept the truncated first half, so the user's terminal lost
+      // /usr/bin as well and the login command never ran at all.
+      const sq = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`
+      const lines = [
+        `export PATH=${sq(allBins)}:"$PATH"`,
+        ...(cwd ? [`cd ${sq(cwd)}`] : []),
+        ...(hint ? [`echo ${sq(hint)}`, "echo"] : []),
+        resolvedCmd,
+      ]
+      // Hand the new shell a temp script to source instead of one inline
+      // string: the command already carries an absolute binary path in double
+      // quotes, and squeezing that through AppleScript's string escaping on
+      // top of the shell's is where the quoting kept coming apart. Sourcing
+      // (`.`) leaves the PATH and cwd set in the user's own shell, so the CLI
+      // stays usable in that window once the sign-in returns.
+      try {
+        const tmpSh = path.join(
+          os.tmpdir(),
+          `openagents-login-${Date.now()}.sh`,
+        )
+        fs.writeFileSync(tmpSh, lines.join("\n") + "\n", "utf-8")
+        spawn(
+          "osascript",
+          [
+            "-e",
+            `tell app "Terminal" to do script ". ${sq(tmpSh)}"`,
+            "-e",
+            'tell app "Terminal" to activate',
+          ],
+          { detached: true, stdio: "ignore" },
+        )
+      } catch {}
     } else {
       const terminals = ["x-terminal-emulator", "gnome-terminal", "xterm"]
       for (const term of terminals) {

--- a/packages/launcher/src/renderer/components/model-field.tsx
+++ b/packages/launcher/src/renderer/components/model-field.tsx
@@ -120,7 +120,11 @@ export function ModelField({
         placeholder={placeholder || t("agents.envFields.model.placeholder")}
       />
       <InputGroupAddon align="inline-end">
-        <Popover open={open} onOpenChange={onOpenChange}>
+        {/* `modal` is what makes the wheel work over the list. Without it
+            the popover portals outside any dialog's scroll lock, which then
+            eats every wheel event that isn't inside its own subtree — the list
+            could only be moved by dragging its scrollbar. */}
+        <Popover open={open} onOpenChange={onOpenChange} modal>
           <PopoverTrigger asChild>
             <InputGroupButton
               size="icon-xs"
@@ -182,13 +186,16 @@ export function ModelField({
                 </CommandList>
               </Command>
             ) : (
-              <div className="flex items-start gap-2 px-3 py-3 text-xs leading-relaxed text-(--text-tertiary)">
+              <div className="flex max-h-48 items-start gap-2 overflow-y-auto px-3 py-3 text-xs leading-relaxed text-(--text-tertiary)">
                 {loading ? (
                   <Spinner className="mt-px size-3.5 shrink-0" />
                 ) : (
                   <EmptyIcon className="mt-px size-3.5 shrink-0" />
                 )}
-                <span className="min-w-0">{emptyMessage}</span>
+                {/* A provider's error is one long unbroken token often enough
+                    (a JSON envelope, a request id) that it has to be allowed
+                    to break mid-word, or it runs straight out of the popover. */}
+                <span className="min-w-0 break-words">{emptyMessage}</span>
               </div>
             )}
             <div className="flex items-center justify-between gap-2 border-t px-2 py-1.5">


### PR DESCRIPTION
Three fixes, all surfaced while configuring Gemini. Ships as launcher 0.9.16.

## 1. The macOS login terminal never ran its command

Clicking Login opened a terminal that answered `export: not valid in this context` and stopped.

The PATH prefix was interpolated unquoted, and one of the dirs on it is the launcher's own bundle — `/Applications/OpenAgents Launcher.app/Contents/MacOS`. zsh read everything after the space as a second assignment, failed, **and kept the truncated first half**, so that window also lost `/usr/bin` for the rest of its life (the `command not found: wc` in the report was the user's prompt theme dying).

Reproduced outside the app; bash and zsh behave the same, so this is our quoting bug, not a platform quirk:

```
$ export PATH=/aaa:/Applications/OpenAgents Launcher.app/Contents/MacOS:$PATH
bash: export: `Launcher.app/...': not a valid identifier
$ echo $PATH
/aaa:/Applications/OpenAgents        ← truncated at the space
```

Affects **every agent that opens a terminal to sign in** — gemini and hermes always (`TERMINAL_ONLY_LOGIN`), claude/codex/cursor/amp whenever the in-app pipe falls back. The Windows branch was already immune: it writes a temp `.cmd` with `set "PATH=..."`.

The macOS path now does the same — a temp script the new shell sources — which also removes the AppleScript-string-escaping layer that was stacked on top of the shell's (the command already carries an absolute binary path in double quotes). Sourcing rather than executing leaves PATH and cwd set in that window, so the CLI stays usable after the sign-in returns.

## 2. Gemini's model picker 401'd on a relay that Test connection had just passed

Both were telling the truth — they hit different endpoints:

| | URL | auth |
|---|---|---|
| Test connection | `…/v1/models/<model>:generateContent?key=…` | `?key=` + `x-goog-api-key` | ✅ |
| Model list | `…/v1/models?key=…` | same | ❌ 401 |

A relay proxies `:generateContent` the Google way but serves `/v1/models` as an OpenAI-compatible surface behind `Authorization: Bearer`. We only ever asked the Google way.

Now: on a non-official base URL, a refused Google-style call is retried with Bearer, and both response dialects are parsed. **Never** against `generativelanguage.googleapis.com` — Google reads a Bearer as an OAuth token and rejects a plain API key with the same 401.

The provider's error is also reduced to the message it actually contains, instead of pasting the whole `{"error":{"code":"","message":"…","type":"new_api_error"}}` envelope into the UI.

## 3. Gemini's Google sign-in was never detected

The panel said "Not signed in" no matter how many times you signed in.

The probe watched for `~/.gemini/oauth_creds.json`. Current CLI builds keep the token in the OS keychain and delete that file (`migrateFromFileStorage` / `clearCredentials` in the bundle), so it never appears.

It now reads `~/.gemini/google_accounts.json`'s `active` — written with the signed-in address on every successful OAuth flow, nulled on sign-out. `oauth_creds.json` stays as the fallback for older CLIs. Note the old check was also wrong in the other direction: mere existence isn't sign-in, since `{"active": null}` is exactly what a signed-out install looks like.

Separately: the CLI remembers the auth method it was last given, and when that is `gemini-api-key` it opens straight into chat — the Google sign-in never runs and nothing on the panel can change. There is no flag to force it (no `login` subcommand, no `--auth-type`; `GEMINI_DEFAULT_AUTH_TYPE` only validates the value, it does not override `settings.json`). So the terminal now prints how to get there: type `/auth` and pick the Google option.

Deliberately **not** rewriting the user's `~/.gemini/settings.json` — the daemon reads the same `selectedType` when it runs the agent headless, so a sign-in the user abandons would break an agent that was working fine on its API key, and there is no reliable place to undo it (the terminal-path session stops polling after 5 minutes without settling, and leaving the page doesn't cancel it).

## Also in the picker

- A long provider error no longer bursts out of the popover (wraps, capped height).
- The model list takes the mouse wheel again. The popover portalled outside the scroll lock, which `preventDefault`s every wheel event not inside its own subtree — dragging the scrollbar worked because that produces no wheel events. Fixed with `modal` on the Popover ([shadcn-ui#4759](https://github.com/shadcn-ui/ui/issues/4759), [cmdk#272](https://github.com/pacocoursey/cmdk/issues/272)).

## Core dependency

`@openagents-org/agent-launcher` 0.2.166 → 0.2.169. That bundled copy is only the fallback for when `GLOBAL_CORE` is missing (`ensureCoreLibrary` keeps the installed one on latest), but the fallback should be a version we have built against.

## Not in this PR

Three registry/core-side issues found along the way are split into a separate PR for the core owners — they do not affect the launcher UI, which computes its own verdict in `health.ts`.

## Testing

`npm run typecheck`, `npx vitest run` (333 passed, +8 new), `npm run build`. Five new cases cover Gemini's sign-in evidence (signed in / signed out / older CLI / nothing at all / unreadable) and three cover the relay retry and error trimming.

Not exercised in the real app on my side — the macOS terminal and the model popover want a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)