### PR TITLE
feat(launcher): remote-testing hooks — control server, CDP passthroug…

### DIFF
--- a/docs/guides/launcher-testing.md
+++ b/docs/guides/launcher-testing.md
@@ -1,0 +1,161 @@
+# Testing the Launcher Desktop App
+
+How to test the OpenAgents launcher efficiently — from unit tests on your
+machine to driving a real instance on a remote, SSH-only box.
+
+## The three layers
+
+| Layer | What it covers | Where it runs | Cost |
+|---|---|---|---|
+| Unit (`npm test`, vitest) | Main-process modules, pure logic | anywhere, no display | seconds |
+| E2E (`npm run e2e`, Playwright) | Real app, real clicks, isolated `$HOME` | a machine with a display | minutes |
+| Remote control (control server / CDP) | A **running** launcher on any machine, incl. headless | over SSH with plain `curl` | interactive |
+
+All commands below run from `packages/launcher/`.
+
+## Unit tests
+
+```bash
+npm test                 # vitest run, ~15s
+npm run typecheck        # tsc -b
+npx vitest run src/main/control-server.test.ts   # one file
+```
+
+Main-process modules are written Electron-free where possible (dependency
+injection — see `control-server.ts`, `renderer-log.ts`) so they unit-test
+without an Electron binary.
+
+## E2E tests (Playwright)
+
+```bash
+npm run build            # electron-vite build → out/main/index.js
+npm run e2e
+```
+
+Fixtures (`e2e/fixtures.ts`) launch `out/main/index.js` with an isolated
+`$HOME`, so `~/.openagents` and the Electron profile start clean each test.
+First launch bootstraps the portable Node runtime — expect minutes, not
+seconds, on a cold machine.
+
+## The control server — remote testing with curl
+
+The launcher can expose a **localhost-only HTTP control surface** for tests
+and diagnostics. It is off unless explicitly requested:
+
+```bash
+# either flag or env var; port 0 = pick any free port (logged to startup.log)
+OpenAgents --headless --control-port=4599
+OPENAGENTS_CONTROL_PORT=4599 OpenAgents --headless
+```
+
+Auth: every start writes a fresh random token to
+`~/.openagents/control.token` (mode 0600). Send it as `Authorization: Bearer`,
+`X-Control-Token`, or `?token=`:
+
+```bash
+TOKEN=$(cat ~/.openagents/control.token)
+curl -s -H "Authorization: Bearer $TOKEN" localhost:4599/status | jq
+```
+
+### Endpoints
+
+| Route | What it does |
+|---|---|
+| `GET /status` | version, platform, headless, uptime, `windowOpen`, `coreReady`, daemon PID, node pairings |
+| `GET /agents` | agent list from the core (`[]` until the core loads) |
+| `GET /logs?file=<name>&tail=N` | tails `startup`, `daemon`, `renderer` logs (default all, 200 lines) |
+| `GET /screenshot` | PNG of the main window (`409` if no window — create one first) |
+| `POST /pair {"code":"XXXX-XXXX"}` | redeem a node pairing code, same path as the UI |
+| `POST /window {"action":"create"\|"show"\|"hide"}` | manage the main window; `create` on a headless instance gives `/screenshot` something to capture |
+
+### A remote smoke test in four commands
+
+```bash
+ssh box 'OPENAGENTS_CONTROL_PORT=4599 ./OpenAgents --headless & sleep 20'
+ssh box 'TOKEN=$(cat ~/.openagents/control.token); curl -s -H "Authorization: Bearer $TOKEN" localhost:4599/status'
+ssh box 'TOKEN=$(cat ~/.openagents/control.token); curl -s -X POST -H "Authorization: Bearer $TOKEN" -d "{\"code\":\"ABCD-EFGH\"}" localhost:4599/pair'
+ssh box 'TOKEN=$(cat ~/.openagents/control.token); curl -s -H "Authorization: Bearer $TOKEN" localhost:4599/logs?tail=50'
+```
+
+## CDP — drive the real UI from another machine
+
+When a display *is* available (local dev, RDP/VNC session, CI runner with a
+desktop), set `OPENAGENTS_DEVTOOLS_PORT` to expose the Chrome DevTools
+Protocol on loopback:
+
+```bash
+OPENAGENTS_DEVTOOLS_PORT=9222 OpenAgents
+```
+
+Then from your machine, tunnel and attach Playwright to the **running app** —
+real window, real clicks, renderer console:
+
+```bash
+ssh -N -L 9222:127.0.0.1:9222 user@box &
+```
+
+```ts
+import { chromium } from "@playwright/test"
+const browser = await chromium.connectOverCDP("http://127.0.0.1:9222")
+const page = browser.contexts()[0].pages()[0]
+await page.screenshot({ path: "launcher.png" })
+```
+
+CDP needs a renderer to attach to, so it is complementary to the control
+server: control server for headless/state/actions, CDP for UI-level driving.
+
+## Renderer logs
+
+The renderer's console is mirrored to `~/.openagents/renderer.log`
+(rotated at ~2 MiB to `renderer.log.old`), including renderer crashes and
+page-load failures. On a remote box this is the only trace of a renderer
+exception — check it first when the UI "does nothing":
+
+```bash
+tail -50 ~/.openagents/renderer.log
+# or through the control server:
+curl -s -H "Authorization: Bearer $TOKEN" "localhost:4599/logs?file=renderer&tail=50"
+```
+
+Other useful files under `~/.openagents/`: `startup.log` (bootstrap +
+updater), `daemon.log` (agent daemon + adapters), `daemon.status.json`
+(per-agent state), `node.json` (workspace pairings), `env/<type>.env`
+(agent credentials), `probes.json` (last smoke-test result per agent type).
+
+## Remote Windows: the traps
+
+Windows over SSH has two failure modes that look like launcher bugs but
+aren't:
+
+1. **Complex PowerShell quoting across ssh mangles commands.** Don't inline;
+   `scp` a `.ps1` file over and run
+   `powershell -ExecutionPolicy Bypass -File script.ps1`.
+
+2. **Processes die with the SSH session.** Anything started from an SSH
+   command — including `agn up`'s "detached" daemon and the launcher itself —
+   is killed when the session closes. Start long-lived processes in their own
+   tree instead:
+
+   ```powershell
+   # survives SSH disconnect
+   Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{
+     CommandLine = '"C:\path\to\OpenAgents.exe" --headless --control-port=4599'
+   }
+   ```
+
+   (A Scheduled Task works too and survives reboots.)
+
+Also note GUI processes launched from an SSH session have no desktop
+(session 0), so a *visible* window may not render — prefer `--headless` plus
+the control server, and `POST /window {"action":"create"}` +
+`GET /screenshot` when you need pixels.
+
+## Testing the agent layer without the GUI
+
+The daemon and agents are fully controllable with the `agn` CLI
+(`~/.openagents/nodejs/node_modules/.bin/agn` when installed by the
+launcher): `agn status`, `agn logs`, `agn probe <type>` (end-to-end
+smoke-test of one agent type), `agn connect <agent> <token>`. A workspace can
+also drive install/configure/start remotely via node commands — see
+`packages/agent-connector/CLAUDE.md` and
+`workspace/backend/app/routers/nodes.py`.

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -1219,6 +1219,17 @@ export class AgentManager extends EventEmitter {
     })
   }
 
+  /** Daemon PID, or null when no daemon runs or the core isn't loaded yet. */
+  getDaemonPid(): number | null {
+    if (!this._connector) return null
+    try {
+      const getDaemonPid = this._connector.getDaemonPid as () => number | null
+      return getDaemonPid.call(this._connector) || null
+    } catch {
+      return null
+    }
+  }
+
   signalReload(): void {
     const getDaemonPid = this._connector!.getDaemonPid as () => number | null
     const pid = getDaemonPid.call(this._connector)

--- a/packages/launcher/src/main/control-server.test.ts
+++ b/packages/launcher/src/main/control-server.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import {
+  configuredControlPort,
+  startControlServer,
+  tailFile,
+  type ControlDeps,
+  type ControlServer,
+} from "./control-server"
+
+let dir: string
+let server: ControlServer | null = null
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "oa-control-"))
+})
+
+afterEach(async () => {
+  if (server) await server.close()
+  server = null
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function deps(overrides: Partial<ControlDeps> = {}): ControlDeps {
+  return {
+    getStatus: () => ({ version: "1.2.3", coreReady: true }),
+    getAgents: () => [{ name: "oc-win", type: "opencode" }],
+    pair: async (code: string) => ({ paired: code }),
+    screenshot: async () => null,
+    window: () => true,
+    logFiles: () => ({}),
+    tokenDir: dir,
+    ...overrides,
+  }
+}
+
+async function start(overrides: Partial<ControlDeps> = {}): Promise<ControlServer> {
+  server = await startControlServer(0, deps(overrides))
+  return server
+}
+
+function call(
+  srv: ControlServer,
+  route: string,
+  init: RequestInit = {},
+  token = srv.token,
+): Promise<Response> {
+  return fetch(`http://127.0.0.1:${srv.port}${route}`, {
+    ...init,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init.headers || {}),
+    },
+  })
+}
+
+describe("startControlServer", () => {
+  it("writes the token file with owner-only permissions and removes it on close", async () => {
+    const srv = await start()
+    expect(fs.readFileSync(srv.tokenFile, "utf-8")).toBe(srv.token)
+    if (process.platform !== "win32") {
+      expect(fs.statSync(srv.tokenFile).mode & 0o777).toBe(0o600)
+    }
+    await srv.close()
+    server = null
+    expect(fs.existsSync(srv.tokenFile)).toBe(false)
+  })
+
+  it("rejects requests without the token, with a wrong token, and accepts all three carriers", async () => {
+    const srv = await start()
+    expect((await call(srv, "/status", {}, "")).status).toBe(401)
+    expect((await call(srv, "/status", {}, "nope")).status).toBe(401)
+    expect((await call(srv, "/status")).status).toBe(200) // Authorization: Bearer
+    const viaHeader = await fetch(`http://127.0.0.1:${srv.port}/status`, {
+      headers: { "X-Control-Token": srv.token },
+    })
+    expect(viaHeader.status).toBe(200)
+    const viaQuery = await fetch(
+      `http://127.0.0.1:${srv.port}/status?token=${srv.token}`,
+    )
+    expect(viaQuery.status).toBe(200)
+  })
+
+  it("serves status and agents from the injected deps", async () => {
+    const srv = await start()
+    expect(await (await call(srv, "/status")).json()).toEqual({
+      version: "1.2.3",
+      coreReady: true,
+    })
+    expect(await (await call(srv, "/agents")).json()).toEqual({
+      agents: [{ name: "oc-win", type: "opencode" }],
+    })
+  })
+
+  it("POST /pair forwards the code and surfaces handler errors as 500", async () => {
+    const srv = await start({
+      pair: async (code: string) => {
+        if (code === "BAD") throw new Error("PAIRING_CODE_INVALID_FORMAT")
+        return { ok: true, code }
+      },
+    })
+    const ok = await call(srv, "/pair", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: "ABCD-EFGH" }),
+    })
+    expect(ok.status).toBe(200)
+    expect(await ok.json()).toEqual({ result: { ok: true, code: "ABCD-EFGH" } })
+
+    const bad = await call(srv, "/pair", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: "BAD" }),
+    })
+    expect(bad.status).toBe(500)
+    expect(((await bad.json()) as { error: string }).error).toMatch(
+      /PAIRING_CODE_INVALID_FORMAT/,
+    )
+
+    const missing = await call(srv, "/pair", { method: "POST", body: "{}" })
+    expect(missing.status).toBe(400)
+  })
+
+  it("GET /screenshot returns PNG bytes, or 409 when no window exists", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    const srv = await start({ screenshot: async () => png })
+    const res = await call(srv, "/screenshot")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("image/png")
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(png)
+
+    await srv.close()
+    server = null
+    const srv2 = await start({ screenshot: async () => null })
+    expect((await call(srv2, "/screenshot")).status).toBe(409)
+  })
+
+  it("GET /logs tails the registered files and 404s unknown names", async () => {
+    const logFile = path.join(dir, "daemon.log")
+    fs.writeFileSync(logFile, ["one", "two", "three", ""].join("\n"))
+    const srv = await start({ logFiles: () => ({ daemon: logFile }) })
+    const res = await call(srv, "/logs?tail=2")
+    expect(await res.json()).toEqual({ daemon: "two\nthree" })
+
+    const missing = await call(srv, "/logs?file=nope")
+    expect(missing.status).toBe(404)
+    expect(((await missing.json()) as { available: string[] }).available).toEqual([
+      "daemon",
+    ])
+  })
+
+  it("POST /window validates the action and reports window presence", async () => {
+    const seen: string[] = []
+    const srv = await start({
+      window: (action) => {
+        seen.push(action)
+        return action !== "hide"
+      },
+    })
+    const created = await call(srv, "/window", {
+      method: "POST",
+      body: JSON.stringify({ action: "create" }),
+    })
+    expect(await created.json()).toEqual({ windowOpen: true })
+    const invalid = await call(srv, "/window", {
+      method: "POST",
+      body: JSON.stringify({ action: "explode" }),
+    })
+    expect(invalid.status).toBe(400)
+    expect(seen).toEqual(["create"])
+  })
+
+  it("unknown routes list what exists", async () => {
+    const srv = await start()
+    const res = await call(srv, "/nope")
+    expect(res.status).toBe(404)
+    expect(((await res.json()) as { routes: string[] }).routes).toContain(
+      "GET /status",
+    )
+  })
+})
+
+describe("configuredControlPort", () => {
+  it("prefers --control-port over the env var, and returns null when unset", () => {
+    expect(configuredControlPort(["--control-port=4599"], {})).toBe(4599)
+    expect(
+      configuredControlPort(["--control-port=4599"], {
+        OPENAGENTS_CONTROL_PORT: "1111",
+      }),
+    ).toBe(4599)
+    expect(configuredControlPort([], { OPENAGENTS_CONTROL_PORT: "1111" })).toBe(1111)
+    expect(configuredControlPort([], {})).toBeNull()
+    expect(configuredControlPort(["--control-port=abc"], {})).toBeNull()
+    expect(configuredControlPort([], { OPENAGENTS_CONTROL_PORT: "abc" })).toBeNull()
+  })
+})
+
+describe("tailFile", () => {
+  it("returns the last N lines and '' for unreadable files", () => {
+    const f = path.join(dir, "t.log")
+    fs.writeFileSync(f, "a\nb\nc\n")
+    expect(tailFile(f, 2)).toBe("b\nc")
+    expect(tailFile(f, 10)).toBe("a\nb\nc")
+    expect(tailFile(path.join(dir, "missing.log"), 5)).toBe("")
+  })
+})

--- a/packages/launcher/src/main/control-server.ts
+++ b/packages/launcher/src/main/control-server.ts
@@ -1,0 +1,259 @@
+import crypto from "crypto"
+import fs from "fs"
+import http from "http"
+import os from "os"
+import path from "path"
+
+/**
+ * Local control server — a scriptable test/diagnostics surface for the
+ * launcher, reachable with plain curl. Opt-in only: it starts when the app is
+ * launched with `--control-port=N` (or OPENAGENTS_CONTROL_PORT=N) and binds
+ * 127.0.0.1 exclusively.
+ *
+ * Motivation: driving the launcher on a remote machine over SSH. There the GUI
+ * is unreachable (on Windows, processes started from an SSH session have no
+ * desktop), so tests need a way to ask the running app what state it is in
+ * (bootstrap, pairing, agents, daemon), trigger the few actions a remote test
+ * needs (pair a node, show/hide the window), and pull evidence (screenshots,
+ * logs) — without a display, a tunnel, or a Playwright install on either end.
+ *
+ * Auth: a per-start random token written to ~/.openagents/control.token
+ * (0600). Loopback binding keeps other hosts out; the token keeps other local
+ * users out. Every request must carry it — Authorization: Bearer, the
+ * X-Control-Token header, or ?token= all work.
+ *
+ * The server is dependency-injected and Electron-free so it can be unit
+ * tested; index.ts supplies the real hooks.
+ */
+
+export interface ControlDeps {
+  /** App/runtime snapshot — everything cheap and synchronous. */
+  getStatus: () => Record<string, unknown>
+  /** Agent list from the core, [] until the core has loaded. */
+  getAgents: () => unknown[]
+  /** Redeem a node pairing code (agentManager.connectNode). */
+  pair: (code: string) => Promise<unknown>
+  /** PNG of the main window, or null when there is no window to capture. */
+  screenshot: () => Promise<Buffer | null>
+  /** Create/show/hide the main window; returns whether a window now exists. */
+  window: (action: "create" | "show" | "hide") => boolean
+  /** Absolute paths of log files exposed by GET /logs. */
+  logFiles: () => Record<string, string>
+  /** Where control.token is written. Defaults to ~/.openagents. */
+  tokenDir?: string
+}
+
+export interface ControlServer {
+  port: number
+  token: string
+  tokenFile: string
+  close: () => Promise<void>
+}
+
+/** Last `tail` lines of a file, '' if unreadable. Reads at most ~256 KiB. */
+export function tailFile(file: string, tail: number): string {
+  try {
+    const stat = fs.statSync(file)
+    const max = 256 * 1024
+    const start = Math.max(0, stat.size - max)
+    const fd = fs.openSync(file, "r")
+    try {
+      const buf = Buffer.alloc(stat.size - start)
+      fs.readSync(fd, buf, 0, buf.length, start)
+      const lines = buf.toString("utf-8").split(/\r?\n/)
+      // Drop a trailing empty element from a final newline, keep blank lines
+      // inside the window.
+      if (lines.length && lines[lines.length - 1] === "") lines.pop()
+      return lines.slice(-tail).join("\n")
+    } finally {
+      fs.closeSync(fd)
+    }
+  } catch {
+    return ""
+  }
+}
+
+function json(res: http.ServerResponse, code: number, body: unknown): void {
+  const data = JSON.stringify(body)
+  res.writeHead(code, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(data),
+  })
+  res.end(data)
+}
+
+async function readBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  let size = 0
+  for await (const chunk of req) {
+    size += (chunk as Buffer).length
+    if (size > 64 * 1024) throw new Error("body too large")
+    chunks.push(chunk as Buffer)
+  }
+  if (!chunks.length) return {}
+  return JSON.parse(Buffer.concat(chunks).toString("utf-8"))
+}
+
+function extractToken(req: http.IncomingMessage, url: URL): string {
+  const auth = req.headers.authorization || ""
+  if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim()
+  const hdr = req.headers["x-control-token"]
+  if (typeof hdr === "string" && hdr) return hdr.trim()
+  return url.searchParams.get("token") || ""
+}
+
+/** Constant-time comparison — a control token must not be guessable byte-by-byte. */
+function tokenMatches(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}
+
+export function startControlServer(
+  port: number,
+  deps: ControlDeps,
+): Promise<ControlServer> {
+  const token = crypto.randomBytes(24).toString("hex")
+  const tokenDir = deps.tokenDir || path.join(os.homedir(), ".openagents")
+  const tokenFile = path.join(tokenDir, "control.token")
+  fs.mkdirSync(tokenDir, { recursive: true })
+  fs.writeFileSync(tokenFile, token, { mode: 0o600 })
+
+  const server = http.createServer(async (req, res) => {
+    let url: URL
+    try {
+      url = new URL(req.url || "/", "http://127.0.0.1")
+    } catch {
+      return json(res, 400, { error: "bad request" })
+    }
+
+    if (!tokenMatches(extractToken(req, url), token)) {
+      return json(res, 401, { error: "missing or invalid control token" })
+    }
+
+    const route = `${req.method} ${url.pathname}`
+    try {
+      switch (route) {
+        case "GET /status":
+          return json(res, 200, deps.getStatus())
+
+        case "GET /agents":
+          return json(res, 200, { agents: deps.getAgents() })
+
+        case "GET /logs": {
+          const tail = Math.min(
+            2000,
+            Math.max(1, Number(url.searchParams.get("tail")) || 200),
+          )
+          const which = url.searchParams.get("file")
+          const files = deps.logFiles()
+          const out: Record<string, string> = {}
+          for (const [name, file] of Object.entries(files)) {
+            if (which && which !== name) continue
+            out[name] = tailFile(file, tail)
+          }
+          if (which && !(which in files)) {
+            return json(res, 404, {
+              error: `unknown log '${which}'`,
+              available: Object.keys(files),
+            })
+          }
+          return json(res, 200, out)
+        }
+
+        case "GET /screenshot": {
+          const png = await deps.screenshot()
+          if (!png) {
+            return json(res, 409, {
+              error:
+                "no window to capture — POST /window {\"action\":\"create\"} first",
+            })
+          }
+          res.writeHead(200, {
+            "Content-Type": "image/png",
+            "Content-Length": png.length,
+          })
+          return res.end(png)
+        }
+
+        case "POST /pair": {
+          const body = await readBody(req)
+          const code = typeof body.code === "string" ? body.code.trim() : ""
+          if (!code) return json(res, 400, { error: "missing 'code'" })
+          const result = await deps.pair(code)
+          return json(res, 200, { result })
+        }
+
+        case "POST /window": {
+          const body = await readBody(req)
+          const action = body.action
+          if (action !== "create" && action !== "show" && action !== "hide") {
+            return json(res, 400, {
+              error: "action must be 'create', 'show' or 'hide'",
+            })
+          }
+          const windowOpen = deps.window(action)
+          return json(res, 200, { windowOpen })
+        }
+
+        default:
+          return json(res, 404, {
+            error: `no route ${route}`,
+            routes: [
+              "GET /status",
+              "GET /agents",
+              "GET /logs?file=<name>&tail=N",
+              "GET /screenshot",
+              "POST /pair {code}",
+              "POST /window {action}",
+            ],
+          })
+      }
+    } catch (err) {
+      return json(res, 500, { error: (err as Error)?.message || String(err) })
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(port, "127.0.0.1", () => {
+      const actual = (server.address() as { port: number }).port
+      resolve({
+        port: actual,
+        token,
+        tokenFile,
+        close: () =>
+          new Promise<void>((r) => {
+            // Don't wait for idle keep-alive sockets on shutdown.
+            server.closeAllConnections?.()
+            server.close(() => {
+              try {
+                fs.unlinkSync(tokenFile)
+              } catch {}
+              r()
+            })
+          }),
+      })
+    })
+  })
+}
+
+/**
+ * The configured control port: --control-port=N beats OPENAGENTS_CONTROL_PORT.
+ * null when neither is set (the default — the server never starts unasked).
+ * 0 is valid and means "any free port" (the chosen one is in the token file's
+ * sibling status output and the startup log).
+ */
+export function configuredControlPort(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+): number | null {
+  for (const arg of argv) {
+    const m = /^--control-port=(\d+)$/.exec(arg)
+    if (m) return Number(m[1])
+  }
+  const fromEnv = env.OPENAGENTS_CONTROL_PORT
+  if (fromEnv !== undefined && /^\d+$/.test(fromEnv)) return Number(fromEnv)
+  return null
+}

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -79,8 +79,14 @@ import {
   markUiReached,
   reportStartupError,
   slog,
+  STARTUP_LOG,
 } from "./bootstrap/startup-log"
 import { InstallProgress } from "./install-progress"
+import {
+  configuredControlPort,
+  startControlServer,
+} from "./control-server"
+import { attachRendererLogging, rendererLogPath } from "./renderer-log"
 import {
   applyDownloadRegion,
   applyProxyFromSettings,
@@ -143,6 +149,17 @@ app.setName("OpenAgents Launcher")
 // keychain access. (Our own credential secrets are encrypted separately; see
 // CredentialsStore.)
 app.commandLine.appendSwitch("use-mock-keychain")
+
+// Remote-driving hook for tests: OPENAGENTS_DEVTOOLS_PORT=9222 exposes the
+// Chrome DevTools Protocol so Playwright's connectOverCDP (through an SSH
+// tunnel, for a remote machine) can attach to the RUNNING app — real clicks,
+// renderer console, screenshots. Gated on the env var and pinned to loopback:
+// never on by default, never reachable from another host.
+const devtoolsPort = process.env.OPENAGENTS_DEVTOOLS_PORT
+if (devtoolsPort && /^\d+$/.test(devtoolsPort)) {
+  app.commandLine.appendSwitch("remote-debugging-port", devtoolsPort)
+  app.commandLine.appendSwitch("remote-debugging-address", "127.0.0.1")
+}
 
 const isHeadless = process.argv.includes("--headless")
 if (process.argv.includes("--disable-gpu") || isHeadless) {
@@ -521,6 +538,9 @@ function createWindow(): void {
 
   setNotificationsWindow(mainWindow)
   hardenWebContents(mainWindow.webContents)
+  // Mirror the renderer console to ~/.openagents/renderer.log — the only
+  // trace of renderer errors on machines reached over SSH.
+  attachRendererLogging(mainWindow.webContents)
 
   // Forget any dim state at the START of a load, not at the end of one. A
   // reload can strand main holding a dim whose dialog is long gone, so it does
@@ -2438,6 +2458,56 @@ if (!gotLock) {
 }
 
 app.whenReady().then(async () => {
+  // Local control server (--control-port=N / OPENAGENTS_CONTROL_PORT): a
+  // curl-able status/driving surface for remote tests and diagnostics. Started
+  // FIRST, before the first-run bootstrap (portable Node download can take
+  // minutes) — every dep below reads the CURRENT module state, so /status
+  // answers immediately (coreReady:false, windowOpen:false) and fills in as
+  // the app boots. See control-server.ts for auth and endpoint details.
+  const controlPort = configuredControlPort()
+  if (controlPort !== null) {
+    const appStartedAt = Date.now()
+    startControlServer(controlPort, {
+      getStatus: () => ({
+        version: app.getVersion(),
+        platform: process.platform,
+        arch: process.arch,
+        headless: isHeadless,
+        uptimeSeconds: Math.round((Date.now() - appStartedAt) / 1000),
+        windowOpen: !!mainWindow && !mainWindow.isDestroyed(),
+        coreReady: !!agentManager,
+        daemonPid: agentManager?.getDaemonPid() ?? null,
+        node: agentManager ? agentManager.getNodeStatus() : null,
+      }),
+      getAgents: () => (agentManager ? agentManager.getAgents() : []),
+      pair: (code) => {
+        if (!agentManager) throw new Error("core not loaded yet — retry shortly")
+        return agentManager.connectNode(code, {})
+      },
+      screenshot: async () => {
+        if (!mainWindow || mainWindow.isDestroyed()) return null
+        const image = await mainWindow.webContents.capturePage()
+        return image.toPNG()
+      },
+      window: (action) => {
+        if (action === "create" || action === "show") createWindow()
+        else if (mainWindow && !mainWindow.isDestroyed()) mainWindow.hide()
+        return !!mainWindow && !mainWindow.isDestroyed()
+      },
+      logFiles: () => ({
+        startup: STARTUP_LOG,
+        daemon: path.join(os.homedir(), ".openagents", "daemon.log"),
+        renderer: rendererLogPath(),
+      }),
+    })
+      .then((srv) =>
+        slog(`Control server on 127.0.0.1:${srv.port} (token: ${srv.tokenFile})`),
+      )
+      .catch((err) =>
+        slog(`Control server FAILED to start: ${(err as Error).message}`),
+      )
+  }
+
   installApplicationMenu()
 
   // The window frame is drawn by the OS, so the OS has to be told which way the

--- a/packages/launcher/src/main/renderer-log.test.ts
+++ b/packages/launcher/src/main/renderer-log.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import {
+  appendRendererLog,
+  attachRendererLogging,
+  type LoggableWebContents,
+} from "./renderer-log"
+
+let dir: string
+let file: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "oa-rlog-"))
+  file = path.join(dir, "renderer.log")
+})
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** Minimal event-emitter standing in for a WebContents. */
+function fakeContents(): LoggableWebContents & {
+  emit: (event: string, ...args: unknown[]) => void
+} {
+  const listeners = new Map<string, (...args: unknown[]) => void>()
+  return {
+    on(event: string, listener: (...args: unknown[]) => void) {
+      listeners.set(event, listener)
+    },
+    emit(event: string, ...args: unknown[]) {
+      listeners.get(event)?.(...args)
+    },
+  } as never
+}
+
+describe("appendRendererLog", () => {
+  it("creates the directory and appends timestamped lines", () => {
+    const nested = path.join(dir, "deep", "renderer.log")
+    appendRendererLog("hello", nested)
+    appendRendererLog("world", nested)
+    const lines = fs.readFileSync(nested, "utf-8").trim().split("\n")
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatch(/^\d{4}-\d{2}-\d{2}T.*hello$/)
+    expect(lines[1]).toMatch(/world$/)
+  })
+
+  it("rotates to .old past the size cap instead of growing forever", () => {
+    fs.writeFileSync(file, "x".repeat(2 * 1024 * 1024))
+    appendRendererLog("after rotation", file)
+    expect(fs.existsSync(`${file}.old`)).toBe(true)
+    expect(fs.readFileSync(file, "utf-8")).toMatch(/after rotation/)
+    expect(fs.statSync(file).size).toBeLessThan(1024)
+  })
+})
+
+describe("attachRendererLogging", () => {
+  it("records console messages with level and trimmed source (legacy positional args)", () => {
+    const wc = fakeContents()
+    attachRendererLogging(wc, file)
+    wc.emit(
+      "console-message",
+      null,
+      3,
+      "boom: undefined is not a function",
+      42,
+      "app://bundle/assets/index-abc123.js",
+    )
+    const out = fs.readFileSync(file, "utf-8")
+    expect(out).toMatch(/\[error\] index-abc123\.js:42 boom/)
+    expect(out).not.toMatch(/app:\/\/bundle\/assets/)
+  })
+
+  it("records console messages from the Electron >= 32 event-object shape", () => {
+    const wc = fakeContents()
+    attachRendererLogging(wc, file)
+    wc.emit("console-message", {
+      message: "modern boom",
+      level: "error",
+      lineNumber: 7,
+      sourceId: "app://bundle/assets/index-def456.js",
+    })
+    const out = fs.readFileSync(file, "utf-8")
+    expect(out).toMatch(/\[error\] index-def456\.js:7 modern boom/)
+  })
+
+  it("records renderer crashes and load failures", () => {
+    const wc = fakeContents()
+    attachRendererLogging(wc, file)
+    wc.emit("render-process-gone", null, { reason: "crashed", exitCode: 5 })
+    wc.emit("did-fail-load", null, -105, "ERR_NAME_NOT_RESOLVED", "app://x")
+    const out = fs.readFileSync(file, "utf-8")
+    expect(out).toMatch(/\[crash\] renderer gone: crashed \(exit 5\)/)
+    expect(out).toMatch(/\[load-error\] -105 ERR_NAME_NOT_RESOLVED app:\/\/x/)
+  })
+})

--- a/packages/launcher/src/main/renderer-log.ts
+++ b/packages/launcher/src/main/renderer-log.ts
@@ -1,0 +1,119 @@
+import fs from "fs"
+import os from "os"
+import path from "path"
+
+/**
+ * Persist renderer console output to ~/.openagents/renderer.log.
+ *
+ * The renderer's console is invisible outside DevTools, which makes remote
+ * machines (SSH-only Windows boxes especially) undiagnosable: a renderer
+ * exception leaves no trace anywhere on disk. This mirrors every
+ * console-message, load failure, and renderer crash into a plain append-only
+ * file that `agn`-style tooling and GET /logs on the control server can tail.
+ *
+ * Rotation is single-generation: at ~2 MiB the file is renamed to
+ * renderer.log.old (replacing the previous .old) and a fresh file begins.
+ * That bounds disk use at ~4 MiB while always retaining recent history.
+ */
+
+const MAX_BYTES = 2 * 1024 * 1024
+
+export function rendererLogPath(): string {
+  return path.join(os.homedir(), ".openagents", "renderer.log")
+}
+
+const LEVELS = ["debug", "log", "warn", "error"] as const
+
+/**
+ * Fields of Electron >= 32's console-message event object. Older Electrons
+ * pass positional args instead; attachRendererLogging accepts both.
+ */
+interface ConsoleMessageEvent {
+  message?: string
+  level?: number | string
+  lineNumber?: number
+  sourceId?: string
+}
+
+export function appendRendererLog(line: string, file = rendererLogPath()): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    try {
+      if (fs.statSync(file).size >= MAX_BYTES) {
+        fs.renameSync(file, `${file}.old`)
+      }
+    } catch {}
+    fs.appendFileSync(file, `${new Date().toISOString()} ${line}\n`)
+  } catch {
+    // Logging must never break the app.
+  }
+}
+
+/**
+ * Shape-only view of the WebContents events we consume, so this module stays
+ * Electron-free and unit-testable.
+ */
+export interface LoggableWebContents {
+  on(
+    event: "console-message",
+    listener: (
+      e: unknown,
+      level?: number,
+      message?: string,
+      line?: number,
+      sourceId?: string,
+    ) => void,
+  ): void
+  on(
+    event: "render-process-gone",
+    listener: (e: unknown, details: { reason?: string; exitCode?: number }) => void,
+  ): void
+  on(
+    event: "did-fail-load",
+    listener: (
+      e: unknown,
+      errorCode: number,
+      errorDescription: string,
+      validatedURL: string,
+    ) => void,
+  ): void
+}
+
+/** Wire a window's console/crash/load events into the renderer log. */
+export function attachRendererLogging(
+  contents: LoggableWebContents,
+  file = rendererLogPath(),
+): void {
+  contents.on(
+    "console-message",
+    (e, legacyLevel, legacyMessage, legacyLine, legacySourceId) => {
+      // Electron >= 32 puts everything on the event object; the positional
+      // args are deprecated (and eventually absent). Prefer the event fields,
+      // fall back to positional for older runtimes.
+      const ev = (e || {}) as ConsoleMessageEvent
+      const message = ev.message ?? legacyMessage ?? ""
+      const rawLevel = ev.level ?? legacyLevel
+      const lvl =
+        typeof rawLevel === "string"
+          ? rawLevel
+          : LEVELS[rawLevel as number] || `level${rawLevel}`
+      const line = ev.lineNumber ?? legacyLine
+      const sourceId = ev.sourceId ?? legacySourceId
+      // sourceId is a bundle URL — keep just the file part, the full URL is noise.
+      const src = sourceId ? `${sourceId.split("/").pop()}:${line}` : ""
+      appendRendererLog(`[${lvl}] ${src} ${message}`.trimEnd(), file)
+    },
+  )
+  contents.on("render-process-gone", (_e, details) => {
+    appendRendererLog(
+      `[crash] renderer gone: ${details?.reason || "unknown"} (exit ${details?.exitCode ?? "?"})`,
+      file,
+    )
+  })
+  contents.on("did-fail-load", (_e, errorCode, errorDescription, validatedURL) => {
+    appendRendererLog(
+      `[load-error] ${errorCode} ${errorDescription} ${validatedURL}`,
+      file,
+    )
+  })
+}


### PR DESCRIPTION
…h, renderer log

Driving the launcher on a remote, SSH-only machine (a Windows box especially) had no sanctioned path: the app's state was invisible from the command line, renderer errors left no trace on disk, and GUI automation needs a desktop the SSH session doesn't have. Three opt-in hooks close that gap:

* Control server (--control-port=N / OPENAGENTS_CONTROL_PORT): a localhost-only HTTP surface started first thing in whenReady, so it answers during first-run bootstrap. GET /status (version, headless, window, core/daemon/node state), GET /agents, GET /logs (tails startup/daemon/renderer logs), GET /screenshot (PNG via capturePage), POST /pair {code}, POST /window {create|show|hide}. Auth is a per-start random token at ~/.openagents/control.token (0600), compared in constant time; the server is dependency-injected and Electron-free for unit testing.

* CDP passthrough (OPENAGENTS_DEVTOOLS_PORT): exposes the DevTools protocol on loopback so Playwright connectOverCDP can attach to the RUNNING app through an SSH tunnel. Off unless the env var is set.

* Renderer console → ~/.openagents/renderer.log (rotated at 2 MiB), including renderer crashes and load failures — previously a renderer exception on a remote box left no trace anywhere. Handles both the Electron >= 32 console-message event object and the legacy positional args.

Also adds AgentManager.getDaemonPid() (public, null-safe) for /status, and docs/guides/launcher-testing.md covering the unit/E2E/remote-control layers plus the Windows-over-SSH traps (quoting, session-death).

Verified live on Windows Server 2025: headless launch with --control-port, /status + 401 + /logs + /pair-path deps, window creation and a real dashboard screenshot fetched over SSH.