### PR TITLE
feat(launcher): differential update downloads

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -129,8 +129,8 @@ jobs:
         # The DMG is unaffected (its .app keeps the symlinks); only the update
         # zip is broken. Repack the already-signed/notarized .app with macOS
         # ditto (which preserves symlinks), sanity-check with codesign, then
-        # recompute the zip's sha512/size in latest-mac.yml and drop the stale
-        # blockmap so electron-updater's hash check passes.
+        # rebuild the blockmap from the repacked bytes and recompute the zip's
+        # sha512/size in latest-mac.yml so electron-updater's hash check passes.
         run: |
           set -euo pipefail
           APP=$(ls -d dist/mac*/*.app | head -1)
@@ -145,6 +145,11 @@ jobs:
           ditto -x -k "$ZIP" "$TMP"
           codesign -v --verbose=4 "$TMP/$(basename "$APP")"
           rm -rf "$TMP"
+          # electron-builder's blockmap (deleted above) indexed ITS zip, not this
+          # one. Rebuild it from the bytes we actually publish: without a
+          # blockmap every update is a full 140 MB download, and with a stale one
+          # the client reassembles the wrong file and fails its checksum.
+          node scripts/gen-blockmap.mjs "$ZIP"
           # Recompute sha512/size for the new zip in latest-mac.yml. Uses ruby
           # (preinstalled on macOS runners) to avoid a pip dependency.
           ruby -ryaml -rdigest -rbase64 -e '
@@ -288,6 +293,17 @@ jobs:
       actions: read
 
     steps:
+      # First, before anything writes into the workspace: actions/checkout wipes
+      # the working directory, so running it later would delete ./signed. Needed
+      # for scripts/gen-blockmap.mjs and the lockfile it is pinned against.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       # SignPath's GitHub connector pulls the binaries-only artifact uploaded by
       # build-windows, verifies it originated from this workflow (trusted build
       # system + origin verification), signs every *.exe/*.msi per the
@@ -316,14 +332,53 @@ jobs:
           name: launcher-windows-unsigned
           path: unsigned
 
+      - name: Rebuild blockmaps for signed binaries
+        # Same staleness problem as the hashes below, and a worse failure mode:
+        # a blockmap built before signing indexes bytes we do not ship, so a
+        # client would reassemble the installer from wrong offsets and fail its
+        # checksum. Rebuild one for every binary that had a blockmap before
+        # signing, from the signed bytes, so differential updates download only
+        # the ~20 MB that actually changed instead of the whole installer.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          MAPS=(unsigned/*.blockmap)
+          if [ ${#MAPS[@]} -eq 0 ]; then
+            echo "::warning::no blockmaps in the unsigned build — differential updates will be unavailable for this build"
+            exit 0
+          fi
+          # app-builder-lib owns the chunking algorithm; pin it to the version
+          # the launcher builds with so old and new blockmaps chunk identically.
+          # A couple of minutes and a lot of transitive packages for one file,
+          # but this job already blocks on a human approving the signing request,
+          # and installing the real dependency beats tracking its imports by hand.
+          VERSION=$(node -p "require('./packages/launcher/package-lock.json').packages['node_modules/app-builder-lib'].version")
+          for i in 1 2 3; do
+            npm install --no-save --ignore-scripts --prefix "$RUNNER_TEMP/blockmap" "app-builder-lib@$VERSION" && break
+            if [ "$i" = 3 ]; then
+              echo "npm registry unreachable after 3 attempts; cannot build blockmaps." >&2
+              exit 1
+            fi
+            echo "::warning::npm install attempt $i failed; retrying in 15s…"
+            sleep 15
+          done
+          export BLOCKMAP_MODULES_DIR="$RUNNER_TEMP/blockmap/node_modules"
+          for map in "${MAPS[@]}"; do
+            name=$(basename "$map" .blockmap)
+            if [ -f "signed/$name" ]; then
+              node packages/launcher/scripts/gen-blockmap.mjs "signed/$name"
+            else
+              echo "::warning::$name was not returned by SignPath — publishing it without a blockmap"
+            fi
+          done
+
       - name: Regenerate update metadata for signed EXE
         # SignPath re-signs the installers *after* electron-builder hashed them,
         # so the sha512/size in the unsigned latest.yml no longer match the bytes
         # we ship and electron-updater would reject the download. Recompute each
         # latest.yml entry from ITS OWN signed binary (matched by filename) — the
         # build emits multiple exes (NSIS installer + portable), so we must not
-        # blanket-apply one hash to every .exe entry. Drop the now-stale blockmap
-        # so the updater falls back to a full download.
+        # blanket-apply one hash to every .exe entry.
         run: |
           set -euo pipefail
           if [ ! -f unsigned/latest.yml ]; then
@@ -341,13 +396,16 @@ jobs:
           signed = {
               os.path.basename(p): p
               for p in glob.glob(os.path.join(signdir, "*"))
-              if os.path.isfile(p) and not p.endswith(".yml")
+              if os.path.isfile(p) and not p.endswith((".yml", ".blockmap"))
           }
           doc = yaml.safe_load(open(src))
           for f in doc.get("files", []):
               b = os.path.basename(f.get("url", ""))
               if b in signed:
                   f["sha512"], f["size"] = digest(signed[b])
+                  # Size of a blockmap embedded *inside* the installer, which
+                  # only nsis-web builds have. Stale here, and unread by the
+                  # differential downloader, which fetches the .blockmap file.
                   f.pop("blockMapSize", None)
           # Top-level path/sha512/size describe the primary installer.
           top = os.path.basename(doc.get("path", ""))
@@ -506,12 +564,46 @@ jobs:
         # mismatches (the metadata describing a different build than the binary)
         # so a known-bad release is never created. Upload truncation is caught
         # separately by the post-upload check below.
+        #
+        # Blockmaps are checked here too. They are not listed in latest*.yml, so
+        # nothing else would notice a missing or stale one — and stale is the
+        # dangerous case, because the client trusts it and reassembles garbage.
+        # Re-derive every chunk checksum the way the client will, rather than
+        # just totalling the sizes: a rewrite that happens to preserve the file
+        # length would sail past a size check.
         run: |
           set -euo pipefail
           pip install --quiet pyyaml
           python3 - <<'PY'
-          import base64, hashlib, glob, os, sys, yaml
-          errors, checked = [], 0
+          import base64, glob, gzip, hashlib, json, os, sys, yaml
+          errors, checked, maps = [], 0, 0
+          # The artifacts electron-builder builds a blockmap for: the mac zips,
+          # the AppImage, and the NSIS installer (which is always the primary
+          # entry). A .deb, .msi or the portable .exe never gets one, so absence
+          # there is normal — but absence on these three is a regression.
+          def differential(doc, url):
+              if url.endswith((".zip", ".AppImage")):
+                  return True
+              return url == doc.get("path") and url.endswith(".exe")
+          def blockmap_error(raw, data):
+              """None when the blockmap indexes exactly these bytes."""
+              try:
+                  f = json.loads(gzip.decompress(raw))["files"][0]
+                  sizes, sums = f["sizes"], f["checksums"]
+              except Exception as e:  # noqa: BLE001
+                  return f"unreadable ({e})"
+              if len(sizes) != len(sums):
+                  return f"{len(sizes)} chunk sizes but {len(sums)} checksums"
+              off = f["offset"]
+              for size, want in zip(sizes, sums):
+                  # blake2b-18, as written by app-builder-lib's chunker.
+                  got = hashlib.blake2b(data[off:off + size], digest_size=18).digest()
+                  if base64.b64encode(got).decode() != want:
+                      return f"chunk at byte {off} differs — indexes a different build"
+                  off += size
+              if off != len(data):
+                  return f"indexes {off} bytes, file is {len(data)}"
+              return None
           for y in sorted(glob.glob("artifacts/latest*.yml")):
               doc = yaml.safe_load(open(y))
               for f in doc.get("files", []):
@@ -529,12 +621,20 @@ jobs:
                       errors.append(f"{os.path.basename(y)} :: {url}: size {got_size} != yml {f['size']}")
                   if f.get("sha512") and got_sha != f["sha512"]:
                       errors.append(f"{os.path.basename(y)} :: {url}: sha512 mismatch (binary != yml)")
+                  if not os.path.exists(path + ".blockmap"):
+                      if differential(doc, url):
+                          errors.append(f"{os.path.basename(y)} :: {url}: no .blockmap — every update would be a full download")
+                      continue
+                  maps += 1
+                  bad = blockmap_error(open(path + ".blockmap", "rb").read(), data)
+                  if bad:
+                      errors.append(f"{os.path.basename(y)} :: {url}.blockmap: {bad}")
           if errors:
               print("::error::Local artifact/metadata mismatch — refusing to publish:")
               for e in errors:
                   print("::error::  " + e)
               sys.exit(1)
-          print(f"OK: {checked} local installer(s) match their latest*.yml sha512/size.")
+          print(f"OK: {checked} local installer(s) match their latest*.yml sha512/size, {maps} blockmap(s) match their installer.")
           PY
 
       - name: Create GitHub Release
@@ -577,8 +677,19 @@ jobs:
           # (electron-updater generic provider url = .../launcher/stable). --delete
           # keeps only the current release's installers + latest*.yml so the
           # updater always resolves exactly this build.
+          #
+          # Blockmaps are exempt from --delete: a client updating from an older
+          # version asks for THAT version's blockmap by name (the URL is the new
+          # one with the version substituted), so deleting it drops anyone whose
+          # local blockmap cache is cold — a fresh install, most of all — back to
+          # a full download. A few hundred KB per release is worth keeping.
+          # --exclude applies to deletes as well as uploads, so the new ones are
+          # copied in separately.
           aws s3 sync artifacts/ "s3://${R2_BUCKET}/launcher/stable/" \
-            --delete --no-progress --endpoint-url "$R2_S3_ENDPOINT"
+            --delete --exclude "*.blockmap" --no-progress --endpoint-url "$R2_S3_ENDPOINT"
+          aws s3 cp artifacts/ "s3://${R2_BUCKET}/launcher/stable/" \
+            --recursive --exclude "*" --include "*.blockmap" \
+            --no-progress --endpoint-url "$R2_S3_ENDPOINT"
           echo "Synced stable channel -> s3://${R2_BUCKET}/launcher/stable/"
 
       - name: Verify published release assets match update metadata (post-upload)
@@ -596,7 +707,7 @@ jobs:
           set -euo pipefail
           pip install --quiet pyyaml
           python3 - <<'PY'
-          import base64, hashlib, glob, os, sys, time, urllib.request, yaml
+          import base64, glob, gzip, hashlib, json, os, sys, time, urllib.request, yaml
           tag, repo = os.environ["GH_TAG"], os.environ["GH_REPO"]
           base = f"https://github.com/{repo}/releases/download/{tag}"
           def fetch(url):
@@ -609,7 +720,25 @@ jobs:
                       last = e
                       time.sleep(5 * (attempt + 1))
               raise last
-          errors, checked = [], 0
+          errors, checked, maps = [], 0, 0
+          def blockmap_error(raw, data):
+              """None when the blockmap indexes exactly these bytes."""
+              try:
+                  f = json.loads(gzip.decompress(raw))["files"][0]
+                  sizes, sums = f["sizes"], f["checksums"]
+              except Exception as e:  # noqa: BLE001
+                  return f"unreadable ({e})"
+              if len(sizes) != len(sums):
+                  return f"{len(sizes)} chunk sizes but {len(sums)} checksums"
+              off = f["offset"]
+              for size, want in zip(sizes, sums):
+                  got = hashlib.blake2b(data[off:off + size], digest_size=18).digest()
+                  if base64.b64encode(got).decode() != want:
+                      return f"chunk at byte {off} differs — indexes a different build"
+                  off += size
+              if off != len(data):
+                  return f"indexes {off} bytes, file is {len(data)}"
+              return None
           for y in sorted(glob.glob("artifacts/latest*.yml")):
               doc = yaml.safe_load(open(y))
               for f in doc.get("files", []):
@@ -623,10 +752,25 @@ jobs:
                       errors.append(f"{os.path.basename(y)} :: {url}: published size {got_size} != yml {f['size']}")
                   if f.get("sha512") and got_sha != f["sha512"]:
                       errors.append(f"{os.path.basename(y)} :: {url}: published sha512 mismatch (asset != yml)")
+                  # Blockmaps are published alongside, but not described by,
+                  # latest*.yml — so check the bytes clients will range-request
+                  # against. The pre-upload step already proved one exists for
+                  # every file that needs one.
+                  if not os.path.exists(os.path.join("artifacts", url + ".blockmap")):
+                      continue
+                  maps += 1
+                  try:
+                      raw = fetch(f"{base}/{url}.blockmap")
+                  except Exception as e:  # noqa: BLE001
+                      errors.append(f"{os.path.basename(y)} :: {url}.blockmap: not published ({e})")
+                      continue
+                  bad = blockmap_error(raw, data)
+                  if bad:
+                      errors.append(f"{os.path.basename(y)} :: {url}.blockmap: {bad}")
           if errors:
               print("::error::Published asset/metadata mismatch — clients will get 'sha512 checksum mismatch'. Re-publish this release:")
               for e in errors:
                   print("::error::  " + e)
               sys.exit(1)
-          print(f"OK: {checked} published asset(s) match their latest*.yml sha512/size.")
+          print(f"OK: {checked} published asset(s) match their latest*.yml sha512/size, {maps} blockmap(s) match their asset.")
           PY

--- a/packages/launcher/changelog/0.9.19.json
+++ b/packages/launcher/changelog/0.9.19.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.9.19",
+  "date": "2026-08-23",
+  "entries": [
+    {
+      "type": "improvement",
+      "title": {
+        "en": "Update downloads are significantly faster",
+        "zh": "更新下载速度显著提升"
+      },
+      "description": {
+        "en": "Updates are now downloaded incrementally, transferring only the content that differs between versions instead of the complete installer. The improvement takes effect from the next update onward.",
+        "zh": "更新已改为增量下载，仅传输版本之间存在差异的内容，无需重新获取完整安装包。该优化自下一次更新起生效。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.16",
+  "version": "0.9.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.9.16",
+      "version": "0.9.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
-        "@openagents-org/agent-launcher": "0.2.169",
+        "@openagents-org/agent-launcher": "0.2.173",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -1219,24 +1219,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
@@ -1254,24 +1236,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
@@ -1285,24 +1249,6 @@
       "os": [
         "openbsd"
       ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1744,9 +1690,9 @@
       }
     },
     "node_modules/@openagents-org/agent-launcher": {
-      "version": "0.2.169",
-      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.169.tgz",
-      "integrity": "sha512-X9IlMbgDbY2A+DSRSlMMjqmJulCLQ9kSmCUl56txsCdeVaP16nhKDSSXyOTNX/1spnb+DG3olhVhLwoL85SSwg==",
+      "version": "0.2.173",
+      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.173.tgz",
+      "integrity": "sha512-FnF+j3VIrTtf2Gtq3bIomRdPDvxKfLKMzQi50/K/Q9pn9aJsq+Javsuj/pFaHHqtkGixSrLva97cOuQ5vNc5qw==",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",
@@ -11279,420 +11225,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
@@ -11718,50 +11250,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
-    "@openagents-org/agent-launcher": "0.2.169",
+    "@openagents-org/agent-launcher": "0.2.173",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -192,7 +192,8 @@
     "publish": {
       "provider": "generic",
       "url": "https://dl.openagents.org/launcher/stable",
-      "channel": "latest"
+      "channel": "latest",
+      "useMultipleRangeRequest": false
     }
   }
 }

--- a/packages/launcher/scripts/gen-blockmap.mjs
+++ b/packages/launcher/scripts/gen-blockmap.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Regenerates the .blockmap files electron-updater needs for differential
+// ("delta") downloads.
+//
+// A blockmap is a gzipped index of an installer: content-defined chunks of
+// ~16 KB, each with its own checksum. Given the old and the new blockmap, the
+// client copies every unchanged chunk out of the copy it already has on disk
+// and range-requests only the rest — a launcher update moves ~10-30 MB instead
+// of the whole 140 MB, because the Electron framework is identical between
+// versions.
+//
+// electron-builder already writes one next to every installer at build time,
+// but two of our release steps rewrite the installer bytes AFTERWARDS: the
+// macOS zip is repacked with ditto (to keep the framework symlinks) and the
+// Windows binaries are re-signed by SignPath. A blockmap describing the
+// pre-rewrite bytes is worse than no blockmap at all — the client reassembles
+// the file from stale offsets and the result fails its sha512 check. So CI
+// deletes the build-time one and calls this script on the exact bytes we ship.
+//
+//   node scripts/gen-blockmap.mjs dist/OpenAgents-Launcher-1.2.3-mac-arm64.zip
+//
+// Writes <file>.blockmap beside each input and prints one JSON line per file
+// with the {size, sha512} that the matching latest*.yml entry must carry.
+//
+// The chunking lives in app-builder-lib (pure JS since electron-builder 26), so
+// this stays byte-identical to what electron-builder itself would have
+// produced. Jobs without the launcher's node_modules can install app-builder-lib
+// anywhere and point BLOCKMAP_MODULES_DIR at the containing node_modules.
+import { createRequire } from "node:module"
+import { join } from "node:path"
+
+const require = createRequire(import.meta.url)
+
+const MODULE_PATH = "app-builder-lib/out/targets/blockmap/blockmap.js"
+
+function loadBuildBlockMap() {
+  const override = process.env.BLOCKMAP_MODULES_DIR
+  const specifier = override ? join(override, MODULE_PATH) : MODULE_PATH
+  try {
+    return require(specifier).buildBlockMap
+  } catch (err) {
+    console.error(
+      `gen-blockmap: cannot load ${specifier} — ${err.message}\n` +
+        "Run from packages/launcher after npm install, or set " +
+        "BLOCKMAP_MODULES_DIR to a node_modules holding app-builder-lib.",
+    )
+    process.exit(1)
+  }
+}
+
+const files = process.argv.slice(2)
+if (files.length === 0) {
+  console.error("usage: gen-blockmap.mjs <installer> [<installer>...]")
+  process.exit(1)
+}
+
+const buildBlockMap = loadBuildBlockMap()
+
+for (const file of files) {
+  const out = `${file}.blockmap`
+  // "gzip" (not "deflate") + a separate output file is the combination
+  // electron-updater fetches over HTTP; "deflate" is only for the copy embedded
+  // inside nsis-web packages, which we do not build.
+  const { size, sha512 } = await buildBlockMap(file, "gzip", out)
+  console.log(JSON.stringify({ file, blockmap: out, size, sha512 }))
+}

--- a/packages/launcher/src/main/updater-cache.test.ts
+++ b/packages/launcher/src/main/updater-cache.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs"
 import { tmpdir } from "os"
 import path from "path"
 
 import {
+  adoptDifferentialBaseFile,
   asciiCacheRootCandidates,
   clearInstallAttempt,
   compareVersions,
@@ -124,6 +132,78 @@ describe("purgePendingUpdateCache", () => {
 
   it("reports false when there is nothing staged", () => {
     expect(purgePendingUpdateCache(dir, "openagents-launcher-updater")).toBe(false)
+  })
+})
+
+describe("adoptDifferentialBaseFile", () => {
+  const NAME = "openagents-launcher-updater"
+  // The move only ever happens on Windows; pass the platform explicitly so the
+  // logic is covered on the macOS/Linux runners too.
+  const adopt = (from: string, to: string) =>
+    adoptDifferentialBaseFile(from, to, NAME, () => {}, "win32")
+
+  it("moves the installer the NSIS setup left on the old path", () => {
+    const oldRoot = path.join(dir, "old")
+    const newRoot = path.join(dir, "new")
+    mkdirSync(path.join(oldRoot, NAME), { recursive: true })
+    writeFileSync(path.join(oldRoot, NAME, "installer.exe"), "v1 setup")
+
+    expect(adopt(oldRoot, newRoot)).toBe(true)
+    expect(existsSync(path.join(oldRoot, NAME, "installer.exe"))).toBe(false)
+    expect(readFileSync(path.join(newRoot, NAME, "installer.exe"), "utf-8")).toBe(
+      "v1 setup",
+    )
+  })
+
+  it("overwrites the previous base file so it tracks the installed version", () => {
+    const oldRoot = path.join(dir, "old")
+    const newRoot = path.join(dir, "new")
+    mkdirSync(path.join(oldRoot, NAME), { recursive: true })
+    mkdirSync(path.join(newRoot, NAME), { recursive: true })
+    writeFileSync(path.join(oldRoot, NAME, "installer.exe"), "v2 setup")
+    writeFileSync(path.join(newRoot, NAME, "installer.exe"), "v1 setup")
+
+    expect(adopt(oldRoot, newRoot)).toBe(true)
+    expect(readFileSync(path.join(newRoot, NAME, "installer.exe"), "utf-8")).toBe(
+      "v2 setup",
+    )
+  })
+
+  it("reads a non-ASCII source path — the only case it ever runs in", () => {
+    // The whole reason the cache gets redirected is a Chinese Windows username,
+    // so the path this reads from always has non-ASCII segments. Node's fs takes
+    // those fine; it is handing them to the Windows shell that breaks.
+    const oldRoot = path.join(dir, "用户", "张三", "AppData", "Local")
+    const newRoot = path.join(dir, "ProgramData", "OpenAgents", "updater-cache")
+    mkdirSync(path.join(oldRoot, NAME), { recursive: true })
+    writeFileSync(path.join(oldRoot, NAME, "installer.exe"), "v1 setup")
+
+    expect(adopt(oldRoot, newRoot)).toBe(true)
+    expect(readFileSync(path.join(newRoot, NAME, "installer.exe"), "utf-8")).toBe(
+      "v1 setup",
+    )
+  })
+
+  it("reports false when there is nothing to adopt", () => {
+    expect(adopt(path.join(dir, "old"), path.join(dir, "new"))).toBe(false)
+  })
+
+  it("does nothing when the cache was not redirected", () => {
+    mkdirSync(path.join(dir, NAME), { recursive: true })
+    writeFileSync(path.join(dir, NAME, "installer.exe"), "v1 setup")
+    expect(adopt(dir, dir)).toBe(false)
+    expect(existsSync(path.join(dir, NAME, "installer.exe"))).toBe(true)
+  })
+
+  it("is a no-op off Windows", () => {
+    const oldRoot = path.join(dir, "old")
+    mkdirSync(path.join(oldRoot, NAME), { recursive: true })
+    writeFileSync(path.join(oldRoot, NAME, "installer.exe"), "v1 setup")
+    const noop = () => {}
+    expect(
+      adoptDifferentialBaseFile(oldRoot, path.join(dir, "new"), NAME, noop, "darwin"),
+    ).toBe(false)
+    expect(existsSync(path.join(oldRoot, NAME, "installer.exe"))).toBe(true)
   })
 })
 

--- a/packages/launcher/src/main/updater-cache.ts
+++ b/packages/launcher/src/main/updater-cache.ts
@@ -24,7 +24,16 @@
 // by remembering which version we last handed to the installer: if we come back
 // up still older than that version the install failed, so drop the poisoned
 // cache and let the next attempt re-download instead of replaying it.
-import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs"
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs"
 import path from "path"
 import { hasNonAsciiPathSegment } from "./windows-update-installer"
 
@@ -159,6 +168,57 @@ export function readUpdaterCacheDirName(configPath: string): string | null {
     return m[1].trim().replace(/^["']|["']$/g, "") || null
   } catch {
     return null
+  }
+}
+
+/**
+ * Move the differential-update base file into a redirected cache.
+ *
+ * Windows differential downloads rebuild the new installer from the copy of the
+ * previous one that the NSIS installer stashes at
+ * `%LOCALAPPDATA%\<cacheDirName>\installer.exe`. That path is baked into the
+ * installer at build time, so it keeps landing on the untouched non-ASCII
+ * profile path even after we redirect the cache — where electron-updater,
+ * which looks for it under the redirected root, never finds it. Left alone,
+ * exactly the users on slow connections keep downloading every release in full.
+ *
+ * Moves rather than copies: it is ~100MB, and the next install writes a fresh
+ * one at the source path anyway. No-op off Windows, or when nothing was
+ * redirected. Returns true when a base file was adopted.
+ */
+export function adoptDifferentialBaseFile(
+  previousRoot: string | null,
+  newRoot: string | null,
+  cacheDirName: string | null,
+  log: (msg: string) => void = () => {},
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== "win32") return false
+  if (!previousRoot || !newRoot || !cacheDirName || previousRoot === newRoot) {
+    return false
+  }
+  const from = path.join(previousRoot, cacheDirName, "installer.exe")
+  const to = path.join(newRoot, cacheDirName, "installer.exe")
+  try {
+    if (!existsSync(from)) return false
+    mkdirSync(path.dirname(to), { recursive: true })
+    try {
+      renameSync(from, to)
+    } catch {
+      // Different volume, or the source is momentarily locked — a copy still
+      // gets the differential path working; the stale original is small beer
+      // next to a full download every release.
+      copyFileSync(from, to)
+      try {
+        unlinkSync(from)
+      } catch {}
+    }
+    log(`[updater] adopted differential base installer from ${from}`)
+    return true
+  } catch (err) {
+    const why = (err as Error).message
+    log(`[updater] could not adopt differential base installer: ${why}`)
+    return false
   }
 }
 

--- a/packages/launcher/src/main/updater.ts
+++ b/packages/launcher/src/main/updater.ts
@@ -20,6 +20,7 @@ import electronUpdater, {
 import { launchWindowsUpdateInstaller } from "./windows-update-installer"
 import { DEFAULT_LAUNCHER_FEED, launcherFeedUrl } from "./mirror"
 import {
+  adoptDifferentialBaseFile,
   clearInstallAttempt,
   purgePendingUpdateCache,
   readUpdaterCacheDirName,
@@ -361,6 +362,19 @@ function registerIpc(): void {
   })
 }
 
+// Provider options that must hold for every feed we point at, mirror or not.
+// Keep in sync with `build.publish` in package.json, which supplies the same
+// options to the packaged app-update.yml when no mirror is set.
+//
+// Differential downloads ask for the changed blocks of an installer. By default
+// electron-updater batches them into one multi-range request and expects a
+// multipart/byteranges reply — which S3-backed origins (ours is R2 behind
+// Cloudflare) don't produce; they answer with the whole object instead, and the
+// client streams the entire installer only to fail parsing it and then download
+// it a second time in full. One range per request is slower but universally
+// supported, and still moves a fraction of the bytes.
+const FEED_OPTIONS = { useMultipleRangeRequest: false } as const
+
 /**
  * Point electron-updater at a mirror of the release feed. Called at startup and
  * whenever the user edits the setting, so switching mirrors doesn't need a
@@ -371,12 +385,16 @@ export function applyUpdateFeedUrl(override: unknown): void {
   const url = launcherFeedUrl(override)
   try {
     if (url) {
-      autoUpdater.setFeedURL({ provider: "generic", url })
+      autoUpdater.setFeedURL({ provider: "generic", url, ...FEED_OPTIONS })
       _log(`[updater] using update feed mirror: ${url}`)
     } else if (_feedOverridden) {
       // Switching back to the default: electron-updater has no "unset feed"
       // call, so restore the packaged origin explicitly.
-      autoUpdater.setFeedURL({ provider: "generic", url: DEFAULT_LAUNCHER_FEED })
+      autoUpdater.setFeedURL({
+        provider: "generic",
+        url: DEFAULT_LAUNCHER_FEED,
+        ...FEED_OPTIONS,
+      })
       _log(`[updater] using default update feed: ${DEFAULT_LAUNCHER_FEED}`)
     }
     _feedOverridden = url !== null
@@ -447,6 +465,10 @@ export function setupAutoUpdater(opts: {
   // failed to install. Reclaim the space.
   if (redirected && previousRoot && _cacheDirName) {
     purgePendingUpdateCache(previousRoot, _cacheDirName, _log)
+    // The staged package is disposable; the installer the NSIS setup stashed
+    // beside it is not — it's the base a differential download builds on, and
+    // it only ever lands on the old path. Bring it across before checking.
+    adoptDifferentialBaseFile(previousRoot, _cacheRoot, _cacheDirName, _log)
   }
 
   // Did the update we handed to the installer last time actually land? A
@@ -478,15 +500,20 @@ export function setupAutoUpdater(opts: {
   // whichever caller set it last; startDownload() owns that decision now.
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
-  // Always pull the full installer and verify its sha512 directly, never the
-  // block-by-block differential path. The delta downloader reassembles the new
-  // installer from the locally-installed file plus changed blocks fetched via
-  // many small HTTP range requests; on flaky / China networks (and whenever a
-  // published .blockmap doesn't correspond byte-for-byte to the published
-  // installer) the reassembled file fails its sha512 check — surfacing as
-  // "sha512 checksum mismatch". A single full download + verify is far more
-  // robust here and only costs bandwidth on the (user-driven) download.
-  autoUpdater.disableDifferentialDownload = true
+  // Differential downloads are left ON (electron-updater's default). Nearly all
+  // of a ~140 MB update is the unchanged Electron framework, so the delta
+  // downloader — which copies every unchanged block out of the installer
+  // already on disk and range-requests only the rest — moves ~20 MB instead.
+  //
+  // This was pinned off for a while because the published .blockmap didn't
+  // describe the published installer byte-for-byte (the macOS zip is repacked
+  // with ditto after signing, the Windows binaries are re-signed by SignPath),
+  // and reassembling from a stale blockmap fails the sha512 check. CI now
+  // rebuilds each blockmap from the exact bytes it publishes and refuses to
+  // release when the two disagree, which removes that failure at the source.
+  // Everything else — a cold cache, a missing blockmap, a dropped range
+  // request — makes electron-updater fall back to a full download on its own,
+  // so the worst case is the behaviour we had before.
   autoUpdater.logger = {
     info: (m: unknown) => _log(`[updater] ${String(m)}`),
     warn: (m: unknown) => _log(`[updater] WARN ${String(m)}`),


### PR DESCRIPTION
Updates currently pull the full ~140 MB installer every time, nearly all of which is the unchanged Electron framework. electron-updater can fetch only the changed blocks and reuse the rest from the copy already on disk — typically ~20 MB instead of 140 — but the feature was pinned off in `updater.ts`, and the blockmaps it needs were never published.

## Why it was off

The published `.blockmap` never described the published installer. Two release steps rewrite the bytes *after* electron-builder has hashed and indexed them:

- the macOS zip is repacked with `ditto` to preserve the framework symlinks
- the Windows binaries are re-signed by SignPath

Shipping an index of the pre-rewrite bytes is worse than shipping none — the client reassembles the installer from stale offsets and fails its sha512 check. So CI deleted the stale one and the client turned the whole path off.

## What changed

**CI rebuilds each blockmap from the exact bytes it publishes**, using app-builder-lib's chunker (pure JS since electron-builder 26, so no `app-builder` binary is involved) via a new `scripts/gen-blockmap.mjs`.

- `build-macos` regenerates it after the ditto repack.
- `sign-windows` regenerates one for every binary that had a blockmap before signing. This needs node, hence `checkout` + `setup-node` on that job — and checkout has to be the **first** step or it wipes `./signed`.
- Both release verifications now check blockmaps. They re-derive every chunk checksum the way the client will, rather than totalling the chunk sizes: a rewrite that happens to preserve the file length would sail past a size check. Blockmaps aren't listed in `latest*.yml`, so nothing else would notice a missing or stale one.
- The R2 `stable` channel keeps old blockmaps. A client updating from an older version asks for *that* version's blockmap by name, so `--delete` was dropping anyone whose local blockmap cache was cold — a fresh install, most of all.

**Client side:** `disableDifferentialDownload` comes off. Multi-range requests stay off (`useMultipleRangeRequest: false`, set on both the mirror feed and `build.publish`): electron-updater only disables them for `s3.amazonaws.com`, but R2 behind Cloudflare answers a multi-range request with the whole object *and* `Accept-Ranges: bytes`, which passes its support check — the client would stream the entire installer, fail to parse it as multipart, then download it in full a second time.

**Non-ASCII Windows usernames:** the base file a delta builds on is the installer NSIS stashes under `%LOCALAPPDATA%`. That path is baked into the installer at build time, so it keeps landing on the untouched non-ASCII profile path while electron-updater looks under the redirected ASCII cache. Left alone, exactly the users on slow connections would keep downloading in full. `adoptDifferentialBaseFile()` moves it across when the cache is redirected.

## When users see it

Windows on the next update, macOS the one after — its base file is only cached once a download completes with differential enabled. Anything that goes wrong (cold cache, missing blockmap, refused range request) falls back to a full download, which is today's behaviour, so the worst case is no regression.

## Also in this PR

`@openagents-org/agent-launcher` 0.2.169 → 0.2.173, matching where this repo's own `packages/agent-connector` already sits. The lockfile had drifted (it still recorded 0.9.16), so regenerating it made npm reshuffle which esbuild gets hoisted — vite's copy moved to a nested 0.28.1, vitest's 0.25.12 hoisted in its place. Every platform variant is present for both copies, so no runner loses its binary; that accounts for the large lockfile diff.

## Verification

- typecheck clean; `updater-cache` suite 25/25 (6 new, including one that exercises a non-ASCII source path). The 31 failures in the full suite are pre-existing on `develop` — same 31 with the branch stashed.
- `npm run build` clean after the dependency bump.
- Workflow YAML parses; all 19 `run` blocks pass `bash -n`; every embedded Python block parses.
- The pre-upload verifier was run against fixtures with real blockmaps: passes when correct, rejects a stale blockmap that preserves file length, rejects a missing blockmap on the mac zip and on the primary Windows installer, and correctly ignores a `.msi` that never has one.
- A blockmap built by a fresh `npm install app-builder-lib@26.15.0` is byte-identical to one built from the launcher's own `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
