### PR TITLE
fix(launcher): make a failed install explain itself, and stop hiding a saved API key

### DIFF
--- a/packages/launcher/changelog/0.9.18.json
+++ b/packages/launcher/changelog/0.9.18.json
@@ -1,0 +1,83 @@
+{
+  "version": "0.9.18",
+  "date": "2026-08-20",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "A saved Claude API key is no longer hidden behind the wrong tab",
+        "zh": "配好的 Claude API 密钥不再藏在另一个标签页后面"
+      },
+      "description": {
+        "en": "Claude can be set up either by signing in through its CLI or by entering an API key, and the two sit on separate tabs. Configure always opened on the sign-in tab — so after saving an API key, reopening it showed \"not signed in\" and no sign of the key, which read as the key having failed to save. It had saved; it was on the other tab. Configure now opens on whichever tab you actually set the agent up with.",
+        "zh": "Claude 可以用命令行登录，也可以填 API 密钥，两者分处两个标签页。而「配置」每次都打开在登录那一页——于是保存完 API 密钥再打开，看到的是「未登录」，密钥则不见踪影，看起来就像密钥没保存成功。它保存成功了，只是在另一页。现在「配置」会直接打开在你实际配置所用的那一页。"
+      }
+    },
+    {
+      "type": "feature",
+      "title": {
+        "en": "The marketplace counters are now filters",
+        "zh": "应用市场右上角的统计现在可以点了"
+      },
+      "description": {
+        "en": "\"1 update available\" told you something was out of date but not what, so finding it meant scrolling the whole catalog reading badges. Each counter in the header is now clickable: it narrows the list to exactly what it counts, and clicking it again clears the filter. When precisely one agent has an update, clicking goes straight to that agent — a filtered list of one helps nobody.",
+        "zh": "「1 个待更新」告诉你有东西该更新了，却没说是哪个，于是只能把整个列表从上往下拉、一个个看标签。现在页头的每个统计都可以点：点一下就把列表缩到它统计的那些，再点一下取消。如果恰好只有一个智能体待更新，点击会直接进入那个智能体——只有一行的筛选结果对谁都没用。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Installing an agent that needs Git now tells you so, instead of stalling",
+        "zh": "需要 Git 的智能体，现在会先告诉你，而不是装到一半卡住"
+      },
+      "description": {
+        "en": "Some agents — Hermes among them — are installed by a script from their authors, and that script needs Git. On a Mac without developer tools, pressing Install used to bring up a system dialog asking to install the command line developer tools, with nothing to say where it had come from, and then the progress bar sat on \"Downloading\" for up to fifteen minutes before failing. The launcher now checks for Git before starting an install that needs it: if it is missing you are told up front, with the command to run and, on macOS, a button that opens Apple's installer for you and a Retry to press once it finishes. Nothing downloads until the requirement is met. On Windows the installer fetches its own copy of Git and needs no help, so nothing is blocked there — but if that download fails, or Windows security policy stops Git Bash from running, the reason is now spelled out instead of being reported as a generic connection problem.",
+        "zh": "有些智能体——Hermes 就是其一——是由其作者提供的脚本安装的，而那个脚本需要 Git。在没装过开发者工具的 Mac 上，点「安装」会弹出一个要求安装命令行开发者工具的系统对话框，完全不说它是从哪冒出来的，接着进度条会停在「下载中」最长十五分钟，然后失败。现在启动器会在开始这类安装前先检查 Git：缺了就直接告诉你，给出要执行的命令；在 macOS 上还提供一个替你打开 Apple 安装程序的按钮，装完点「重试」即可。在真正满足条件之前，不会下载任何东西。在 Windows 上，安装脚本会自己下载一份 Git，不需要帮忙，所以那里不会拦截——但如果那次下载失败，或者 Windows 安全策略挡住了 Git Bash，现在会直接说清楚原因，而不是报成一个笼统的连接问题。"
+      }
+    },
+    {
+      "type": "improvement",
+      "title": {
+        "en": "Install logs are kept on disk, and a failed install stays on screen",
+        "zh": "安装日志会保存到本地，安装失败的记录也不会消失"
+      },
+      "description": {
+        "en": "The output of an install used to exist only while its page was open — leave the page and the log, along with the Copy log button, was gone, so the only way to find out why something failed was to install it again. Every install now writes a log file under .openagents/installs, reachable from the progress block via Show in Finder, and a failed install keeps its progress block when you come back to the page.",
+        "zh": "以前安装过程的输出只在它所在的页面打开时存在——一离开页面，日志连同「复制日志」按钮就一起没了，想知道为什么失败就只能再装一遍。现在每次安装都会在 .openagents/installs 下写一份日志文件，可以从进度区域的「在访达中显示」直接找到；安装失败的进度区域在你回到页面时也会保留。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "The install progress bar no longer blames the wrong step",
+        "zh": "安装进度不再把失败算在错误的步骤上"
+      },
+      "description": {
+        "en": "The progress bar worked out which step an install was on by reading its output, and it counted any line containing the letters \"mb\" as a download — which ordinary words like \"number\" and \"symbol\" satisfy. So an install could sit on \"Downloading\" while doing something else entirely, and a failure elsewhere would be reported as a failed download. It now looks for an actual size.",
+        "zh": "进度条是靠读取输出来判断安装进行到哪一步的，而它把任何含有「mb」这两个字母的行都算作下载——「number」「symbol」这类普通单词都满足。于是安装明明在做别的事，进度却停在「下载中」，别处的失败也会被报成下载失败。现在它只认真正的大小数字。"
+      }
+    },
+    {
+      "type": "improvement",
+      "title": {
+        "en": "An install that hangs is now stopped instead of waiting forever",
+        "zh": "卡住的安装会被主动结束，不再无限等下去"
+      },
+      "description": {
+        "en": "Installers written by other people can decide to wait — for a dialog, for a prompt nobody is answering, for a download that never returns — and the launcher had no limit of its own, so a progress bar could sit still indefinitely with no way to tell whether anything was still happening. An install that produces no output for ten minutes is now stopped, along with everything it started, and says so.",
+        "zh": "别人写的安装脚本可能会自己等下去——等一个对话框、等一个没人回答的提问、等一个永远不返回的下载——而启动器这边没有任何时限，于是进度条可以一动不动地停在那儿，也没法判断到底还有没有在跑。现在，十分钟没有任何输出的安装会被结束（连同它启动的所有子进程），并明确告诉你原因。"
+      }
+    },
+    {
+      "type": "improvement",
+      "title": {
+        "en": "You are now told when an installer replaces your default Node",
+        "zh": "安装脚本换掉你的默认 Node 时会告诉你"
+      },
+      "description": {
+        "en": "Hermes's installer, when it judges the system Node too old, installs its own and repoints node, npm and npx in ~/.local/bin at it. On most machines that directory comes first on PATH, so the default Node changes for every shell and every unrelated project, silently. The install now checks afterwards and, if it shadowed a Node you already had, says exactly what changed and the one command that undoes it.",
+        "zh": "Hermes 的安装脚本在判定系统 Node 版本过旧时，会装一份自己的，并把 ~/.local/bin 里的 node、npm、npx 指向它。在大多数机器上这个目录排在 PATH 最前面，于是默认的 Node 就悄悄换了——对所有终端、所有毫不相干的项目都生效。现在安装完成后会做一次检查，如果它确实盖掉了你原有的 Node，就会明确说明改动了什么，以及一条撤销它的命令。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1952,6 +1952,33 @@ function setupIPC(): void {
     return true
   })
 
+  // Hand the user Apple's own Command Line Tools installer.
+  //
+  // Some agents install through a `curl … | bash` script that needs git, which
+  // a mac without developer tools does not have. The install preflight now
+  // refuses to start those scripts, and this is what the resulting UI offers
+  // instead — the same dialog the script would have triggered, except the user
+  // asked for it and knows what it is. Apple gates the tools behind this
+  // dialog; there is no headless path without MDM.
+  ipcMain.handle("system:install-xcode-clt", () => {
+    if (process.platform !== "darwin") {
+      return { ok: false, error: "Only available on macOS" }
+    }
+    try {
+      const { spawn } = require("child_process") as typeof import("child_process")
+      // Detached + unref: the dialog and the download outlive this call, which
+      // returns as soon as the request is made. Progress lives in Apple's UI.
+      const proc = spawn("xcode-select", ["--install"], {
+        detached: true,
+        stdio: "ignore",
+      })
+      proc.unref()
+      return { ok: true }
+    } catch (e: unknown) {
+      return { ok: false, error: (e as Error).message }
+    }
+  })
+
   // The running app's own version. `system:info` also carries it, but that call
   // walks the process tree and stats the disk — far too much for the release
   // notes check that runs on every startup.

--- a/packages/launcher/src/main/install-progress.test.ts
+++ b/packages/launcher/src/main/install-progress.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  asMissingPrereq,
+  classifyInstallChunk,
+  logStamp,
+  userFacingInstallError,
+} from "./install-progress"
+
+describe("classifyInstallChunk", () => {
+  it("treats a real size as a download", () => {
+    expect(classifyInstallChunk("fetched 12.4 MB", "install").phase).toBe(
+      "downloading",
+    )
+    expect(classifyInstallChunk("Downloading node v26", "install").phase).toBe(
+      "downloading",
+    )
+    expect(classifyInstallChunk("  47% complete", "install").phase).toBe(
+      "downloading",
+    )
+  })
+
+  it("does not call a line a download because it contains the letters mb", () => {
+    // The bug this guards: `line.includes("mb")` matched any of these, so a
+    // failure at another step was reported as "Failed while downloading".
+    for (const line of [
+      "resolving symbols",
+      "a large number of files",
+      "assembly step failed",
+    ]) {
+      expect(classifyInstallChunk(line, "install").phase).toBeUndefined()
+    }
+  })
+})
+
+describe("userFacingInstallError", () => {
+  it("names git when the installer tripped over a missing one", () => {
+    const msg = userFacingInstallError(
+      new Error("✗ Git not found\nRequesting Apple Command Line Tools"),
+      "downloading",
+      "install",
+    )
+    expect(msg).toMatch(/Git is missing/)
+    expect(msg).toMatch(/xcode-select --install/)
+  })
+
+  it("names the PortableGit download when Windows fails to fetch it", () => {
+    // The real shape: install.ps1's error plus whatever the failed download
+    // printed, which is usually full of network words.
+    const msg = userFacingInstallError(
+      new Error(
+        "Install failed with exit code 1\n\nCould not install portable Git: The operation has timed out.",
+      ),
+      "downloading",
+      "install",
+    )
+    expect(msg).toMatch(/downloading a portable copy failed/)
+    expect(msg).toMatch(/git-scm\.com/)
+    // Must NOT be claimed by the generic network branch, which would say
+    // "check your VPN" to a machine that just has no Git.
+    expect(msg).not.toMatch(/proxy, or VPN/)
+  })
+
+  it("explains a Git Bash that cannot launch MSYS programs", () => {
+    const msg = userFacingInstallError(
+      new Error(
+        "Git Bash at C:\\Program Files\\Git\\bin\\bash.exe exists but cannot launch required MSYS programs.",
+      ),
+      "installing",
+      "install",
+    )
+    expect(msg).toMatch(/cannot run the programs/)
+    expect(msg).toMatch(/ASLR/)
+  })
+
+  it("does not mistake an ordinary git mention for a Git Bash failure", () => {
+    const msg = userFacingInstallError(
+      new Error("cloning with git bash succeeded, then npm ERR! code E404"),
+      "installing",
+      "install",
+    )
+    expect(msg).not.toMatch(/ASLR/)
+  })
+
+  it("still falls back to the generic copy", () => {
+    const msg = userFacingInstallError(new Error("kaboom"), "installing", "install")
+    expect(msg).toMatch(/Failed while running the installer/)
+  })
+})
+
+describe("asMissingPrereq", () => {
+  const remedy = {
+    name: "git",
+    action: "install-xcode-clt",
+    summary: "Git is required.",
+    command: "xcode-select --install",
+    alternative: "brew install git",
+  }
+
+  it("recognises the core's preflight error", () => {
+    const err = Object.assign(new Error("Hermes needs git"), {
+      code: "MISSING_PREREQ",
+      missing: [remedy],
+    })
+    expect(asMissingPrereq(err)).toEqual({
+      message: "Hermes needs git",
+      missing: [remedy],
+    })
+  })
+
+  it("ignores anything else", () => {
+    expect(asMissingPrereq(new Error("network down"))).toBeNull()
+    expect(asMissingPrereq(null)).toBeNull()
+    expect(asMissingPrereq("MISSING_PREREQ")).toBeNull()
+    // Right code, but no payload to render — not usable as a prereq failure.
+    expect(
+      asMissingPrereq(Object.assign(new Error("x"), { code: "MISSING_PREREQ" })),
+    ).toBeNull()
+  })
+})
+
+describe("logStamp", () => {
+  it("is filename-safe and sorts chronologically", () => {
+    const early = logStamp(new Date(2026, 7, 20, 9, 5, 3))
+    const later = logStamp(new Date(2026, 7, 20, 12, 47, 1))
+    expect(early).toBe("20260820-090503")
+    expect(later).toBe("20260820-124701")
+    expect(early < later).toBe(true)
+  })
+})

--- a/packages/launcher/src/main/install-progress.ts
+++ b/packages/launcher/src/main/install-progress.ts
@@ -6,8 +6,17 @@
  * transition. The other half is error copy: a raw "ENOENT" or "short read"
  * means nothing to a user, so `userFacingInstallError` maps the common
  * failures onto what actually went wrong and what to do about it.
+ *
+ * Everything streamed is also written to a file under ~/.openagents/installs/.
+ * Until it was, an install log lived only in the renderer's memory, and the one
+ * screen showing it disappeared the moment the user left the detail page — so
+ * the only way to see why an install failed was to reproduce it.
  */
+import fs from "fs"
+import path from "path"
 import type { BrowserWindow } from "electron"
+
+import { CONFIG_DIR } from "./agents/paths"
 
 export type InstallPhase =
   | "idle"
@@ -19,6 +28,20 @@ export type InstallPhase =
   | "error"
 export type InstallVerb = "install" | "update" | "uninstall" | "rollback"
 
+/**
+ * One missing dependency, as reported by the core's install preflight. The
+ * shape is defined there (agent-connector/src/install-preflight.js); it is
+ * carried through to the renderer so the UI can offer a button instead of
+ * parsing prose out of an error message.
+ */
+export interface PrereqRemedy {
+  name: string
+  action: string | null
+  summary: string
+  command: string
+  alternative: string | null
+}
+
 export interface InstallProgressPayload {
   agent: string
   verb: InstallVerb
@@ -26,6 +49,108 @@ export interface InstallProgressPayload {
   detail?: string
   log?: string
   error?: string
+  /** Present when the install was refused for a missing dependency. */
+  missing?: PrereqRemedy[]
+  /** Absolute path to this run's log file, once one has been opened. */
+  logFile?: string
+}
+
+/** Where install logs are kept, one file per run. */
+export const INSTALL_LOG_DIR = path.join(CONFIG_DIR, "installs")
+
+/** How many log files to keep before the oldest are pruned. */
+const KEEP_LOGS = 30
+
+interface MissingPrereq {
+  message: string
+  missing: PrereqRemedy[]
+}
+
+/**
+ * The core refuses to run a third-party installer whose hard dependencies are
+ * missing, and throws an error carrying the remedies. That message is already
+ * written for a human, so it is passed through verbatim rather than being run
+ * through userFacingInstallError's "Failed while …" phrasing.
+ */
+export function asMissingPrereq(err: unknown): MissingPrereq | null {
+  if (!err || typeof err !== "object") return null
+  const e = err as { code?: unknown; missing?: unknown; message?: unknown }
+  if (e.code !== "MISSING_PREREQ" || !Array.isArray(e.missing)) return null
+  return {
+    message: String(e.message || ""),
+    missing: e.missing as PrereqRemedy[],
+  }
+}
+
+/**
+ * A file the run's output is mirrored into. Every operation is best-effort: a
+ * failure to write a log must never fail an install.
+ */
+function openInstallLog(
+  agent: string,
+  verb: InstallVerb,
+  stamp: string,
+): { file: string | undefined; write: (chunk: string) => void; close: () => void } {
+  let handle: number | null = null
+  let file: string | undefined
+  try {
+    fs.mkdirSync(INSTALL_LOG_DIR, { recursive: true })
+    pruneInstallLogs()
+    file = path.join(INSTALL_LOG_DIR, `${agent}-${verb}-${stamp}.log`)
+    handle = fs.openSync(file, "a")
+    fs.writeSync(handle, `# ${verb} ${agent} — ${new Date().toISOString()}\n\n`)
+  } catch {
+    handle = null
+    file = undefined
+  }
+  return {
+    file,
+    write: (chunk: string) => {
+      if (handle === null) return
+      try {
+        fs.writeSync(handle, chunk)
+      } catch {
+        /* disk full, file removed mid-run — keep installing */
+      }
+    },
+    close: () => {
+      if (handle === null) return
+      try {
+        fs.closeSync(handle)
+      } catch {
+        /* already gone */
+      }
+      handle = null
+    },
+  }
+}
+
+/** Keep the newest KEEP_LOGS files; these are diagnostics, not history. */
+function pruneInstallLogs(): void {
+  try {
+    const entries = fs
+      .readdirSync(INSTALL_LOG_DIR)
+      .filter((f) => f.endsWith(".log"))
+      .sort()
+    for (const stale of entries.slice(0, Math.max(0, entries.length - KEEP_LOGS))) {
+      try {
+        fs.unlinkSync(path.join(INSTALL_LOG_DIR, stale))
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    /* directory unreadable — nothing to prune */
+  }
+}
+
+/** Sortable, filename-safe timestamp: 20260820-124701. */
+export function logStamp(now: Date): string {
+  const p = (n: number): string => String(n).padStart(2, "0")
+  return (
+    `${now.getFullYear()}${p(now.getMonth() + 1)}${p(now.getDate())}` +
+    `-${p(now.getHours())}${p(now.getMinutes())}${p(now.getSeconds())}`
+  )
 }
 
 export function installStepLabel(
@@ -57,7 +182,44 @@ export function userFacingInstallError(
   let reason = "The installer stopped before it could finish."
   let hint = "Open the log for details, then try again."
 
+  // Git failures are checked FIRST, ahead of the generic network and
+  // permission buckets. An installer that dies fetching PortableGit prints a
+  // stack full of "timeout"/"ssl", which the network branch would happily
+  // claim — and "check your VPN" is the wrong advice for a machine that simply
+  // has no Git.
   if (
+    text.includes("could not install portable git") ||
+    text.includes("portablegit extraction")
+  ) {
+    // Windows: install.ps1 downloads PortableGit from github.com when the
+    // machine has no usable git. ~50MB, no admin needed, and its own error
+    // names no cause.
+    reason = "Windows needs Git, and downloading a portable copy failed."
+    hint =
+      "Install Git from https://git-scm.com/download/win, then retry — or check whether your network blocks github.com."
+  } else if (
+    text.includes("msys programs") ||
+    text.includes("git bash installation could not be located") ||
+    (text.includes("git bash") && text.includes("cannot launch"))
+  ) {
+    // Windows: git IS installed, but its bash cannot start MSYS programs —
+    // usually mandatory ASLR from an endpoint-security policy. The installer's
+    // own wording means nothing to anyone who has not read its source.
+    reason = "The Git Bash on this machine cannot run the programs this agent needs."
+    hint =
+      "This is usually a Windows security policy (mandatory ASLR) blocking Git Bash. Reinstall Git for Windows, or exempt bash.exe, then retry."
+  } else if (
+    text.includes("xcode-select") ||
+    text.includes("command line developer tools") ||
+    text.includes("git not found")
+  ) {
+    // The installer got far enough to discover git is missing on its own. On
+    // macOS it handles that by opening a system dialog and polling for 15
+    // minutes, so say what actually needs to happen instead of "try again".
+    reason = "Git is missing, and this agent's installer needs it."
+    hint =
+      "Run `xcode-select --install` (macOS) or install Git for your system, then retry."
+  } else if (
     text.includes("not recognized as an internal or external command") ||
     text.includes("not recognized") ||
     text.includes("enoent") ||
@@ -108,7 +270,12 @@ export function classifyInstallChunk(
   if (
     line.includes("downloading") ||
     /\b\d+\s*%/.test(line) ||
-    line.includes("mb")
+    // A size, not the letters "mb" anywhere in the line — that bare substring
+    // matched ordinary words ("number", "symbol", "assembly") and pinned the
+    // progress bar to "downloading" for output that had nothing to do with a
+    // download, which is how a failure at a completely different step came to
+    // be reported as "Failed while downloading".
+    /\b\d+(?:\.\d+)?\s*[mg]b\b/.test(line)
   ) {
     return { phase: "downloading", detail: chunk.trim().slice(0, 80) }
   }
@@ -149,40 +316,67 @@ export class InstallProgress {
     runner: (onData: (data: string) => void) => Promise<T>,
   ): Promise<T> {
     let currentPhase: InstallPhase = "preparing"
+    const log = openInstallLog(agent, verb, logStamp(new Date()))
     this.broadcast({
       agent,
       verb,
       phase: "preparing",
       detail: "Resolving dependencies",
+      logFile: log.file,
     })
 
     const onData = (data: string): void => {
+      log.write(data)
       const win = this.getWindow()
       if (win && !win.isDestroyed())
         win.webContents.send("install:output", data)
       const { phase, detail } = classifyInstallChunk(data, verb)
       if (phase && phase !== currentPhase) {
         currentPhase = phase
-        this.broadcast({ agent, verb, phase, detail })
+        this.broadcast({ agent, verb, phase, detail, logFile: log.file })
       } else if (detail) {
-        this.broadcast({ agent, verb, phase: currentPhase, detail })
+        this.broadcast({ agent, verb, phase: currentPhase, detail, logFile: log.file })
       }
     }
 
     try {
       const result = await runner(onData)
-      this.broadcast({ agent, verb, phase: "done", detail: "Complete" })
+      log.close()
+      this.broadcast({
+        agent,
+        verb,
+        phase: "done",
+        detail: "Complete",
+        logFile: log.file,
+      })
       return result
     } catch (e: unknown) {
-      const friendlyError = userFacingInstallError(e, currentPhase, verb)
+      const prereq = asMissingPrereq(e)
+      const friendlyError = prereq
+        ? prereq.message
+        : userFacingInstallError(e, currentPhase, verb)
+      log.write(`\n${friendlyError}\n`)
+      log.close()
       this.broadcast({
         agent,
         verb,
         phase: "error",
-        detail: friendlyError,
+        // The prereq message is several lines of instructions; the detail line
+        // is a single truncated row, so it gets the summary and the UI renders
+        // the rest from `missing`.
+        detail: prereq
+          ? prereq.missing.map((m) => m.summary).join(" ")
+          : friendlyError,
         error: friendlyError,
+        missing: prereq?.missing,
+        logFile: log.file,
       })
-      throw new Error(friendlyError)
+      // What is thrown becomes a toast, so a refused install gets the one-line
+      // summary; the full instructions are already on screen in the progress
+      // block and in the log file.
+      throw new Error(
+        prereq ? prereq.missing.map((m) => m.summary).join(" ") : friendlyError,
+      )
     }
   }
 }

--- a/packages/launcher/src/preload/index.ts
+++ b/packages/launcher/src/preload/index.ts
@@ -108,6 +108,7 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('agents:login-clear-key', type, agentName),
 
   openExternal: (url: string) => ipcRenderer.invoke('shell:open-external', url),
+  installXcodeCommandLineTools: () => ipcRenderer.invoke('system:install-xcode-clt'),
   openTerminal: (cmd: string) => ipcRenderer.invoke('shell:open-terminal', cmd),
 
   // ── In-app CLI sign-in ──

--- a/packages/launcher/src/renderer/hooks/useInstallProgress.ts
+++ b/packages/launcher/src/renderer/hooks/useInstallProgress.ts
@@ -16,7 +16,17 @@ export function useInstallProgress(): void {
       if (!state.jobs[ev.agent] && ev.phase !== 'done' && ev.phase !== 'error') {
         state.startJob({ agent: ev.agent, verb: ev.verb, phase: ev.phase, detail: ev.detail })
       }
-      state.updateJob(ev.agent, { phase: ev.phase, detail: ev.detail ?? '', error: ev.error })
+      state.updateJob(ev.agent, {
+        phase: ev.phase,
+        detail: ev.detail ?? '',
+        error: ev.error,
+        // Only ever set alongside a failure; a later event for the same job
+        // (a retry) legitimately clears it back to undefined.
+        missing: ev.missing,
+        // Keep the last known path — progress events after the file is opened
+        // all carry it, but a 'done' broadcast racing a close should not blank it.
+        logFile: ev.logFile ?? state.jobs[ev.agent]?.logFile,
+      })
     }
     const onOutput = (data: string): void => {
       const state = useInstallStore.getState()

--- a/packages/launcher/src/renderer/i18n/locales/en/install.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/install.json
@@ -6,7 +6,12 @@
   "stats": {
     "available": "available",
     "installed": "installed",
-    "updatable": "need updates"
+    "updatable": "need updates",
+    "filterHint": {
+      "available": "Show all agents",
+      "installed": "Show only installed agents",
+      "updatable": "Show only agents with an update"
+    }
   },
   "status": {
     "installed": "Installed",
@@ -118,6 +123,21 @@
       "rollingBack": "Rolling back",
       "failedStatus": "FAILED",
       "doneStatus": "DONE"
+    },
+    "prereq": {
+      "title": "One thing is missing first",
+      "installCommand": "Run this in a terminal:",
+      "alternative": "Or, if you use Homebrew:",
+      "installClt": "Install Command Line Tools",
+      "cltRequested": "Apple's installer has been opened. Finish it, then press Retry.",
+      "cltFailed": "Could not open Apple's installer. Run xcode-select --install in a terminal.",
+      "retry": "I've installed it — retry",
+      "copyCommand": "Copy command",
+      "copied": "Copied"
+    },
+    "logFile": {
+      "label": "Full log saved to disk",
+      "reveal": "Show in Finder"
     }
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/install.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/install.json
@@ -6,7 +6,12 @@
   "stats": {
     "available": "个可用",
     "installed": "个已安装",
-    "updatable": "个待更新"
+    "updatable": "个待更新",
+    "filterHint": {
+      "available": "显示全部智能体",
+      "installed": "只看已安装的",
+      "updatable": "只看待更新的"
+    }
   },
   "status": {
     "installed": "已安装",
@@ -118,6 +123,21 @@
       "rollingBack": "正在回滚",
       "failedStatus": "失败",
       "doneStatus": "完成"
+    },
+    "prereq": {
+      "title": "还差一个前置工具",
+      "installCommand": "在终端里执行：",
+      "alternative": "或者，如果你用 Homebrew：",
+      "installClt": "安装命令行工具",
+      "cltRequested": "已打开 Apple 的安装程序，装完后点「重试」。",
+      "cltFailed": "无法打开 Apple 的安装程序，请在终端执行 xcode-select --install。",
+      "retry": "我装好了，重试",
+      "copyCommand": "复制命令",
+      "copied": "已复制"
+    },
+    "logFile": {
+      "label": "完整日志已保存到本地",
+      "reveal": "在访达中显示"
     }
   }
 }

--- a/packages/launcher/src/renderer/lib/agent-auth.test.ts
+++ b/packages/launcher/src/renderer/lib/agent-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { isCliLoginDetected } from "./agent-auth"
+import { isCliLoginDetected, preferredAuthTab } from "./agent-auth"
 
 describe("isCliLoginDetected", () => {
   it("does not label API-key readiness as a CLI login", () => {
@@ -33,5 +33,51 @@ describe("isCliLoginDetected", () => {
         true,
       ),
     ).toBe(true)
+  })
+})
+
+describe("preferredAuthTab", () => {
+  // Claude's real field set: two secrets, plus a base URL and model that carry
+  // defaults and must not count as "configured with a key".
+  const claudeFields = [
+    { name: "ANTHROPIC_API_KEY", password: true },
+    { name: "ANTHROPIC_BASE_URL" },
+    { name: "ANTHROPIC_MODEL" },
+    { name: "CLAUDE_CODE_OAUTH_TOKEN", password: true },
+  ]
+
+  it("opens on the key tab once an API key is saved", () => {
+    expect(
+      preferredAuthTab(claudeFields, {
+        ANTHROPIC_API_KEY: "sk-ant-123",
+        ANTHROPIC_BASE_URL: "https://yinli.one",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+      }),
+    ).toBe("key")
+  })
+
+  it("opens on the key tab for a saved OAuth token too", () => {
+    expect(
+      preferredAuthTab(claudeFields, { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-x" }),
+    ).toBe("key")
+  })
+
+  it("stays on the CLI tab when only non-secret fields are set", () => {
+    // A base URL and model alone mean nothing was authenticated — this is the
+    // case that would otherwise send every agent to the key tab, since both
+    // fields ship with defaults.
+    expect(
+      preferredAuthTab(claudeFields, {
+        ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+      }),
+    ).toBe("cli")
+  })
+
+  it("treats blank and missing values the same", () => {
+    expect(preferredAuthTab(claudeFields, { ANTHROPIC_API_KEY: "   " })).toBe("cli")
+    expect(preferredAuthTab(claudeFields, {})).toBe("cli")
+    expect(preferredAuthTab(claudeFields, null)).toBe("cli")
+    expect(preferredAuthTab([], { ANTHROPIC_API_KEY: "sk-ant-123" })).toBe("cli")
   })
 })

--- a/packages/launcher/src/renderer/lib/agent-auth.ts
+++ b/packages/launcher/src/renderer/lib/agent-auth.ts
@@ -44,3 +44,28 @@ export function isCliLoginDetected(
   }
   return !hasEnvFields && health.ready === true
 }
+
+/**
+ * Which tab a dual-auth agent's Configure dialog should open on.
+ *
+ * Claude (and any other agent offering BOTH a CLI sign-in and API-key fields)
+ * shows the two as tabs. That tab used to always open on "cli", which meant
+ * someone who had configured an API key reopened Configure, landed on the CLI
+ * tab, saw "not signed in", and concluded the key had not saved — it had, it
+ * was simply on the tab they were not looking at. Opening on the tab the user
+ * actually configured is the whole fix.
+ *
+ * A saved secret decides it: `password` fields are the credentials (API key,
+ * OAuth token), while base URL and model carry defaults and would otherwise
+ * make every agent look key-configured.
+ */
+export function preferredAuthTab(
+  fields: Array<{ name: string; password?: boolean }>,
+  saved: Record<string, string> | null | undefined,
+): "cli" | "key" {
+  if (!saved) return "cli"
+  const configured = fields.some(
+    (f) => f.password && (saved[f.name] || "").trim(),
+  )
+  return configured ? "key" : "cli"
+}

--- a/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
@@ -25,7 +25,7 @@ import { CliLoginPanel } from "@renderer/components/agent-auth/cli-login-panel"
 import { useCliLogin } from "@renderer/components/agent-auth/use-cli-login"
 import { ConfigureWorkDir } from "./configure-workdir"
 import { AgentEnvFields } from "@renderer/components/agent-env-fields"
-import { isCliLoginDetected } from "@renderer/lib/agent-auth"
+import { isCliLoginDetected, preferredAuthTab } from "@renderer/lib/agent-auth"
 import { hasModelPicker } from "@renderer/lib/model-fields"
 import { capture } from "@renderer/lib/analytics"
 import type { EnvField } from "@renderer/types"
@@ -140,6 +140,11 @@ export function ConfigureDialog({
             initial[field.name] = merged[field.name] || field.default || ""
           })
           setValues(initial)
+          // Open on the tab this agent is actually configured with. Reopening
+          // Configure after saving an API key used to land on the CLI tab, which
+          // shows "not signed in" — the key was saved, just not on screen, and
+          // it read as "the key would not save".
+          setAuthTab(preferredAuthTab(f, merged))
         }
         // Always resolve a CLI login command. Hosted agents (Cursor/Hermes) have
         // ONLY a login; dual-auth agents (Claude) have BOTH env fields AND a

--- a/packages/launcher/src/renderer/pages/install/components/marketplace-stats.tsx
+++ b/packages/launcher/src/renderer/pages/install/components/marketplace-stats.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 
 import { cn } from "@renderer/lib/utils"
+import type { StatusFilter } from "../use-marketplace"
 
 export interface MarketplaceCounts {
   available: number
@@ -15,30 +16,73 @@ const TONE: Record<keyof MarketplaceCounts, string> = {
   updatable: "text-warning",
 }
 
+/** Which filter each counter turns on. "available" is the reset. */
+const FILTER: Record<keyof MarketplaceCounts, StatusFilter> = {
+  available: "all",
+  installed: "installed",
+  updatable: "updatable",
+}
+
 /**
- * Catalog counters for the page header. Zero counts still render — "0 待更新"
- * is the answer to "is anything out of date?", and hiding it would leave the
- * question open.
+ * Catalog counters for the page header, each one a filter.
+ *
+ * They started as plain text, which left "1 待更新" as a fact with nowhere to
+ * go: the one agent it referred to was somewhere in a list of a dozen, and the
+ * only way to find it was to scroll and read badges. Clicking a counter now
+ * narrows the catalog to exactly what it counts (and clicking the active one
+ * again clears it) — with the single-update case jumping straight to that
+ * agent, since a filter showing one row helps nobody.
+ *
+ * Zero counts still render — "0 待更新" is the answer to "is anything out of
+ * date?" — but a zero is not clickable; there is nothing to show.
  */
 export function MarketplaceStats({
   counts,
+  active = "all",
+  onSelect,
 }: {
   counts: MarketplaceCounts
+  active?: StatusFilter
+  onSelect?: (filter: StatusFilter) => void
 }): React.JSX.Element {
   const { t } = useTranslation()
   const keys = Object.keys(TONE) as Array<keyof MarketplaceCounts>
 
   return (
     <div className="flex items-center gap-2 text-2xs text-muted-foreground">
-      {keys.map((key, i) => (
-        <React.Fragment key={key}>
-          {i > 0 && <span className="opacity-40">/</span>}
-          <span>
-            <span className={cn("font-semibold", TONE[key])}>{counts[key]}</span>{" "}
-            {t(`install.stats.${key}`)}
-          </span>
-        </React.Fragment>
-      ))}
+      {keys.map((key, i) => {
+        const filter = FILTER[key]
+        const isActive = active === filter && filter !== "all"
+        // "available" is always actionable — it is how you get back to the full
+        // list — but a zero counter has nothing to filter to.
+        const actionable = !!onSelect && (filter === "all" || counts[key] > 0)
+
+        return (
+          <React.Fragment key={key}>
+            {i > 0 && <span className="opacity-40">/</span>}
+            <button
+              type="button"
+              data-testid={`stats-filter-${key}`}
+              disabled={!actionable}
+              aria-pressed={isActive}
+              title={t(`install.stats.filterHint.${key}`)}
+              onClick={() => onSelect?.(isActive ? "all" : filter)}
+              className={cn(
+                "rounded-sm px-1 py-0.5 transition-colors",
+                actionable
+                  ? "cursor-pointer hover:bg-muted"
+                  : "cursor-default opacity-70",
+                isActive && "bg-muted text-foreground",
+              )}
+            >
+              <span className={cn("font-semibold", TONE[key])}>
+                {counts[key]}
+              </span>{" "}
+              {t(`install.stats.${key}`)}
+            </button>
+          </React.Fragment>
+        )
+      })}
     </div>
   )
 }

--- a/packages/launcher/src/renderer/pages/install/detail/detail-progress.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-progress.tsx
@@ -7,6 +7,7 @@ import type { InstallJob } from "@renderer/store/install"
 import { STAGES, stageIndex } from "@renderer/components/install-progress/stages"
 
 import { DetailSection } from "./detail-section"
+import { InstallPrereqNotice } from "./install-prereq-notice"
 
 const VERB_LABEL: Record<InstallJob["verb"], string> = {
   install: "install.progress.verb.install",
@@ -106,6 +107,26 @@ export function DetailProgress({ job, onCopyLog, onRetry }: Props): React.JSX.El
       >
         {detail}
       </p>
+
+      {/* A refused install is not a failed one: nothing ran, and the fix is a
+          concrete step the user can take right here. */}
+      {errored && job.missing && job.missing.length > 0 && (
+        <InstallPrereqNotice missing={job.missing} onRetry={onRetry} />
+      )}
+
+      {job.logFile && (
+        <p className="m-0 mt-3 flex min-w-0 items-center gap-2 text-2xs text-muted-foreground">
+          <span className="shrink-0">{t("install.progress.logFile.label")}</span>
+          <button
+            type="button"
+            className="min-w-0 truncate underline underline-offset-2 hover:text-foreground"
+            title={job.logFile}
+            onClick={() => void window.api.showPath(job.logFile as string)}
+          >
+            {t("install.progress.logFile.reveal")}
+          </button>
+        </p>
+      )}
 
       {logOpen && (
         <pre className="log-viewer mt-3 max-h-60 overflow-auto text-2xs leading-relaxed break-words whitespace-pre-wrap">

--- a/packages/launcher/src/renderer/pages/install/detail/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/index.tsx
@@ -69,8 +69,15 @@ export default function AgentDetail({
   useEffect(() => {
     if (busy) setProgressSticky(true)
   }, [busy])
+  // A finished job stays visible while the page is open (progressSticky), and a
+  // FAILED one stays visible even after navigating away and back: its log and
+  // its remedy are the only record of what went wrong, and the store keeps the
+  // job around for exactly that reason. Without the `error` clause the block —
+  // "Copy log" included — vanished the moment the user left the page.
   const showProgress =
-    !!detail.job && detail.job.verb !== "uninstall" && (busy || progressSticky)
+    !!detail.job &&
+    detail.job.verb !== "uninstall" &&
+    (busy || progressSticky || detail.job.phase === "error")
 
   const installedAtLabel = detail.installed?.installedAt
     ? new Date(detail.installed.installedAt).toLocaleString()

--- a/packages/launcher/src/renderer/pages/install/detail/install-prereq-notice.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/install-prereq-notice.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@renderer/components/ui/button"
+import type { PrereqRemedy } from "@renderer/types"
+
+interface Props {
+  missing: PrereqRemedy[]
+  onRetry?: () => void
+}
+
+/**
+ * What the user sees when an install was refused before it started, because
+ * the machine is missing something the agent's installer needs.
+ *
+ * This exists because the alternative is worse than useless: hermes's install
+ * script reacts to a missing git by opening a bare macOS dialog nobody asked
+ * for and then polling silently for fifteen minutes. Here the requirement is
+ * named, the command is copyable, and on macOS the same Apple installer can be
+ * opened deliberately — with a Retry sitting next to it.
+ */
+export function InstallPrereqNotice({ missing, onRetry }: Props): React.JSX.Element {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState<string | null>(null)
+  const [cltState, setCltState] = useState<"idle" | "requested" | "failed">("idle")
+
+  const copy = (value: string): void => {
+    void navigator.clipboard.writeText(value)
+    setCopied(value)
+    window.setTimeout(() => setCopied((c) => (c === value ? null : c)), 2000)
+  }
+
+  const requestClt = async (): Promise<void> => {
+    try {
+      const result = await window.api.installXcodeCommandLineTools()
+      setCltState(result?.ok ? "requested" : "failed")
+    } catch {
+      setCltState("failed")
+    }
+  }
+
+  return (
+    <div className="mt-3 rounded-lg border border-(--danger-border) bg-(--danger-bg) p-4">
+      <p className="m-0 text-sm font-medium text-foreground">
+        {t("install.progress.prereq.title")}
+      </p>
+
+      {missing.map((item) => (
+        <div key={item.name} className="mt-3 flex flex-col gap-2">
+          <p className="m-0 text-xs text-muted-foreground">{item.summary}</p>
+
+          <CommandRow
+            label={t("install.progress.prereq.installCommand")}
+            command={item.command}
+            copied={copied === item.command}
+            onCopy={() => copy(item.command)}
+            copyLabel={t("install.progress.prereq.copyCommand")}
+            copiedLabel={t("install.progress.prereq.copied")}
+          />
+
+          {item.alternative && (
+            <CommandRow
+              label={t("install.progress.prereq.alternative")}
+              command={item.alternative}
+              copied={copied === item.alternative}
+              onCopy={() => copy(item.alternative as string)}
+              copyLabel={t("install.progress.prereq.copyCommand")}
+              copiedLabel={t("install.progress.prereq.copied")}
+            />
+          )}
+
+          {item.action === "install-xcode-clt" && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button size="sm" onClick={() => void requestClt()}>
+                {t("install.progress.prereq.installClt")}
+              </Button>
+              {cltState !== "idle" && (
+                <span className="text-2xs text-muted-foreground">
+                  {t(
+                    cltState === "requested"
+                      ? "install.progress.prereq.cltRequested"
+                      : "install.progress.prereq.cltFailed",
+                  )}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {onRetry && (
+        <Button size="sm" variant="outline" className="mt-3" onClick={onRetry}>
+          {t("install.progress.prereq.retry")}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+interface CommandRowProps {
+  label: string
+  command: string
+  copied: boolean
+  onCopy: () => void
+  copyLabel: string
+  copiedLabel: string
+}
+
+function CommandRow({
+  label,
+  command,
+  copied,
+  onCopy,
+  copyLabel,
+  copiedLabel,
+}: CommandRowProps): React.JSX.Element {
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span className="text-2xs text-muted-foreground">{label}</span>
+      <div className="flex min-w-0 items-center gap-2">
+        <code className="min-w-0 flex-1 overflow-x-auto rounded-sm bg-muted px-2 py-1 text-2xs whitespace-pre">
+          {command}
+        </code>
+        <Button size="sm" variant="ghost" onClick={onCopy}>
+          {copied ? copiedLabel : copyLabel}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/launcher/src/renderer/pages/install/index.test.tsx
+++ b/packages/launcher/src/renderer/pages/install/index.test.tsx
@@ -159,6 +159,49 @@ describe("marketplace", () => {
     expect(screen.getByTestId("agent-card-openclaw")).toBeInTheDocument()
   })
 
+  it("jumps straight to the agent when exactly one update is pending", async () => {
+    // The feedback that prompted this: the counter said "1 update" but not
+    // WHICH, so finding it meant scrolling the whole catalog.
+    render(<Install showToast={showToast} />)
+    await screen.findByTestId("agent-card-codex")
+
+    await userEvent.click(await screen.findByTestId("stats-filter-updatable"))
+
+    // Landed on claude's detail page, not a one-row filtered list.
+    expect(
+      await screen.findByRole("heading", { name: "Claude Code CLI" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("agent-card-codex")).not.toBeInTheDocument()
+  })
+
+  it("filters down to the installed agents and back", async () => {
+    render(<Install showToast={showToast} />)
+    await screen.findByTestId("agent-card-codex")
+
+    const installedCounter = await screen.findByTestId("stats-filter-installed")
+    await userEvent.click(installedCounter)
+
+    // Only the agent with an installed record survives.
+    await waitFor(() =>
+      expect(screen.queryByTestId("agent-card-openclaw")).not.toBeInTheDocument(),
+    )
+    expect(screen.getByTestId("agent-card-codex")).toBeInTheDocument()
+    expect(installedCounter).toHaveAttribute("aria-pressed", "true")
+
+    // Clicking the active counter again clears it.
+    await userEvent.click(installedCounter)
+    expect(await screen.findByTestId("agent-card-openclaw")).toBeInTheDocument()
+    expect(installedCounter).toHaveAttribute("aria-pressed", "false")
+  })
+
+  it("does not offer a filter for a counter that counts nothing", async () => {
+    installApi({ checkAgentUpdates: vi.fn().mockResolvedValue([]) })
+    render(<Install showToast={showToast} />)
+    await screen.findByTestId("agent-card-codex")
+
+    expect(await screen.findByTestId("stats-filter-updatable")).toBeDisabled()
+  })
+
   it("switches to the list view and keeps the same rows", async () => {
     render(<Install showToast={showToast} />)
     await screen.findByTestId("agent-card-codex")

--- a/packages/launcher/src/renderer/pages/install/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/index.tsx
@@ -14,7 +14,11 @@ import { hasPendingUpdate, useInstallStore } from "@renderer/store/install"
 import { useUiStore } from "@renderer/store/ui"
 import type { CatalogEntry } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
-import { useMarketplace, type MarketplaceRow } from "./use-marketplace"
+import {
+  useMarketplace,
+  type MarketplaceRow,
+  type StatusFilter,
+} from "./use-marketplace"
 import { useInstallActions } from "./use-install-actions"
 import { GRID, MarketplaceGrid } from "./components/marketplace-grid"
 import { MarketplaceCategories } from "./components/marketplace-categories"
@@ -92,6 +96,21 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
     [market.catalog, installedList, updates],
   )
 
+  /**
+   * Header counter → catalog filter. The exception that makes the feature worth
+   * having: with exactly one agent out of date, "1 待更新" opens THAT agent
+   * rather than filtering a list down to a single row the user still has to
+   * click. This is the ask from the feedback — the counter said something was
+   * out of date but not what, so finding it meant scrolling the whole catalog.
+   */
+  const selectStatusFilter = (filter: StatusFilter): void => {
+    if (filter === "updatable" && market.updatable.length === 1) {
+      setSelectedName(market.updatable[0].name)
+      return
+    }
+    market.setStatusFilter(filter)
+  }
+
   const startInstall = (row: MarketplaceRow): void =>
     actions.requestInstall(
       row.entry,
@@ -155,7 +174,15 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
       <PageHeader
         title={t("install.topbar.title")}
         subtitle={t("install.topbar.subtitle")}
-        actions={market.loading ? null : <MarketplaceStats counts={counts} />}
+        actions={
+          market.loading ? null : (
+            <MarketplaceStats
+              counts={counts}
+              active={market.statusFilter}
+              onSelect={selectStatusFilter}
+            />
+          )
+        }
       />
 
       {/* A block container, not a flex column: flex children default to
@@ -210,12 +237,19 @@ export default function Install({ showToast }: InstallProps): React.JSX.Element 
                 : t("install.empty.noMatch")
             }
             action={
-              market.search || prefs.category !== "all"
+              market.search ||
+              prefs.category !== "all" ||
+              market.statusFilter !== "all"
                 ? {
                     label: t("install.empty.resetFilters"),
                     onClick: () => {
                       market.setSearch("")
                       setCategory("all")
+                      // The header counters are a filter like any other, so
+                      // "clear filters" has to clear them too — otherwise the
+                      // button appears to do nothing when a counter is what
+                      // emptied the list.
+                      market.setStatusFilter("all")
                     },
                   }
                 : undefined

--- a/packages/launcher/src/renderer/pages/install/use-marketplace.ts
+++ b/packages/launcher/src/renderer/pages/install/use-marketplace.ts
@@ -26,14 +26,26 @@ export interface MarketplaceRow {
   job: InstallJob | undefined
 }
 
+/**
+ * Narrows the catalog by install state, independently of the tag categories.
+ * Driven by the header counters — see MarketplaceStats. Deliberately NOT
+ * persisted in prefs: a filter the user cannot remember setting, silently
+ * hiding most of the catalog on next launch, is worse than re-picking it.
+ */
+export type StatusFilter = "all" | "installed" | "updatable"
+
 interface Marketplace {
   catalog: CatalogEntry[]
   setCatalog: React.Dispatch<React.SetStateAction<CatalogEntry[]>>
   loading: boolean
   search: string
   setSearch: (v: string) => void
+  statusFilter: StatusFilter
+  setStatusFilter: (v: StatusFilter) => void
   prefs: Prefs
   rows: MarketplaceRow[]
+  /** Entries with an update pending, in the order they appear in the catalog. */
+  updatable: CatalogEntry[]
   loadAll: () => Promise<void>
   refreshAgentsStore: () => Promise<void>
 }
@@ -43,6 +55,7 @@ export function useMarketplace(): Marketplace {
   const [catalog, setCatalog] = useState<CatalogEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState("")
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
 
   const setInstalled = useInstallStore((s) => s.setInstalled)
   const setUpdates = useInstallStore((s) => s.setUpdates)
@@ -109,6 +122,10 @@ export function useMarketplace(): Marketplace {
     const q = search.trim().toLowerCase()
     const result = catalog.filter((c) => {
       if (!cat.match(c)) return false
+      if (statusFilter === "installed" && !installedList.some((r) => r.name === c.name))
+        return false
+      if (statusFilter === "updatable" && !hasPendingUpdate(updates, c.name))
+        return false
       if (!q) return true
       const haystack =
         `${c.name} ${c.label || ""} ${c.description || ""} ${(c.tags || []).join(" ")}`.toLowerCase()
@@ -144,7 +161,7 @@ export function useMarketplace(): Marketplace {
     // chosen sort. Applied last; Array.sort is stable so in-group order holds.
     result.sort((a, b) => (a.comingSoon ? 1 : 0) - (b.comingSoon ? 1 : 0))
     return result
-  }, [catalog, search, prefs.prefs, installedList])
+  }, [catalog, search, prefs.prefs, installedList, statusFilter, updates])
 
   const rows = useMemo(
     () =>
@@ -158,14 +175,24 @@ export function useMarketplace(): Marketplace {
     [filtered, updates, installedList, jobs],
   )
 
+  // Not derived from `rows`: the answer must not change when the user filters
+  // or searches, because it is what the header counter acts on.
+  const updatable = useMemo(
+    () => catalog.filter((c) => hasPendingUpdate(updates, c.name)),
+    [catalog, updates],
+  )
+
   return {
     catalog,
     setCatalog,
     loading,
     search,
     setSearch,
+    statusFilter,
+    setStatusFilter,
     prefs,
     rows,
+    updatable,
     loadAll,
     refreshAgentsStore,
   }

--- a/packages/launcher/src/renderer/store/install.ts
+++ b/packages/launcher/src/renderer/store/install.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand'
 import { isUpgradeAvailable } from '../../shared/version-compare'
-import type { AgentUpdateInfo, InstallPhase, InstalledAgentRecord } from '../types'
+import type {
+  AgentUpdateInfo,
+  InstallPhase,
+  InstalledAgentRecord,
+  PrereqRemedy,
+} from '../types'
 
 export interface InstallJob {
   agent: string
@@ -9,6 +14,10 @@ export interface InstallJob {
   detail: string
   log: string
   error?: string
+  /** Dependencies the machine is missing — the install never started. */
+  missing?: PrereqRemedy[]
+  /** Where the streamed output was written on disk. */
+  logFile?: string
   startedAt: number
 }
 

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -222,6 +222,19 @@ export interface AgentUpdateInfo {
 
 export type InstallPhase = 'idle' | 'preparing' | 'downloading' | 'installing' | 'verifying' | 'done' | 'error'
 
+/**
+ * One dependency an agent's installer needs but the machine does not have,
+ * as reported by the core's install preflight. `action` names a fix the
+ * launcher can perform itself (currently only 'install-xcode-clt').
+ */
+export interface PrereqRemedy {
+  name: string
+  action: string | null
+  summary: string
+  command: string
+  alternative: string | null
+}
+
 export interface InstallProgressEvent {
   agent: string
   verb: 'install' | 'update' | 'uninstall' | 'rollback'
@@ -229,6 +242,10 @@ export interface InstallProgressEvent {
   detail?: string
   log?: string
   error?: string
+  /** Set when the install was refused because a dependency is missing. */
+  missing?: PrereqRemedy[]
+  /** This run's log file under ~/.openagents/installs/. */
+  logFile?: string
 }
 
 export interface Workspace {
@@ -620,6 +637,7 @@ declare global {
       refreshLogin(type: string): Promise<HealthCheck>
       clearLoginKey(type: string, agentName?: string): Promise<{ success: boolean }>
       openExternal(url: string): Promise<void>
+      installXcodeCommandLineTools(): Promise<{ ok: boolean; error?: string }>
       openTerminal(cmd: string): Promise<void>
 
       // ── In-app CLI sign-in ──


### PR DESCRIPTION
## Summary

Five fixes, all from user reports on the install and configure screens. v0.9.18.

Pairs with #634 (core) but **does not depend on it to merge** — see the note at the bottom.

---

### 1. A missing dependency renders as an action, not a mystery

The core (#634) refuses an install whose dependencies are missing and reports what they are. The detail page turns that into a card: what is missing, the command to run, a button that opens Apple's Command Line Tools installer, and a Retry once it is done.

The user-visible change: no more unexplained macOS dialog seconds after pressing Install, and no more fifteen-minute freeze on "downloading". Nothing runs until the requirement is met.

### 2. A saved Claude API key was hidden behind the wrong tab

**Reported as "claude 配不了 api，key 配完了但显示不出来".** Ruled out the relay first — the reporter's endpoint answers `/v1/models` and `/v1/messages` with 200 on both `x-api-key` and `Bearer`. The bug is ours.

Claude offers a CLI sign-in **and** key fields, shown as two tabs, and `authTab` was hardcoded to open on `"cli"` regardless of how the agent was configured. So: save an API key → reopen Configure → land on the sign-in tab → see "not signed in" and no key → conclude the key did not save. It had saved. It was on the other tab.

`preferredAuthTab` picks the tab the agent is actually configured with. It keys off `password` fields only — base URL and model ship with defaults and would otherwise make every agent look key-configured.

(Also ruled out: the required-field validation, since `launcherAuthFields` already clears `required` for dual-login agents; and `normalizeEnvForSave`, which preserves the key and merely mirrors it into `ANTHROPIC_AUTH_TOKEN` for relay Bearer auth.)

### 3. Install logs survive the page

They lived only in renderer memory, and the progress block — **Copy log included** — rendered only while a job was busy or sticky, so it vanished the moment the user navigated away. The only way to learn why an install failed was to run it again. That is literally how today's report had to be diagnosed.

Every run now writes `~/.openagents/installs/<agent>-<verb>-<stamp>.log` (30 kept, every write best-effort so a full disk cannot fail an install), reachable via Show in Finder. A failed job keeps its progress block when you come back.

### 4. The marketplace counters are filters

**Requested in feedback:** "1 个待更新" named no agent, so finding it meant scrolling the whole catalog reading badges.

Each counter now narrows the list; clicking the active one clears it; a zero is not clickable. With exactly one update pending it **opens that agent directly** — a filtered list of one row helps nobody, and jumping to it is what was actually asked for.

Deliberately not persisted: a filter nobody remembers setting, hiding most of the catalog on next launch, is worse than re-picking it. "Clear filters" clears it too, or the button appears to do nothing.

### 5. Progress no longer blames the wrong step

`line.includes("mb")` counted "number", "symbol" and "assembly" as downloads. That is why the reporter's screenshot shows a red **"下载中"** for a failure that happened nowhere near a download. It now wants an actual size.

Git failures are also matched **ahead of** the generic network bucket: a failed PortableGit fetch prints plenty of "timeout", and "check your network, proxy, or VPN" is the wrong advice for a machine that simply has no Git. Windows additionally gets a real explanation when Git Bash is blocked by mandatory ASLR, instead of the installer's own "cannot launch required MSYS programs".

---

## Merge order

This can merge first. The two are independent at build time — the core is loaded at runtime, never imported.

Against an older core with no preflight, item 1 simply never triggers and the behaviour is exactly what ships today; items 2–5 are pure launcher and take effect immediately. Once #634 is published to npm, `ensureCoreLibrary()` upgrades users to it on the next launch and item 1 lights up on its own.

## Testing

`npm run typecheck` clean, `npx vitest run` 365 pass / 0 fail, `npm run check:changelog` OK.

New coverage: the auth-tab choice (saved key, saved OAuth token, defaults-only, blank/missing), the counter filters (single-update jump, filter and clear, disabled zero), the error mapping (PortableGit, Git Bash/ASLR, and that an ordinary "git bash" mention is not misread), and `classifyInstallChunk` size-vs-substring.

**Note on running the suite locally:** if 28 tests fail on `localStorage`, your `node` is v26 — that is the Node hijack #634 detects, not a repo problem. The suite is green on v22.