### PR TITLE
fix(launcher): Gemini's Google sign-in, plus model-picker and drag-region fixes

### DIFF
--- a/packages/launcher/changelog/0.9.17.json
+++ b/packages/launcher/changelog/0.9.17.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.9.17",
+  "date": "2026-08-20",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "Signing in to Gemini with a Google account now actually opens the sign-in",
+        "zh": "Gemini 的「账号登录」现在真的会打开 Google 登录"
+      },
+      "description": {
+        "en": "Clicking Sign in opened a terminal that went straight to Gemini's chat screen, with the Google sign-in nowhere in sight — so the panel kept saying \"not signed in\", correctly, because nothing had happened. The CLI remembers the last sign-in method it was given, and for anyone who had ever entered an API key that is the one it keeps using; there is no option to tell it otherwise from outside. The sign-in now runs in a folder of the launcher's own, where it asks for the Google account flow just for that run. Your own Gemini settings are left exactly as they are, so an agent already working on its API key keeps working even if you close the sign-in halfway.",
+        "zh": "点「登录」打开的终端会直接进入 Gemini 的对话界面，根本看不到 Google 登录——面板也就一直显示「未登录」，而且这是对的，因为登录压根没发生。命令行工具会记住上次使用的登录方式，只要填过一次 API 密钥，它之后就一直用这个，而且没有任何办法从外部让它改用别的。现在登录会在启动器自己的一个目录里进行，只在这一次运行中要求走 Google 账号登录。你自己的 Gemini 设置分毫未动，所以就算中途关掉登录，原本靠 API 密钥跑着的智能体也照常工作。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/agents/auth-specs.test.ts
+++ b/packages/launcher/src/main/agents/auth-specs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import { CORE_AGENTS, launcherAuthFields } from "./auth-specs"
+
+/**
+ * Field ORDER is part of the contract, not cosmetics.
+ *
+ * The model picker's empty state says "fill in the API key above, then the
+ * models this endpoint serves will load" — because the list is fetched FROM the
+ * key and base URL. Pi shipped with its model field above its key, so that
+ * sentence pointed at nothing: the input it named was further down the form.
+ */
+describe("launcher auth field order", () => {
+  const nameOf = (f: Record<string, unknown>): string => String(f.name || "")
+
+  for (const type of CORE_AGENTS) {
+    const fields = launcherAuthFields(type) as
+      | Array<Record<string, unknown>>
+      | null
+    if (!fields) continue
+
+    it(`${type}: credentials come before the model field`, () => {
+      const names = fields.map(nameOf)
+      const model = names.findIndex((n) => n.endsWith("_MODEL"))
+      if (model < 0) return
+      const key = names.findIndex(
+        (n) => n.endsWith("_API_KEY") || n.endsWith("_TOKEN"),
+      )
+      const base = names.findIndex((n) => n.endsWith("_BASE_URL"))
+      // Only assert on inputs this agent actually has.
+      if (key >= 0) expect(key).toBeLessThan(model)
+      if (base >= 0) expect(base).toBeLessThan(model)
+    })
+  }
+
+  it("pi asks for provider, key, endpoint, protocol, then model", () => {
+    // Pinned in full: this is the one that was wrong, and the order is also the
+    // order the fields depend on each other in.
+    const names = (launcherAuthFields("pi") as Array<Record<string, unknown>>)
+      .map(nameOf)
+      .filter((n) => n !== "PI_THINKING" && n !== "PI_TRUST_PROJECT")
+    expect(names).toEqual([
+      "PI_PROVIDER",
+      "PI_API_KEY",
+      "PI_BASE_URL",
+      "PI_API_FORMAT",
+      "PI_MODEL",
+    ])
+  })
+})

--- a/packages/launcher/src/main/agents/auth-specs.ts
+++ b/packages/launcher/src/main/agents/auth-specs.ts
@@ -497,13 +497,13 @@ export const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
       { path: ".gemini/google_accounts.json", key: "active" },
       { path: ".gemini/oauth_creds.json" },
     ],
-    // Gemini remembers the auth method it was last given in its own settings
-    // file, and when that says "gemini-api-key" it goes straight to the chat
-    // screen — the Google sign-in never runs and nothing on this panel ever
-    // changes. There is no flag to force it (no `login` subcommand, no
-    // --auth-type), so the terminal says the one thing that gets there.
+    // The terminal runs in a directory whose workspace settings ask for the
+    // Google flow (see gemini-signin.ts), so the sign-in should come up on its
+    // own. This line is the fallback for the case it doesn't — an older CLI
+    // without workspace settings, or a folder-trust policy that overrides ours
+    // — because `/auth` is the only other way in.
     terminalHint:
-      "To sign in with your Google account, type /auth in Gemini and pick the Google option.",
+      "Signing in with your Google account. If Gemini opens into chat instead, type /auth and pick the Google option.",
   },
 }
 

--- a/packages/launcher/src/main/agents/auth-specs.ts
+++ b/packages/launcher/src/main/agents/auth-specs.ts
@@ -126,6 +126,10 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       required: true,
     },
   ],
+  // Credentials first, then the endpoint, then the model: the model list is
+  // loaded FROM the key + base URL, so a picker sitting above them can only
+  // ever say "fill in the API key above" while pointing at nothing. Every
+  // other agent here is already in this order.
   pi: [
     {
       name: "PI_PROVIDER",
@@ -144,11 +148,18 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       ],
     },
     {
-      name: "PI_MODEL",
+      name: "PI_API_KEY",
       description:
-        "Exact model id exposed by the provider or relay — pick one from the list, which is loaded from the provider you selected above.",
+        "API key for the selected provider or relay. Leave blank to reuse an existing Pi /login session.",
       required: false,
-      placeholder: "claude-opus-5",
+      password: true,
+    },
+    {
+      name: "PI_BASE_URL",
+      description:
+        "Optional relay/proxy base URL. Leave blank for the provider's native API.",
+      required: false,
+      placeholder: "https://relay.example.com/v1",
     },
     {
       name: "PI_API_FORMAT",
@@ -164,18 +175,11 @@ const LAUNCHER_AUTH_OVERRIDES: Record<
       ],
     },
     {
-      name: "PI_BASE_URL",
+      name: "PI_MODEL",
       description:
-        "Optional relay/proxy base URL. Leave blank for the provider's native API.",
+        "Exact model id exposed by the provider or relay — pick one from the list, which is loaded from the provider you selected above.",
       required: false,
-      placeholder: "https://relay.example.com/v1",
-    },
-    {
-      name: "PI_API_KEY",
-      description:
-        "API key for the selected provider or relay. Leave blank to reuse an existing Pi /login session.",
-      required: false,
-      password: true,
+      placeholder: "claude-opus-5",
     },
     {
       name: "PI_THINKING",

--- a/packages/launcher/src/main/agents/gemini-signin.test.ts
+++ b/packages/launcher/src/main/agents/gemini-signin.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { prepareGeminiSignIn } from "./gemini-signin"
+
+/**
+ * The contract the Gemini sign-in terminal depends on, verified against the
+ * CLI's real settings loader (gemini-cli 0.56):
+ *
+ *   sign-in dir, no trust env  → gemini-api-key   (workspace settings dropped)
+ *   sign-in dir + trust env    → oauth-personal   (what we want)
+ *   the user's home            → gemini-api-key   (untouched)
+ *
+ * Both halves matter — without GEMINI_CLI_TRUST_WORKSPACE the CLI discards
+ * workspace settings entirely, so the override would silently do nothing.
+ */
+describe("prepareGeminiSignIn", () => {
+  let configDir: string
+
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "oa-config-"))
+  })
+  afterEach(() => {
+    fs.rmSync(configDir, { recursive: true, force: true })
+  })
+
+  const settingsOf = (cwd: string): Record<string, never> =>
+    JSON.parse(
+      fs.readFileSync(path.join(cwd, ".gemini", "settings.json"), "utf-8"),
+    )
+
+  it("asks for the Google flow in a directory of ours, not the user's home", () => {
+    const prep = prepareGeminiSignIn(configDir)!
+    expect(prep.cwd.startsWith(configDir)).toBe(true)
+    expect(prep.cwd).not.toBe(os.homedir())
+    expect(settingsOf(prep.cwd)).toEqual({
+      security: { auth: { selectedType: "oauth-personal" } },
+    })
+  })
+
+  it("marks the folder trusted — without it the CLI ignores workspace settings", () => {
+    expect(prepareGeminiSignIn(configDir)!.env).toEqual({
+      GEMINI_CLI_TRUST_WORKSPACE: "true",
+    })
+  })
+
+  it("never touches the user's own ~/.gemini/settings.json", () => {
+    // The whole reason for the workspace file: the daemon reads the user's
+    // selectedType when it runs the agent headless, so a sign-in the user
+    // abandons must not leave an agent that worked on its API key broken.
+    const prep = prepareGeminiSignIn(configDir)!
+    expect(prep.cwd).not.toContain(path.join(os.homedir(), ".gemini"))
+  })
+
+  it("rewrites a stale file rather than merging into it", () => {
+    const prep = prepareGeminiSignIn(configDir)!
+    fs.writeFileSync(
+      path.join(prep.cwd, ".gemini", "settings.json"),
+      JSON.stringify({ security: { auth: { selectedType: "gemini-api-key" } } }),
+    )
+    prepareGeminiSignIn(configDir)
+    expect(settingsOf(prep.cwd)).toEqual({
+      security: { auth: { selectedType: "oauth-personal" } },
+    })
+  })
+
+  it("returns null instead of throwing when the directory can't be made", () => {
+    // A file where the directory needs to be — the caller falls back to a
+    // plain terminal, which still reaches the sign-in via /auth.
+    const blocked = path.join(configDir, "blocked")
+    fs.writeFileSync(blocked, "not a directory")
+    expect(prepareGeminiSignIn(blocked)).toBeNull()
+  })
+})

--- a/packages/launcher/src/main/agents/gemini-signin.ts
+++ b/packages/launcher/src/main/agents/gemini-signin.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import path from "path"
+
+import { CONFIG_DIR } from "./paths"
+
+/**
+ * A folder the launcher owns, used only as the working directory of the Gemini
+ * sign-in terminal. Not the user's home: Gemini reads a workspace settings file
+ * from the directory it is started in, and pointing that at home would mean
+ * editing the user's own config.
+ */
+const SIGNIN_DIR_NAME = "gemini-signin"
+
+/**
+ * What the workspace settings file asks for — the Google account flow, by the
+ * CLI's own name for it (`AuthType.LOGIN_WITH_GOOGLE`).
+ */
+const GOOGLE_AUTH = "oauth-personal"
+
+/**
+ * Prepare a working directory that makes `gemini` open its Google sign-in.
+ *
+ * Gemini has no `login` subcommand and no auth flag: the method is picked in
+ * its TUI and remembered in ~/.gemini/settings.json as
+ * `security.auth.selectedType`. Once that says "gemini-api-key" — which is
+ * where it lands for anyone who ever configured a key — launching `gemini`
+ * goes straight to the chat screen. The Google sign-in never runs, nothing is
+ * written, and the launcher's Sign in button looks like it did nothing at all
+ * while the panel keeps saying "not signed in", because the sign-in genuinely
+ * never happened. `GEMINI_DEFAULT_AUTH_TYPE` is no help: the CLI only uses it
+ * to validate a value, never to override the setting.
+ *
+ * What works without touching the user's own config is Gemini's settings
+ * layering. It merges `<cwd>/.gemini/settings.json` OVER the user file, so a
+ * directory the launcher owns can ask for the Google flow for that run only.
+ * Two conditions come with it:
+ *
+ *   • workspace settings are honored only in a folder the CLI considers
+ *     trusted, and `GEMINI_CLI_TRUST_WORKSPACE=true` is the documented way to
+ *     say so non-interactively — it is exactly what the CLI's own
+ *     `--skip-trust` flag sets;
+ *   • the sign-in itself is global (the account is recorded in ~/.gemini and
+ *     the token goes to the OS keychain), so the probe sees it afterwards and
+ *     the agent keeps whatever auth method the user actually configured.
+ *
+ * Returns the cwd + env for the terminal, or null if the directory could not be
+ * prepared — in which case the caller should still open the terminal, just
+ * without the override. The user can always reach the same place with `/auth`,
+ * which is what the terminal prints.
+ */
+export function prepareGeminiSignIn(configDir: string = CONFIG_DIR): {
+  cwd: string
+  env: Record<string, string>
+} | null {
+  try {
+    const dir = path.join(configDir, SIGNIN_DIR_NAME)
+    const settingsDir = path.join(dir, ".gemini")
+    fs.mkdirSync(settingsDir, { recursive: true })
+    // Rewritten every time rather than merged: this file is ours, nobody else
+    // writes it, and a stale value here would silently put the user back where
+    // they started.
+    fs.writeFileSync(
+      path.join(settingsDir, "settings.json"),
+      JSON.stringify(
+        { security: { auth: { selectedType: GOOGLE_AUTH } } },
+        null,
+        2,
+      ) + "\n",
+      "utf-8",
+    )
+    return { cwd: dir, env: { GEMINI_CLI_TRUST_WORKSPACE: "true" } }
+  } catch {
+    return null
+  }
+}

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -28,6 +28,7 @@ import {
   type NodeStatus,
 } from "./agent-manager"
 import { CliLoginManager } from "./cli-login"
+import { prepareGeminiSignIn } from "./agents/gemini-signin"
 import {
   ConnectionsStore,
   CredentialsStore,
@@ -2098,7 +2099,12 @@ function setupIPC(): void {
   // Open a terminal running `cmd`, optionally cd'd into `cwd` first. Shared by
   // the CLI-login flow (no cwd) and the per-agent "Chat" button, which opens an
   // interactive CLI session inside the agent's working folder.
-  const runTerminal = (cmd: string, cwd?: string, agentType?: string): void => {
+  const runTerminal = (
+    cmd: string,
+    cwd?: string,
+    agentType?: string,
+    extraEnv?: Record<string, string>,
+  ): void => {
     const { spawn } = require("child_process")
     // Resolve the CLI to an ABSOLUTE binary path so the terminal never depends
     // on PATH. A CLI's own installer only edits the *registry* PATH (Cursor
@@ -2179,6 +2185,9 @@ function setupIPC(): void {
           "@echo off",
           "chcp 65001 >nul",
           `set "PATH=${allBins};%PATH%"`,
+          ...Object.entries(extraEnv || {}).map(
+            ([k, v]) => `set "${k}=${v}"`,
+          ),
           ...(cwd ? [`cd /d "${cwd}"`] : []),
           ...(hint ? [`echo ${hint.replace(/[&<>|^]/g, " ")}`, "echo."] : []),
           resolvedCmd,
@@ -2233,6 +2242,9 @@ function setupIPC(): void {
       const sq = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`
       const lines = [
         `export PATH=${sq(allBins)}:"$PATH"`,
+        ...Object.entries(extraEnv || {}).map(
+          ([k, v]) => `export ${k}=${sq(v)}`,
+        ),
         ...(cwd ? [`cd ${sq(cwd)}`] : []),
         ...(hint ? [`echo ${sq(hint)}`, "echo"] : []),
         resolvedCmd,
@@ -2303,7 +2315,13 @@ function setupIPC(): void {
     // The type is passed explicitly: the fallback terminal must resolve the
     // SAME binary the piped attempt just used, not re-guess it from the
     // command's first word.
-    openTerminal: (cmd, type) => runTerminal(cmd, undefined, type),
+    openTerminal: (cmd, type) => {
+      // Gemini opens straight into chat when it remembers an API key, so the
+      // sign-in runs in a directory of ours whose workspace settings ask for
+      // the Google flow. Everything else gets the plain terminal.
+      const prep = type === "gemini" ? prepareGeminiSignIn() : null
+      runTerminal(cmd, prep?.cwd, type, prep?.env)
+    },
     emit: (ev) => {
       if (mainWindow && !mainWindow.isDestroyed())
         mainWindow.webContents.send("cli-login:event", ev)

--- a/packages/launcher/src/renderer/components/model-field.test.tsx
+++ b/packages/launcher/src/renderer/components/model-field.test.tsx
@@ -94,4 +94,58 @@ describe("ModelField", () => {
     await userEvent.click(await screen.findByText("gpt-5.6-sol"))
     expect(onChange).toHaveBeenCalledWith("gpt-5.6-sol")
   })
+
+  it("drops the list when the credentials it came from change", async () => {
+    // The bug: clearing the key and reopening the picker re-presented the old
+    // provider's models as if they still applied.
+    const api = installApi([{ id: "relay-only-model" }])
+    const props = {
+      id: "m",
+      agentType: "codex",
+      value: "",
+      path: "key" as const,
+      onChange: vi.fn(),
+    }
+    const { rerender } = render(
+      <ModelField {...props} env={{ OPENAI_API_KEY: "sk-old" }} />,
+    )
+    await userEvent.click(screen.getByRole("button"))
+    expect(await screen.findByText("relay-only-model")).toBeTruthy()
+    await userEvent.keyboard("{Escape}")
+
+    api.listModels.mockResolvedValue({
+      models: [],
+      source: "none",
+      code: "need_key",
+    })
+    rerender(<ModelField {...props} env={{ OPENAI_API_KEY: "" }} />)
+    await userEvent.click(screen.getByRole("button"))
+    await waitFor(() => expect(api.listModels).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText("relay-only-model")).toBeNull()
+  })
+
+  it("keeps the list while only the model text changes", async () => {
+    // The other half: keying off the whole form would re-fetch on every
+    // keystroke in the model box.
+    const api = installApi([{ id: "gpt-5.6-sol" }])
+    const props = {
+      id: "m",
+      agentType: "codex",
+      value: "",
+      path: "key" as const,
+      onChange: vi.fn(),
+    }
+    const { rerender } = render(
+      <ModelField {...props} env={{ OPENAI_API_KEY: "sk-x", CODEX_MODEL: "" }} />,
+    )
+    await userEvent.click(screen.getByRole("button"))
+    await waitFor(() => expect(api.listModels).toHaveBeenCalledTimes(1))
+    await userEvent.keyboard("{Escape}")
+
+    rerender(
+      <ModelField {...props} env={{ OPENAI_API_KEY: "sk-x", CODEX_MODEL: "g" }} />,
+    )
+    await userEvent.click(screen.getByRole("button"))
+    expect(api.listModels).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/launcher/src/renderer/components/model-field.tsx
+++ b/packages/launcher/src/renderer/components/model-field.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Check,
@@ -88,6 +88,24 @@ export function ModelField({
     setOpen(next)
     if (next && !result && !loading) void load()
   }
+
+  // …but a list belongs to the credentials it was fetched with. Clearing the
+  // key and reopening the picker used to re-present the old provider's models
+  // as if they still applied — the one thing this field exists to stop. Only
+  // the credential inputs count: keying off the whole form would throw the
+  // list away on every keystroke in the model box itself.
+  const credentials = useMemo(
+    () =>
+      Object.keys(env)
+        .filter((k) => /API_KEY$|BASE_URL$|_TOKEN$|_PROVIDER$/.test(k))
+        .sort()
+        .map((k) => `${k}=${env[k] || ""}`)
+        .join("\n"),
+    [env],
+  )
+  useEffect(() => {
+    setResult(null)
+  }, [credentials, path])
 
   const hasModels = !!result?.models.length
   const sourceLabel = result

--- a/packages/launcher/src/renderer/globals.css
+++ b/packages/launcher/src/renderer/globals.css
@@ -676,16 +676,27 @@ code {
   --titlebar-h: 0px;
 }
 
-.titlebar-drag {
-  -webkit-app-region: drag;
-  user-select: none;
-}
+/* A drag region is invisible by definition, and on macOS the rail is the ONLY
+   one — the traffic lights sit over it, so the content pane reserves no strip
+   of its own and its handle collapses to zero height. Nothing on screen says
+   so. The grab cursor is the entire affordance: it costs no pixels, adds no
+   ornament, and answers the question the moment the pointer passes over. */
+.titlebar-drag,
 .sidebar-drag {
   -webkit-app-region: drag;
   user-select: none;
+  cursor: grab;
 }
+.titlebar-drag:active,
+.sidebar-drag:active {
+  cursor: grabbing;
+}
+/* `cursor` inherits, so anything that opts back out of the drag region has to
+   take its own cursor back too — otherwise every nav row in the rail would
+   offer to be dragged. Buttons and links set their own and are unaffected. */
 .sidebar-no-drag {
   -webkit-app-region: no-drag;
+  cursor: auto;
 }
 
 /* ===========================================================


### PR DESCRIPTION
Follow-up to #629. That PR got the terminal to open and run its command; this one gets the sign-in to actually start, and carries three smaller fixes found while testing it.

## 1. Gemini opened its chat screen instead of the Google sign-in

Clicking Sign in opened the terminal, printed the `/auth` hint, and Gemini came up on `Authenticated with gemini-api-key`. The panel then said "not signed in", which was correct: nothing had happened.

Gemini has no `login` subcommand and no auth flag. The method is picked inside its TUI and remembered in `~/.gemini/settings.json` as `security.auth.selectedType`, and for anyone who has ever entered an API key that is what it stays on. `GEMINI_DEFAULT_AUTH_TYPE` looks like the way out but isn't — the CLI only uses it to validate a value:

```js
const defaultAuthType = process.env["GEMINI_DEFAULT_AUTH_TYPE"];
if (defaultAuthType && !Object.values(AuthType).includes(defaultAuthType)) {
  onAuthError(`Invalid value for GEMINI_DEFAULT_AUTH_TYPE: …`);
  return;
}
await config.refreshAuth(authType);   // ← still settings.security.auth.selectedType
```

**The fix.** Gemini merges a workspace settings file (`<cwd>/.gemini/settings.json`) over the user one:

```js
function mergeSettings(system, systemDefaults, user, workspace, isTrusted) {
  const safeWorkspace = isTrusted ? workspace : {};
  return customDeepMerge(getMergeStrategyForPath, schemaDefaults, systemDefaults, user, safeWorkspace, system);
}
```

So the sign-in runs in `~/.openagents/gemini-signin/`, whose `.gemini/settings.json` asks for `oauth-personal`. Note `isTrusted`: without it the workspace file is discarded outright, and `GEMINI_CLI_TRUST_WORKSPACE=true` is the documented non-interactive way to say the folder is trusted (`--skip-trust` sets exactly that env var).

Verified against the CLI's real loader — importing `loadSettings` from the installed gemini-cli 0.56 bundle, one process per case (its settings cache has a 10s TTL and will otherwise answer the second call from the first):

| cwd | env | merged selectedType | trusted |
|---|---|---|---|
| sign-in dir | — | `gemini-api-key` | false |
| sign-in dir | `GEMINI_CLI_TRUST_WORKSPACE=true` | **`oauth-personal`** | true |
| user's home | — | `gemini-api-key` | true |

Row 1 is why the env var is not optional.

**Why not just rewrite the user's settings.json.** The daemon reads the same `selectedType` when it runs the agent headless, so a sign-in the user starts and abandons would leave an agent that was working fine on its API key unable to run — and there is nowhere reliable to undo it (the terminal-path session stops polling after five minutes without settling, and leaving the page deliberately doesn't cancel it).

⚠️ **What this does not achieve, verified on a real sign-in.** An earlier version of this description claimed the user's own settings are left untouched. They are not. The launcher never writes that file, but Gemini does: when the CLI shows its `Get started` picker and the user confirms "Sign in with Google", it calls `settings.setValue(User, "security.auth.selectedType", …)` itself. The workspace file only decides what the picker is *defaulted to*. So the abandonment risk above is reduced, not eliminated — it now requires the user to have confirmed the picker.

**Also from that real sign-in, worth knowing before this merges:** Google now rejects individual accounts at the Code Assist layer —

> Failed to sign in. This client is no longer supported for Gemini Code Assist for individuals. To continue using Gemini, please migrate to the Antigravity suite of products.

OAuth succeeds (the account lands in `google_accounts.json`, the panel correctly reads "signed in"), and then every request fails. [Google's announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) puts the hard cutoff at **2026-06-18** for AI Pro/Ultra and free Code Assist for individuals; enterprise licences and paid Gemini Agent Platform API keys keep working, as do third-party relays (they never touch Code Assist). So this fix makes the sign-in *work*, but the sign-in itself is a dead end for most personal accounts. Telling the user that in the panel — and Antigravity CLI as an agent type — are follow-ups, not this PR.

## 2. The model picker kept the previous provider's list

Fetched once, then held for as long as the form stayed open. Clear the API key, reopen the picker, and it re-presented the old endpoint's models as if they still applied — the one thing this field exists to prevent. Editing a credential (`*_API_KEY`, `*_BASE_URL`, `*_TOKEN`, `*_PROVIDER`) now drops the list. Deliberately not the whole form: that would re-fetch on every keystroke in the model box itself. Both halves are tested.

## 3. Pi asked for the model above the key

The picker's empty state reads "fill in the API key above, then the models this endpoint serves will load" — and Pi's key was further down the form, so the sentence pointed at nothing. Pi was the only agent in this shape:

```
claude/gemini/codex/kimi/openclaw/opencode/cline   KEY → BASE_URL → MODEL
pi                       PROVIDER → MODEL → API_FORMAT → BASE_URL → KEY
```

Now `PROVIDER → API_KEY → BASE_URL → API_FORMAT → MODEL`, which is both what the others already do and the order the fields depend on each other in. A new test pins "credentials before model" for every agent, so the next one added can't drift.

## 4. Nothing said the window could be dragged from the rail

On macOS the traffic lights sit over the rail, so the content pane reserves no strip and its drag handle collapses to zero height (`--content-top-inset: 0`). The rail is the only place the window can be moved from — and a drag region is invisible by definition, so users try the page header and nothing happens.

The drag regions now carry `cursor: grab`. No pixels, no ornament, and it answers the question the moment the pointer passes over. `sidebar-no-drag` takes its own cursor back, since `cursor` inherits and every nav row would otherwise offer to be dragged. Windows is unaffected by the underlying problem (its buttons are top-right, so the content pane keeps a real 40px strip) but gains the same cue.

Considered and rejected: making `PageHeader` itself a drag handle. It would work, but every interactive child then has to opt back out of the drag region, and the next header that forgets silently stops taking clicks.

## Testing

`npm run typecheck`, `npx vitest run` (348 passed, +15), `npm run build`. New cases cover the sign-in workspace (settings contents, trust env, stale-file rewrite, null return when the directory can't be made), model-list invalidation both ways, and field order across every agent.

The end-to-end sign-in was run by hand: terminal opens in the sign-in directory, Gemini goes straight to the Google flow, OAuth completes, `google_accounts.json` gets the address, and the panel flips to "signed in" on its own. What it then hits is the Code Assist rejection above, not a launcher problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)