### PR TITLE
fix(core): stop third-party installers from hanging on a missing git

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.169",
+  "version": "0.2.170",
   "description": "OpenAgents Launcher \u2014 install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -822,7 +822,7 @@
     "builtin": true,
     "install": {
       "binary": "hermes",
-      "requires": ["python3"],
+      "requires": ["python3", "git"],
       "macos": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
       "linux": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
       "windows": "\"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -ExecutionPolicy Bypass -Command \"Invoke-RestMethod -UseBasicParsing 'https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1' | Invoke-Expression\""

--- a/packages/agent-connector/src/install-preflight.js
+++ b/packages/agent-connector/src/install-preflight.js
@@ -1,0 +1,233 @@
+/**
+ * Pre-flight checks for install commands that shell out to a third-party script.
+ *
+ * `curl … | bash` installers are black boxes: whatever they decide to do about a
+ * missing dependency happens with no way for us to explain it, cancel it, or
+ * even show a useful progress line. Hermes is the case that forced this file to
+ * exist. Its install.sh needs git to clone the repo, and on a mac with no
+ * developer tools it:
+ *   1. runs `git --version`, which on macOS is a SHIM that opens the system
+ *      "The 'git' command requires the command line developer tools" dialog —
+ *      a dialog with no OpenAgents branding, appearing seconds after the user
+ *      pressed Install in our marketplace;
+ *   2. calls `xcode-select --install`, opening it a second time;
+ *   3. sleeps in a 5-second poll loop for up to 900 SECONDS waiting for git to
+ *      appear, printing one line per minute.
+ * In the launcher that reads as a progress bar frozen on "downloading" for a
+ * quarter of an hour, so users retry, which starts the whole thing again.
+ *
+ * Catching the missing dependency BEFORE spawning the installer turns all of
+ * that into one actionable message.
+ *
+ * Only dependencies with a probe below are enforced. `install.requires` is
+ * hand-maintained and partly aspirational — hermes lists python3 even though
+ * its installer provisions Python through uv when none is found — so an unknown
+ * entry is left to the installer rather than blocking an install that would
+ * have worked.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const IS_MACOS = process.platform === 'darwin';
+
+/** Directories on PATH, minus any the caller wants skipped. */
+function pathDirs(exclude = []) {
+  const raw = process.env.PATH || '';
+  return raw
+    .split(path.delimiter)
+    .map((d) => d.trim())
+    .filter((d) => d && !exclude.includes(d));
+}
+
+function existsIn(dirs, name, exists, isWindows) {
+  const names = isWindows ? [`${name}.exe`, `${name}.cmd`, name] : [name];
+  for (const dir of dirs) {
+    for (const n of names) {
+      const full = path.join(dir, n);
+      try {
+        if (exists(full)) return full;
+      } catch {
+        /* unreadable dir on PATH — skip */
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The active developer directory, or null when none is selected. `xcode-select
+ * -p` is safe to run with no tools installed: it exits 2 and prints to stderr
+ * WITHOUT opening the install dialog. Running `git` is what opens it.
+ */
+function activeDeveloperDir() {
+  try {
+    return (
+      execFileSync('xcode-select', ['-p'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim() || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is a REAL git available?
+ *
+ * The hard constraint on macOS: never execute `git`, and never execute
+ * `/usr/bin/git` in particular. That file exists on every mac whether or not
+ * the Command Line Tools are installed, and running it is precisely what opens
+ * the install dialog we are trying to get ahead of. So this probe only ever
+ * touches the filesystem plus `xcode-select -p`, which reports the active
+ * developer directory (exit code 2, no dialog, when there is none).
+ *
+ * Two platforms are deliberately exempt, because on them a missing git is
+ * something the installer genuinely recovers from:
+ *
+ * - **Windows.** install.ps1's Install-Git downloads PortableGit from
+ *   github.com into %LOCALAPPDATA%\hermes\git — no admin rights, no dialog, no
+ *   winget. It is slow (the script's own comment budgets five minutes) and it
+ *   can fail on a restricted network, but blocking the install would break the
+ *   many machines where it works. What Windows needs from us is a readable
+ *   error when that download fails, not a refusal — see userFacingInstallError
+ *   in the launcher.
+ * - **Linux as root.** install.sh shells out to apt/dnf/pacman, which succeeds
+ *   without a password prompt when we are already root. As a normal user the
+ *   sudo call has no tty to ask on and fails, so the refusal stands there.
+ *
+ * @param {object} [deps] - seams for tests; production passes nothing.
+ */
+function probeGit(deps = {}) {
+  const platform = deps.platform || process.platform;
+  const exists = deps.exists || ((p) => fs.existsSync(p));
+  const dirs = deps.dirs || null;
+
+  if (platform === 'win32') {
+    return { ok: true, detail: 'installer provisions PortableGit itself' };
+  }
+
+  if (platform !== 'darwin') {
+    const search = dirs || [...pathDirs(), '/usr/bin', '/usr/local/bin'];
+    const found = existsIn(search, 'git', exists, false);
+    if (found) return { ok: true, detail: found };
+    const uid = deps.uid !== undefined ? deps.uid : (process.getuid ? process.getuid() : null);
+    if (uid === 0) return { ok: true, detail: 'root can install git unattended' };
+    return { ok: false };
+  }
+
+  // A git outside /usr/bin (Homebrew, MacPorts, a manual install) is a real
+  // binary and safe to trust without running it.
+  const search = dirs || [
+    ...pathDirs(['/usr/bin']),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ];
+  const found = existsIn(search, 'git', exists, false);
+  if (found) return { ok: true, detail: found };
+
+  // Otherwise the only candidate left is the /usr/bin shim, which forwards to
+  // the active developer directory. Resolve that directory and look for the git
+  // it would forward to: present means the shim works, absent means running it
+  // would open the dialog — which is exactly the case we refuse to walk into.
+  const developerDir =
+    'developerDir' in deps ? deps.developerDir : activeDeveloperDir();
+
+  const candidates = [];
+  if (developerDir) candidates.push(path.join(developerDir, 'usr', 'bin', 'git'));
+  candidates.push('/Library/Developer/CommandLineTools/usr/bin/git');
+  for (const c of candidates) {
+    try {
+      if (exists(c)) return { ok: true, detail: c };
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return { ok: false };
+}
+
+/**
+ * How the user fixes each missing dependency, phrased for the install screen.
+ * `action` is a hint the launcher UI can turn into a button; everything else
+ * degrades to plain text.
+ */
+function gitRemedy() {
+  if (IS_MACOS) {
+    return {
+      name: 'git',
+      action: 'install-xcode-clt',
+      summary: 'Git is required, and it comes with the Xcode Command Line Tools.',
+      command: 'xcode-select --install',
+      alternative: 'brew install git',
+    };
+  }
+  return {
+    name: 'git',
+    action: null,
+    summary: 'Git is required to download this agent.',
+    command: 'sudo apt install git   # or dnf / pacman, per your distro',
+    alternative: null,
+  };
+}
+
+const PROBES = {
+  git: { probe: probeGit, remedy: gitRemedy },
+};
+
+/**
+ * Check a registry entry's `install.requires` against the machine.
+ * @returns {{ ok: boolean, missing: Array<{name: string, action: string|null, summary: string, command: string, alternative: string|null}> }}
+ */
+function checkInstallPrereqs(entry) {
+  const requires = entry && entry.install ? entry.install.requires : null;
+  if (!Array.isArray(requires) || requires.length === 0) return { ok: true, missing: [] };
+
+  const missing = [];
+  for (const name of requires) {
+    const spec = PROBES[String(name || '').toLowerCase()];
+    if (!spec) continue; // no probe → the installer's problem, not ours
+    let result;
+    try {
+      result = spec.probe();
+    } catch {
+      continue; // a probe that throws must never block an install
+    }
+    if (!result || !result.ok) missing.push(spec.remedy());
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * The error thrown in place of running the installer. Carries `code` and
+ * `missing` so the launcher can render buttons instead of parsing prose, and a
+ * message that stands on its own for the CLI and the log.
+ */
+function missingPrereqError(agentLabel, missing) {
+  const lines = [
+    `${agentLabel} cannot be installed yet — a required tool is missing.`,
+    '',
+  ];
+  for (const item of missing) {
+    lines.push(`• ${item.summary}`);
+    lines.push(`  Install it with:  ${item.command}`);
+    if (item.alternative) lines.push(`  Or:               ${item.alternative}`);
+  }
+  lines.push('', 'Once it is installed, come back and press Install again.');
+
+  const err = new Error(lines.join('\n'));
+  err.code = 'MISSING_PREREQ';
+  err.missing = missing;
+  return err;
+}
+
+module.exports = {
+  checkInstallPrereqs,
+  missingPrereqError,
+  probeGit,
+};

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -8,9 +8,31 @@ const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache, a
 const { EnvManager } = require('./env');
 const { nodeDistUrls, installRegistry } = require('./mirrors');
 const { readinessReason, REASON } = require('./adapters/health-status');
+const { checkInstallPrereqs, missingPrereqError } = require('./install-preflight');
+const { detectShadowedNodeShims, shadowedNodeWarning } = require('./node-shims');
 
 const STATUS_CACHE_TTL_MS = 10000;
 const statusCache = new Map();
+
+/**
+ * How long a streaming install may produce NO output before it is treated as
+ * hung and killed. Generous on purpose: a slow npm postinstall or a large
+ * extraction can legitimately go quiet for a while, and killing a working
+ * install is worse than waiting. Set OPENAGENTS_INSTALL_STALL_MS=0 to disable.
+ */
+const INSTALL_STALL_MS = (() => {
+  const raw = process.env.OPENAGENTS_INSTALL_STALL_MS;
+  if (raw === undefined || raw === '') return 10 * 60 * 1000;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 10 * 60 * 1000;
+})();
+
+/**
+ * How often the stall watchdog checks. Capped at half the stall budget so the
+ * poll granularity never dominates the deadline (matters for a short budget in
+ * tests; in production the 15s ceiling applies).
+ */
+const STALL_POLL_MS = Math.max(50, Math.min(15000, Math.floor(INSTALL_STALL_MS / 2) || 15000));
 
 // Version detection is comparatively expensive (spawns `<bin> --version`), so
 // results are cached briefly and invalidated on install/uninstall.
@@ -976,6 +998,8 @@ class Installer {
       return { success: true, output: `${entry.label || agentType} uses direct API mode; no binary install needed.` };
     }
 
+    this._assertPrereqs(agentType, entry);
+
     let cmd = this._getInstallCommand(entry.install);
     if (!cmd) {
       throw new Error(`No install command for ${agentType} on ${Installer.platform()}`);
@@ -1044,6 +1068,8 @@ class Installer {
       if (onData) onData(`\nDone! ${agentType} is now installed.\n`);
       return { success: true, command: 'api-only' };
     }
+
+    this._assertPrereqs(agentType, entry, onData);
 
     let rawCmd = this._getInstallCommand(entry.install);
     if (!rawCmd) {
@@ -1127,14 +1153,30 @@ class Installer {
 
     return new Promise((resolve, reject) => {
       // windowsHide stops a console window from flashing up on every install.
-      const proc = spawn(spawnFile, spawnArgs, { shell: useShell, env, cwd: installCwd, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+      //
+      // detached (Unix): puts the installer in its own process group, which is
+      // what makes the stall watchdog able to stop the WHOLE tree. Without it
+      // the direct child is a shell and the actual work — curl, git, uv — runs
+      // in grandchildren that survive a signal aimed at the shell. It does not
+      // change lifetime semantics: an install was never killed by the launcher
+      // exiting, before or after this.
+      const proc = spawn(spawnFile, spawnArgs, {
+        shell: useShell,
+        env,
+        cwd: installCwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        detached: process.platform !== 'win32',
+      });
 
       if (proc.stdout) proc.stdout.setEncoding('utf-8');
       if (proc.stderr) proc.stderr.setEncoding('utf-8');
 
       let outputTail = '';
+      let lastOutputAt = Date.now();
       const captureOutput = (d) => {
         const text = String(d);
+        lastOutputAt = Date.now();
         outputTail = (outputTail + text).slice(-4000);
         if (onData) onData(text);
       };
@@ -1142,8 +1184,40 @@ class Installer {
       if (proc.stdout) proc.stdout.on('data', captureOutput);
       if (proc.stderr) proc.stderr.on('data', captureOutput);
 
-      proc.on('error', (err) => reject(err));
+      // Stall watchdog. A third-party installer that decides to wait — hermes's
+      // install.sh polls for up to 900s after asking macOS for the developer
+      // tools — otherwise hangs this promise indefinitely, and the only visible
+      // symptom is a progress bar that stopped moving. The preflight now
+      // prevents that specific case, but the general shape (a download that
+      // never returns, a prompt on a stdin nobody is reading) is not specific
+      // to any one installer, so time is bounded here for all of them.
+      let stallTimer = null;
+      let stalled = false;
+      const clearStallTimer = () => {
+        if (stallTimer) { clearInterval(stallTimer); stallTimer = null; }
+      };
+      if (INSTALL_STALL_MS > 0) {
+        stallTimer = setInterval(() => {
+          if (Date.now() - lastOutputAt < INSTALL_STALL_MS) return;
+          stalled = true;
+          clearStallTimer();
+          const minutes = Math.round(INSTALL_STALL_MS / 60000);
+          const msg = `Install stalled: no output for ${minutes} minutes. `
+            + 'The installer was stopped. It may be waiting on a prompt, or on a '
+            + 'download that never returns.';
+          if (onData) onData(`\n${msg}\n`);
+          this._killProcessTree(proc);
+          reject(new Error(msg));
+        }, STALL_POLL_MS);
+        // Never hold the event loop open for the watchdog alone.
+        if (typeof stallTimer.unref === 'function') stallTimer.unref();
+      }
+
+      proc.on('error', (err) => { clearStallTimer(); reject(err); });
       proc.on('close', (code) => {
+        clearStallTimer();
+        // The watchdog already rejected; this close is the kill it performed.
+        if (stalled) return;
         if (code === 0) {
           // Aider-only: confirm a real, genuine binary exists before recording
           // the install (verify-before-mark; never writes a marker on
@@ -1181,6 +1255,13 @@ class Installer {
               return;
             }
             if (onData) onData(`\nHermes CLI resolved: ${hermes.path}\n`);
+            // Its installer may have repointed the machine's node/npm/npx at
+            // its own Node. See node-shims.js — we report, never rewrite.
+            const shimWarning = shadowedNodeWarning(
+              entry.label || agentType,
+              detectShadowedNodeShims(),
+            );
+            if (shimWarning && onData) onData(`${shimWarning}\n`);
           }
           // Cursor-only: same failure shape as hermes above — its installer
           // exits 0 after a failed download. See _verifyCursorBinary.
@@ -1359,6 +1440,51 @@ class Installer {
         }
       });
     });
+  }
+
+  /**
+   * Refuse to run a third-party installer whose hard dependencies are missing.
+   *
+   * See install-preflight.js for why this is worth doing before the spawn: the
+   * scripts we shell out to handle a missing dependency by opening OS dialogs
+   * and sleeping for minutes, which the launcher can only render as a frozen
+   * progress bar.
+   */
+  _assertPrereqs(agentType, entry, onData, check = checkInstallPrereqs) {
+    const { ok, missing } = check(entry);
+    if (ok) return;
+    const err = missingPrereqError(entry.label || agentType, missing);
+    if (onData) onData(`${err.message}\n`);
+    throw err;
+  }
+
+  /**
+   * Stop a spawned installer and everything it started.
+   *
+   * The child is usually a shell (`curl … | bash`, powershell) whose real work
+   * happens in grandchildren, so signalling the direct child alone leaves the
+   * download running. On Unix the process group is signalled; on Windows
+   * taskkill /T walks the tree.
+   */
+  _killProcessTree(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    try {
+      if (process.platform === 'win32') {
+        try {
+          execSync(`taskkill /F /T /PID ${proc.pid}`, {
+            stdio: 'ignore', timeout: 5000, windowsHide: true,
+          });
+        } catch { proc.kill(); }
+        return;
+      }
+      try { process.kill(-proc.pid, 'SIGTERM'); } catch { proc.kill('SIGTERM'); }
+      setTimeout(() => {
+        if (proc.exitCode !== null) return;
+        try { process.kill(-proc.pid, 'SIGKILL'); } catch { proc.kill('SIGKILL'); }
+      }, 5000).unref();
+    } catch {
+      /* the process is already gone */
+    }
   }
 
   /**

--- a/packages/agent-connector/src/node-shims.js
+++ b/packages/agent-connector/src/node-shims.js
@@ -1,0 +1,103 @@
+/**
+ * Detecting an agent installer that has taken over the machine's `node`.
+ *
+ * Hermes's install.sh, when it decides the system Node is too old, downloads
+ * its own and then does this:
+ *
+ *   ln -sf "$HERMES_HOME/node/bin/node" "$HOME/.local/bin/node"
+ *   ln -sf "$HERMES_HOME/node/bin/npm"  "$HOME/.local/bin/npm"
+ *   ln -sf "$HERMES_HOME/node/bin/npx"  "$HOME/.local/bin/npx"
+ *
+ * `ln -sf` overwrites. On a machine where ~/.local/bin comes before nvm or
+ * Homebrew on PATH — a very common layout — the user's default `node` silently
+ * becomes the agent's, for every shell and every unrelated project, and npm's
+ * global prefix is rewritten to ~/.local along with it. Nothing announces this,
+ * and nothing connects a project that suddenly builds differently back to
+ * having installed an agent.
+ *
+ * This module only looks and reports. Rewriting a user's PATH or deleting their
+ * symlinks would be a second uninvited change on top of the first, and the
+ * agent's Node may be exactly what they want. Telling them precisely what
+ * happened, and how to undo it, is the part that was missing.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/**
+ * node/npm/npx under `linkDir` that are symlinks into `ownerDir`, together with
+ * whether they shadow another installation the user already had.
+ *
+ * @param {object} [deps] - seams for tests; production passes nothing.
+ * @returns {{ shims: Array<{name: string, link: string, target: string}>, shadowed: string|null }}
+ */
+function detectShadowedNodeShims(deps = {}) {
+  const home = deps.home || os.homedir();
+  const linkDir = deps.linkDir || path.join(home, '.local', 'bin');
+  const ownerDir = deps.ownerDir || path.join(home, '.hermes', 'node', 'bin');
+  const readLink = deps.readLink || defaultReadLink;
+  const exists = deps.exists || ((p) => fs.existsSync(p));
+  const entries = deps.pathEntries || (process.env.PATH || '').split(path.delimiter);
+
+  const shims = [];
+  for (const name of ['node', 'npm', 'npx']) {
+    const link = path.join(linkDir, name);
+    const target = readLink(link);
+    if (!target) continue;
+    const resolved = path.resolve(linkDir, target);
+    if (resolved === path.join(ownerDir, name) || resolved.startsWith(ownerDir + path.sep)) {
+      shims.push({ name, link, target: resolved });
+    }
+  }
+  if (shims.length === 0) return { shims: [], shadowed: null };
+
+  // Only a problem if the user HAD another node. On a machine with none, these
+  // symlinks are the installer doing something useful.
+  const normalized = entries.map((d) => d.trim()).filter(Boolean);
+  const linkIndex = normalized.indexOf(linkDir);
+  const after = linkIndex === -1 ? normalized : normalized.slice(linkIndex + 1);
+  for (const dir of after) {
+    if (dir === linkDir) continue;
+    const candidate = path.join(dir, 'node');
+    try {
+      if (exists(candidate)) return { shims, shadowed: candidate };
+    } catch {
+      /* unreadable dir on PATH — skip */
+    }
+  }
+  return { shims, shadowed: null };
+}
+
+/** lstat + readlink, or null when the path is absent or not a symlink. */
+function defaultReadLink(p) {
+  try {
+    if (!fs.lstatSync(p).isSymbolicLink()) return null;
+    return fs.readlinkSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The warning text, or null when there is nothing worth saying. Written to be
+ * read in an install log by someone who did not expect any of this.
+ */
+function shadowedNodeWarning(agentLabel, detection) {
+  if (!detection || detection.shims.length === 0 || !detection.shadowed) return null;
+  const names = detection.shims.map((s) => s.name).join(', ');
+  const dir = path.dirname(detection.shims[0].link);
+  return [
+    '',
+    `Note: the ${agentLabel} installer replaced ${names} in ${dir} with links to its own Node.`,
+    `That now takes precedence over ${detection.shadowed} for every shell on this machine,`,
+    'so other projects will build with the agent\'s Node version from here on.',
+    '',
+    'To put your own Node back, remove the links (this does not affect the agent):',
+    `  rm -f ${detection.shims.map((s) => s.link).join(' ')}`,
+  ].join('\n');
+}
+
+module.exports = { detectShadowedNodeShims, shadowedNodeWarning };

--- a/packages/agent-connector/test/install-preflight.test.js
+++ b/packages/agent-connector/test/install-preflight.test.js
@@ -3,11 +3,21 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
+const path = require('node:path');
+
 const {
   checkInstallPrereqs,
   missingPrereqError,
   probeGit,
 } = require('../src/install-preflight');
+
+// Paths are built with path.join so the expectations match what the probe
+// itself builds. Hardcoded POSIX literals passed on macOS/Linux and failed on
+// the Windows runner, where path.join yields backslashes — a defect in the
+// test, not in the code it covers. Skipping Windows instead would have dropped
+// the coverage rather than fixed it.
+const HOMEBREW_GIT = path.join('/opt/homebrew/bin', 'git');
+const USR_BIN_GIT = path.join('/usr/bin', 'git');
 
 /** A mac with nothing developer-ish installed: no brew git, no CLT, no Xcode. */
 const CLEAN_MAC = { platform: 'darwin', dirs: [], developerDir: null, exists: () => false };
@@ -26,10 +36,11 @@ test('git probe: Command Line Tools alone is enough', () => {
 
 test('git probe: a full Xcode install is enough', () => {
   const developerDir = '/Applications/Xcode.app/Contents/Developer';
+  const xcodeGit = path.join(developerDir, 'usr', 'bin', 'git');
   const result = probeGit({
     ...CLEAN_MAC,
     developerDir,
-    exists: (p) => p === `${developerDir}/usr/bin/git`,
+    exists: (p) => p === xcodeGit,
   });
   assert.strictEqual(result.ok, true);
 });
@@ -39,14 +50,14 @@ test('git probe: a Homebrew git satisfies it without touching xcode-select', () 
   const result = probeGit({
     platform: 'darwin',
     dirs: ['/opt/homebrew/bin'],
-    exists: (p) => p === '/opt/homebrew/bin/git',
+    exists: (p) => p === HOMEBREW_GIT,
     get developerDir() {
       developerDirRead = true;
       return null;
     },
   });
   assert.strictEqual(result.ok, true);
-  assert.strictEqual(result.detail, '/opt/homebrew/bin/git');
+  assert.strictEqual(result.detail, HOMEBREW_GIT);
   assert.strictEqual(developerDirRead, false, 'should short-circuit before the CLT check');
 });
 
@@ -64,7 +75,7 @@ test('git probe: Linux looks at PATH', () => {
     false,
   );
   assert.strictEqual(
-    probeGit({ platform: 'linux', dirs: ['/usr/bin'], exists: (p) => p === '/usr/bin/git', uid: 1000 }).ok,
+    probeGit({ platform: 'linux', dirs: ['/usr/bin'], exists: (p) => p === USR_BIN_GIT, uid: 1000 }).ok,
     true,
   );
 });

--- a/packages/agent-connector/test/install-preflight.test.js
+++ b/packages/agent-connector/test/install-preflight.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  checkInstallPrereqs,
+  missingPrereqError,
+  probeGit,
+} = require('../src/install-preflight');
+
+/** A mac with nothing developer-ish installed: no brew git, no CLT, no Xcode. */
+const CLEAN_MAC = { platform: 'darwin', dirs: [], developerDir: null, exists: () => false };
+
+test('git probe: a mac with no developer tools reports missing', () => {
+  assert.deepStrictEqual(probeGit(CLEAN_MAC), { ok: false });
+});
+
+test('git probe: Command Line Tools alone is enough', () => {
+  const result = probeGit({
+    ...CLEAN_MAC,
+    exists: (p) => p === '/Library/Developer/CommandLineTools/usr/bin/git',
+  });
+  assert.strictEqual(result.ok, true);
+});
+
+test('git probe: a full Xcode install is enough', () => {
+  const developerDir = '/Applications/Xcode.app/Contents/Developer';
+  const result = probeGit({
+    ...CLEAN_MAC,
+    developerDir,
+    exists: (p) => p === `${developerDir}/usr/bin/git`,
+  });
+  assert.strictEqual(result.ok, true);
+});
+
+test('git probe: a Homebrew git satisfies it without touching xcode-select', () => {
+  let developerDirRead = false;
+  const result = probeGit({
+    platform: 'darwin',
+    dirs: ['/opt/homebrew/bin'],
+    exists: (p) => p === '/opt/homebrew/bin/git',
+    get developerDir() {
+      developerDirRead = true;
+      return null;
+    },
+  });
+  assert.strictEqual(result.ok, true);
+  assert.strictEqual(result.detail, '/opt/homebrew/bin/git');
+  assert.strictEqual(developerDirRead, false, 'should short-circuit before the CLT check');
+});
+
+test('git probe: Windows is exempt — install.ps1 downloads PortableGit itself', () => {
+  // Refusing here would break every Windows machine where that download works,
+  // and it needs no admin rights and shows no dialog. Windows gets a readable
+  // error when the download fails instead (see the launcher's install-progress).
+  const result = probeGit({ platform: 'win32', dirs: [], exists: () => false });
+  assert.strictEqual(result.ok, true);
+});
+
+test('git probe: Linux looks at PATH', () => {
+  assert.strictEqual(
+    probeGit({ platform: 'linux', dirs: ['/usr/bin'], exists: () => false, uid: 1000 }).ok,
+    false,
+  );
+  assert.strictEqual(
+    probeGit({ platform: 'linux', dirs: ['/usr/bin'], exists: (p) => p === '/usr/bin/git', uid: 1000 }).ok,
+    true,
+  );
+});
+
+test('git probe: Linux as root is exempt — apt/dnf need no password there', () => {
+  const result = probeGit({ platform: 'linux', dirs: [], exists: () => false, uid: 0 });
+  assert.strictEqual(result.ok, true);
+});
+
+test('git probe: the real machine running these tests has git', () => {
+  // Guards the production code path (real PATH, real xcode-select): anything
+  // able to check this repo out has git, so a false here means the probe is
+  // broken, not the machine.
+  assert.strictEqual(probeGit().ok, true);
+});
+
+test('checkInstallPrereqs: no requires means nothing to check', () => {
+  assert.deepStrictEqual(checkInstallPrereqs({ install: {} }), { ok: true, missing: [] });
+  assert.deepStrictEqual(checkInstallPrereqs({}), { ok: true, missing: [] });
+  assert.deepStrictEqual(checkInstallPrereqs(null), { ok: true, missing: [] });
+});
+
+test('checkInstallPrereqs: a dependency with no probe never blocks an install', () => {
+  // hermes lists python3, but its installer provisions Python via uv. Blocking
+  // on it would break installs that work today.
+  const result = checkInstallPrereqs({ install: { requires: ['python3', 'ruby', 'go'] } });
+  assert.deepStrictEqual(result, { ok: true, missing: [] });
+});
+
+test('checkInstallPrereqs: hermes declares git', () => {
+  const hermes = require('../registry.json').find((e) => e.name === 'hermes');
+  assert.ok(hermes.install.requires.includes('git'), 'hermes must require git');
+});
+
+test('missingPrereqError: carries a machine-readable payload and a readable message', () => {
+  const missing = [
+    {
+      name: 'git',
+      action: 'install-xcode-clt',
+      summary: 'Git is required, and it comes with the Xcode Command Line Tools.',
+      command: 'xcode-select --install',
+      alternative: 'brew install git',
+    },
+  ];
+  const err = missingPrereqError('Hermes Agent', missing);
+
+  assert.strictEqual(err.code, 'MISSING_PREREQ');
+  assert.deepStrictEqual(err.missing, missing);
+  assert.match(err.message, /Hermes Agent/);
+  assert.match(err.message, /xcode-select --install/);
+  assert.match(err.message, /brew install git/);
+});
+
+test('installer refuses the install instead of spawning a black-box script', () => {
+  const { Installer } = require('../src/installer');
+  // Bare prototype: the wiring under test is one method, and a real Installer
+  // would drag in a config dir and a registry it never touches here.
+  const installer = Object.create(Installer.prototype);
+  const entry = { label: 'Hermes Agent', install: { requires: ['git'] } };
+  const streamed = [];
+
+  const missing = [
+    {
+      name: 'git',
+      action: 'install-xcode-clt',
+      summary: 'Git is required, and it comes with the Xcode Command Line Tools.',
+      command: 'xcode-select --install',
+      alternative: 'brew install git',
+    },
+  ];
+
+  assert.throws(
+    () => installer._assertPrereqs('hermes', entry, (d) => streamed.push(d), () => ({
+      ok: false,
+      missing,
+    })),
+    (err) => err.code === 'MISSING_PREREQ' && err.missing === missing,
+  );
+  // The refusal is streamed too, so it lands in the install log file.
+  assert.match(streamed.join(''), /Hermes Agent/);
+});
+
+test('installer proceeds when every requirement is met', () => {
+  const { Installer } = require('../src/installer');
+  const installer = Object.create(Installer.prototype);
+  assert.doesNotThrow(() =>
+    installer._assertPrereqs('hermes', { install: { requires: ['git'] } }, null, () => ({
+      ok: true,
+      missing: [],
+    })),
+  );
+});

--- a/packages/agent-connector/test/install-stall-watchdog.test.js
+++ b/packages/agent-connector/test/install-stall-watchdog.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * The watchdog exists for installers that go silent and never come back —
+ * hermes's install.sh polling for the macOS developer tools was the case that
+ * prompted it, but the shape is general. These tests drive a real spawn with a
+ * very short stall budget rather than faking timers, because what matters is
+ * that the process tree actually dies.
+ */
+function loadInstallerWithStall(ms) {
+  process.env.OPENAGENTS_INSTALL_STALL_MS = String(ms);
+  // The stall budget is read once at module load.
+  delete require.cache[require.resolve('../src/installer')];
+  const { Installer } = require('../src/installer');
+  return Installer;
+}
+
+function makeInstaller(Installer, command) {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oa-stall-'));
+  const registry = {
+    getEntry: () => ({
+      label: 'Silent Agent',
+      install: { binary: 'silent', macos: command, linux: command, windows: command },
+    }),
+  };
+  const installer = new Installer(registry, configDir);
+  return { installer, configDir };
+}
+
+const isWindows = process.platform === 'win32';
+
+test('a silent installer is killed and reported, not waited on forever', { skip: isWindows }, async () => {
+  const Installer = loadInstallerWithStall(1500);
+  // Prints once, then goes quiet for far longer than any patience we have.
+  const { installer } = makeInstaller(Installer, 'echo starting; sleep 120');
+
+  const chunks = [];
+  const started = Date.now();
+  await assert.rejects(
+    () => installer.installStreaming('silent', (d) => chunks.push(d)),
+    (err) => /no output for/i.test(err.message),
+  );
+  const elapsed = Date.now() - started;
+
+  assert.ok(elapsed < 10000, `should give up quickly, took ${elapsed}ms`);
+  assert.match(chunks.join(''), /starting/);
+  assert.match(chunks.join(''), /Install stalled/);
+
+  // The point of the process-group kill: the shell's CHILD (the sleep) has to
+  // die too. Signalling only the direct child would leave it running, which is
+  // exactly the "download that never returns" case this guards.
+  const { execSync } = require('child_process');
+  let survivors = '';
+  try {
+    survivors = execSync('pgrep -f "sleep 120" || true', { encoding: 'utf-8' }).trim();
+  } catch { /* pgrep missing — skip the assertion */ }
+  assert.strictEqual(survivors, '', `orphaned processes survived: ${survivors}`);
+});
+
+test('an installer that keeps talking is left alone', { skip: isWindows }, async () => {
+  const Installer = loadInstallerWithStall(2000);
+  // Output every 300ms for ~1.5s: never silent long enough to trip the watchdog.
+  const { installer } = makeInstaller(
+    Installer,
+    'for i in 1 2 3 4 5; do echo tick $i; sleep 0.3; done',
+  );
+
+  const chunks = [];
+  const result = await installer.installStreaming('silent', (d) => chunks.push(d));
+  assert.strictEqual(result.success, true);
+  assert.match(chunks.join(''), /tick 5/);
+});
+
+test('the stall budget is configurable and can be switched off', () => {
+  process.env.OPENAGENTS_INSTALL_STALL_MS = '0';
+  delete require.cache[require.resolve('../src/installer')];
+  assert.doesNotThrow(() => require('../src/installer'));
+  delete process.env.OPENAGENTS_INSTALL_STALL_MS;
+  delete require.cache[require.resolve('../src/installer')];
+});
+
+test.after(() => {
+  delete process.env.OPENAGENTS_INSTALL_STALL_MS;
+  delete require.cache[require.resolve('../src/installer')];
+});

--- a/packages/agent-connector/test/install-stall-watchdog.test.js
+++ b/packages/agent-connector/test/install-stall-watchdog.test.js
@@ -35,10 +35,42 @@ function makeInstaller(Installer, command) {
 
 const isWindows = process.platform === 'win32';
 
+/**
+ * Wait for a pid to disappear, or give up.
+ *
+ * Signal delivery is asynchronous: the watchdog rejects as soon as it has
+ * signalled, so asserting immediately is a race the test would lose on a slow
+ * machine. Polling keeps the assertion meaningful — a process that is genuinely
+ * never killed still fails, it just gets a few seconds to prove it.
+ */
+async function waitForExit(pid, timeoutMs = 8000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true; // ESRCH — gone
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
 test('a silent installer is killed and reported, not waited on forever', { skip: isWindows }, async () => {
   const Installer = loadInstallerWithStall(1500);
   // Prints once, then goes quiet for far longer than any patience we have.
-  const { installer } = makeInstaller(Installer, 'echo starting; sleep 120');
+  //
+  // The grandchild records its OWN pid so the assertion below can check that
+  // exact process. Matching on a command line instead (pgrep/ps) is unreliable:
+  // the shell running the search has the search string in its own argv, so it
+  // matches itself — green on macOS, red on Linux, for reasons having nothing
+  // to do with the code under test.
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oa-stall-pid-'));
+  const pidFile = path.join(configDir, 'child.pid');
+  const { installer } = makeInstaller(
+    Installer,
+    `echo starting; sleep 120 & echo $! > "${pidFile}"; wait`,
+  );
 
   const chunks = [];
   const started = Date.now();
@@ -53,14 +85,15 @@ test('a silent installer is killed and reported, not waited on forever', { skip:
   assert.match(chunks.join(''), /Install stalled/);
 
   // The point of the process-group kill: the shell's CHILD (the sleep) has to
-  // die too. Signalling only the direct child would leave it running, which is
-  // exactly the "download that never returns" case this guards.
-  const { execSync } = require('child_process');
-  let survivors = '';
-  try {
-    survivors = execSync('pgrep -f "sleep 120" || true', { encoding: 'utf-8' }).trim();
-  } catch { /* pgrep missing — skip the assertion */ }
-  assert.strictEqual(survivors, '', `orphaned processes survived: ${survivors}`);
+  // die too. Signalling only the direct child leaves the real work running,
+  // which is exactly the "download that never returns" case this guards.
+  const childPid = Number(fs.readFileSync(pidFile, 'utf-8').trim());
+  assert.ok(Number.isInteger(childPid) && childPid > 0, 'grandchild pid not recorded');
+  assert.strictEqual(
+    await waitForExit(childPid),
+    true,
+    `grandchild ${childPid} survived the kill`,
+  );
 });
 
 test('an installer that keeps talking is left alone', { skip: isWindows }, async () => {

--- a/packages/agent-connector/test/node-shims.test.js
+++ b/packages/agent-connector/test/node-shims.test.js
@@ -6,9 +6,18 @@ const path = require('path');
 
 const { detectShadowedNodeShims, shadowedNodeWarning } = require('../src/node-shims');
 
-const HOME = '/home/u';
-const LINK_DIR = '/home/u/.local/bin';
-const OWNER_DIR = '/home/u/.hermes/node/bin';
+// An absolute root the current platform actually recognises, so path.resolve
+// inside the detector returns what these expectations compare against. POSIX
+// literals looked fine on macOS/Linux and broke on the Windows runner, where
+// path.resolve('/home/u', …) acquires a drive letter.
+const ROOT = process.platform === 'win32' ? 'C:\\t' : '/t';
+const HOME = path.join(ROOT, 'home', 'u');
+const LINK_DIR = path.join(HOME, '.local', 'bin');
+const OWNER_DIR = path.join(HOME, '.hermes', 'node', 'bin');
+const NVM_BIN = path.join(HOME, '.nvm', 'versions', 'node', 'v22.16.0', 'bin');
+const NVM_NODE = path.join(NVM_BIN, 'node');
+const USR_BIN = path.join(ROOT, 'usr', 'bin');
+const LOCAL_BIN = path.join(ROOT, 'usr', 'local', 'bin');
 
 /** A machine where the installer has taken over all three shims. */
 function hijackedLinks(p) {
@@ -24,8 +33,8 @@ test('reports the takeover when another node is shadowed', () => {
   const result = detectShadowedNodeShims({
     ...base,
     readLink: hijackedLinks,
-    pathEntries: [LINK_DIR, '/home/u/.nvm/versions/node/v22.16.0/bin', '/usr/bin'],
-    exists: (p) => p === '/home/u/.nvm/versions/node/v22.16.0/bin/node',
+    pathEntries: [LINK_DIR, NVM_BIN, USR_BIN],
+    exists: (p) => p === NVM_NODE,
   });
 
   assert.strictEqual(result.shims.length, 3);
@@ -33,7 +42,7 @@ test('reports the takeover when another node is shadowed', () => {
     result.shims.map((s) => s.name),
     ['node', 'npm', 'npx'],
   );
-  assert.strictEqual(result.shadowed, '/home/u/.nvm/versions/node/v22.16.0/bin/node');
+  assert.strictEqual(result.shadowed, NVM_NODE);
 });
 
 test('stays quiet when the machine had no other node', () => {
@@ -42,7 +51,7 @@ test('stays quiet when the machine had no other node', () => {
   const result = detectShadowedNodeShims({
     ...base,
     readLink: hijackedLinks,
-    pathEntries: [LINK_DIR, '/usr/bin'],
+    pathEntries: [LINK_DIR, USR_BIN],
     exists: () => false,
   });
 
@@ -56,8 +65,8 @@ test('ignores a node that comes BEFORE the link dir on PATH', () => {
   const result = detectShadowedNodeShims({
     ...base,
     readLink: hijackedLinks,
-    pathEntries: ['/usr/local/bin', LINK_DIR],
-    exists: (p) => p === '/usr/local/bin/node',
+    pathEntries: [LOCAL_BIN, LINK_DIR],
+    exists: (p) => p === path.join(LOCAL_BIN, 'node'),
   });
 
   assert.strictEqual(result.shadowed, null);
@@ -66,9 +75,8 @@ test('ignores a node that comes BEFORE the link dir on PATH', () => {
 test('ignores symlinks pointing somewhere other than the agent', () => {
   const result = detectShadowedNodeShims({
     ...base,
-    readLink: (p) =>
-      path.basename(p) === 'node' ? '/home/u/.nvm/versions/node/v22.16.0/bin/node' : null,
-    pathEntries: [LINK_DIR, '/usr/bin'],
+    readLink: (p) => (path.basename(p) === 'node' ? NVM_NODE : null),
+    pathEntries: [LINK_DIR, USR_BIN],
     exists: () => true,
   });
 
@@ -79,7 +87,7 @@ test('ignores real files that are not symlinks', () => {
   const result = detectShadowedNodeShims({
     ...base,
     readLink: () => null, // lstat says "not a symlink"
-    pathEntries: [LINK_DIR, '/usr/bin'],
+    pathEntries: [LINK_DIR, USR_BIN],
     exists: () => true,
   });
 
@@ -90,14 +98,17 @@ test('the warning names the agent, what it shadowed, and how to undo it', () => 
   const detection = detectShadowedNodeShims({
     ...base,
     readLink: hijackedLinks,
-    pathEntries: [LINK_DIR, '/home/u/.nvm/versions/node/v22.16.0/bin'],
-    exists: (p) => p === '/home/u/.nvm/versions/node/v22.16.0/bin/node',
+    pathEntries: [LINK_DIR, NVM_BIN],
+    exists: (p) => p === NVM_NODE,
   });
   const warning = shadowedNodeWarning('Hermes Agent', detection);
 
   assert.match(warning, /Hermes Agent/);
-  assert.match(warning, /nvm\/versions\/node\/v22\.16\.0/);
-  assert.match(warning, /rm -f .*\.local\/bin\/node .*\.local\/bin\/npm .*\.local\/bin\/npx/);
+  assert.ok(warning.includes(NVM_NODE), 'names the Node it shadowed');
+  for (const name of ['node', 'npm', 'npx']) {
+    assert.ok(warning.includes(path.join(LINK_DIR, name)), `names the ${name} link`);
+  }
+  assert.match(warning, /rm -f /);
 });
 
 test('no shims, no warning', () => {

--- a/packages/agent-connector/test/node-shims.test.js
+++ b/packages/agent-connector/test/node-shims.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+const { detectShadowedNodeShims, shadowedNodeWarning } = require('../src/node-shims');
+
+const HOME = '/home/u';
+const LINK_DIR = '/home/u/.local/bin';
+const OWNER_DIR = '/home/u/.hermes/node/bin';
+
+/** A machine where the installer has taken over all three shims. */
+function hijackedLinks(p) {
+  const name = path.basename(p);
+  if (path.dirname(p) !== LINK_DIR) return null;
+  if (!['node', 'npm', 'npx'].includes(name)) return null;
+  return path.join(OWNER_DIR, name);
+}
+
+const base = { home: HOME, linkDir: LINK_DIR, ownerDir: OWNER_DIR };
+
+test('reports the takeover when another node is shadowed', () => {
+  const result = detectShadowedNodeShims({
+    ...base,
+    readLink: hijackedLinks,
+    pathEntries: [LINK_DIR, '/home/u/.nvm/versions/node/v22.16.0/bin', '/usr/bin'],
+    exists: (p) => p === '/home/u/.nvm/versions/node/v22.16.0/bin/node',
+  });
+
+  assert.strictEqual(result.shims.length, 3);
+  assert.deepStrictEqual(
+    result.shims.map((s) => s.name),
+    ['node', 'npm', 'npx'],
+  );
+  assert.strictEqual(result.shadowed, '/home/u/.nvm/versions/node/v22.16.0/bin/node');
+});
+
+test('stays quiet when the machine had no other node', () => {
+  // Here the installer's Node is the only one — the symlinks are a favour, not
+  // a hijack, and warning about them would be noise.
+  const result = detectShadowedNodeShims({
+    ...base,
+    readLink: hijackedLinks,
+    pathEntries: [LINK_DIR, '/usr/bin'],
+    exists: () => false,
+  });
+
+  assert.strictEqual(result.shims.length, 3);
+  assert.strictEqual(result.shadowed, null);
+  assert.strictEqual(shadowedNodeWarning('Hermes Agent', result), null);
+});
+
+test('ignores a node that comes BEFORE the link dir on PATH', () => {
+  // Something earlier on PATH already wins; the symlinks shadow nothing.
+  const result = detectShadowedNodeShims({
+    ...base,
+    readLink: hijackedLinks,
+    pathEntries: ['/usr/local/bin', LINK_DIR],
+    exists: (p) => p === '/usr/local/bin/node',
+  });
+
+  assert.strictEqual(result.shadowed, null);
+});
+
+test('ignores symlinks pointing somewhere other than the agent', () => {
+  const result = detectShadowedNodeShims({
+    ...base,
+    readLink: (p) =>
+      path.basename(p) === 'node' ? '/home/u/.nvm/versions/node/v22.16.0/bin/node' : null,
+    pathEntries: [LINK_DIR, '/usr/bin'],
+    exists: () => true,
+  });
+
+  assert.deepStrictEqual(result, { shims: [], shadowed: null });
+});
+
+test('ignores real files that are not symlinks', () => {
+  const result = detectShadowedNodeShims({
+    ...base,
+    readLink: () => null, // lstat says "not a symlink"
+    pathEntries: [LINK_DIR, '/usr/bin'],
+    exists: () => true,
+  });
+
+  assert.deepStrictEqual(result, { shims: [], shadowed: null });
+});
+
+test('the warning names the agent, what it shadowed, and how to undo it', () => {
+  const detection = detectShadowedNodeShims({
+    ...base,
+    readLink: hijackedLinks,
+    pathEntries: [LINK_DIR, '/home/u/.nvm/versions/node/v22.16.0/bin'],
+    exists: (p) => p === '/home/u/.nvm/versions/node/v22.16.0/bin/node',
+  });
+  const warning = shadowedNodeWarning('Hermes Agent', detection);
+
+  assert.match(warning, /Hermes Agent/);
+  assert.match(warning, /nvm\/versions\/node\/v22\.16\.0/);
+  assert.match(warning, /rm -f .*\.local\/bin\/node .*\.local\/bin\/npm .*\.local\/bin\/npx/);
+});
+
+test('no shims, no warning', () => {
+  assert.strictEqual(shadowedNodeWarning('X', { shims: [], shadowed: null }), null);
+  assert.strictEqual(shadowedNodeWarning('X', null), null);
+});

--- a/registry/hermes.json
+++ b/registry/hermes.json
@@ -23,7 +23,8 @@
   "install": {
     "binary": "hermes",
     "requires": [
-      "python3"
+      "python3",
+      "git"
     ],
     "macos": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
     "linux": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",


### PR DESCRIPTION
## Why

A user could not install Hermes on macOS. What they saw: an unexplained system dialog asking to install the command line developer tools, then a progress bar frozen on "downloading" for a quarter of an hour, then a failure. They retried, and it happened again.

Hermes is installed by running its authors' `install.sh`. On a Mac with no developer tools that script:

1. runs `git --version` — on macOS `/usr/bin/git` is a **shim** whose only job, when the tools are absent, is to open that dialog;
2. calls `xcode-select --install`, opening it a second time;
3. polls in a 5-second sleep loop for **up to 900 seconds**, printing one line per minute.

Confirmed on the reporter's machine — the terminal window title read `sleep 5` while it sat there.

## What changed

All three are in the installer, and all three generalise past Hermes.

### 1. Preflight (`install-preflight.js`)

`install.requires` is now checked before anything is spawned; a missing dependency throws a structured `MISSING_PREREQ` error naming the fix. That field was previously decoration — nothing in the repo read it.

Only dependencies with a probe are enforced, so hermes' aspirational `python3` (its installer provisions Python through uv) still does not block an install that would have succeeded.

**The macOS probe never executes `git`** — executing `/usr/bin/git` is the thing that opens the dialog. It checks the filesystem, plus `xcode-select -p`, which reports the active developer directory and exits 2 without any dialog when there is none.

Two deliberate exemptions, both from reading the upstream installers rather than guessing:

- **Windows** — `install.ps1`'s `Install-Git` downloads PortableGit itself (no admin, no dialog). Refusing would break machines that work today. Windows instead gets readable errors on the launcher side.
- **Linux as root** — `install.sh` shells out to apt/dnf/pacman, which needs no password there. As a normal user the sudo call has no tty and fails, so the refusal stands.

### 2. Stall watchdog

An install producing no output for ten minutes is stopped and reported (`OPENAGENTS_INSTALL_STALL_MS` to tune, `0` to disable). The preflight prevents this specific hang, but the shape — a download that never returns, a prompt on a stdin nobody reads — is not specific to any one installer.

Installs now spawn into their own process group on Unix. Without it the kill reaches the shell and leaves `curl`/`git` running; the test asserts the grandchild is actually gone.

### 3. Node shim detection (`node-shims.js`)

Hermes, when it judges the system Node too old, installs its own and runs `ln -sf` over `node`, `npm` and `npx` in `~/.local/bin`. That directory is usually first on PATH, so the machine's **default Node changes for every unrelated project**, silently, and npm's global prefix is rewritten to `~/.local` alongside it.

Verified live while working on this: it replaced a nvm v22 with Node 26 and broke this repo's own launcher test suite (28 failures) — a breakage with no visible connection to having installed an agent.

This only reports. It warns solely when a Node the user already had is shadowed (on a machine with no Node, those symlinks are the installer doing something useful), and it never rewrites anything — that would be a second uninvited change on top of the first.

## Version

Bumped to `0.2.170`. The publish job skips a version already on npm, so without a bump this would merge and never ship, leaving the launcher-side work with nothing to talk to.

## Testing

`npm test` — 1206 pass, 0 fail. New coverage: the macOS shim/CLT/Xcode/Homebrew probe paths, the Windows and root exemptions, the refusal wiring, a real stalled process tree being killed, and the shim detection including the cases it must stay quiet for.