### PR TITLE
fix(core): creds_file readiness — Gemini's evidence moved, Hermes' never parsed, Python's never ran

### DIFF
--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -450,7 +450,8 @@
       ]
     },
     "check_ready": {
-      "creds_file": "~/.gemini/oauth_creds.json",
+      "creds_file": "~/.gemini/google_accounts.json",
+      "creds_key": "active",
       "creds_no_parse": true,
       "creds_path_env": [
         "GOOGLE_APPLICATION_CREDENTIALS"
@@ -831,6 +832,7 @@
     },
     "check_ready": {
       "creds_file": "~/.hermes/config.yaml",
+      "creds_no_parse": true,
       "status_command": "hermes status",
       "login_command": "hermes setup",
       "not_ready_message": "Hermes not configured — run: hermes setup"

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -868,6 +868,17 @@ class Installer {
         }
         return 'absent';
       }
+      // A named field, for a file that exists in both states. Gemini's
+      // google_accounts.json is written on install and records a signed-OUT
+      // account as `active: null`, so its existence proves nothing — only the
+      // field does. Still content-free: the value is tested for emptiness, never
+      // read out, logged or returned.
+      if (checkReady.creds_key) {
+        const parsed = JSON.parse(fs.readFileSync(p, 'utf-8'));
+        const value = parsed && typeof parsed === 'object' ? parsed[checkReady.creds_key] : null;
+        const filled = typeof value === 'string' ? !!value.trim() : !!value;
+        return filled ? 'present' : 'absent';
+      }
       return st.size > 0 ? 'present' : 'absent';
     } catch {
       return 'unreadable';

--- a/packages/agent-connector/test/creds-file-detection.test.js
+++ b/packages/agent-connector/test/creds-file-detection.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * The shapes a registry entry's `creds_file` can take, at the level the state
+ * machine sees them. Three exist in the catalog today and each used to be read
+ * wrong somewhere:
+ *
+ *   • a DIRECTORY of session files (Claude's ~/.claude/sessions) — an empty one
+ *     is a fresh install, not a sign-in;
+ *   • a JSON file with a named field (`creds_key`) — Gemini's
+ *     google_accounts.json exists from install onward and records a signed-OUT
+ *     account as `active: null`, so existence alone says nothing;
+ *   • a file that is not JSON at all (Hermes' config.yaml) — parsing it can
+ *     only ever throw, so the check has to be existence-based.
+ *
+ * All three are content-free at the level that matters: a value is tested for
+ * emptiness, never read out, logged or returned.
+ *
+ * Run: node --test test/creds-file-detection.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { Installer } = require('../src/installer');
+
+const mockRegistry = { getEntry: () => null, getResolveRules: () => [] };
+
+let tmpDir;
+let inst;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-creds-'));
+  inst = new Installer(mockRegistry, tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('creds_file — a directory of sessions', () => {
+  it('counts when it holds anything', () => {
+    const dir = path.join(tmpDir, 'sessions');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, 'a.json'), '{}');
+    assert.equal(inst._credsFileState({ creds_file: dir }), 'present');
+  });
+
+  it('is absent while empty — a fresh install is not a sign-in', () => {
+    const dir = path.join(tmpDir, 'sessions');
+    fs.mkdirSync(dir);
+    assert.equal(inst._credsFileState({ creds_file: dir }), 'absent');
+  });
+});
+
+describe('creds_file — a JSON file with a named field', () => {
+  const write = (body) => {
+    const p = path.join(tmpDir, 'google_accounts.json');
+    fs.writeFileSync(p, body);
+    return p;
+  };
+
+  it('present when the field carries a value', () => {
+    const p = write('{"active":"ada@example.com","old":[]}');
+    assert.equal(inst._credsFileState({ creds_file: p, creds_key: 'active' }), 'present');
+  });
+
+  it('absent when the field is null — that is how a sign-out is recorded', () => {
+    const p = write('{"active":null,"old":["ada@example.com"]}');
+    assert.equal(inst._credsFileState({ creds_file: p, creds_key: 'active' }), 'absent');
+  });
+
+  it('absent when the field is an empty string', () => {
+    const p = write('{"active":"   ","old":[]}');
+    assert.equal(inst._credsFileState({ creds_file: p, creds_key: 'active' }), 'absent');
+  });
+
+  it('absent when the field is missing entirely', () => {
+    const p = write('{"old":[]}');
+    assert.equal(inst._credsFileState({ creds_file: p, creds_key: 'active' }), 'absent');
+  });
+
+  it('unreadable — not absent — when the file will not parse', () => {
+    // The distinction the UI depends on: "we cannot tell" gets its own message
+    // instead of asserting the user is signed out.
+    const p = write('{ half a file');
+    assert.equal(inst._credsFileState({ creds_file: p, creds_key: 'active' }), 'unreadable');
+  });
+
+  it('ignores the field when the entry declares none (existing agents unchanged)', () => {
+    const p = write('{"active":null}');
+    assert.equal(inst._credsFileState({ creds_file: p }), 'present');
+  });
+});
+
+describe('creds_file — a file that is not JSON', () => {
+  it('counts on existence, which is all a YAML config can offer', () => {
+    const p = path.join(tmpDir, 'config.yaml');
+    fs.writeFileSync(p, 'provider: openai\n');
+    assert.equal(inst._credsFileState({ creds_file: p }), 'present');
+  });
+
+  it('is absent while empty', () => {
+    const p = path.join(tmpDir, 'config.yaml');
+    fs.writeFileSync(p, '');
+    assert.equal(inst._credsFileState({ creds_file: p }), 'absent');
+  });
+});
+
+describe('registry entries that depend on the above', () => {
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'registry.json'), 'utf-8'),
+  );
+  const entry = (name) => (registry.agents || registry).find((a) => a.name === name);
+
+  it('hermes opts into the existence-based check', () => {
+    // Without this its config.yaml reaches JSON.parse in _checkCredsReady,
+    // throws, and the whole creds_file declaration is dead weight.
+    const hermes = entry('hermes').check_ready;
+    assert.equal(hermes.creds_file, '~/.hermes/config.yaml');
+    assert.equal(hermes.creds_no_parse, true);
+  });
+
+  it('gemini names the field that separates signed in from signed out', () => {
+    const gemini = entry('gemini').check_ready;
+    assert.equal(gemini.creds_file, '~/.gemini/google_accounts.json');
+    assert.equal(gemini.creds_key, 'active');
+  });
+});

--- a/packages/agent-connector/test/gemini-readiness.test.js
+++ b/packages/agent-connector/test/gemini-readiness.test.js
@@ -3,10 +3,14 @@
 /**
  * Gemini credential/readiness detection (the "logged in via OAuth but UI shows
  * Not logged in" fix). Verifies the installer detects ALL of Gemini CLI's auth
- * paths — OAuth credential file, GEMINI_API_KEY / GOOGLE_API_KEY, and a
- * GOOGLE_APPLICATION_CREDENTIALS service-account file — without parsing or
- * logging the token, and maps an unreadable credential to a distinct 'unknown'
+ * paths — the recorded Google account, GEMINI_API_KEY / GOOGLE_API_KEY, and a
+ * GOOGLE_APPLICATION_CREDENTIALS service-account file — without reading out or
+ * logging any credential, and maps an unreadable one to a distinct 'unknown'
  * state rather than "no credentials". No real Gemini CLI or model call.
+ *
+ * The account file replaced the OAuth token file: current CLI builds move the
+ * token into the OS keychain and delete ~/.gemini/oauth_creds.json, so watching
+ * for that file reported "signed out" forever.
  */
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
@@ -28,6 +32,7 @@ function geminiEntry(credsPath, overrides = {}) {
     install: { binary: 'gemini', macos: 'npm install -g @google/gemini-cli', linux: 'npm install -g @google/gemini-cli' },
     check_ready: {
       creds_file: credsPath,
+      creds_key: 'active',
       creds_no_parse: true,
       creds_path_env: ['GOOGLE_APPLICATION_CREDENTIALS'],
       env_vars: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
@@ -67,17 +72,17 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe('Gemini readiness — OAuth credential file (6.1)', () => {
-  it('OAuth creds file present & readable → Ready', () => {
-    const p = path.join(tmpDir, 'oauth_creds.json');
-    fs.writeFileSync(p, '{"access_token":"REDACTED"}');
+describe('Gemini readiness — the recorded Google account (6.1)', () => {
+  it('signed-in account recorded & readable → Ready', () => {
+    const p = path.join(tmpDir, 'google_accounts.json');
+    fs.writeFileSync(p, '{"active":"ada@example.com","old":[]}');
     const r = evaluate(geminiEntry(p));
     assert.equal(r.ready, true);
     assert.equal(r.auth_status, 'ready');
     assert.equal(r.auth_mode, 'cli_login');
   });
 
-  it('OAuth creds file absent → not ready, no_credentials, "Needs sign-in" (not "Not logged in")', () => {
+  it('account file absent → not ready, no_credentials, "Needs sign-in" (not "Not logged in")', () => {
     const r = evaluate(geminiEntry(path.join(tmpDir, 'does-not-exist.json')));
     assert.equal(r.ready, false);
     assert.equal(r.auth_status, 'no_credentials');
@@ -85,15 +90,15 @@ describe('Gemini readiness — OAuth credential file (6.1)', () => {
     assert.doesNotMatch(r.message, /^Not logged in/);
   });
 
-  it('OAuth creds file exists but unreadable → unknown (NOT "Not logged in"), never Ready', () => {
+  it('account file exists but unreadable → unknown (NOT "Not logged in"), never Ready', () => {
     if (process.platform === 'win32') {
       return; // chmod(0o000) is a no-op on Windows; an unreadable file can't be simulated
     }
     if (typeof process.getuid === 'function' && process.getuid() === 0) {
       return; // root bypasses file permissions; the unreadable path can't be simulated
     }
-    const p = path.join(tmpDir, 'oauth_creds.json');
-    fs.writeFileSync(p, '{"access_token":"REDACTED"}');
+    const p = path.join(tmpDir, 'google_accounts.json');
+    fs.writeFileSync(p, '{"active":"ada@example.com","old":[]}');
     fs.chmodSync(p, 0o000);
     try {
       const r = evaluate(geminiEntry(p));
@@ -105,18 +110,30 @@ describe('Gemini readiness — OAuth credential file (6.1)', () => {
     }
   });
 
-  it('empty OAuth creds file is treated as absent (not Ready)', () => {
-    const p = path.join(tmpDir, 'oauth_creds.json');
+  it('empty account file is treated as absent (not Ready)', () => {
+    const p = path.join(tmpDir, 'google_accounts.json');
     fs.writeFileSync(p, '');
     const r = evaluate(geminiEntry(p));
     assert.equal(r.ready, false);
   });
 
-  it('credential check never reads file contents (no JSON parse) — invalid JSON still Ready', () => {
-    const p = path.join(tmpDir, 'oauth_creds.json');
-    fs.writeFileSync(p, 'not-json-at-all'); // content-free check ⇒ still present
+  it('signed OUT (active: null) is not Ready — the file exists from install onward', () => {
+    // The regression this guards: the file's existence used to be the whole
+    // check, so an account that had signed out — or never signed in — read as
+    // signed in.
+    const p = path.join(tmpDir, 'google_accounts.json');
+    fs.writeFileSync(p, '{"active":null,"old":["ada@example.com"]}');
     const r = evaluate(geminiEntry(p));
-    assert.equal(r.ready, true);
+    assert.equal(r.ready, false);
+    assert.equal(r.auth_status, 'no_credentials');
+  });
+
+  it('an unparseable account file is unknown, not signed out', () => {
+    const p = path.join(tmpDir, 'google_accounts.json');
+    fs.writeFileSync(p, 'not-json-at-all');
+    const r = evaluate(geminiEntry(p));
+    assert.equal(r.ready, false);
+    assert.equal(r.auth_status, 'unknown');
   });
 });
 
@@ -154,9 +171,9 @@ describe('Gemini readiness — API key & service account (6.2)', () => {
     assert.equal(r.auth_status, 'no_credentials');
   });
 
-  it('OAuth file AND API key both present → Ready', () => {
-    const p = path.join(tmpDir, 'oauth_creds.json');
-    fs.writeFileSync(p, '{"access_token":"REDACTED"}');
+  it('signed-in account AND API key both present → Ready', () => {
+    const p = path.join(tmpDir, 'google_accounts.json');
+    fs.writeFileSync(p, '{"active":"ada@example.com","old":[]}');
     process.env.GEMINI_API_KEY = 'AIza-REDACTED';
     assert.equal(evaluate(geminiEntry(p)).ready, true);
   });
@@ -196,8 +213,12 @@ describe('Gemini readiness — registry config (status mapping)', () => {
   const registry = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'registry.json'), 'utf-8'));
   const entry = (registry.agents || registry).find((a) => a.name === 'gemini');
 
-  it('registry declares OAuth file + env + service-account detection', () => {
-    assert.equal(entry.check_ready.creds_file, '~/.gemini/oauth_creds.json');
+  it('registry declares OAuth account + env + service-account detection', () => {
+    // Not oauth_creds.json: current CLI builds keep the token in the OS
+    // keychain and delete that file, so it never appears however many times
+    // the user signs in. google_accounts.json is written on every sign-in.
+    assert.equal(entry.check_ready.creds_file, '~/.gemini/google_accounts.json');
+    assert.equal(entry.check_ready.creds_key, 'active');
     assert.equal(entry.check_ready.creds_no_parse, true);
     assert.deepEqual(entry.check_ready.creds_path_env, ['GOOGLE_APPLICATION_CREDENTIALS']);
     assert.ok(entry.check_ready.env_vars.includes('GEMINI_API_KEY'));

--- a/registry/gemini.json
+++ b/registry/gemini.json
@@ -48,7 +48,8 @@
     ]
   },
   "check_ready": {
-    "creds_file": "~/.gemini/oauth_creds.json",
+    "creds_file": "~/.gemini/google_accounts.json",
+    "creds_key": "active",
     "creds_no_parse": true,
     "creds_path_env": [
       "GOOGLE_APPLICATION_CREDENTIALS"

--- a/registry/hermes.json
+++ b/registry/hermes.json
@@ -36,6 +36,7 @@
   },
   "check_ready": {
     "creds_file": "~/.hermes/config.yaml",
+    "creds_no_parse": true,
     "status_command": "hermes status",
     "login_command": "hermes setup",
     "not_ready_message": "Hermes not configured — run: hermes setup"

--- a/sdk/src/openagents/registry/gemini.yaml
+++ b/sdk/src/openagents/registry/gemini.yaml
@@ -12,12 +12,20 @@ install:
   windows: "npm install -g @google/gemini-cli"
 
 # Readiness covers BOTH of Gemini CLI's auth paths: the default OAuth login
-# (credentials cached at ~/.gemini/oauth_creds.json — detected by existence,
-# never parsed) and API-key / service-account env vars. creds_no_parse keeps
-# the check content-free; creds_path_env validates that
-# GOOGLE_APPLICATION_CREDENTIALS points at a real readable file.
+# (detected from the account the CLI records, never from the token itself) and
+# API-key / service-account env vars. creds_no_parse keeps the check
+# content-free — the recorded address is tested for emptiness, never read out;
+# creds_path_env validates that GOOGLE_APPLICATION_CREDENTIALS points at a real
+# readable file.
 check_ready:
-  creds_file: "~/.gemini/oauth_creds.json"
+  # The signed-in Google address, which the CLI writes on every successful
+  # OAuth flow and nulls on sign-out. It used to be oauth_creds.json — current
+  # builds keep the token in the OS keychain and never write that file, so the
+  # check could never come back true however many times the user signed in.
+  # creds_key is what makes `active: null` (signed out) read as signed out;
+  # the file itself exists from install onward.
+  creds_file: "~/.gemini/google_accounts.json"
+  creds_key: "active"
   creds_no_parse: true
   creds_path_env: [GOOGLE_APPLICATION_CREDENTIALS]
   env_vars: [GEMINI_API_KEY, GOOGLE_API_KEY]

--- a/sdk/src/openagents/registry/loader.py
+++ b/sdk/src/openagents/registry/loader.py
@@ -479,18 +479,42 @@ def _make_plugin_from_yaml(data: dict):
                 if saved.get(saved_key):
                     model = saved.get("LLM_MODEL", "default")
                     return True, f"Ready ({model})"
-            # Check credentials file
+            # Check credentials file. Three shapes, matching the JS core's
+            # installer.js so both implementations read one registry the same
+            # way:
+            #   • a DIRECTORY of session files (Claude's ~/.claude/sessions)
+            #     counts when it holds anything;
+            #   • a ``creds_key`` means the file is JSON and that field has to
+            #     carry a value — Gemini's google_accounts.json exists from
+            #     install and records a signed-OUT account as ``active: null``,
+            #     so its existence proves nothing;
+            #   • anything else counts on existence alone, which is what
+            #     ``creds_no_parse`` has always declared and what a non-JSON
+            #     config (Hermes' config.yaml) needs.
+            # Previously every one of these fell through: without a creds_key
+            # the True was unreachable, and read_text/json.loads raised on the
+            # directory and on the YAML — so the whole check was dead code for
+            # all three agents that use it.
             creds_file = check_cfg.get("creds_file")
             if creds_file:
                 creds_path = Path(os.path.expanduser(creds_file))
-                if creds_path.exists():
-                    try:
-                        creds = json.loads(creds_path.read_text(encoding="utf-8"))
-                        creds_key = check_cfg.get("creds_key")
-                        if creds_key and creds.get(creds_key):
+                creds_key = check_cfg.get("creds_key")
+                try:
+                    if creds_path.is_dir():
+                        if any(creds_path.iterdir()):
                             return True, "Ready (logged in)"
-                    except Exception:
-                        pass
+                    elif creds_path.is_file():
+                        if creds_key:
+                            creds = json.loads(
+                                creds_path.read_text(encoding="utf-8")
+                            )
+                            value = creds.get(creds_key) if isinstance(creds, dict) else None
+                            if value.strip() if isinstance(value, str) else value:
+                                return True, "Ready (logged in)"
+                        elif creds_path.stat().st_size > 0:
+                            return True, "Ready (logged in)"
+                except Exception:
+                    pass
             # Check macOS Keychain
             keychain_svc = check_cfg.get("keychain_service")
             if keychain_svc and platform.system() == "Darwin":

--- a/tests/agents/test_registry_creds_readiness.py
+++ b/tests/agents/test_registry_creds_readiness.py
@@ -1,0 +1,136 @@
+"""Readiness from a registry entry's ``check_ready.creds_file``.
+
+Three shapes exist in the catalog and every one of them used to fall through
+this check silently, so the whole ``creds_file`` declaration was dead code:
+
+- a **directory** of session files (Claude's ``~/.claude/sessions``) —
+  ``read_text()`` raises on a directory;
+- a file that is **not JSON** (Hermes' ``config.yaml``) — ``json.loads`` raises;
+- a JSON file with **no** ``creds_key`` — the only ``return True`` was guarded
+  on ``creds_key``, so it was unreachable.
+
+The behaviour now matches the JS core's ``installer.js``, so both
+implementations read one registry the same way. Nothing here reads a credential
+out: a value is only ever tested for emptiness.
+
+Run:
+    pytest tests/agents/test_registry_creds_readiness.py -v
+"""
+
+import json
+
+import pytest
+
+import openagents.registry.loader as loader
+
+
+def _plugin(check_ready):
+    """A minimal installed plugin whose readiness rests on ``check_ready``."""
+    plugin = loader._make_plugin_from_yaml(
+        {
+            "name": "creds-probe",
+            # Only builtin entries become full plugins; catalog-only ones
+            # return None.
+            "builtin": True,
+            "install": {"binary": "creds-probe"},
+            "adapter": {
+                "module": "openagents.adapters.gemini",
+                "class": "GeminiAdapter",
+            },
+            "check_ready": check_ready,
+        }
+    )
+    assert plugin is not None
+    # Installation is not what these cases are about, and resolving a real
+    # binary would drag PATH into it.
+    plugin.is_installed = lambda: True
+    return plugin
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_keys(monkeypatch):
+    """An API key in the ambient env would satisfy readiness before the file."""
+    for var in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestCredsDirectory:
+    def test_non_empty_directory_is_signed_in(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        (sessions / "a.json").write_text("{}")
+        ready, _ = _plugin({"creds_file": str(sessions)}).check_ready()
+        assert ready is True
+
+    def test_empty_directory_is_not(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        ready, msg = _plugin(
+            {"creds_file": str(sessions), "not_ready_message": "Sign in"}
+        ).check_ready()
+        assert ready is False
+        assert msg == "Sign in"
+
+
+class TestCredsKey:
+    def _accounts(self, tmp_path, body):
+        path = tmp_path / "google_accounts.json"
+        path.write_text(json.dumps(body))
+        return {"creds_file": str(path), "creds_key": "active"}
+
+    def test_named_field_with_a_value_is_signed_in(self, tmp_path):
+        cfg = self._accounts(tmp_path, {"active": "ada@example.com", "old": []})
+        assert _plugin(cfg).check_ready()[0] is True
+
+    def test_null_field_is_signed_out(self, tmp_path):
+        # How the CLI records a sign-out — and how the file sits from install
+        # onward for someone who never signed in at all.
+        cfg = self._accounts(tmp_path, {"active": None, "old": ["ada@example.com"]})
+        assert _plugin(cfg).check_ready()[0] is False
+
+    def test_blank_field_is_signed_out(self, tmp_path):
+        cfg = self._accounts(tmp_path, {"active": "   "})
+        assert _plugin(cfg).check_ready()[0] is False
+
+    def test_unparseable_file_is_not_signed_in(self, tmp_path):
+        path = tmp_path / "google_accounts.json"
+        path.write_text("{ half a file")
+        cfg = {"creds_file": str(path), "creds_key": "active"}
+        assert _plugin(cfg).check_ready()[0] is False
+
+
+class TestExistenceOnly:
+    def test_non_json_config_counts_on_existence(self, tmp_path):
+        # Hermes' config.yaml: json.loads could only ever raise here, so the
+        # file being there is the whole of the evidence.
+        path = tmp_path / "config.yaml"
+        path.write_text("provider: openai\n")
+        assert _plugin({"creds_file": str(path)}).check_ready()[0] is True
+
+    def test_empty_file_does_not_count(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text("")
+        assert _plugin({"creds_file": str(path)}).check_ready()[0] is False
+
+    def test_missing_file_does_not_count(self, tmp_path):
+        cfg = {"creds_file": str(tmp_path / "nope.yaml")}
+        assert _plugin(cfg).check_ready()[0] is False
+
+    def test_json_without_a_creds_key_counts_on_existence(self, tmp_path):
+        # Unchanged for entries that never named a field.
+        path = tmp_path / "creds.json"
+        path.write_text('{"anything": 1}')
+        assert _plugin({"creds_file": str(path)}).check_ready()[0] is True
+
+
+class TestRegistryDeclarations:
+    def test_gemini_names_the_account_field(self):
+        data = next(
+            d for d in loader.load_registry_yamls() if d.get("name") == "gemini"
+        )
+        check = data["check_ready"]
+        # Not oauth_creds.json: current CLI builds move the token into the OS
+        # keychain and delete that file, so watching for it reported "signed
+        # out" however many times the user signed in.
+        assert check["creds_file"] == "~/.gemini/google_accounts.json"
+        assert check["creds_key"] == "active"

--- a/workspace/backend/registry/gemini.json
+++ b/workspace/backend/registry/gemini.json
@@ -48,7 +48,8 @@
     ]
   },
   "check_ready": {
-    "creds_file": "~/.gemini/oauth_creds.json",
+    "creds_file": "~/.gemini/google_accounts.json",
+    "creds_key": "active",
     "creds_no_parse": true,
     "creds_path_env": [
       "GOOGLE_APPLICATION_CREDENTIALS"

--- a/workspace/backend/registry/hermes.json
+++ b/workspace/backend/registry/hermes.json
@@ -36,6 +36,7 @@
   },
   "check_ready": {
     "creds_file": "~/.hermes/config.yaml",
+    "creds_no_parse": true,
     "status_command": "hermes status",
     "login_command": "hermes setup",
     "not_ready_message": "Hermes not configured — run: hermes setup"


### PR DESCRIPTION
Found while fixing the launcher's Gemini sign-in panel (#629). These are core/registry-side and **independent of that PR** — the launcher computes its own verdict in `health.ts` and is unaffected either way, so nothing here needs a launcher release. Splitting them out because they touch core, sdk and workspace.

Three separate problems, all in `check_ready.creds_file`.

---

## 1. Gemini watches for a file the CLI no longer writes

`~/.gemini/oauth_creds.json` was the evidence of a Google sign-in. Current CLI builds keep the token in the OS keychain and **delete** that file. From the shipped bundle (`@google/gemini-cli` 0.55.1):

```js
static async clearCredentials() {
  await this.storage.deleteCredentials(MAIN_ACCOUNT_KEY);
  const oldFilePath = path.join(homedir(), GEMINI_DIR, OAUTH_FILE);
  await fs.rm(oldFilePath, { force: true });
}
static async migrateFromFileStorage() { /* … */ }
```

So the check could never come back true, however many times the user signed in: with no API key the agent stayed "not ready", and the sign-in state stayed "signed out".

**Now:** `~/.gemini/google_accounts.json`, field `active`. The CLI writes the signed-in address there on every successful OAuth flow (`fetchAndCacheUserInfo` → `cacheGoogleAccount(email)`) and nulls it on sign-out (`clearCachedGoogleAccount`). Cross-platform, no keychain prompt, and it doubles as the account label.

**Why `creds_key` and not just the path:** that file exists from install onward. A signed-out install looks like `{"active": null, "old": [...]}` — mere existence would report every never-signed-in user as signed in. This is a real state on disk, not a hypothetical; it is what the machine I found this on was sitting at.

## 2. Hermes' creds_file could only ever throw

`~/.hermes/config.yaml` is YAML. Both cores hand it to a JSON parser, so the branch always raised and fell through — the declaration has been dead weight next to `hermes status` since it landed. `creds_no_parse: true` makes existence of a non-empty config the evidence, which is all a YAML file can offer here.

⚠️ **Assumption worth checking by someone with Hermes installed:** that `hermes setup` is what creates `config.yaml`, and that the installer doesn't drop an empty/default one first. The state machine requires non-empty, so a stub with content would still read as configured.

## 3. The Python loader never read *any* of it

```python
creds = json.loads(creds_path.read_text(encoding="utf-8"))
creds_key = check_cfg.get("creds_key")
if creds_key and creds.get(creds_key):
    return True, "Ready (logged in)"
```

- no `creds_key` → the only `return True` is unreachable
- a **directory** (`~/.claude/sessions`) → `read_text()` raises
- **YAML** (`~/.hermes/config.yaml`) → `json.loads` raises
- `creds_no_parse`, declared in the registry since Gemini's detection landed, is **never read by this implementation at all**

Every agent using `creds_file` hit one of those. The JS core handles the first three; the two implementations have been reading one registry differently.

**Now** both agree: a directory counts when it holds anything, a `creds_key` means the file is JSON and that field must carry a value, anything else counts on existence. Still content-free — a value is tested for emptiness, never read out, logged or returned.

The JS side needed one addition: `_credsFileState` had no way to express "the evidence is a field inside this file". It now takes `creds_key` next to the `creds_json_has_entries` mode it already had. Dropping `creds_no_parse` from the Gemini entry would have been the other option, but that collapses **unreadable** into **signed out** — the distinction the `unreadable_message` path depends on, and the one that keeps a permissions problem from being reported as "you are not signed in".

---

## Four copies, three sources

They are not generated from one another, so all four had to move:

| file | read by |
|---|---|
| `sdk/src/openagents/registry/*.yaml` | the Python loader |
| `registry/*.json` | canonical catalog, served by the workspace backend |
| `workspace/backend/registry/*.json` | its synced copy — regenerated with `sync_registry.py` |
| `packages/agent-connector/registry.json` | the JS core and the launcher |

`packages/agent-connector/registry.json` is nominally generated by `build-registry.js` from the YAML, but in practice hand-maintained and **already drifted** — hermes has a `check_ready` there and none in the YAML. Hand-edited to match rather than regenerating, per the note in the package README; running the generator would have dropped hermes' block entirely.

## Found but deliberately not touched

**Claude's entry says three different things.** Worth a decision, not a drive-by fix from me:

| source | creds_file | creds_key |
|---|---|---|
| `sdk/.../claude.yaml` | `~/.claude/.credentials.json` | `claudeAiOauth` |
| `registry/claude.json` | `~/.claude/sessions` | `null` |
| `packages/agent-connector/registry.json` | `~/.claude/sessions` | `null` |

Both work after this PR (the directory path was the one that used to fail on the Python side), so nothing is broken — but they are checking different things, and if Claude Code has moved its credentials the way Gemini did, the file variant may be as stale as Gemini's was. I have not verified where current Claude Code builds keep them.

**`_simple_yaml_parse` cannot parse the registry it is the fallback for.** With PyYAML absent, `_load_yaml` falls back to it, and on `gemini.yaml` it returns `install` as a *list* and `check_ready` as `None` — enough for `plugin_registry` to raise `AttributeError` at import time. Pre-existing, unrelated to this change, but it means the fallback isn't one.

## Testing

- `packages/agent-connector`: `npm test` → 1172 pass, 0 fail. `gemini-readiness.test.js` rewritten around the account file (its pinned registry assertions were the one failure this change caused) and gains the signed-out case the old existence check would have failed. New `creds-file-detection.test.js` covers all three shapes at the state-machine level, plus the two registry declarations.
- Python: new `tests/agents/test_registry_creds_readiness.py`, 11 cases. **4 of them fail without the loader change** (verified by stashing it) — the directory, the non-JSON config, the JSON-without-creds_key, and the blank-string field.
- `npm run lint` not run — eslint isn't installed in my checkout.
- No real Gemini/Hermes CLI or network call in any of it. Gemini's behaviour above was read off the installed 0.55.1 bundle and the on-disk state of an install that had signed in and out; **Hermes was not installed and is untested here** — see the assumption flagged in §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)