### PR TITLE
feat(launcher): guide the pairing step, and make the pairing the only authority for workspace membership

### DIFF
--- a/packages/launcher/changelog/0.9.22.json
+++ b/packages/launcher/changelog/0.9.22.json
@@ -1,0 +1,50 @@
+{
+  "version": "0.9.22",
+  "date": "2026-08-25",
+  "entries": [
+    {
+      "type": "improvement",
+      "title": {
+        "en": "Setup's pairing step now stands on its own",
+        "zh": "设置向导的配对步骤现在自成一体"
+      },
+      "description": {
+        "en": "Everyone who reaches this step is here for the first time, usually without an account and always without a workspace — yet it opened with a field for a code they had no way to obtain. What to do on the web now comes first: sign up at workspace.openagents.org, create a workspace, copy its pairing code. Skipping is gone, because skipping led to an empty launcher with no workspace to install an agent from. Once the device is in, the panel offers the two routes that actually exist — finish the setup here, or open the workspace and do it remotely — instead of mixing one call to action with a list of identifiers and two more buttons in the footer.",
+        "zh": "走到这一步的都是初次使用的用户，通常尚未注册账号，也必然还没有工作区，而页面开门见山就是一个无从取得的配对码输入框。现在网页端要做的事写在前面：在 workspace.openagents.org 注册登录、创建一个工作区、复制它的配对码。「跳过」已经移除，因为跳过之后得到的是一个没有工作区、无处安装智能体的空启动器。设备连接成功后，面板只给出真正存在的两条路径——在启动器里完成设置，或打开工作区远程完成——不再把一个主操作、一组标识信息和页脚的两个按钮混在一起。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "A workspace that removes this device is removed from this device",
+        "zh": "工作区移除本设备后，本机也不再保留该工作区"
+      },
+      "description": {
+        "en": "Only the pairing was dropped: the workspace stayed in the list with its agents still filed under it, and neither could reach it any more — a card with nothing to open, agents that could not run, and a status the launcher had to guess at, which it read as an error. The pairing, the local entry and the agent bindings now go together, and a notice at the top of Workspaces says which workspace removed the device and how many agents were unbound; their instances and data stay, and joining that workspace again files them back under it. The reason is written to disk, so it survives a restart. \"Add to workspace\" is drawn from the pairings too, and re-checks them as it opens: it used to list workspaces this device had been removed from, and binding an agent to one produced a join that could not authenticate.",
+        "zh": "此前仅删除配对：工作区仍留在列表中，智能体也仍归属于它，而两者都已无法连接——卡片打不开、智能体跑不起来，状态只能靠猜，于是被显示成异常。现在配对、本机的工作区记录与智能体绑定一并移除，工作区页顶部会说明是哪个工作区移除了本设备、有多少智能体被解除绑定；实例与数据均保留，重新加入同一工作区时会自动归位。移除原因也会写入磁盘，因而可跨重启保留。「加入工作区」同样以配对为准，并在打开时重新核对：此前它会列出早已把本设备移除的工作区，而绑定到那样的工作区，得到的是一个无法通过鉴权的连接。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "An agent with no workspace reads as one, everywhere",
+        "zh": "未连接工作区的智能体，各处都如实显示"
+      },
+      "description": {
+        "en": "An agent with a workspace runs a loop that polls it and calls the CLI per message. An agent without one is registered with the daemon and nothing drives it — no message source, no process — yet the state written for it is \"running\", and every list passed that straight through. They now report it as not connected, from one shared definition: the same agent used to read \"Running\" on the dashboard and \"No workspace\" on the agents list, because each page decided for itself. None of them offers to start or stop such an agent any more, the command palette included, and the running counts leave it out for the same reason — there is no process to act on. What is offered instead is the one thing that changes something: joining a workspace. A workspace whose credential has gone still reports an error, with the reason behind it — that one is worth reading.",
+        "zh": "连接了工作区的智能体会运行一个轮询循环：拉取工作区消息，并逐条调用 CLI。未连接工作区的智能体只是在守护进程中登记，没有任何东西驱动它——没有消息来源，也没有进程——但为它写入的状态却是「运行中」，各处列表都原样照搬。现在它们一律如实显示为「未连接工作区」，且取自同一份定义：此前同一个智能体在仪表盘显示「运行中」、在智能体列表显示「无工作区」，因为两个页面各判各的。列表与命令面板也不再对这类智能体提供启动或停止，「运行中」的计数同样不再将其计入——没有任何进程可供操作。给出的是唯一有意义的那个操作：加入工作区。工作区凭据失效的情况仍显示为异常，并保留可查看的原因——那条信息值得一读。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "An agent's page no longer offers \"Reinstall\" while an update is waiting",
+        "zh": "智能体详情页不再对待更新的智能体显示「重新安装」"
+      },
+      "description": {
+        "en": "Which buttons belong on that page depends on comparing the installed version with the latest one, and both arrive a moment after the page opens — so it rendered the default set first and swapped it afterwards, showing \"Reinstall\" and \"Installed\" to someone who had come specifically because an update was waiting. The actions and the status now wait for the answer, and when the marketplace list has already fetched it, they have it immediately.",
+        "zh": "该页面显示哪些按钮，取决于已安装版本与最新版本的比较结果，而两者都在页面打开后才返回——此前页面先渲染默认按钮再行替换，于是专程因为有更新而进来的用户，看到的却是「重新安装」与「已安装」。现在操作按钮与状态标记会等待该结果；若应用市场列表已经取得过，则直接沿用，无需等待。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -6,11 +6,14 @@ import { spawn } from "child_process"
 import {
   PAIRING_CODE_LENGTH,
   clearPairing,
+  clearRevocation,
   gatherDeviceInfo,
   inferDeviceType,
   listPairings,
+  listRevocations,
   normalizePairingCode,
   recordPairing,
+  revokePairing,
   type DeviceInfo,
   type NodePairing,
 } from "./node-pairing"
@@ -136,6 +139,8 @@ export interface RevokedPairing {
   workspaceId: string
   workspaceSlug: string | null
   workspaceName: string | null
+  /** Agents unbound with it; re-joining files them back under the workspace. */
+  agents?: string[]
 }
 
 // The chat and install types now live with the code that owns them, but the
@@ -175,8 +180,6 @@ export class AgentManager extends EventEmitter {
   _connector: Record<string, unknown> | null = null
   /** Last time the active node pairing was checked against its workspace. */
   private _nodeVerifiedAt = 0
-  /** Pairings dropped because the workspace deleted this node (session memory). */
-  private _revokedPairings: RevokedPairing[] = []
 
   /** Sign-in state for CLIs that own their own login (Cursor, Hermes, Claude). */
   private _login: LoginProbe
@@ -1273,25 +1276,39 @@ export class AgentManager extends EventEmitter {
   }
 
   /**
-   * Bind an agent to a workspace this device already knows, by slug or id.
+   * Bind an agent to a workspace this device is paired with, by slug or id.
    *
    * Tokens and workspace links are no longer accepted, and neither is creating
    * a workspace from here: pairing is the only way a workspace reaches this
    * launcher, and pairing registers it (endpoint + per-node credential) as it
-   * goes. So everything bindable is already in `networks[]`, and a reference
-   * that is not there cannot be made to work by resolving a credential for it
-   * — say so instead of reaching for the network.
+   * goes.
+   *
+   * The pairing is what is checked, not the local `networks[]` entry. They are
+   * two records kept in step by hand, so a workspace that has dropped this
+   * device can sit in `networks[]` long after its pairing is gone — and an
+   * agent bound to that one joins nothing: every call it makes carries a
+   * credential the workspace has stopped honouring. The entry is still what
+   * the core binds by, so it has to be there too; if it is not, the two
+   * records have drifted and re-pairing is the fix, not a silent bind.
    */
   async connectWorkspace(agentName: string, input: string): Promise<unknown> {
     const ref = (input || "").trim()
     if (!ref) throw new Error("Missing workspace")
+
+    const paired = listPairings().some(
+      (p) => p.workspace_slug === ref || p.workspace_id === ref,
+    )
+    if (!paired)
+      throw new Error(
+        `WORKSPACE_NOT_PAIRED: '${ref}' is not a workspace this device is paired with`,
+      )
 
     const known = (
       this.getNetworks() as Array<{ id?: string; slug?: string }>
     ).find((n) => n.slug === ref || n.id === ref)
     if (!known)
       throw new Error(
-        `WORKSPACE_NOT_PAIRED: '${ref}' is not a workspace this device is paired with`,
+        `WORKSPACE_NOT_REGISTERED: '${ref}' is paired but has no local entry — re-pair this device`,
       )
 
     const connectWorkspace = this._connector!.connectWorkspace as (
@@ -1412,20 +1429,23 @@ export class AgentManager extends EventEmitter {
         token,
       )
     } else if (endpoint && token && pairing?.node_id) {
+      // A per-node token stops verifying the moment the node row is deleted,
+      // so 401/403 here is not a refusal — it is the workspace having already
+      // removed this device (from its own UI, most likely). Aborting on that
+      // would leave a dead pairing on this machine that no UI can clear.
       warning = await this._deleteFromWorkspaceApi(
         `${endpoint}/v1/nodes/${encodeURIComponent(pairing.node_id)}`,
         token,
+        [401, 403],
       )
     }
 
     // Local half — nothing below can leave the server ahead of us.
-    if (pairing) {
-      clearPairing(pairing.workspace_id)
-      // A removal is a deliberate act, not a revocation: no re-pair alarm.
-      this._revokedPairings = this._revokedPairings.filter(
-        (r) => r.workspaceId !== pairing.workspace_id,
-      )
-    }
+    // A removal is a deliberate act, not a revocation: it settles the alarm
+    // rather than raising one. Done even with no pairing left to drop — a
+    // device the workspace already removed has only the record to clear.
+    if (pairing) clearPairing(pairing.workspace_id)
+    if (workspaceId) clearRevocation(workspaceId)
     this._removeNetworkAndUnbind(workspaceSlug, workspaceId)
 
     if (pairing) {
@@ -1452,6 +1472,33 @@ export class AgentManager extends EventEmitter {
   }
 
   /** Names of this device's agents bound to any of `refs` (slug and/or id). */
+  /**
+   * Re-file agents under a workspace, skipping any that no longer exist. Uses
+   * the connector's own `config.updateAgent` for the same reason
+   * `setAgentWorkingDir` does: it is the core's serializer, and rewriting
+   * daemon.yaml from here would risk diverging from it.
+   */
+  private _rebindAgents(names: string[], ref: string | null): void {
+    if (!ref || !names.length) return
+    const config = (this._connector as { config?: unknown } | null)?.config as
+      | { updateAgent?: (name: string, updates: unknown) => unknown }
+      | undefined
+    if (!config?.updateAgent) return
+    const existing = new Set(
+      (this.getAgents() as Array<{ name?: string }>).map((a) => a.name),
+    )
+    for (const name of names) {
+      if (!existing.has(name)) continue
+      try {
+        config.updateAgent(name, { network: ref })
+      } catch {
+        // One agent that refuses to be re-filed is not a reason to fail a
+        // pairing that has already succeeded.
+      }
+    }
+    this._agentsCache = { value: [], at: 0 }
+  }
+
   private _agentsOnWorkspace(refs: Array<string | null>): string[] {
     const keys = new Set(refs.filter((r): r is string => !!r))
     return (this.getAgents() as Array<{ name?: string; network?: string }>)
@@ -1508,6 +1555,8 @@ export class AgentManager extends EventEmitter {
   private async _deleteFromWorkspaceApi(
     url: string,
     token: string,
+    /** Statuses that mean "already gone", not "refused". 404 always does. */
+    gone: readonly number[] = [],
   ): Promise<string | null> {
     let res: Response
     try {
@@ -1518,7 +1567,7 @@ export class AgentManager extends EventEmitter {
     } catch (err) {
       return `server unreachable — ${(err as Error).message}`
     }
-    if (res.ok || res.status === 404) return null
+    if (res.ok || res.status === 404 || gone.includes(res.status)) return null
     const body = (await res.json().catch(() => null)) as {
       message?: string
     } | null
@@ -1644,7 +1693,21 @@ export class AgentManager extends EventEmitter {
       hostname: os.hostname(),
       deviceType: inferDeviceType(),
       workspaces,
-      revoked: this._revokedPairings.slice(),
+      // Read from disk every time rather than kept in memory: a revocation
+      // outlives the session that noticed it, and the UI's whole answer for
+      // this device ("removed by the workspace", not "erroring") hangs on it.
+      revoked: listRevocations().flatMap((r) =>
+        r.workspace_id
+          ? [
+              {
+                workspaceId: r.workspace_id,
+                workspaceSlug: r.workspace_slug || null,
+                workspaceName: r.workspace_name || null,
+                agents: r.agents || [],
+              },
+            ]
+          : [],
+      ),
     }
   }
 
@@ -1698,20 +1761,31 @@ export class AgentManager extends EventEmitter {
       if (!Array.isArray(nodes)) return
 
       if (!nodes.some((n) => String(n.nodeId) === String(pairing.node_id))) {
-        clearPairing(pairing.workspace_id)
-        // Not silent anymore: the card says so and offers to join again.
-        if (
-          pairing.workspace_id &&
-          !this._revokedPairings.some(
-            (r) => r.workspaceId === pairing.workspace_id,
-          )
-        ) {
-          this._revokedPairings.push({
-            workspaceId: pairing.workspace_id,
-            workspaceSlug: pairing.workspace_slug || null,
-            workspaceName: pairing.workspace_name || null,
-          })
+        // The workspace let this device go, so the device stops claiming it —
+        // all of it. Leaving the local network entry and the agent bindings
+        // behind left a workspace on screen that this machine is not in, with
+        // agents still filed under it: nothing to open, nothing to run, and no
+        // honest state to render. What survives is the revocation record: it
+        // says why the workspace went, and carries the bindings back if the
+        // user joins it again.
+        const refs = [
+          pairing.workspace_slug || null,
+          pairing.workspace_id || null,
+        ]
+        let bound: string[] = []
+        try {
+          this._ensureConnector()
+          bound = this._agentsOnWorkspace(refs)
+        } catch {
+          // No core loaded — the bindings live in its config, so they are not
+          // ours to read or clear right now. The pairing still goes.
         }
+        if (pairing.workspace_id) revokePairing(pairing.workspace_id, bound)
+        else clearPairing(pairing.workspace_id)
+        try {
+          this._removeNetworkAndUnbind(refs[0], refs[1])
+          this._agentsCache = { value: [], at: 0 }
+        } catch {}
       }
     } catch {
       // Offline — keep what we have.
@@ -1752,6 +1826,12 @@ export class AgentManager extends EventEmitter {
       this.configuredWorkspaceEndpoint() ||
       undefined
 
+    // Read before recordPairing settles the revocation: if this workspace once
+    // removed the device, these are the agents that were filed under it.
+    const orphaned =
+      listRevocations().find((r) => r.workspace_id === res.workspaceId)
+        ?.agents || []
+
     // Additive: each workspace issues its own node row for this device, and the
     // daemon heartbeats every pairing, so connecting here does NOT take the
     // device away from the workspaces it already belongs to.
@@ -1781,6 +1861,9 @@ export class AgentManager extends EventEmitter {
       endpoint,
       token: res.token,
     })
+    // Joining the same workspace again puts its agents back where they were,
+    // so a removal on the workspace's side is not a re-setup on this one.
+    this._rebindAgents(orphaned, res.workspaceSlug || res.workspaceId)
 
     // The node heartbeat — and with it remote agent management — lives in the
     // daemon. A running daemon re-reads node.json every tick, but one left over
@@ -1796,10 +1879,8 @@ export class AgentManager extends EventEmitter {
     }
     this._statusCache = { value: {}, at: 0 }
     this._nodeVerifiedAt = Date.now()
-    // A successful (re-)pair supersedes any recorded revocation.
-    this._revokedPairings = this._revokedPairings.filter(
-      (r) => r.workspaceId !== res.workspaceId,
-    )
+    // A successful (re-)pair supersedes any recorded revocation; recordPairing
+    // has already cleared it on disk.
 
     return { ...this.getNodeStatus(), warning }
   }

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -86,6 +86,7 @@ import {
   configuredControlPort,
   startControlServer,
 } from "./control-server"
+import { clearRevocation } from "./node-pairing"
 import { attachRendererLogging, rendererLogPath } from "./renderer-log"
 import {
   applyDownloadRegion,
@@ -1372,6 +1373,12 @@ function setupIPC(): void {
   ipcMain.handle("node:connect", (_e, code, opts) =>
     requireManager().connectNode(code, opts || {}),
   )
+  // "I have seen that this workspace removed me." The record exists to tell
+  // the user once; dismissing it is how that ends without re-joining.
+  ipcMain.handle("node:dismiss-revocation", (_e, workspaceId: string) => {
+    clearRevocation(String(workspaceId || ""))
+    return agentManager ? agentManager.getNodeStatus() : null
+  })
   // Native folder picker for onboarding's "Create your first agent" step. The
   // chosen directory becomes the agent's working directory. Returns null when
   // the user cancels.

--- a/packages/launcher/src/main/node-pairing.test.ts
+++ b/packages/launcher/src/main/node-pairing.test.ts
@@ -5,12 +5,15 @@ import path from "path"
 
 import {
   clearPairing,
+  clearRevocation,
   formatPairingCode,
   listPairings,
+  listRevocations,
   loadNode,
   nodeFilePath,
   normalizePairingCode,
   recordPairing,
+  revokePairing,
 } from "./node-pairing"
 
 describe("pairing codes", () => {
@@ -151,6 +154,60 @@ describe("pairing history", () => {
   it("clearing when nothing is paired is a no-op", () => {
     expect(clearPairing()).toBeNull()
     expect(clearPairing("w-nope")).toBeNull()
+  })
+
+  // Why revocations are written down at all: the pairing is deleted the moment
+  // the workspace's answer arrives, so nothing else on the machine remembers
+  // that this device was ever in there. Without the record, the next launch
+  // reads a workspace bound to agents with no pairing — which the UI reported
+  // as an erroring workspace rather than a removed device.
+  it("remembers which workspace revoked this device", () => {
+    recordPairing("dev-1", shared)
+    recordPairing("dev-1", ccc)
+
+    const dropped = revokePairing("w-shared")
+    expect(dropped?.workspace_slug).toBe("shared")
+    expect(listPairings().map((p) => p.workspace_slug)).toEqual(["ccc"])
+    expect(listRevocations().map((r) => r.workspace_slug)).toEqual(["shared"])
+  })
+
+  // saveNode rebuilds the record from the fields it is handed, so every write
+  // has to carry the list forward — this is the regression that catches one
+  // that does not.
+  it("keeps revocations across later pairing writes", () => {
+    recordPairing("dev-1", shared)
+    revokePairing("w-shared")
+
+    recordPairing("dev-1", ccc)
+    expect(listRevocations().map((r) => r.workspace_slug)).toEqual(["shared"])
+
+    clearPairing("w-ccc")
+    expect(listRevocations().map((r) => r.workspace_slug)).toEqual(["shared"])
+  })
+
+  it("settles the revocation when the device joins that workspace again", () => {
+    recordPairing("dev-1", shared)
+    revokePairing("w-shared")
+    expect(listRevocations()).toHaveLength(1)
+
+    recordPairing("dev-1", shared)
+    expect(listRevocations()).toEqual([])
+    expect(listPairings().map((p) => p.workspace_slug)).toEqual(["shared"])
+  })
+
+  // Removing the leftover card is the other way a revocation ends.
+  it("clears a revocation on request", () => {
+    recordPairing("dev-1", shared)
+    revokePairing("w-shared")
+
+    clearRevocation("w-shared")
+    expect(listRevocations()).toEqual([])
+  })
+
+  it("has nothing to revoke for a workspace it was never paired to", () => {
+    recordPairing("dev-1", ccc)
+    expect(revokePairing("w-nope")).toBeNull()
+    expect(listRevocations()).toEqual([])
   })
 
   // A node.json written before `pairings` existed carries a single top-level

--- a/packages/launcher/src/main/node-pairing.ts
+++ b/packages/launcher/src/main/node-pairing.ts
@@ -40,6 +40,26 @@ export interface NodePairing {
   paired_at?: string
 }
 
+/**
+ * A workspace that removed this device. Written when the pairing it describes
+ * is dropped, so the fact survives the restart that used to erase it: the
+ * pairing is gone by then, and without this record nothing on the machine can
+ * tell "the workspace removed us" from "we were never in it".
+ */
+export interface RevokedPairing {
+  workspace_id?: string
+  workspace_slug?: string
+  workspace_name?: string
+  revoked_at?: string
+  /**
+   * Agents that were bound to this workspace when it let the device go. The
+   * bindings are dropped with it — a workspace this machine is not in must not
+   * go on owning agents here — and this is what puts them back if the user
+   * joins the same workspace again.
+   */
+  agents?: string[]
+}
+
 export interface NodeRecord extends NodePairing {
   /** Stable per-device id. Generated once, survives re-pairing. */
   node_key?: string
@@ -53,6 +73,12 @@ export interface NodeRecord extends NodePairing {
    * multi-pairing still finds one workspace to report to.
    */
   pairings?: NodePairing[]
+  /**
+   * Workspaces that revoked this device, newest first. Every write below has
+   * to carry it forward by hand: `saveNode` rebuilds the record from the
+   * fields it is handed, so a field left out of one call is a field deleted.
+   */
+  revoked?: RevokedPairing[]
 }
 
 export interface DeviceInfo {
@@ -76,7 +102,11 @@ export function loadNode(): NodeRecord | null {
 export function saveNode(record: NodeRecord): void {
   const file = nodeFilePath()
   fs.mkdirSync(path.dirname(file), { recursive: true })
-  fs.writeFileSync(file, JSON.stringify(record, null, 2))
+  // An empty revocation list is the absence of one, and the daemon reads this
+  // file: it should not grow a field that says nothing.
+  const { revoked, ...rest } = record
+  const payload = revoked?.length ? { ...rest, revoked } : rest
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2))
   // The file holds the workspace token — keep it owner-only.
   try {
     fs.chmodSync(file, 0o600)
@@ -101,7 +131,13 @@ export function recordPairing(nodeKey: string, pairing: NodePairing): void {
       (p) => p.workspace_id !== pairing.workspace_id,
     ),
   ]
-  saveNode({ node_key: nodeKey, ...stamped, pairings })
+  saveNode({
+    node_key: nodeKey,
+    ...stamped,
+    pairings,
+    // Joining again is the answer to having been removed.
+    revoked: revocationsWithout(existing, pairing.workspace_id),
+  })
 }
 
 /**
@@ -129,8 +165,74 @@ export function clearPairing(workspaceId?: string): NodePairing | null {
   // The daemon reads the top level, so promoting the next pairing is what keeps
   // the surviving workspaces reporting rather than going quiet with this one.
   const { token: _t, ...droppedSafe } = dropped
-  saveNode({ node_key: record.node_key, ...remaining[0], pairings: remaining })
+  saveNode({
+    node_key: record.node_key,
+    ...remaining[0],
+    pairings: remaining,
+    // A deliberate removal is not a revocation, and it settles any that stood.
+    revoked: revocationsWithout(record, target),
+  })
   return droppedSafe
+}
+
+/**
+ * Drop a pairing the workspace has already deleted, and remember that it did.
+ *
+ * One write, not `clearPairing` plus a note: between the two the machine would
+ * hold neither the pairing nor the reason it went, which is exactly the state
+ * that made a removed device read as a workspace in error.
+ */
+export function revokePairing(
+  workspaceId: string,
+  agents: string[] = [],
+): NodePairing | null {
+  const record = loadNode()
+  if (!record) return null
+  const pairings = normalizePairings(record)
+  const dropped = pairings.find((p) => p.workspace_id === workspaceId)
+  if (!dropped) return null
+
+  const remaining = pairings.filter((p) => p.workspace_id !== workspaceId)
+  const { token: _t, ...droppedSafe } = dropped
+  saveNode({
+    node_key: record.node_key,
+    ...remaining[0],
+    pairings: remaining,
+    revoked: [
+      {
+        workspace_id: dropped.workspace_id,
+        workspace_slug: dropped.workspace_slug,
+        workspace_name: dropped.workspace_name,
+        revoked_at: new Date().toISOString(),
+        agents: agents.length ? agents : undefined,
+      },
+      ...revocationsWithout(record, workspaceId),
+    ],
+  })
+  return droppedSafe
+}
+
+/** Every workspace that has removed this device, newest first. */
+export function listRevocations(): RevokedPairing[] {
+  return loadNode()?.revoked || []
+}
+
+/** Forget one — the user re-joined it, or cleared the leftover record. */
+export function clearRevocation(workspaceId: string): void {
+  const record = loadNode()
+  if (!record?.revoked?.length) return
+  const revoked = revocationsWithout(record, workspaceId)
+  if (revoked.length === record.revoked.length) return
+  saveNode({ ...record, revoked })
+}
+
+function revocationsWithout(
+  record: NodeRecord | null,
+  workspaceId?: string,
+): RevokedPairing[] {
+  const revoked = record?.revoked || []
+  if (!workspaceId) return revoked
+  return revoked.filter((r) => r.workspace_id !== workspaceId)
 }
 
 /** Every workspace this device is paired to, most recent first. */

--- a/packages/launcher/src/preload/index.ts
+++ b/packages/launcher/src/preload/index.ts
@@ -72,6 +72,8 @@ contextBridge.exposeInMainWorld('api', {
   refreshNodeStatus: (force?: boolean) => ipcRenderer.invoke('node:refresh', !!force),
   connectNode: (code: string, opts?: { name?: string; deviceType?: string }) =>
     ipcRenderer.invoke('node:connect', code, opts),
+  dismissNodeRevocation: (workspaceId: string) =>
+    ipcRenderer.invoke('node:dismiss-revocation', workspaceId),
 
   getSetting: (key: string) => ipcRenderer.invoke('settings:get', key),
   setSetting: (key: string, value: unknown) => ipcRenderer.invoke('settings:set', key, value),

--- a/packages/launcher/src/renderer/components/command-palette/use-commands.ts
+++ b/packages/launcher/src/renderer/components/command-palette/use-commands.ts
@@ -19,6 +19,7 @@ import {
 import { useShallow } from "zustand/react/shallow"
 import { useTranslation } from "react-i18next"
 
+import { isRunning, stateKeyOf } from "@renderer/lib/agent-state"
 import { useUiStore } from "@renderer/store/ui"
 import { useAgentsStore } from "@renderer/store/agents"
 import { useThemeStore, type ThemeMode } from "@renderer/store/theme"
@@ -53,8 +54,6 @@ const THEME_ICON: Record<ThemeMode, LucideIcon> = {
   system: Monitor,
 }
 
-const RUNNING_STATES = ["online", "running", "idle"]
-
 /** Every command the palette can run, in a stable order (groups stay together). */
 export function useCommands(): Command[] {
   const { t } = useTranslation()
@@ -82,19 +81,24 @@ export function useCommands(): Command[] {
     }))
 
     const agentCmds = agents.flatMap((a): Command[] => {
-      const running = RUNNING_STATES.includes(a.state)
+      const open: Command = {
+        id: `agent:open:${a.name}`,
+        title: t("commandPalette.commands.openAgent", { name: a.name }),
+        subtitle: a.type,
+        group: t("commandPalette.groups.agents"),
+        icon: Cpu,
+        // Agents page only. `setInstallFocusAgent` used to be called here
+        // too, but nothing on this page reads it — it just left a marketplace
+        // deep-link armed, to fire on some later, unrelated visit there.
+        run: () => setCurrentTab("agents"),
+      }
+      // Nothing drives an agent with no workspace, so neither command would do
+      // what it says — and "Stop" is what the palette offered, because that is
+      // the state the core writes for one.
+      if (stateKeyOf(a) === "notConnected") return [open]
+      const running = isRunning(a)
       return [
-        {
-          id: `agent:open:${a.name}`,
-          title: t("commandPalette.commands.openAgent", { name: a.name }),
-          subtitle: a.type,
-          group: t("commandPalette.groups.agents"),
-          icon: Cpu,
-          // Agents page only. `setInstallFocusAgent` used to be called here
-          // too, but nothing on this page reads it — it just left a marketplace
-          // deep-link armed, to fire on some later, unrelated visit there.
-          run: () => setCurrentTab("agents"),
-        },
+        open,
         running
           ? {
               id: `agent:stop:${a.name}`,

--- a/packages/launcher/src/renderer/components/onboarding/OnboardingFlow.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/OnboardingFlow.tsx
@@ -27,7 +27,13 @@ function StepBody({
     case "welcome":
       return <WelcomeStep />
     case "pairNode":
-      return <PairNodeStep pairing={pairing} />
+      return (
+        <PairNodeStep
+          pairing={pairing}
+          onContinueLocal={flow.goNext}
+          onFinish={() => flow.close(true)}
+        />
+      )
     case "agent":
       return <AgentSelectionStep agents={agents} />
     case "configure":

--- a/packages/launcher/src/renderer/components/onboarding/onboarding-footer.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/onboarding-footer.tsx
@@ -21,7 +21,7 @@ export function OnboardingFooter({
   flow: OnboardingFlowApi
 }): React.JSX.Element {
   const { t } = useTranslation()
-  const { steps, stepIndex, stepId, goNext, goBack, close } = flow
+  const { steps, stepIndex, stepId, goNext, goBack } = flow
   const { agents, auth, provision, pairing } = flow
 
   const bar = (children: React.ReactNode, withBack = true): React.JSX.Element => (
@@ -32,11 +32,6 @@ export function OnboardingFooter({
     >
       {children}
     </FooterBar>
-  )
-  const skip = (
-    <Button variant="ghost" onClick={() => close(true)}>
-      {t("onboarding.flow.footer.skipToApp")}
-    </Button>
   )
 
   switch (stepId) {
@@ -50,26 +45,20 @@ export function OnboardingFooter({
       )
 
     // Pairing alone is a complete onboarding (the workspace installs agents
-    // here remotely), so once the device is in the user chooses: finish, or
-    // continue into the optional local-agent steps. This is the only way into
-    // those steps — the panel's own call to action leads out to the browser —
-    // so it stays, drawn as the secondary of the two.
+    // here remotely), so once the device is in there is a choice to make —
+    // finish here in the launcher, or hand the rest to the workspace. The
+    // panel puts both routes on screen as the step's own content; repeating
+    // them down here would make a two-way fork look like four options.
+    //
+    // No skip while there is nothing to skip TO: a launcher with no workspace
+    // has no agents to run and no place to run them from, so "skip" only ever
+    // led to an empty app that asked for a pairing code again. The way past
+    // this step is a code — or Back, for anyone who opened the wizard by
+    // mistake.
     case "pairNode":
       return bar(
-        pairing.connected ? (
+        pairing.connected ? null : (
           <>
-            <Button variant="outline" onClick={goNext}>
-              {t("onboarding.flow.footer.addFirstAgent")}
-              <ChevronRight />
-            </Button>
-            <Button onClick={() => close(true)}>
-              <Check />
-              {t("onboarding.flow.footer.finishSetup")}
-            </Button>
-          </>
-        ) : (
-          <>
-            {skip}
             <Button
               onClick={() => void pairing.connect()}
               disabled={!pairing.canConnect}

--- a/packages/launcher/src/renderer/components/onboarding/steps/pair-node-step.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/steps/pair-node-step.tsx
@@ -1,22 +1,31 @@
 import React from "react"
-import { AlertCircle, Check, ExternalLink, Info } from "lucide-react"
+import { AlertCircle, ExternalLink, Info } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "@renderer/components/ui/button"
 import { Input } from "@renderer/components/ui/input"
-import { capture } from "@renderer/lib/analytics"
-import { workspaceWebBaseUrl } from "@renderer/lib/workspace-urls"
+import {
+  workspaceDisplayHost,
+  workspaceWebBaseUrl,
+} from "@renderer/lib/workspace-urls"
 
 import { FieldLabel, SectionLabel } from "../onboarding-chrome"
 import type { OnboardingPairingApi } from "../use-onboarding-pairing"
+import { PairedPanel } from "./paired-panel"
 
-/** The workspace-side trail that produces a code, shown as an ordered list. */
-const WHERE_IDS = ["open", "nodes", "copy"] as const
+/** What the user does on the web before a pairing code exists, in order. */
+const START_IDS = ["signIn", "createWorkspace", "copyCode"] as const
 
 export function PairNodeStep({
   pairing,
+  onContinueLocal,
+  onFinish,
 }: {
   pairing: OnboardingPairingApi
+  /** Take the local route: pick, configure and create an agent right here. */
+  onContinueLocal: () => void
+  /** Take the workspace route: the rest happens in the browser, so we're done. */
+  onFinish: () => void
 }): React.JSX.Element {
   const { t } = useTranslation()
   const {
@@ -32,11 +41,29 @@ export function PairNodeStep({
     connect,
   } = pairing
 
-  if (connected) return <PairedPanel pairing={pairing} />
+  if (connected)
+    return (
+      <PairedPanel
+        pairing={pairing}
+        onContinueLocal={onContinueLocal}
+        onFinish={onFinish}
+      />
+    )
 
   return (
     <>
-      <SectionLabel>{t("onboarding.flow.sections.pairing")}</SectionLabel>
+      {/* Everyone who reaches this step is here for the first time: no
+          workspace, often no account. So the web trail that produces a code
+          comes first — above the field it fills in, not tucked underneath it,
+          where someone with nothing to paste would never scroll to find it. */}
+      <SectionLabel>
+        {t("onboarding.flow.sections.beforeYouStart")}
+      </SectionLabel>
+      <StartGuide />
+
+      <SectionLabel className="mt-9">
+        {t("onboarding.flow.sections.pairing")}
+      </SectionLabel>
 
       <FieldLabel
         htmlFor="onboarding-pairing-code"
@@ -113,132 +140,48 @@ export function PairNodeStep({
           </div>
         </div>
       )}
-
-      <div className="mt-7 rounded-lg border border-(--border) bg-(--bg-card) p-5">
-        <div className="text-sm font-semibold">
-          {t("onboarding.flow.pairNode.whereTitle")}
-        </div>
-        <ol className="m-0 mt-3 flex list-none flex-col gap-2 p-0">
-          {WHERE_IDS.map((id, i) => (
-            <li key={id} className="flex items-center gap-2.5 text-xs">
-              <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--accent-bg) font-mono text-2xs font-bold text-(--accent)">
-                {i + 1}
-              </span>
-              <span className="text-(--text-secondary)">
-                {t(`onboarding.flow.pairNode.where.${id}`)}
-              </span>
-            </li>
-          ))}
-        </ol>
-        {/* Step 1 presumes a workspace is already open somewhere; a first-time
-            user may have none. Give them the front door — sign in on the web,
-            where a workspace is provisioned, then come back for the code. */}
-        <p className="m-0 mt-3 text-xs text-(--text-secondary)">
-          {t("onboarding.flow.pairNode.noWorkspaceYet")}{" "}
-          <button
-            type="button"
-            onClick={() =>
-              window.api.openExternal("https://workspace.openagents.org")
-            }
-            className="cursor-pointer border-0 bg-transparent p-0 text-xs text-(--accent) underline underline-offset-2"
-          >
-            workspace.openagents.org
-          </button>
-        </p>
-      </div>
     </>
   )
 }
 
 /**
- * After a successful redeem. The device is registered and the daemon is up, so
- * everything else — installing agents, starting them — happens in the
- * workspace; there is nothing left to do here but leave.
+ * Sign in on the web → create a workspace → copy the code. The launcher cannot
+ * do any of the three, so the only thing this panel owes the user is the front
+ * door, drawn large enough to be the obvious first move.
  */
-function PairedPanel({
-  pairing,
-}: {
-  pairing: OnboardingPairingApi
-}): React.JSX.Element {
+function StartGuide(): React.JSX.Element {
   const { t } = useTranslation()
-  const node = pairing.connected!
-  // The user came here from the workspace's "Connect agent" page, code in hand.
-  // Everything after pairing (installing and starting agents on this device)
-  // happens over there, so hand them straight back to the browser. We can't
-  // refocus the exact tab they left, but opening the workspace URL brings the
-  // browser forward and lands on the page where the flow continues.
-  const workspaceRef = node.workspaceSlug || node.workspaceId
-  const browserUrl = workspaceRef
-    ? `${workspaceWebBaseUrl(node.endpoint ?? undefined)}/${workspaceRef}`
-    : null
-  const rows: Array<{ id: string; value: string }> = [
-    {
-      id: "workspace",
-      value: node.workspaceName || node.workspaceSlug || "—",
-    },
-    { id: "device", value: pairing.deviceName.trim() || node.hostname },
-    { id: "nodeId", value: node.nodeId || "—" },
-  ]
+  const host = workspaceDisplayHost()
 
   return (
-    <>
-      <SectionLabel>{t("onboarding.flow.sections.pairing")}</SectionLabel>
-
-      <div className="rounded-lg border border-(--success-border) bg-(--success-bg) p-5">
-        <div className="flex items-center gap-2.5">
-          <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-(--success) text-white">
-            <Check className="size-4" />
-          </span>
-          <div className="min-w-0">
-            <div className="text-base font-semibold">
-              {t("onboarding.flow.pairNode.connectedTitle")}
-            </div>
-            <p className="m-0 mt-1 text-xs leading-relaxed text-(--text-secondary)">
-              {t("onboarding.flow.pairNode.connectedDesc")}
-            </p>
-          </div>
-        </div>
-        {/* The one move worth making from here, so it is drawn as one: full
-            width and large, not a link-sized button tucked under a paragraph.
-            Adding agents happens in the workspace — this panel's whole job is
-            to get the user back there rather than into the local agent steps. */}
-        {browserUrl && (
-          <Button
-            size="lg"
-            className="mt-4 w-full"
-            onClick={() => {
-              capture("onboarding_continue_in_browser", {
-                workspace_id: node.workspaceSlug,
-              })
-              void window.api.openExternal(browserUrl)
-            }}
-          >
-            <ExternalLink className="size-4" />
-            {t("onboarding.flow.pairNode.continueInBrowser")}
-          </Button>
-        )}
+    <div className="rounded-lg border border-(--border) bg-(--bg-card) p-5">
+      <div className="text-sm font-semibold">
+        {t("onboarding.flow.pairNode.start.title")}
       </div>
-
-      <ul className="m-0 mt-3 list-none overflow-hidden rounded-lg border border-(--border) bg-(--bg-card) p-0">
-        {rows.map((row) => (
-          <li
-            key={row.id}
-            className="flex items-center gap-3 border-b border-(--border) px-4 py-2.5 last:border-b-0"
-          >
-            <span className="size-1.5 shrink-0 rounded-full bg-(--success)" />
-            <span className="text-sm">
-              {t(`onboarding.flow.pairNode.summary.${row.id}`)}
+      <p className="m-0 mt-1 text-xs text-(--text-secondary)">
+        {t("onboarding.flow.pairNode.start.desc")}
+      </p>
+      <ol className="m-0 mt-4 flex list-none flex-col gap-2.5 p-0">
+        {START_IDS.map((id, i) => (
+          <li key={id} className="flex items-center gap-2.5 text-sm">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-(--accent-bg) font-mono text-2xs font-bold text-(--accent)">
+              {i + 1}
             </span>
-            <span className="ml-auto truncate font-mono text-2xs text-(--text-secondary)">
-              {row.value}
+            <span className="text-(--text-secondary)">
+              {t(`onboarding.flow.pairNode.start.steps.${id}`, { host })}
             </span>
           </li>
         ))}
-      </ul>
-
-      <p className="mt-5 mb-0 text-xs text-(--text-tertiary)">
-        {t("onboarding.flow.pairNode.connectedFootnote")}
-      </p>
-    </>
+      </ol>
+      <Button
+        variant="outline"
+        size="lg"
+        className="mt-4 w-full"
+        onClick={() => void window.api.openExternal(workspaceWebBaseUrl())}
+      >
+        <ExternalLink className="size-4" />
+        {t("onboarding.flow.pairNode.start.open", { host })}
+      </Button>
+    </div>
   )
 }

--- a/packages/launcher/src/renderer/components/onboarding/steps/paired-panel.tsx
+++ b/packages/launcher/src/renderer/components/onboarding/steps/paired-panel.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from "react"
+import { Check, ChevronRight, ExternalLink, Globe, Laptop } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@renderer/components/ui/button"
+import { capture } from "@renderer/lib/analytics"
+import { cn } from "@renderer/lib/utils"
+import { workspaceWebBaseUrl } from "@renderer/lib/workspace-urls"
+
+import { SectionLabel } from "../onboarding-chrome"
+import type { OnboardingPairingApi } from "../use-onboarding-pairing"
+
+/**
+ * After a successful redeem. The device is in; what is left is a real fork —
+ * finish the setup here in the launcher, or hand it to the workspace in the
+ * browser — so the panel asks for that choice and nothing else. Both routes
+ * end with an agent in the paired workspace; only the place you do the work
+ * differs. The identifiers this used to list (workspace, device, node id) told
+ * the user nothing they had to act on, so they are gone.
+ */
+export function PairedPanel({
+  pairing,
+  onContinueLocal,
+  onFinish,
+}: {
+  pairing: OnboardingPairingApi
+  onContinueLocal: () => void
+  onFinish: () => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  const node = pairing.connected!
+  // We can't refocus the exact tab the user left, but opening the workspace URL
+  // brings the browser forward and lands on the page where the flow continues.
+  const workspaceRef = node.workspaceSlug || node.workspaceId
+  const base = workspaceWebBaseUrl(node.endpoint ?? undefined)
+  const browserUrl = workspaceRef ? `${base}/${workspaceRef}` : base
+  // Handing the setup to the browser does not end the wizard by itself: the
+  // browser takes a moment to come forward, and closing behind it drops the
+  // user into the main window with no idea what happened or whether it worked.
+  // We say what we did, leave both cards live, and let them close this.
+  const [handedOff, setHandedOff] = useState(false)
+
+  const openWorkspace = (): void => {
+    capture("onboarding_continue_in_browser", {
+      workspace_id: node.workspaceSlug,
+    })
+    void window.api.openExternal(browserUrl)
+    setHandedOff(true)
+  }
+
+  return (
+    <>
+      <SectionLabel>{t("onboarding.flow.sections.pairing")}</SectionLabel>
+
+      <div className="flex items-center gap-2.5 rounded-lg border border-(--success-border) bg-(--success-bg) px-4 py-3.5">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-(--success) text-white">
+          <Check className="size-4" />
+        </span>
+        <div className="min-w-0">
+          <div className="text-sm font-semibold">
+            {t("onboarding.flow.pairNode.connectedTitle")}
+          </div>
+          <p className="m-0 mt-0.5 text-xs leading-relaxed text-(--text-secondary)">
+            {t("onboarding.flow.pairNode.connectedDesc")}
+          </p>
+        </div>
+      </div>
+
+      <SectionLabel className="mt-9">
+        {t("onboarding.flow.sections.nextStep")}
+      </SectionLabel>
+      <p className="m-0 mb-4 text-sm text-(--text-secondary)">
+        {t("onboarding.flow.pairNode.next.prompt")}
+      </p>
+
+      {/* Two cards, equal weight: neither route is the fallback of the other,
+          and the launcher has no way of knowing which one this user wants. */}
+      <div className="grid gap-3 md:grid-cols-2">
+        <ChoiceCard
+          icon={<Laptop className="size-4" />}
+          id="local"
+          cta={<ChevronRight className="size-4" />}
+          onClick={() => {
+            capture("onboarding_continue_in_launcher", {
+              workspace_id: node.workspaceSlug,
+            })
+            onContinueLocal()
+          }}
+        />
+        <ChoiceCard
+          icon={<Globe className="size-4" />}
+          id="workspace"
+          cta={<ExternalLink className="size-4" />}
+          onClick={openWorkspace}
+        />
+      </div>
+
+      {/* Appears only once they have actually taken the remote route — before
+          that there is nothing to finish, and a third button next to a two-way
+          choice would just be a third option. Pressing the card again reopens
+          the browser, so "it didn't open" needs no button of its own. */}
+      {handedOff && (
+        <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg border border-(--accent-border) bg-(--accent-bg) px-4 py-3.5">
+          <div className="min-w-50 flex-1">
+            <div className="text-sm font-semibold">
+              {t("onboarding.flow.pairNode.next.handoff.title")}
+            </div>
+            <p className="m-0 mt-0.5 text-xs leading-relaxed text-(--text-secondary)">
+              {t("onboarding.flow.pairNode.next.handoff.desc")}
+            </p>
+          </div>
+          <Button onClick={onFinish}>
+            <Check className="size-4" />
+            {t("onboarding.flow.pairNode.next.handoff.finish")}
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}
+
+function ChoiceCard({
+  id,
+  icon,
+  cta,
+  onClick,
+}: {
+  /** Keys the card's copy under `onboarding.flow.pairNode.next.<id>`. */
+  id: "local" | "workspace"
+  icon: React.ReactNode
+  cta: React.ReactNode
+  onClick: () => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex cursor-pointer flex-col items-start gap-2 rounded-lg border border-(--border) bg-(--bg-card) p-5 text-left transition-colors",
+        "hover:border-(--accent) hover:bg-(--accent-bg)",
+      )}
+    >
+      <span className="flex size-8 items-center justify-center rounded-lg bg-(--accent-bg) text-(--accent)">
+        {icon}
+      </span>
+      <span className="text-sm font-semibold">
+        {t(`onboarding.flow.pairNode.next.${id}.title`)}
+      </span>
+      <span className="text-xs leading-relaxed text-(--text-secondary)">
+        {t(`onboarding.flow.pairNode.next.${id}.desc`)}
+      </span>
+      <span className="mt-1 inline-flex items-center gap-1.5 text-xs font-medium text-(--accent)">
+        {t(`onboarding.flow.pairNode.next.${id}.cta`)}
+        {cta}
+      </span>
+    </button>
+  )
+}

--- a/packages/launcher/src/renderer/components/workspaces/WorkspaceCard.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/WorkspaceCard.tsx
@@ -213,7 +213,16 @@ export function WorkspaceCard({
         </Metric>
         <Metric label={t("workspaces.card.lastActive")}>
           <span className="truncate" title={activityTitle}>
-            {relativeTimeAgo(t, lastActiveAt) || t("workspaces.relativeTime.never")}
+            {/* "Never" is a claim about the workspace's whole history, and a
+                revoked card is in no position to make it: the pairing that fed
+                this number is gone, so what we have is an absence of data, not
+                a workspace that was never used. */}
+            {relativeTimeAgo(t, lastActiveAt) ||
+              t(
+                health === "revoked"
+                  ? "workspaces.relativeTime.unknown"
+                  : "workspaces.relativeTime.never",
+              )}
           </span>
         </Metric>
       </div>

--- a/packages/launcher/src/renderer/components/workspaces/WorkspaceRemoveDialog.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/WorkspaceRemoveDialog.tsx
@@ -13,6 +13,13 @@ const EFFECT_KEYS = [
   "workspaces.remove.effects.local",
 ]
 
+/** The same three facts once the workspace has already cut this device loose. */
+const REVOKED_EFFECT_KEYS = [
+  "workspaces.remove.revoked.effects.credential",
+  "workspaces.remove.revoked.effects.agents",
+  "workspaces.remove.revoked.effects.local",
+]
+
 /**
  * Remove a workspace — from this device, and optionally from existence.
  *
@@ -26,10 +33,24 @@ const EFFECT_KEYS = [
  * The checkbox is the second, far larger act: `DELETE /v1/workspaces/{id}`
  * takes the workspace away from **everyone**, recoverable only by an admin
  * flipping the row's status back, which no UI offers.
+ *
+ * `revoked` changes what the prompt says, not what kind of prompt it is. The
+ * workspace has already removed this device: the pairing is gone, its
+ * credential no longer verifies, and nothing here can reach the server any
+ * more — so the copy is about clearing the stale local record, and the
+ * delete-for-everyone checkbox is dropped, since with a dead credential it
+ * could only fail. It stays a destructive prompt, drawn exactly like its
+ * sibling: this still unbinds agents and drops a workspace off the machine.
+ *
+ * Both variants read from a snapshot rather than the live props. Closing sets
+ * the target to null, which empties the name and drops `revoked` back to false
+ * — while the dialog is still fading out, so cancelling a "clear the record"
+ * prompt flashed the unpair copy on its way off screen.
  */
 export function WorkspaceRemoveDialog({
   workspace,
   displayName,
+  revoked = false,
   busy,
   onConfirm,
   onCancel,
@@ -37,12 +58,15 @@ export function WorkspaceRemoveDialog({
   /** Non-null opens the dialog — the workspace about to be removed. */
   workspace: Workspace | null
   displayName: string
+  /** This device's pairing was already revoked on the workspace side. */
+  revoked?: boolean
   busy: boolean
   onConfirm: (deleteRemote: boolean) => void
   onCancel: () => void
 }): React.JSX.Element {
   const { t } = useTranslation()
   const [deleteRemote, setDeleteRemote] = useState(false)
+  const [shown, setShown] = useState({ name: displayName, revoked })
 
   // Destroying the workspace for everyone must be chosen every time, never
   // inherited from the last time this dialog was open.
@@ -50,17 +74,43 @@ export function WorkspaceRemoveDialog({
     if (workspace) setDeleteRemote(false)
   }, [workspace])
 
+  // Held past the close so the fade-out shows the prompt the user answered.
+  // Synced during render, not in an effect: an effect lands after the paint,
+  // so opening this on a different workspace would show one frame of the
+  // previous target's prompt — the same flash, at the other end.
+  if (workspace && (shown.name !== displayName || shown.revoked !== revoked)) {
+    setShown({ name: displayName, revoked })
+  }
+
+  if (shown.revoked)
+    return (
+      <ConfirmDialog
+        open={!!workspace}
+        title={t("workspaces.remove.revoked.title", { name: shown.name })}
+        description={t("workspaces.remove.revoked.description")}
+        confirmLabel={t("workspaces.remove.revoked.confirm")}
+        destructive
+        busy={busy}
+        onConfirm={() => onConfirm(false)}
+        onCancel={onCancel}
+      >
+        <Effects keys={REVOKED_EFFECT_KEYS} />
+      </ConfirmDialog>
+    )
+
   return (
     <ConfirmDialog
       open={!!workspace}
-      title={t("workspaces.remove.title", { name: displayName })}
+      title={t("workspaces.remove.title", { name: shown.name })}
       description={t(
         deleteRemote
           ? "workspaces.remove.descriptionRemote"
           : "workspaces.remove.description",
       )}
       confirmLabel={t(
-        deleteRemote ? "workspaces.remove.confirmRemote" : "workspaces.remove.confirm",
+        deleteRemote
+          ? "workspaces.remove.confirmRemote"
+          : "workspaces.remove.confirm",
       )}
       // Destructive either way: unchecked still revokes this device's pairing
       // and unbinds its agents, so nothing here may read as a tidy-up.
@@ -69,14 +119,7 @@ export function WorkspaceRemoveDialog({
       onConfirm={() => onConfirm(deleteRemote)}
       onCancel={onCancel}
     >
-      <ul className="space-y-1.5 rounded-md border bg-muted/40 px-3 py-2.5 text-xs leading-snug text-muted-foreground">
-        {EFFECT_KEYS.map((key) => (
-          <li key={key} className="flex items-start gap-2">
-            <span className="mt-1.5 size-1 shrink-0 rounded-full bg-current" />
-            <span>{t(key)}</span>
-          </li>
-        ))}
-      </ul>
+      <Effects keys={EFFECT_KEYS} />
 
       <label className="flex cursor-pointer items-start gap-2.5 rounded-md border bg-muted/40 px-3 py-2.5 transition-colors hover:bg-muted/70">
         <Checkbox
@@ -99,5 +142,19 @@ export function WorkspaceRemoveDialog({
         </div>
       )}
     </ConfirmDialog>
+  )
+}
+
+function Effects({ keys }: { keys: string[] }): React.JSX.Element {
+  const { t } = useTranslation()
+  return (
+    <ul className="space-y-1.5 rounded-md border bg-muted/40 px-3 py-2.5 text-xs leading-snug text-muted-foreground">
+      {keys.map((key) => (
+        <li key={key} className="flex items-start gap-2">
+          <span className="mt-1.5 size-1 shrink-0 rounded-full bg-current" />
+          <span>{t(key)}</span>
+        </li>
+      ))}
+    </ul>
   )
 }

--- a/packages/launcher/src/renderer/components/workspaces/WorkspaceRevokedNotice.tsx
+++ b/packages/launcher/src/renderer/components/workspaces/WorkspaceRevokedNotice.tsx
@@ -1,0 +1,69 @@
+import React from "react"
+import { Unplug } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "../ui/button"
+import type { RevokedPairing } from "../../types"
+
+/**
+ * One workspace removed this device, so the launcher removed the workspace:
+ * the pairing, the local entry and the agent bindings all go together — a
+ * workspace this machine is not in cannot be opened, cannot run anything, and
+ * has no honest state to draw as a card.
+ *
+ * What is left is telling the user. Without this the workspace would simply be
+ * gone one launch, along with whatever its agents were filed under, and the
+ * only visible trace would be agents that had quietly become workspace-less.
+ */
+export function WorkspaceRevokedNotice({
+  notices,
+  onRejoin,
+  onDismiss,
+}: {
+  notices: RevokedPairing[]
+  onRejoin: () => void
+  onDismiss: (workspaceId: string) => void
+}): React.JSX.Element | null {
+  const { t } = useTranslation()
+  if (notices.length === 0) return null
+
+  return (
+    <div className="mb-4 flex flex-col gap-2">
+      {notices.map((n) => {
+        const count = n.agents?.length || 0
+        return (
+          <div
+            key={n.workspaceId}
+            className="flex flex-wrap items-center gap-3 rounded-lg border border-(--warning-border) bg-(--warning-bg) px-4 py-3"
+          >
+            <Unplug className="size-4 shrink-0 text-(--warning-text)" />
+            <div className="min-w-50 flex-1">
+              <div className="text-sm font-medium">
+                {t("workspaces.revokedNotice.title", {
+                  name: n.workspaceName || n.workspaceSlug || n.workspaceId,
+                })}
+              </div>
+              <p className="m-0 mt-0.5 text-xs text-(--text-secondary)">
+                {count > 0
+                  ? t("workspaces.revokedNotice.bodyAgents", { count })
+                  : t("workspaces.revokedNotice.body")}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button size="sm" onClick={onRejoin}>
+                {t("workspaces.revokedNotice.rejoin")}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => onDismiss(n.workspaceId)}
+              >
+                {t("workspaces.revokedNotice.dismiss")}
+              </Button>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/launcher/src/renderer/hooks/use-paired-workspaces.ts
+++ b/packages/launcher/src/renderer/hooks/use-paired-workspaces.ts
@@ -6,8 +6,11 @@ import { useEffect, useState } from "react"
  * mount — pairing changes are rare and every consumer re-mounts on
  * navigation.
  */
-export function usePairedWorkspaces(): Set<string> {
-  const [paired, setPaired] = useState<Set<string>>(() => new Set())
+export function usePairedWorkspaces(): Set<string> | null {
+  // null until the node has answered. An empty set is a real answer — this
+  // device is in no workspace — and the two must not be confused: treating
+  // "not yet" as "in none" flags every agent as unconnected for a frame.
+  const [paired, setPaired] = useState<Set<string> | null>(null)
 
   useEffect(() => {
     let cancelled = false

--- a/packages/launcher/src/renderer/i18n/locales/en/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agents.json
@@ -16,7 +16,6 @@
     "coreUpdateRequired": "Launcher core update required",
     "apiPrefix": "API: {{value}}",
     "modelPrefix": "Model: {{value}}",
-    "notConnected": "Not in a workspace",
     "stopping": "Stopping...",
     "starting": "Starting...",
     "stop": "Stop",
@@ -61,9 +60,11 @@
     },
     "statuses": {
       "running": "Running",
+      "idle": "Idle",
+      "starting": "Starting",
       "error": "Error",
-      "stopped": "Stopped",
-      "disconnected": "No workspace"
+      "offline": "Stopped",
+      "notConnected": "Not connected"
     },
     "error": {
       "view": "View the error",
@@ -94,9 +95,7 @@
     "workspaceLine": "Workspace · {{name}}",
     "emptyTitle": "No agents yet",
     "emptyNoMatchTitle": "Nothing matches that search",
-    "emptyNoFilterMatchTitle": "Nothing matches this filter",
-    "legacyBadge": "legacy",
-    "legacyHint": "Connected with a manual workspace token — a path being retired. Join the workspace with a pairing code to switch."
+    "emptyNoFilterMatchTitle": "Nothing matches this filter"
   },
   "newDialog": {
     "title": "New Agent",

--- a/packages/launcher/src/renderer/i18n/locales/en/dashboard.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/dashboard.json
@@ -45,7 +45,6 @@
       "lastActive": "Last active",
       "actions": "Actions"
     },
-    "noWorkspace": "No workspace connected",
     "openTerminal": "Open terminal",
     "start": "Start",
     "stop": "Stop",
@@ -53,12 +52,14 @@
     "more": "More actions",
     "empty": "No agents configured yet.",
     "states": {
-      "running": "Running",
-      "idle": "Idle",
-      "starting": "Starting",
-      "error": "Error",
-      "offline": "Stopped"
-    }
+      "running": "$t(agents.list.statuses.running)",
+      "idle": "$t(agents.list.statuses.idle)",
+      "starting": "$t(agents.list.statuses.starting)",
+      "error": "$t(agents.list.statuses.error)",
+      "offline": "$t(agents.list.statuses.offline)",
+      "notConnected": "$t(agents.list.statuses.notConnected)"
+    },
+    "connect": "$t(agents.list.connect)"
   },
   "workspaces": {
     "title": "Recently used workspaces",

--- a/packages/launcher/src/renderer/i18n/locales/en/onboarding.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/onboarding.json
@@ -47,7 +47,9 @@
       "runtimeScan": "Local runtime scan",
       "env": "Environment variables",
       "instance": "Instance",
-      "launchPreview": "Launch preview"
+      "launchPreview": "Launch preview",
+      "beforeYouStart": "Before you start",
+      "nextStep": "What's next"
     },
     "field": {
       "required": "REQUIRED"
@@ -74,11 +76,8 @@
       "connectDevice": "Connect device",
       "saving": "Saving…",
       "saveAndContinue": "Save & continue",
-      "skipToApp": "Skip",
       "creating": "Creating…",
       "connecting": "Connecting…",
-      "finishSetup": "Finish setup",
-      "addFirstAgent": "Add an agent",
       "createAndFinish": "Create & finish"
     },
     "toast": {
@@ -110,7 +109,17 @@
     },
     "pairNode": {
       "title": "Connect this device",
-      "subtitle": "Enter the pairing code from your workspace. This machine joins as a device, and the workspace can install and start agents on it.",
+      "subtitle": "Pairing codes are issued by a workspace on the web. Follow the three steps below to get one, paste it in, and this machine joins as a device.",
+      "start": {
+        "title": "First time here? Set up your workspace on the web",
+        "desc": "A pairing code is issued by a workspace, so you need one first.",
+        "steps": {
+          "signIn": "Sign up and log in at {{host}}",
+          "createWorkspace": "Create a workspace",
+          "copyCode": "Open the workspace and copy the pairing code"
+        },
+        "open": "Open {{host}}"
+      },
       "codeLabel": "Pairing code",
       "codePlaceholder": "XXXX-XXXX",
       "codeHint": "Eight characters, shown in the workspace under $t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes). Each code works once and expires after 30 minutes.",
@@ -120,20 +129,25 @@
       "alreadyPairedTitle": "This device is already in \"{{name}}\"",
       "alreadyPairedTitleMany": "This device is already in {{count}} workspaces",
       "alreadyPairedBody": "A device can belong to several workspaces at once, so this code adds one more — the workspaces it is already in keep it.",
-      "whereTitle": "Where to find the code",
-      "where": {
-        "open": "Open your workspace in the browser and go to $t(common.workspaceMenu.connectAgent).",
-        "nodes": "On the $t(common.workspaceMenu.nodes) tab, the pairing code is shown under $t(common.workspaceMenu.connectedNodes).",
-        "copy": "Copy it and paste it above — no token or link needed."
-      },
       "connectedTitle": "This device is connected",
       "connectedDesc": "It now appears under $t(common.workspaceMenu.connectedNodes) in the workspace, and stays online while $t(common.appName) is running.",
-      "continueInBrowser": "Back to browser to add an agent",
-      "connectedFootnote": "Next: install and start agents on this device from the workspace — or use \"$t(onboarding.flow.footer.addFirstAgent)\" below to install one right here. Either way the agent belongs to this workspace.",
-      "summary": {
-        "workspace": "Workspace",
-        "device": "Device",
-        "nodeId": "Node ID"
+      "next": {
+        "prompt": "Where do you want to set up an agent for this device? Both routes end with one installed on this machine — pick one to continue.",
+        "local": {
+          "title": "Set up in the launcher",
+          "desc": "Stay here: pick an agent, enter its credentials and create the instance.",
+          "cta": "Continue here"
+        },
+        "workspace": {
+          "title": "Set up in the workspace",
+          "desc": "Back to the browser, where the workspace installs and starts agents on this device remotely.",
+          "cta": "Open the workspace"
+        },
+        "handoff": {
+          "title": "The workspace is open in your browser",
+          "desc": "Install and start agents on this device from there. It stays online for as long as the launcher keeps running.",
+          "finish": "Finish setup and close"
+        }
       },
       "errors": {
         "length": "A pairing code is 8 characters, like XXXX-XXXX.",
@@ -141,8 +155,7 @@
       },
       "toast": {
         "connected": "This device joined workspace \"{{name}}\""
-      },
-      "noWorkspaceYet": "Don't have a workspace yet? Sign in and one is created for you at"
+      }
     },
     "installPhase": {
       "preparing": "Preparing…",

--- a/packages/launcher/src/renderer/i18n/locales/en/workspaces.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/workspaces.json
@@ -23,7 +23,8 @@
     "deleted": "Deleted workspace \"{{name}}\"",
     "renamed": "Workspace renamed",
     "renamedWorkspace": "Renamed to \"{{name}}\" for everyone in the workspace",
-    "error": "Error: {{message}}"
+    "error": "Error: {{message}}",
+    "cleared": "Cleared the local record for \"{{name}}\""
   },
   "remove": {
     "title": "Remove \"{{name}}\"?",
@@ -37,7 +38,17 @@
     "alsoDelete": "Delete the workspace on the server too — all members",
     "alsoDeleteWarning": "Everyone loses access immediately. Only an admin restoring the record by hand can undo it.",
     "confirm": "Unpair",
-    "confirmRemote": "Delete workspace"
+    "confirmRemote": "Delete workspace",
+    "revoked": {
+      "title": "Clear the local record for \"{{name}}\"?",
+      "description": "The workspace removed this device, so the pairing and its credential stopped working some time ago. This only clears what is left behind on this machine — the workspace itself, its members and its other devices are untouched.",
+      "effects": {
+        "credential": "The pairing credential stored here is deleted — it no longer works anyway.",
+        "agents": "Agents bound to this workspace are unbound locally; the instances and their data stay.",
+        "local": "The card disappears from this list, and you can re-join at any time with a new pairing code."
+      },
+      "confirm": "Clear record"
+    }
   },
   "card": {
     "unfavorite": "Unfavorite",
@@ -76,7 +87,7 @@
     "deviceBadgeHint": "This machine is paired to this workspace as a node — agents can be installed and run on it from there.",
     "repair": "Join again",
     "revokedTitle": "This device was removed from the workspace",
-    "revokedBody": "Its pairing was revoked on the workspace side. Agents here can no longer reach it — join again with a fresh code to reconnect."
+    "revokedBody": "The workspace revoked this pairing, so the agents here can no longer connect."
   },
   "health": {
     "healthy": "Healthy",
@@ -97,7 +108,8 @@
     "justNow": "just now",
     "minutesAgo": "{{count}}m ago",
     "hoursAgo": "{{count}}h ago",
-    "daysAgo": "{{count}}d ago"
+    "daysAgo": "{{count}}d ago",
+    "unknown": "—"
   },
   "quickConnect": {
     "title": "$t(common.actions.addWorkspace)",
@@ -157,5 +169,12 @@
   },
   "emptyNoneTitle": "No workspaces yet",
   "emptyNoMatchTitle": "Nothing matches that search",
-  "emptyNoFilterMatchTitle": "Nothing matches this filter"
+  "emptyNoFilterMatchTitle": "Nothing matches this filter",
+  "revokedNotice": {
+    "title": "\"{{name}}\" removed this device",
+    "body": "The workspace has been removed from this machine. Joining again needs a new pairing code.",
+    "bodyAgents": "The workspace has been removed from this machine, and the {{count}} agents filed under it were unbound — the instances and their data stay. Joining the same workspace again files them back under it.",
+    "rejoin": "Join again",
+    "dismiss": "Dismiss"
+  }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agents.json
@@ -16,7 +16,6 @@
     "coreUpdateRequired": "需要更新启动器核心",
     "apiPrefix": "API：{{value}}",
     "modelPrefix": "模型：{{value}}",
-    "notConnected": "未加入工作区",
     "stopping": "正在停止…",
     "starting": "正在启动…",
     "stop": "停止",
@@ -61,9 +60,11 @@
     },
     "statuses": {
       "running": "运行中",
+      "idle": "空闲",
+      "starting": "启动中",
       "error": "异常",
-      "stopped": "已停止",
-      "disconnected": "无工作区"
+      "offline": "已停止",
+      "notConnected": "未连接工作区"
     },
     "error": {
       "view": "查看错误信息",
@@ -94,9 +95,7 @@
     "workspaceLine": "工作区 · {{name}}",
     "emptyTitle": "还没有智能体",
     "emptyNoMatchTitle": "没有匹配的智能体",
-    "emptyNoFilterMatchTitle": "该筛选下没有智能体",
-    "legacyBadge": "旧版连接",
-    "legacyHint": "通过手动令牌连接（该方式将逐步停用）。用配对码重新加入该工作区即可切换。"
+    "emptyNoFilterMatchTitle": "该筛选下没有智能体"
   },
   "newDialog": {
     "title": "新建智能体",

--- a/packages/launcher/src/renderer/i18n/locales/zh/dashboard.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/dashboard.json
@@ -43,7 +43,6 @@
       "lastActive": "最近活动",
       "actions": "操作"
     },
-    "noWorkspace": "未连接工作区",
     "openTerminal": "打开终端",
     "start": "启动",
     "stop": "停止",
@@ -51,12 +50,14 @@
     "more": "更多操作",
     "empty": "尚未配置任何智能体。",
     "states": {
-      "running": "运行中",
-      "idle": "空闲",
-      "starting": "启动中",
-      "error": "连接异常",
-      "offline": "已停止"
-    }
+      "running": "$t(agents.list.statuses.running)",
+      "idle": "$t(agents.list.statuses.idle)",
+      "starting": "$t(agents.list.statuses.starting)",
+      "error": "$t(agents.list.statuses.error)",
+      "offline": "$t(agents.list.statuses.offline)",
+      "notConnected": "$t(agents.list.statuses.notConnected)"
+    },
+    "connect": "$t(agents.list.connect)"
   },
   "workspaces": {
     "title": "最近使用的工作区",

--- a/packages/launcher/src/renderer/i18n/locales/zh/onboarding.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/onboarding.json
@@ -47,7 +47,9 @@
       "runtimeScan": "本地环境检测",
       "env": "环境变量",
       "instance": "实例信息",
-      "launchPreview": "启动预览"
+      "launchPreview": "启动预览",
+      "beforeYouStart": "开始之前",
+      "nextStep": "接下来"
     },
     "field": {
       "required": "必填"
@@ -74,11 +76,8 @@
       "connectDevice": "连接设备",
       "saving": "正在保存…",
       "saveAndContinue": "保存并继续",
-      "skipToApp": "跳过",
       "creating": "正在创建…",
       "connecting": "正在连接…",
-      "finishSetup": "完成设置",
-      "addFirstAgent": "添加智能体",
       "createAndFinish": "创建并完成"
     },
     "toast": {
@@ -110,7 +109,17 @@
     },
     "pairNode": {
       "title": "连接这台设备",
-      "subtitle": "输入工作区里的配对码，这台机器就会作为设备接入，工作区就能在它上面安装和启动智能体。",
+      "subtitle": "配对码在网页端的工作区里生成。按下面三步拿到配对码，粘贴进来，这台机器就会作为设备接入。",
+      "start": {
+        "title": "第一次使用？先在网页端准备好工作区",
+        "desc": "配对码由工作区签发，所以要先有一个工作区。",
+        "steps": {
+          "signIn": "在 {{host}} 注册并登录",
+          "createWorkspace": "创建一个工作区",
+          "copyCode": "进入工作区，复制配对码"
+        },
+        "open": "打开 {{host}}"
+      },
       "codeLabel": "配对码",
       "codePlaceholder": "XXXX-XXXX",
       "codeHint": "共 8 位，在工作区的「$t(common.workspaceMenu.connectAgent) → $t(common.workspaceMenu.nodes)」里查看。每个配对码只能用一次，30 分钟后失效。",
@@ -120,20 +129,25 @@
       "alreadyPairedTitle": "这台设备已经接入「{{name}}」",
       "alreadyPairedTitleMany": "这台设备已经接入 {{count}} 个工作区",
       "alreadyPairedBody": "一台设备可以同时属于多个工作区，所以这个配对码是新增一个归属，已经接入的工作区不受影响。",
-      "whereTitle": "配对码在哪里",
-      "where": {
-        "open": "在浏览器里打开工作区，进入「$t(common.workspaceMenu.connectAgent)」。",
-        "nodes": "切到「$t(common.workspaceMenu.nodes)」标签页，「$t(common.workspaceMenu.connectedNodes)」下方就是配对码。",
-        "copy": "复制后粘贴到上面 —— 不需要 token 或链接。"
-      },
       "connectedTitle": "这台设备已连接",
       "connectedDesc": "它已经出现在工作区的「$t(common.workspaceMenu.connectedNodes)」里，只要 $t(common.appName) 在运行就保持在线。",
-      "continueInBrowser": "回到浏览器添加智能体",
-      "connectedFootnote": "接下来：在工作区里就能给这台设备安装并启动智能体；也可以点下方的「$t(onboarding.flow.footer.addFirstAgent)」，直接在启动器里安装。无论用哪种方式，智能体都属于这个工作区。",
-      "summary": {
-        "workspace": "工作区",
-        "device": "设备",
-        "nodeId": "设备 ID"
+      "next": {
+        "prompt": "接下来在哪里为这台设备设置智能体？两条路最终都会把智能体装到这台设备上，选一个继续。",
+        "local": {
+          "title": "在启动器里设置",
+          "desc": "留在这里挑选智能体、填写密钥并创建实例。",
+          "cta": "在这里继续"
+        },
+        "workspace": {
+          "title": "在工作区里设置",
+          "desc": "回到浏览器，在工作区里远程为这台设备安装并启动智能体。",
+          "cta": "打开工作区"
+        },
+        "handoff": {
+          "title": "已在浏览器里打开工作区",
+          "desc": "在工作区里为这台设备安装并启动智能体。只要启动器保持运行，这台设备就一直在线。",
+          "finish": "完成设置，关闭向导"
+        }
       },
       "errors": {
         "length": "配对码是 8 位，形如 XXXX-XXXX。",
@@ -141,8 +155,7 @@
       },
       "toast": {
         "connected": "这台设备已加入工作区「{{name}}」"
-      },
-      "noWorkspaceYet": "还没有工作区？登录后会自动为你创建一个："
+      }
     },
     "installPhase": {
       "preparing": "正在准备…",

--- a/packages/launcher/src/renderer/i18n/locales/zh/workspaces.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/workspaces.json
@@ -23,7 +23,8 @@
     "deleted": "已删除工作区「{{name}}」",
     "renamed": "已重命名工作区",
     "renamedWorkspace": "已重命名为「{{name}}」，工作区所有成员可见",
-    "error": "错误：{{message}}"
+    "error": "错误：{{message}}",
+    "cleared": "已清除「{{name}}」的本机记录"
   },
   "remove": {
     "title": "移除工作区「{{name}}」？",
@@ -37,7 +38,17 @@
     "alsoDelete": "同时删除服务器上的工作区 —— 影响所有成员",
     "alsoDeleteWarning": "所有人立刻失去访问权限，只有管理员手工改回数据记录才能恢复。",
     "confirm": "取消配对",
-    "confirmRemote": "删除工作区"
+    "confirmRemote": "删除工作区",
+    "revoked": {
+      "title": "清除「{{name}}」的本机记录？",
+      "description": "这台设备已在工作区端被移除，配对与凭据早已失效。这里只是清掉本机残留的记录，工作区本身、其他成员和设备都不受影响。",
+      "effects": {
+        "credential": "本机保存的配对凭据会被删除 —— 它已经无法再使用。",
+        "agents": "该工作区下的智能体会在本机解除绑定，实例和数据都保留。",
+        "local": "这张卡片会从列表消失，之后随时可以用新的配对码重新加入。"
+      },
+      "confirm": "清除记录"
+    }
   },
   "card": {
     "unfavorite": "取消收藏",
@@ -76,7 +87,7 @@
     "deviceBadgeHint": "这台机器作为节点接入了该工作区 —— 可以在工作区里给它安装并运行智能体。",
     "repair": "重新加入",
     "revokedTitle": "本设备已被工作区移除",
-    "revokedBody": "工作区侧已撤销该配对，这里的智能体无法再连接。用新的配对码重新加入即可恢复。"
+    "revokedBody": "工作区侧已撤销该配对，这里的智能体无法再连接。"
   },
   "health": {
     "healthy": "正常",
@@ -97,7 +108,8 @@
     "justNow": "刚刚",
     "minutesAgo": "{{count}} 分钟前",
     "hoursAgo": "{{count}} 小时前",
-    "daysAgo": "{{count}} 天前"
+    "daysAgo": "{{count}} 天前",
+    "unknown": "—"
   },
   "quickConnect": {
     "title": "$t(common.actions.addWorkspace)",
@@ -157,5 +169,12 @@
   },
   "emptyNoneTitle": "还没有工作区",
   "emptyNoMatchTitle": "没有匹配的工作区",
-  "emptyNoFilterMatchTitle": "该筛选下没有工作区"
+  "emptyNoFilterMatchTitle": "该筛选下没有工作区",
+  "revokedNotice": {
+    "title": "工作区「{{name}}」已把这台设备移除",
+    "body": "该工作区已从本机移除。重新加入需要一个新的配对码。",
+    "bodyAgents": "该工作区已从本机移除，原先归属它的 {{count}} 个智能体已解除绑定（实例与数据保留）。重新加入同一个工作区会自动把它们绑回去。",
+    "rejoin": "重新加入",
+    "dismiss": "知道了"
+  }
 }

--- a/packages/launcher/src/renderer/lib/agent-state.ts
+++ b/packages/launcher/src/renderer/lib/agent-state.ts
@@ -1,16 +1,50 @@
 import type { Agent } from "@renderer/types"
 
-export type StateKey = "running" | "idle" | "starting" | "error" | "offline"
+export type StateKey =
+  | "running"
+  | "idle"
+  | "starting"
+  | "error"
+  | "offline"
+  /** No workspace: registered with the daemon, but nothing is driving it. */
+  | "notConnected"
 
 export const RUNNING_STATES = ["online", "running", "idle"]
 
-/** Lifecycle state → the label key and the tint the dashboard shows for it. */
+/**
+ * Lifecycle state → the label key and the tint every list shows for it.
+ *
+ * Membership is not a separate question here, because the core does not treat
+ * it as one. An agent with a workspace runs the adapter loop — poll the
+ * workspace, run the CLI per message. An agent without one takes the branch in
+ * daemon.js that writes `state: 'running'` and starts nothing at all
+ * ("running (local only, no workspace connected)"): no message source, no
+ * process, nothing to be running. Passing that `running` through to the UI
+ * reports work that is not happening, so the absence of a workspace is
+ * reported as what it is.
+ *
+ * A workspace whose credential has gone (this device was unpaired) is a
+ * different case again: the core sets `error` with "workspace credentials
+ * missing — re-pair this device", which is exactly what the user needs to
+ * read, so it stays an error.
+ */
 export function stateKeyOf(agent: Agent): StateKey {
+  if (!agent.network) return "notConnected"
   if (agent.state === "error" || agent.lastError) return "error"
   if (["online", "running"].includes(agent.state)) return "running"
   if (agent.state === "idle") return "idle"
   if (["starting", "reconnecting"].includes(agent.state)) return "starting"
   return "offline"
+}
+
+/**
+ * Running as every surface reports it — counts and the command palette
+ * included. Not `RUNNING_STATES.includes(agent.state)`: see `stateKeyOf` for
+ * why an agent with no workspace is not running whatever the core wrote.
+ */
+export function isRunning(agent: Agent): boolean {
+  const key = stateKeyOf(agent)
+  return key === "running" || key === "idle"
 }
 
 export const STATE_TEXT_CLASS: Record<StateKey, string> = {
@@ -19,6 +53,7 @@ export const STATE_TEXT_CLASS: Record<StateKey, string> = {
   starting: "text-(--warning-text)",
   error: "text-(--danger-text)",
   offline: "text-muted-foreground",
+  notConnected: "text-muted-foreground",
 }
 
 export const AGENT_FILTERS = ["all", "running", "error", "stopped"] as const
@@ -28,7 +63,8 @@ export function matchesFilter(agent: Agent, filter: AgentFilter): boolean {
   const key = stateKeyOf(agent)
   if (filter === "running") return key === "running" || key === "idle"
   if (filter === "error") return key === "error"
-  if (filter === "stopped") return key === "offline" || key === "starting"
+  if (filter === "stopped")
+    return key === "offline" || key === "starting" || key === "notConnected"
   return true
 }
 

--- a/packages/launcher/src/renderer/pages/agents/components/agent-card.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/agent-card.tsx
@@ -15,8 +15,6 @@ import {
   Unplug,
 } from "lucide-react"
 
-import { Badge } from "@renderer/components/ui/badge"
-import { usePairedWorkspaces } from "@renderer/hooks/use-paired-workspaces"
 import { Button } from "@renderer/components/ui/button"
 import { Card } from "@renderer/components/ui/card"
 import {
@@ -28,20 +26,12 @@ import {
 } from "@renderer/components/ui/dropdown-menu"
 import AgentIcon from "@renderer/components/AgentIcon"
 import { relativeTimeAgo } from "@renderer/lib/relative-time"
+import { STATE_TEXT_CLASS } from "@renderer/lib/agent-state"
+import { cn } from "@renderer/lib/utils"
 import { formatHealthLabel } from "../format-health-label"
-import type { AgentRow, AgentStatus } from "../use-agents-view"
+import type { AgentRow } from "../use-agents-view"
 import { AgentErrorDialog } from "./agent-error-dialog"
 import type { AgentActionHandlers } from "./agent-actions"
-
-const RUNNING_STATES = ["online", "running", "idle"]
-
-/** Same status vocabulary — and the same precedence — as the table view. */
-const STATUS_VARIANT: Record<AgentStatus, "success" | "danger" | "muted"> = {
-  running: "success",
-  error: "danger",
-  stopped: "muted",
-  disconnected: "muted",
-}
 
 interface Props extends AgentActionHandlers {
   row: AgentRow
@@ -80,9 +70,12 @@ export function AgentCard({
   onRemove,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
-  const pairedWorkspaces = usePairedWorkspaces()
   const { agent, providerLabel, model, auth, workspace, status, lastActiveAt } = row
-  const running = RUNNING_STATES.includes(agent.state)
+  // The status the tile is already showing, not a second opinion on the raw
+  // state: an agent with no workspace has `running` written for it while
+  // nothing drives it.
+  const running = status === "running" || status === "idle"
+  const connected = status !== "notConnected"
 
   return (
     <Card
@@ -101,12 +94,14 @@ export function AgentCard({
               {agent.name}
             </span>
             <span className="flex shrink-0 items-center gap-1">
-              <Badge variant={STATUS_VARIANT[status]} size="sm">
+              <span
+                className={cn("text-xs font-medium", STATE_TEXT_CLASS[status])}
+              >
                 {t(`agents.list.statuses.${status}`)}
-              </Badge>
+              </span>
               {/* Same affordance as the table: the tile has no room for the
                   message either, and both views must know the same facts. */}
-              {agent.lastError && (
+              {status === "error" && agent.lastError && (
                 <AgentErrorDialog
                   agentName={agent.name}
                   message={agent.lastError}
@@ -135,20 +130,11 @@ export function AgentCard({
             nothing to someone who has never met a workspace, and the same word
             "connected" used to appear here, on the badge and on the button for
             three different facts. */}
+        {/* The field keeps its shape whether or not there is a workspace: an
+            em dash where the name would be, not a second sentence — the status
+            above already says this agent is not connected to one. */}
         <Field icon={<FolderClosed />}>
-          {workspace
-            ? t("agents.list.workspaceLine", { name: workspace })
-            : t("agents.list.notConnected")}
-          {agent.network && !pairedWorkspaces.has(agent.network) && (
-            <Badge
-              variant="outline"
-              size="sm"
-              className="ml-1.5 shrink-0"
-              title={t("agents.list.legacyHint")}
-            >
-              {t("agents.list.legacyBadge")}
-            </Badge>
-          )}
+          {t("agents.list.workspaceLine", { name: workspace || "—" })}
         </Field>
       </div>
 
@@ -239,14 +225,23 @@ export function AgentCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              disabled={pending}
-              data-testid={`agent-toggle-${agent.name}`}
-              onClick={() => onToggle(agent)}
-            >
-              {running ? <Square /> : <Play />}
-              {running ? t("agents.list.stop") : t("agents.list.start")}
-            </DropdownMenuItem>
+            {/* Nothing to start or stop without a workspace — there is no
+                message source and no process, so both are offers the launcher
+                cannot keep. Joining one is the only move, and the tile's own
+                button already offers it. */}
+            {connected && (
+              <DropdownMenuItem
+                // Stopping is a destructive entry point and is coloured like
+                // every other one; starting is not.
+                variant={running ? "destructive" : "default"}
+                disabled={pending}
+                data-testid={`agent-toggle-${agent.name}`}
+                onClick={() => onToggle(agent)}
+              >
+                {running ? <Square /> : <Play />}
+                {running ? t("agents.list.stop") : t("agents.list.start")}
+              </DropdownMenuItem>
+            )}
             {agent.network ? (
               <>
                 <DropdownMenuItem onClick={() => onOpenWorkspace(agent)}>

--- a/packages/launcher/src/renderer/pages/agents/components/agents-table.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/agents-table.tsx
@@ -11,7 +11,6 @@ import {
   Unplug,
 } from "lucide-react"
 
-import { Badge } from "@renderer/components/ui/badge"
 import { Button } from "@renderer/components/ui/button"
 import {
   DropdownMenu,
@@ -29,21 +28,12 @@ import {
   TableRow,
 } from "@renderer/components/ui/table"
 import AgentIcon from "@renderer/components/AgentIcon"
-import { usePairedWorkspaces } from "@renderer/hooks/use-paired-workspaces"
 import { relativeTimeAgo } from "@renderer/lib/relative-time"
+import { STATE_TEXT_CLASS } from "@renderer/lib/agent-state"
 import { cn } from "@renderer/lib/utils"
-import type { AgentRow, AgentStatus } from "../use-agents-view"
+import type { AgentRow } from "../use-agents-view"
 import { AgentErrorDialog } from "./agent-error-dialog"
 import type { AgentActionHandlers } from "./agent-actions"
-
-const STATUS_VARIANT: Record<AgentStatus, "success" | "danger" | "muted"> = {
-  running: "success",
-  error: "danger",
-  stopped: "muted",
-  disconnected: "muted",
-}
-
-const RUNNING_STATES = ["online", "running", "idle"]
 
 const COLUMNS = [
   "agent",
@@ -76,7 +66,6 @@ export function AgentsTable({
   onRemove,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
-  const pairedWorkspaces = usePairedWorkspaces()
 
   return (
     <div className="overflow-hidden rounded-xl border bg-card">
@@ -101,7 +90,11 @@ export function AgentsTable({
         </TableHeader>
         <TableBody>
           {rows.map(({ agent, providerLabel, model, auth, workspace, status, lastActiveAt }) => {
-            const running = RUNNING_STATES.includes(agent.state)
+            // Read from the status the row is already showing, not a second
+            // opinion on the raw state: an agent with no workspace has
+            // `running` written for it while nothing drives it.
+            const running = status === "running" || status === "idle"
+            const connected = status !== "notConnected"
             const busy = pending.has(agent.name)
             return (
               <TableRow
@@ -171,19 +164,7 @@ export function AgentsTable({
                       <span className="truncate">{workspace}</span>
                     </Button>
                   ) : (
-                    <span className="text-xs text-muted-foreground">—</span>
-                  )}
-                  {/* Manual-token connection to a workspace this device is
-                      not paired with — the path being retired. */}
-                  {agent.network && !pairedWorkspaces.has(agent.network) && (
-                    <Badge
-                      variant="outline"
-                      size="sm"
-                      className="ml-1.5 shrink-0"
-                      title={t("agents.list.legacyHint")}
-                    >
-                      {t("agents.list.legacyBadge")}
-                    </Badge>
+                    <span className="text-sm text-muted-foreground">—</span>
                   )}
                 </TableCell>
 
@@ -192,10 +173,15 @@ export function AgentsTable({
                     widened the column at every other column's expense. */}
                 <TableCell>
                   <div className="flex items-center gap-1">
-                    <Badge variant={STATUS_VARIANT[status]}>
+                    <span
+                      className={cn(
+                        "text-sm font-medium",
+                        STATE_TEXT_CLASS[status],
+                      )}
+                    >
                       {t(`agents.list.statuses.${status}`)}
-                    </Badge>
-                    {agent.lastError && (
+                    </span>
+                    {status === "error" && agent.lastError && (
                       <AgentErrorDialog
                         agentName={agent.name}
                         message={agent.lastError}
@@ -264,16 +250,25 @@ export function AgentsTable({
                           <SlidersHorizontal />
                           {t("agents.list.configure")}
                         </DropdownMenuItem>
-                        <DropdownMenuItem
-                          disabled={busy}
-                          data-testid={`agent-toggle-${agent.name}`}
-                          onClick={() => onToggle(agent)}
-                        >
-                          {running ? <Square /> : <Play />}
-                          {running
-                            ? t("agents.list.stop")
-                            : t("agents.list.start")}
-                        </DropdownMenuItem>
+                        {/* Nothing to start or stop without a workspace —
+                            there is no message source and no process, so both
+                            are offers the launcher cannot keep. Joining one is
+                            the only move, and the row already offers it. */}
+                        {connected && (
+                          <DropdownMenuItem
+                            // Stopping is a destructive entry point and is
+                            // coloured like every other one; starting is not.
+                            variant={running ? "destructive" : "default"}
+                            disabled={busy}
+                            data-testid={`agent-toggle-${agent.name}`}
+                            onClick={() => onToggle(agent)}
+                          >
+                            {running ? <Square /> : <Play />}
+                            {running
+                              ? t("agents.list.stop")
+                              : t("agents.list.start")}
+                          </DropdownMenuItem>
+                        )}
                         {agent.network && (
                           <DropdownMenuItem onClick={() => onDisconnect(agent)}>
                             <Unplug />

--- a/packages/launcher/src/renderer/pages/agents/components/connect-workspace-dialog.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/connect-workspace-dialog.tsx
@@ -12,11 +12,13 @@ import {
   DialogTitle,
 } from "@renderer/components/ui/dialog"
 import { Button } from "@renderer/components/ui/button"
+import { Skeleton } from "@renderer/components/ui/skeleton"
 import { SearchInput } from "@renderer/components/ui-kit"
 import { useAgentsStore } from "@renderer/store/agents"
 import { useUiStore } from "@renderer/store/ui"
 import { capture } from "@renderer/lib/analytics"
 import { cn } from "@renderer/lib/utils"
+import type { NodeStatus } from "@renderer/types"
 import type { ToastType } from "@renderer/hooks/useToast"
 
 interface WorkspaceOption {
@@ -25,6 +27,28 @@ interface WorkspaceOption {
   name?: string
   endpoint?: string
   token?: string
+}
+
+/**
+ * The workspaces this device actually holds a pairing for.
+ *
+ * `listWorkspaces()` returns the core's local entries, which are a separate
+ * record from the pairings in node.json and only kept in step by hand — so a
+ * workspace that has removed this device stays in it until something notices.
+ * Offering one of those to bind to produces a join that cannot authenticate,
+ * so the pairing set is what the list is drawn from. No pairings, no options:
+ * the empty state sends the user to the Workspaces page to join one.
+ */
+function pairedOnly(
+  list: WorkspaceOption[],
+  node: NodeStatus | null,
+): WorkspaceOption[] {
+  const keys = new Set<string>()
+  for (const w of node?.workspaces || []) {
+    if (w.workspaceSlug) keys.add(w.workspaceSlug)
+    if (w.workspaceId) keys.add(w.workspaceId)
+  }
+  return list.filter((ws) => keys.has(ws.slug) || keys.has(ws.id))
 }
 
 export function ConnectWorkspaceDialog({
@@ -43,7 +67,9 @@ export function ConnectWorkspaceDialog({
   const { t } = useTranslation()
   const agents = useAgentsStore((s) => s.agents)
   const requestCreate = useUiStore((s) => s.requestCreate)
-  const [workspaces, setWorkspaces] = useState<WorkspaceOption[]>([])
+  // null until the pairings have answered — an empty list is a real answer
+  // ("this device is in no workspace") and the two must not read alike.
+  const [workspaces, setWorkspaces] = useState<WorkspaceOption[] | null>(null)
   const [query, setQuery] = useState("")
   const [cursor, setCursor] = useState(0)
   const listRef = useRef<HTMLDivElement>(null)
@@ -52,16 +78,56 @@ export function ConnectWorkspaceDialog({
     if (!open) return
     setQuery("")
     setCursor(0)
-    window.api.listWorkspaces().then(setWorkspaces).catch(() => {})
+    setWorkspaces(null)
+    let cancelled = false
+
+    void (async () => {
+      // node.json first: it is on disk, so the list is right without waiting
+      // for the network.
+      let list: WorkspaceOption[] = []
+      let node: NodeStatus | null = null
+      try {
+        ;[list, node] = await Promise.all([
+          window.api.listWorkspaces(),
+          window.api.getNodeStatus(),
+        ])
+      } catch {
+        // Either record unreadable — offer nothing. Binding needs a pairing,
+        // so an empty list is the honest answer, not a reason to fall back to
+        // the unverified one.
+      }
+      if (cancelled) return
+      setWorkspaces(pairedOnly(list, node))
+
+      // Then ask the workspaces themselves, since being removed happens on
+      // their side and nothing tells this machine. Until now only the
+      // Workspaces page ever asked, so a device removed while the user was
+      // anywhere else went on offering the workspace it had lost. `force`
+      // skips the once-a-minute throttle that page's polling relies on.
+      let fresh: NodeStatus | null = null
+      try {
+        fresh = await window.api.refreshNodeStatus(true)
+      } catch {
+        // Offline — what is on disk stands.
+      }
+      if (cancelled || !fresh) return
+      setWorkspaces(pairedOnly(list, fresh))
+    })()
+
+    return () => {
+      cancelled = true
+    }
   }, [open])
+
+  const options = workspaces || []
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
-    if (!q) return workspaces
-    return workspaces.filter((ws) =>
+    if (!q) return options
+    return options.filter((ws) =>
       [ws.name, ws.slug, ws.id].some((v) => v?.toLowerCase().includes(q)),
     )
-  }, [workspaces, query])
+  }, [options, query])
 
   // Keep the cursor inside the result set as the query narrows it.
   useEffect(() => setCursor(0), [query])
@@ -117,18 +183,28 @@ export function ConnectWorkspaceDialog({
           <DialogTitle>
             {t("agents.connectDialog.title", { name: agentName })}
           </DialogTitle>
-          {workspaces.length > 0 && (
+          {options.length > 0 && (
             <DialogDescription>
               {t("agents.connectDialog.keyboardHint")}
             </DialogDescription>
           )}
         </DialogHeader>
 
-        {workspaces.length === 0 ? (
-          /* This dialog picks from the workspaces this device has already
-             joined; joining one is the Workspaces page's job, so with none to
-             pick from the empty state hands the user over to it rather than
-             growing a second pairing form. */
+        {workspaces === null ? (
+          /* Not the empty state: until the pairings answer, "this device is in
+             no workspace" is not yet known, and showing it would send the user
+             off to re-pair a device that is paired. */
+          <DialogBody className="gap-2 py-6">
+            <Skeleton className="h-9 shrink-0" />
+            <Skeleton className="h-9 shrink-0" />
+            <Skeleton className="h-9 shrink-0" />
+          </DialogBody>
+        ) : options.length === 0 ? (
+          /* This dialog picks from the workspaces this device is paired with;
+             pairing is the Workspaces page's job, so with none to pick from the
+             empty state hands the user over to it rather than growing a second
+             pairing form. A workspace that removed this device lands here too:
+             it is gone from the list the moment its pairing is. */
           <>
             <DialogBody className="items-center gap-2 py-10 text-center">
               <Laptop className="size-6 text-muted-foreground" />

--- a/packages/launcher/src/renderer/pages/agents/index.test.tsx
+++ b/packages/launcher/src/renderer/pages/agents/index.test.tsx
@@ -43,6 +43,15 @@ function installApi(overrides: Partial<Api> = {}): Api {
       workspaces: [],
       revoked: [],
     }),
+    // The connect dialog re-checks the pairings against the workspaces
+    // themselves before it offers any: being removed happens on their side.
+    refreshNodeStatus: vi.fn().mockResolvedValue({
+      connected: false,
+      workspaceSlug: null,
+      workspaceName: null,
+      workspaces: [],
+      revoked: [],
+    }),
     connectNode: vi.fn().mockResolvedValue({
       connected: true,
       workspaceSlug: "paired-ws",
@@ -183,6 +192,16 @@ describe("ConnectWorkspaceDialog — picking a workspace", () => {
     return user
   }
 
+  const PAIRED_TEAM_A = {
+    connected: true,
+    workspaceSlug: "team-a",
+    workspaceName: "Team A",
+    workspaces: [
+      { nodeId: "n1", workspaceId: "id-1", workspaceSlug: "team-a" },
+    ],
+    revoked: [],
+  }
+
   it("connects to an existing workspace from the list", async () => {
     const api = installApi({
       listAgents: vi
@@ -191,6 +210,8 @@ describe("ConnectWorkspaceDialog — picking a workspace", () => {
       listWorkspaces: vi.fn().mockResolvedValue([
         { id: "id-1", slug: "team-a", name: "Team A", endpoint: "", token: "t" },
       ]),
+      getNodeStatus: vi.fn().mockResolvedValue(PAIRED_TEAM_A),
+      refreshNodeStatus: vi.fn().mockResolvedValue(PAIRED_TEAM_A),
     })
     const user = await openConnectDialog(api)
 
@@ -217,6 +238,66 @@ describe("ConnectWorkspaceDialog — picking a workspace", () => {
     expect(useUiStore.getState().pendingCreate).toBe("workspace")
   })
 
+  /**
+   * The workspace's own record and this device's pairing are two separate
+   * files kept in step by hand, so a workspace that removed this device goes
+   * on sitting in the local list. Binding an agent to that one produces a join
+   * that cannot authenticate — every call carries a credential the workspace
+   * has stopped honouring — so the pairing decides what is offered.
+   */
+  it("does not offer a workspace this device is no longer paired with", async () => {
+    const api = installApi({
+      listAgents: vi
+        .fn()
+        .mockResolvedValue([makeAgent({ name: "lonely", network: null })]),
+      // Still in the core's local list...
+      listWorkspaces: vi.fn().mockResolvedValue([
+        { id: "id-1", slug: "team-a", name: "Team A", endpoint: "", token: "t" },
+      ]),
+      // ...but the workspace removed this device, so there is no pairing.
+      getNodeStatus: vi.fn().mockResolvedValue({
+        connected: false,
+        workspaceSlug: null,
+        workspaceName: null,
+        workspaces: [],
+        revoked: [
+          { workspaceId: "id-1", workspaceSlug: "team-a", workspaceName: "Team A" },
+        ],
+      }),
+    })
+    await openConnectDialog(api)
+
+    await screen.findByText(/isn't in any workspace yet/i)
+    expect(screen.queryByRole("button", { name: /team a/i })).not.toBeInTheDocument()
+    expect(api.connectWorkspace).not.toHaveBeenCalled()
+  })
+
+  // Being removed happens on the workspace's side and nothing tells this
+  // machine, so opening the dialog is itself a reason to go and ask.
+  it("re-checks the pairings against the workspaces when it opens", async () => {
+    const api = installApi({
+      listAgents: vi
+        .fn()
+        .mockResolvedValue([makeAgent({ name: "lonely", network: null })]),
+      listWorkspaces: vi.fn().mockResolvedValue([
+        { id: "id-1", slug: "team-a", name: "Team A", endpoint: "", token: "t" },
+      ]),
+      getNodeStatus: vi.fn().mockResolvedValue(PAIRED_TEAM_A),
+      // The check comes back saying the pairing is gone.
+      refreshNodeStatus: vi.fn().mockResolvedValue({
+        connected: false,
+        workspaceSlug: null,
+        workspaceName: null,
+        workspaces: [],
+        revoked: [],
+      }),
+    })
+    await openConnectDialog(api)
+
+    await waitFor(() => expect(api.refreshNodeStatus).toHaveBeenCalledWith(true))
+    await screen.findByText(/isn't in any workspace yet/i)
+  })
+
   // Neither manual tokens nor a pairing form live here: this dialog picks from
   // the workspaces this device has already joined, and does nothing else.
   it("offers no pairing form of its own", async () => {
@@ -227,6 +308,8 @@ describe("ConnectWorkspaceDialog — picking a workspace", () => {
       listWorkspaces: vi.fn().mockResolvedValue([
         { id: "id-1", slug: "team-a", name: "Team A", endpoint: "", token: "t" },
       ]),
+      getNodeStatus: vi.fn().mockResolvedValue(PAIRED_TEAM_A),
+      refreshNodeStatus: vi.fn().mockResolvedValue(PAIRED_TEAM_A),
     })
     await openConnectDialog(api)
 

--- a/packages/launcher/src/renderer/pages/agents/use-agents-view.ts
+++ b/packages/launcher/src/renderer/pages/agents/use-agents-view.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 
 import type { Agent } from "@renderer/types"
 import { deriveModel } from "@renderer/lib/agent-model"
+import { stateKeyOf, type StateKey } from "@renderer/lib/agent-state"
 import { useAgentActivity } from "./use-agent-activity"
 
 export const AGENT_FILTERS = ["all", "running", "error", "disconnected"] as const
@@ -15,9 +16,8 @@ export type AgentView = (typeof AGENT_VIEWS)[number]
 
 export const PAGE_SIZES = [10, 20, 50] as const
 
-const RUNNING_STATES = ["online", "running", "idle"]
-
-export type AgentStatus = "running" | "error" | "stopped" | "disconnected"
+/** The list shows the same five process states the dashboard does. */
+export type AgentStatus = StateKey
 
 export interface AgentRow {
   agent: Agent
@@ -28,20 +28,11 @@ export interface AgentRow {
   /** How the agent authenticates, once a health check has reported it. */
   auth: "api_key" | "cli_login" | null
   workspace: string | null
+  /** What the process is doing. Membership is `connected`, not a status. */
   status: AgentStatus
+  /** Whether the agent belongs to a workspace at all. */
+  connected: boolean
   lastActiveAt: string | null
-}
-
-/**
- * Status precedence. An agent with no workspace is "not connected" whatever
- * its process state — connecting it is the next thing to do either way, and
- * that is what the row's action offers.
- */
-function deriveStatus(agent: Agent): AgentStatus {
-  if (!agent.network) return "disconnected"
-  if (agent.state === "error" || agent.lastError) return "error"
-  if (RUNNING_STATES.includes(agent.state)) return "running"
-  return "stopped"
 }
 
 export interface AgentsView {
@@ -105,7 +96,8 @@ export function useAgentsView(
             ? "cli_login"
             : null,
         workspace: agent.networkName || agent.network || null,
-        status: deriveStatus(agent),
+        status: stateKeyOf(agent),
+        connected: !!agent.network,
         lastActiveAt: lastActive[agent.name] || null,
       })),
     [agents, labels, lastActive],
@@ -119,9 +111,9 @@ export function useAgentsView(
       disconnected: 0,
     }
     for (const r of allRows) {
-      if (r.status === "running") c.running += 1
+      if (r.status === "running" || r.status === "idle") c.running += 1
       else if (r.status === "error") c.error += 1
-      else if (r.status === "disconnected") c.disconnected += 1
+      if (!r.connected) c.disconnected += 1
     }
     return c
   }, [allRows])
@@ -129,7 +121,18 @@ export function useAgentsView(
   const rows = useMemo(() => {
     const q = search.trim().toLowerCase()
     const out = allRows.filter((r) => {
-      if (filter !== "all" && r.status !== filter) return false
+      // "disconnected" asks about membership, the others about the process —
+      // an agent with no workspace can still be running, and both tabs are
+      // entitled to it.
+      if (filter !== "all") {
+        const inTab =
+          filter === "disconnected"
+            ? !r.connected
+            : filter === "running"
+              ? r.status === "running" || r.status === "idle"
+              : r.status === filter
+        if (!inTab) return false
+      }
       if (!q) return true
       return (
         r.agent.name.toLowerCase().includes(q) ||
@@ -141,9 +144,11 @@ export function useAgentsView(
     })
     const STATUS_ORDER: AgentStatus[] = [
       "error",
+      "starting",
       "running",
-      "stopped",
-      "disconnected",
+      "idle",
+      "offline",
+      "notConnected",
     ]
     out.sort((a, b) => {
       if (sort === "name") return a.agent.name.localeCompare(b.agent.name)

--- a/packages/launcher/src/renderer/pages/dashboard/components/agents-card.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/components/agents-card.tsx
@@ -30,7 +30,6 @@ import {
   TableRow,
 } from "@renderer/components/ui/table"
 import {
-  RUNNING_STATES,
   STATE_TEXT_CLASS,
   stateKeyOf,
   workspaceLabel,
@@ -56,6 +55,7 @@ interface Props {
   pending: Set<string>
   onToggle: (agent: Agent) => void
   onOpenTerminal: (agent: Agent) => void
+  onConnect: (agent: Agent) => void
   onManage: (agent: Agent) => void
   onViewAll: () => void
   onNewAgent: () => void
@@ -74,6 +74,7 @@ export function AgentsCard({
   pending,
   onToggle,
   onOpenTerminal,
+  onConnect,
   onManage,
   onViewAll,
   onNewAgent,
@@ -137,6 +138,7 @@ export function AgentsCard({
                   busy={pending.has(agent.name)}
                   onToggle={() => onToggle(agent)}
                   onOpenTerminal={() => onOpenTerminal(agent)}
+                  onConnect={() => onConnect(agent)}
                   onManage={() => onManage(agent)}
                 />
               ))}
@@ -154,6 +156,7 @@ interface RowProps {
   busy: boolean
   onToggle: () => void
   onOpenTerminal: () => void
+  onConnect: () => void
   onManage: () => void
 }
 
@@ -163,13 +166,18 @@ function AgentTableRow({
   busy,
   onToggle,
   onOpenTerminal,
+  onConnect,
   onManage,
 }: RowProps): React.JSX.Element {
   const { t } = useTranslation()
 
   const stateKey = stateKeyOf(agent)
-  const running = RUNNING_STATES.includes(agent.state)
-  const workspace = workspaceLabel(agent) || t("dashboard.agents.noWorkspace")
+  // Not "what did the core write" — an agent with no workspace has `running`
+  // written for it while nothing runs, so starting, stopping and stepping into
+  // it are all offers the launcher cannot keep.
+  const notConnected = stateKey === "notConnected"
+  const running = stateKey === "running" || stateKey === "idle"
+  const workspace = workspaceLabel(agent)
   const model = deriveModel(agent) || agent.type
 
   return (
@@ -190,11 +198,11 @@ function AgentTableRow({
         </div>
       </TableCell>
 
-      <TableCell
-        className="max-w-40 truncate text-xs text-muted-foreground"
-        title={workspace}
-      >
-        {workspace}
+      {/* Same shape as the agents list: the name when there is one, an em
+          dash when there is not — never a sentence, which the status column
+          next to it is already saying. */}
+      <TableCell className="max-w-40 truncate text-sm" title={workspace}>
+        {workspace || <span className="text-muted-foreground">—</span>}
       </TableCell>
 
       <TableCell>
@@ -214,7 +222,15 @@ function AgentTableRow({
               with no CLI to step into — stop it. Whatever the row does not
               show inline is the only thing the menu adds; repeating the inline
               button inside the menu is what made it read as duplicated. */}
-          {!running ? (
+          {notConnected ? (
+            // The one move that changes anything here, and the same one the
+            // agents list offers: give it a workspace to work in. It is dressed
+            // the same as there too — primary, unadorned — because the same
+            // offer wearing two different buttons reads as two offers.
+            <Button size="sm" onClick={onConnect}>
+              {t("dashboard.agents.connect")}
+            </Button>
+          ) : !running ? (
             <Button
               size="sm"
               variant="outline"
@@ -254,7 +270,7 @@ function AgentTableRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {running && agent.hasCli && (
+              {!notConnected && running && agent.hasCli && (
                 <DropdownMenuItem
                   variant="destructive"
                   disabled={busy}

--- a/packages/launcher/src/renderer/pages/dashboard/index.tsx
+++ b/packages/launcher/src/renderer/pages/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React, { useMemo, useState } from "react"
 import { useShallow } from "zustand/react/shallow"
 
 import { useAgentsStore } from "@renderer/store/agents"
@@ -7,7 +7,7 @@ import { useInstallStore } from "@renderer/store/install"
 import { useNotificationsStore } from "@renderer/store/notifications"
 import { useUpdateDismissals } from "@renderer/hooks/useUpdateDismissals"
 import { useWorkspacePrefs } from "@renderer/store/workspace-prefs"
-import { RUNNING_STATES } from "@renderer/lib/agent-state"
+import { isRunning } from "@renderer/lib/agent-state"
 import { workspacePageUrl } from "@renderer/lib/workspace-urls"
 import { isUpgradeAvailable } from "../../../shared/version-compare"
 import type { ToastType } from "@renderer/hooks/useToast"
@@ -17,6 +17,7 @@ import { useAgentActions } from "./use-agent-actions"
 import { mergeActivity, pickRecentAgents, pickRecentWorkspaces } from "./recent"
 import { PendingUpdatesBanner } from "./components/pending-updates-banner"
 import { WelcomeHero } from "./components/welcome-hero"
+import { ConnectWorkspaceDialog } from "../agents/components/connect-workspace-dialog"
 import { AgentsCard } from "./components/agents-card"
 import { WorkspacesCard } from "./components/workspaces-card"
 import { HealthCard } from "./components/health-card"
@@ -75,9 +76,7 @@ export default function Dashboard({
     [data.workspaces, lastUsedAt],
   )
 
-  const runningCount = agents.filter((a) =>
-    RUNNING_STATES.includes(a.state),
-  ).length
+  const runningCount = agents.filter(isRunning).length
   const attentionCount = agents.filter(
     (a) => a.state === "error" || !!a.lastError,
   ).length
@@ -98,6 +97,11 @@ export default function Dashboard({
   // — so the request sat unconsumed in the store and fired on some later,
   // unrelated visit there, opening an agent nobody had asked for.
   const manageAgent = (): void => setCurrentTab("agents")
+
+  // Joining a workspace is offered here as well as on the agents list, so the
+  // dashboard opens the same dialog rather than dropping the user on a page
+  // and leaving them to find it.
+  const [connectAgent, setConnectAgent] = useState<string>("")
 
   // Same as the workspaces page: opening one is what marks it as used, which is
   // what this card orders by.
@@ -142,6 +146,7 @@ export default function Dashboard({
             pending={pendingAgentActions}
             onToggle={(a) => void actions.toggle(a)}
             onOpenTerminal={(a) => actions.openTerminal(a)}
+            onConnect={(a) => setConnectAgent(a.name)}
             onManage={() => manageAgent()}
             onViewAll={() => setCurrentTab("agents")}
             onNewAgent={() => requestCreate("agent")}
@@ -164,6 +169,14 @@ export default function Dashboard({
           <ActivityCard uiActivity={activityLog} notifications={notifItems} />
         </div>
       </div>
+
+      <ConnectWorkspaceDialog
+        open={!!connectAgent}
+        agentName={connectAgent}
+        onClose={() => setConnectAgent("")}
+        showToast={showToast}
+        onConnected={data.refresh}
+      />
     </section>
   )
 }

--- a/packages/launcher/src/renderer/pages/install/detail/detail-actions.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-actions.tsx
@@ -3,6 +3,7 @@ import { Download, RefreshCw, Trash2, Undo2, Wand2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "@renderer/components/ui/button"
+import { Skeleton } from "@renderer/components/ui/skeleton"
 import { Spinner } from "@renderer/components/ui/spinner"
 import type { CatalogEntry, InstalledAgentRecord } from "@renderer/types"
 import type { InstallJob } from "@renderer/store/install"
@@ -12,6 +13,8 @@ import { isJobBusy } from "../entry-meta"
 
 interface Props {
   entry: CatalogEntry
+  /** This agent's installed/latest versions are still being read. */
+  loading: boolean
   installed: InstalledAgentRecord | null
   job: InstallJob | undefined
   latestVersion: string | null
@@ -45,6 +48,7 @@ const BUSY_LABEL: Record<InstallJob["verb"], string> = {
  */
 export function DetailActions({
   entry,
+  loading,
   installed,
   job,
   latestVersion,
@@ -76,6 +80,21 @@ export function DetailActions({
         <Spinner />
         {t(BUSY_LABEL[job.verb])}
       </Button>
+    )
+  }
+
+  // Which buttons belong here is decided by facts that arrive from IPC —
+  // installed version, latest version, rollback history. Rendering the default
+  // set meanwhile put "Reinstall" under an agent that had an update pending,
+  // then swapped it out; the user opened this page BECAUSE of that update.
+  // Placeholders until we know: only the count is guessed, from the catalog.
+  if (loading) {
+    return (
+      <>
+        {Array.from({ length: entry.installed ? 3 : 1 }, (_, i) => (
+          <Skeleton key={i} className="h-9 w-full" />
+        ))}
+      </>
     )
   }
 

--- a/packages/launcher/src/renderer/pages/install/detail/detail-header.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-header.tsx
@@ -3,6 +3,7 @@ import { ExternalLink } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import AgentIcon from "@renderer/components/AgentIcon"
+import { Skeleton } from "@renderer/components/ui/skeleton"
 import type { CatalogEntry } from "@renderer/types"
 import { isUpgradeAvailable } from "../../../../shared/version-compare"
 
@@ -17,6 +18,8 @@ interface Props {
   github?: string
   docs?: string
   installedAtLabel?: string | null
+  /** Versions are still being read, so the status is not known yet. */
+  loading: boolean
 }
 
 /**
@@ -32,6 +35,7 @@ export function DetailHeader({
   github,
   docs,
   installedAtLabel,
+  loading,
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
   const status = entryStatus(
@@ -61,7 +65,14 @@ export function DetailHeader({
           <h2 className="m-0 truncate text-2xl font-bold tracking-tight">
             {entry.label || entry.name}
           </h2>
-          <AgentStatusBadge status={status} />
+          {/* "Installed" and "Update available" are the same badge in two
+              states, and the second one is why most people open this page —
+              so it waits for the versions rather than claiming the first. */}
+          {loading ? (
+            <Skeleton className="h-5 w-16 rounded-full" />
+          ) : (
+            <AgentStatusBadge status={status} />
+          )}
         </div>
 
         <p className="m-0 mt-1.5 text-sm leading-relaxed text-muted-foreground">

--- a/packages/launcher/src/renderer/pages/install/detail/detail-rail.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/detail-rail.tsx
@@ -11,6 +11,8 @@ import { UnmanagedNotice } from "./detail-unmanaged-notice"
 
 interface Props {
   entry: CatalogEntry
+  /** This agent's own state has not been read yet — see DetailActions. */
+  loading: boolean
   installed: InstalledAgentRecord | null
   job: InstallJob | undefined
   currentVersion: string | null
@@ -32,6 +34,7 @@ interface Props {
  */
 export function DetailRail({
   entry,
+  loading,
   installed,
   job,
   currentVersion,
@@ -49,6 +52,7 @@ export function DetailRail({
       <RailCard>
         <DetailActions
           entry={entry}
+          loading={loading}
           installed={installed}
           job={job}
           currentVersion={currentVersion}

--- a/packages/launcher/src/renderer/pages/install/detail/index.tsx
+++ b/packages/launcher/src/renderer/pages/install/detail/index.tsx
@@ -97,6 +97,7 @@ export default function AgentDetail({
 
         <DetailHeader
           entry={entry}
+          loading={detail.loading}
           currentVersion={detail.currentVersion}
           latestVersion={detail.latestVersion}
           homepage={entry.homepage || detail.changelog.homepage}
@@ -195,6 +196,7 @@ export default function AgentDetail({
         <DetailRail
           className="lg:-mt-1 lg:min-h-0 lg:w-72 lg:shrink-0 lg:overflow-y-auto lg:pt-1 lg:pr-2 lg:pb-2"
           entry={entry}
+          loading={detail.loading}
           installed={detail.installed}
           job={detail.job}
           currentVersion={detail.currentVersion}

--- a/packages/launcher/src/renderer/pages/install/detail/use-agent-detail.ts
+++ b/packages/launcher/src/renderer/pages/install/detail/use-agent-detail.ts
@@ -30,6 +30,12 @@ interface Options {
 }
 
 interface AgentDetailView {
+  /**
+   * True until this agent's own state has been read. The rail and the status
+   * badge answer "is there an update" from it, and neither may guess: the
+   * facts arrive together, a few hundred ms in.
+   */
+  loading: boolean
   envFields: EnvField[]
   envValues: Record<string, string>
   setEnvValues: (next: Record<string, string>) => void
@@ -69,6 +75,13 @@ export function useAgentDetail({
     latest: null,
     loading: true,
   })
+  /**
+   * Which agent the state above actually describes. Not a boolean: the fetch
+   * re-runs on the same agent (after an install finishes) and must not blank
+   * the rail each time, while switching agents must not show the previous
+   * one's answers for a frame.
+   */
+  const [loadedFor, setLoadedFor] = useState<string | null>(null)
 
   const setStoreAgents = useAgentsStore((s) => s.setAgents)
   // Read from the shared agents store so other tabs' polling and the wizard's
@@ -79,6 +92,17 @@ export function useAgentDetail({
   )
   const job = useInstallStore((s) => s.jobs[entry.name])
   const jobPhase = job?.phase
+  // Seeded from what the marketplace list already fetched, so arriving from it
+  // — the way most people get here — renders the right buttons at once, not a
+  // spinner over facts we hold. Only PRESENCE counts: an agent missing
+  // from `updates` may be one the background probe has not reached yet, which
+  // is not the same as an agent that is up to date.
+  const storeInstalled = useInstallStore(
+    (s) => s.installed.find((i) => i.name === entry.name) || null,
+  )
+  const storeUpdate = useInstallStore(
+    (s) => s.updates.find((u) => u.name === entry.name) || null,
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -127,8 +151,13 @@ export function useAgentDetail({
           error: change.error,
           loading: false,
         })
+        setLoadedFor(entry.name)
       } catch {
-        if (!cancelled) setChangelog((s) => ({ ...s, loading: false }))
+        if (cancelled) return
+        setChangelog((s) => ({ ...s, loading: false }))
+        // Failed is still answered: what we know is what we have, and holding
+        // skeletons forever would be worse than showing it.
+        setLoadedFor(entry.name)
       }
     })()
     return () => {
@@ -239,20 +268,28 @@ export function useAgentDetail({
     }
   }, [job?.log, showToast, t])
 
+  const record = installed || storeInstalled
+  const latestVersion =
+    update?.latest || storeUpdate?.latest || changelog.latest || null
+
   return {
+    // An agent that is not installed has one button, and the catalog already
+    // said so. The wait only applies to the installed case, where which button
+    // belongs here depends on a version comparison we cannot make yet.
+    loading: !!entry.installed && loadedFor !== entry.name && !latestVersion,
     envFields,
     envValues,
     setEnvValues,
-    installed,
+    installed: record,
     changelog,
     hasInstance,
     job,
-    currentVersion: installed?.version || health?.version || null,
+    currentVersion: record?.version || health?.version || null,
     // Where the CLI resolved to. Only interesting for an install outside
     // ~/.openagents/, where it is the difference between "the button is broken"
     // and "there is a second copy over here".
     binaryPath: health?.binary || null,
-    latestVersion: update?.latest || changelog.latest || null,
+    latestVersion,
     startInstall,
     startUninstall,
     startRollback,

--- a/packages/launcher/src/renderer/pages/settings/sections/agents-section.tsx
+++ b/packages/launcher/src/renderer/pages/settings/sections/agents-section.tsx
@@ -4,7 +4,7 @@ import { ChevronRight } from "lucide-react"
 
 import { Button } from "@renderer/components/ui/button"
 import { Switch } from "@renderer/components/ui/switch"
-import { RUNNING_STATES } from "@renderer/lib/agent-state"
+import { isRunning } from "@renderer/lib/agent-state"
 import { useUiStore } from "@renderer/store/ui"
 import { SettingsCard,
   Row,
@@ -33,7 +33,7 @@ export function AgentsSection({
   const setCurrentTab = useUiStore((s) => s.setCurrentTab)
   const goToInstallList = useUiStore((s) => s.goToInstallList)
 
-  const running = agents.filter((a) => RUNNING_STATES.includes(a.state)).length
+  const running = agents.filter(isRunning).length
   const types = new Set(agents.map((a) => a.type).filter(Boolean)).size
 
   return (

--- a/packages/launcher/src/renderer/pages/workspaces/index.tsx
+++ b/packages/launcher/src/renderer/pages/workspaces/index.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "@renderer/components/ui-kit"
 import { WorkspaceCard } from "@renderer/components/workspaces/WorkspaceCard"
 import { WorkspaceQuickConnect } from "@renderer/components/workspaces/WorkspaceQuickConnect"
 import { WorkspaceRemoveDialog } from "@renderer/components/workspaces/WorkspaceRemoveDialog"
+import { WorkspaceRevokedNotice } from "@renderer/components/workspaces/WorkspaceRevokedNotice"
 import { WorkspaceRenameDialog } from "@renderer/components/workspaces/WorkspaceRenameDialog"
 import { useConnectionsStore } from "@renderer/store/connections"
 import { useUiStore } from "@renderer/store/ui"
@@ -51,12 +52,26 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
   const [sort, setSort] = useState<WorkspaceSort>("recent")
   const [quickOpen, setQuickOpen] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
-  const [removeTarget, setRemoveTarget] = useState<Workspace | null>(null)
+  // The card's own view of the pairing rides along: a workspace that already
+  // dropped this device gets a different prompt, and by then the local pairing
+  // record is gone, so the workspace object alone can no longer tell us.
+  const [removeTarget, setRemoveTarget] = useState<{
+    ws: Workspace
+    revoked: boolean
+  } | null>(null)
   const [removing, setRemoving] = useState(false)
   const [renameTarget, setRenameTarget] = useState<Workspace | null>(null)
 
-  const { workspaces, aliases, setAliases, filtered, stats, loading, reload } =
-    useWorkspacesData(search, filter, sort)
+  const {
+    workspaces,
+    aliases,
+    setAliases,
+    filtered,
+    stats,
+    loading,
+    reload,
+    notices,
+  } = useWorkspacesData(search, filter, sort)
   const activity = useWorkspaceActivity(workspaces)
 
   const openQuick = (): void => setQuickOpen(true)
@@ -96,7 +111,7 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
 
   const performRemove = async (deleteRemote: boolean): Promise<void> => {
     if (!removeTarget) return
-    const ws = removeTarget
+    const { ws, revoked } = removeTarget
     // Same display name the confirm dialog shows.
     const name = aliases[ws.id] || ws.name || ws.slug || ws.id
     setRemoving(true)
@@ -120,7 +135,9 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
           t(
             deleteRemote
               ? "workspaces.toast.deleted"
-              : "workspaces.toast.removed",
+              : revoked
+                ? "workspaces.toast.cleared"
+                : "workspaces.toast.removed",
             { name },
           ),
           "success",
@@ -163,6 +180,14 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
           onSort={setSort}
           onRefresh={runRefresh}
           refreshing={refreshing}
+        />
+
+        <WorkspaceRevokedNotice
+          notices={notices}
+          onRejoin={openQuick}
+          onDismiss={(id) => {
+            void window.api.dismissNodeRevocation(id).then(() => reload())
+          }}
         />
 
         {loading ? (
@@ -226,7 +251,12 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
                 onCopyUrl={() => copyUrl(c.ws)}
                 onOpen={() => openInBrowser(c.ws)}
                 onRename={() => setRenameTarget(c.ws)}
-                onRemove={() => setRemoveTarget(c.ws)}
+                onRemove={() =>
+                  setRemoveTarget({
+                    ws: c.ws,
+                    revoked: c.health === "revoked",
+                  })
+                }
                 onRepair={openQuick}
               />
             ))}
@@ -264,15 +294,16 @@ export default function Workspaces({ showToast }: Props): React.JSX.Element {
       />
 
       <WorkspaceRemoveDialog
-        workspace={removeTarget}
+        workspace={removeTarget?.ws ?? null}
         displayName={
           removeTarget
-            ? aliases[removeTarget.id] ||
-              removeTarget.name ||
-              removeTarget.slug ||
-              removeTarget.id
+            ? aliases[removeTarget.ws.id] ||
+              removeTarget.ws.name ||
+              removeTarget.ws.slug ||
+              removeTarget.ws.id
             : ""
         }
+        revoked={removeTarget?.revoked}
         busy={removing}
         onConfirm={(deleteRemote) => void performRemove(deleteRemote)}
         onCancel={() => setRemoveTarget(null)}

--- a/packages/launcher/src/renderer/pages/workspaces/use-workspaces-data.ts
+++ b/packages/launcher/src/renderer/pages/workspaces/use-workspaces-data.ts
@@ -6,7 +6,12 @@ import { useConnectionsStore } from "@renderer/store/connections"
 import { useWorkspacePrefs } from "@renderer/store/workspace-prefs"
 import type { WorkspaceCardData } from "@renderer/components/workspaces/WorkspaceCard"
 import type { WorkspaceHealthState } from "@renderer/components/workspaces/WorkspaceHealth"
-import type { Agent, ChatSessionMeta, Workspace } from "@renderer/types"
+import type {
+  Agent,
+  ChatSessionMeta,
+  RevokedPairing,
+  Workspace,
+} from "@renderer/types"
 
 /** How often the list re-polls the daemon for workspace/agent state. */
 const POLL_MS = 8000
@@ -20,11 +25,18 @@ function deriveHealth(
   agents: Agent[],
   device: boolean,
   revoked: boolean,
+  /** False while the node status is still loading — see `nodeWorkspaces`. */
+  nodeKnown: boolean,
 ): WorkspaceHealthState {
   // A revoked pairing outranks agent health: the workspace kicked this device,
   // so whatever the agents report locally, the connection needs re-pairing.
   if (revoked) return "revoked"
   if (agents.length === 0) return device ? "device" : "disconnected"
+  // Agents bound here, but this machine is not in the workspace — nothing of
+  // theirs reaches it, whatever they last reported locally. Their stale errors
+  // used to surface here as a workspace in "Error", which named the wrong
+  // problem: the connection is gone, not broken.
+  if (nodeKnown && !device) return "disconnected"
   if (agents.some((a) => a.state === "error" || a.lastError)) return "error"
   if (agents.some((a) => a.state === "starting" || a.state === "reconnecting"))
     return "warning"
@@ -50,6 +62,8 @@ export type WorkspaceSort = (typeof WORKSPACE_SORTS)[number]
 
 interface WorkspacesData {
   workspaces: Workspace[]
+  /** Workspaces that removed this device, and are gone from the list. */
+  notices: RevokedPairing[]
   aliases: Record<string, string>
   setAliases: React.Dispatch<React.SetStateAction<Record<string, string>>>
   filtered: WorkspaceCardData[]
@@ -81,13 +95,15 @@ export function useWorkspacesData(
    * be what a workspace record is keyed by locally). A device can be a node in
    * several workspaces at once, so this is a set rather than one value.
    */
-  const [nodeWorkspaces, setNodeWorkspaces] = useState<Set<string>>(
-    () => new Set(),
-  )
-  /** Workspaces whose pairing the server revoked — card offers to re-join. */
-  const [revokedWorkspaces, setRevokedWorkspaces] = useState<Set<string>>(
-    () => new Set(),
-  )
+  // null until the node has answered: an empty set means this device is in no
+  // workspace, which is a different thing to not knowing yet.
+  const [nodeWorkspaces, setNodeWorkspaces] = useState<Set<string> | null>(null)
+  /**
+   * Workspaces that removed this device. The local entry goes with the pairing
+   * (main-side), so these are no longer in `workspaces` at all — they are kept
+   * to say so once, rather than letting a workspace vanish without a word.
+   */
+  const [revocations, setRevocations] = useState<RevokedPairing[]>([])
   const [loading, setLoading] = useState(true)
   const mounted = useRef(true)
 
@@ -134,12 +150,7 @@ export function useWorkspacesData(
           if (w.workspaceId) keys.add(w.workspaceId)
         }
         setNodeWorkspaces(keys)
-        const revoked = new Set<string>()
-        for (const r of node.revoked || []) {
-          if (r.workspaceSlug) revoked.add(r.workspaceSlug)
-          if (r.workspaceId) revoked.add(r.workspaceId)
-        }
-        setRevokedWorkspaces(revoked)
+        setRevocations(node.revoked || [])
       } catch {}
       // Pull session metadata across all workspaces in parallel so we can
       // show "Last message" + previews on each card.
@@ -222,13 +233,14 @@ export function useWorkspacesData(
       // than folded into it: once an agent binds here, health becomes
       // "healthy" and the card would otherwise stop saying that this machine
       // is the node behind it.
-      const device = nodeWorkspaces.has(slug) || nodeWorkspaces.has(ws.id)
-      const revoked =
-        revokedWorkspaces.has(slug) || revokedWorkspaces.has(ws.id)
+      const device = !!nodeWorkspaces?.has(slug) || !!nodeWorkspaces?.has(ws.id)
+      const revoked = revocations.some(
+        (r) => r.workspaceSlug === slug || r.workspaceId === ws.id,
+      )
       return {
         ws: aliasName ? { ...ws, name: aliasName } : ws,
         agents: linkedAgents,
-        health: deriveHealth(linkedAgents, device, revoked),
+        health: deriveHealth(linkedAgents, device, revoked, !!nodeWorkspaces),
         device,
         lastActiveAt: topSession?.lastMessageAt || lastUsedAt[ws.id] || null,
         lastMessageAt: topSession?.lastMessageAt || null,
@@ -245,7 +257,7 @@ export function useWorkspacesData(
     lastUsedAt,
     platformsByWorkspace,
     nodeWorkspaces,
-    revokedWorkspaces,
+    revocations,
   ])
 
   const filtered = useMemo(() => {
@@ -305,5 +317,27 @@ export function useWorkspacesData(
     return { healthy, warning, error, disconnected, total: cards.length }
   }, [cards])
 
-  return { workspaces, aliases, setAliases, filtered, stats, loading, reload }
+  // Only the ones with nothing left on this machine: a revocation the user has
+  // already answered by re-joining is settled, and says nothing worth saying.
+  const notices = useMemo(
+    () =>
+      revocations.filter(
+        (r) =>
+          !workspaces.some(
+            (w) => w.id === r.workspaceId || (w.slug || w.id) === r.workspaceSlug,
+          ),
+      ),
+    [revocations, workspaces],
+  )
+
+  return {
+    workspaces,
+    aliases,
+    setAliases,
+    filtered,
+    stats,
+    loading,
+    reload,
+    notices,
+  }
 }

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -143,12 +143,20 @@ export interface NodeStatus {
   deviceType: string
   /** Every workspace this device is paired to, most recent first. */
   workspaces: NodeConnection[]
-  /** Pairings the workspace side revoked (node row gone) — card offers re-join. */
-  revoked: Array<{
-    workspaceId: string
-    workspaceSlug: string | null
-    workspaceName: string | null
-  }>
+  /**
+   * Workspaces that removed this device. The local entry and its agent
+   * bindings go with the pairing, so these name workspaces that are no longer
+   * in the list — kept so the launcher can say what happened to them.
+   */
+  revoked: RevokedPairing[]
+}
+
+export interface RevokedPairing {
+  workspaceId: string
+  workspaceSlug: string | null
+  workspaceName: string | null
+  /** Agents unbound with it; re-joining files them back under the workspace. */
+  agents?: string[]
 }
 
 export interface CatalogEntry {
@@ -577,6 +585,8 @@ declare global {
         code: string,
         opts?: { name?: string; deviceType?: string },
       ): Promise<NodeStatus & { warning: string | null }>
+      /** Forget the notice that a workspace removed this device. */
+      dismissNodeRevocation(workspaceId: string): Promise<NodeStatus | null>
       getSetting(key: string): Promise<unknown>
       setSetting(key: string, value: unknown): Promise<unknown>
       /** Themes the OS-drawn window frame to match the app's theme. */


### PR DESCRIPTION
Launcher 0.9.22.

## Setup's pairing step stands on its own

Everyone who reaches it is there for the first time, usually without an account and always without a workspace — yet it opened with a field for a code they had no way to obtain, and explained where to find it below the fold. What to do on the web now comes first: sign up, create a workspace, copy its pairing code.

Skipping is gone. It led to an empty launcher: no workspace to install an agent from, nothing for one to join, and a prompt for a pairing code again on the next launch.

A connected device is offered the two routes that actually exist — finish the setup here, or open the workspace and do it remotely — instead of one call to action mixed with a list of identifiers and two more buttons in the footer.

## A workspace that removes this device is removed from this device

Previously only the pairing was dropped. The workspace stayed in the list with its agents still filed under it, and neither could reach it any more: a card with nothing to open, agents that could not run, and a status the launcher had to guess at, which it read as an error.

The pairing, the local entry and the agent bindings now go together. A notice at the top of Workspaces says which workspace removed the device and how many agents were unbound; their instances and data stay, and joining that workspace again files them back under it. The reason is written to disk, so it survives the restart that used to turn a removed device into a workspace in "Error".

## Membership is read from the pairings

The pairings (`node.json`) are the only record that carries a credential. The core's `networks[]` entries are a separate file kept in step by hand, so a workspace that has dropped this device can outlive its pairing there.

Both paths trusted the wrong one: the "Add to workspace" dialog listed `networks[]`, and `connectWorkspace` validated against it — so an agent could be bound to a workspace this device is not in, producing a join whose every call carries a credential the workspace has stopped honouring. Both now check the pairings, and the dialog re-verifies them as it opens: until now only the Workspaces page ever called `refreshNodeStatus`, so a device removed while the user was anywhere else went on offering the workspace it had lost.

Two regression tests cover it: a workspace whose pairing is gone is not offered and cannot be bound, and opening the dialog re-checks.

Not addressed here: `_verifyPairing` treats a rejected credential (401/403) the same as a network failure and keeps the pairing. If the workspace revokes the per-node token when it deletes the device row, revocation is never detected at all — pending confirmation of the server's response code.

## An agent with no workspace reads as one, everywhere

An agent with a workspace runs a loop that polls it and calls the CLI per message. An agent without one is registered with the daemon and nothing drives it — no message source, no process — yet the state written for it is `running`, and every list passed that through. The same agent read "Running" on the dashboard and "No workspace" on the agents list, because each page decided for itself.

They now report it as not connected from one shared definition, and none of them offers to start or stop it — the command palette included. The running counts on the dashboard and in Settings leave it out for the same reason. A workspace whose credential has gone still reports an error with the reason behind it.

## An agent's page waits for the version comparison

Which buttons belong there depends on comparing the installed version with the latest, and both arrive a moment after the page opens — so it rendered the default set first and swapped it afterwards, showing "Reinstall" and "Installed" to someone who had come specifically because an update was waiting. The actions and the status now wait, and reuse the marketplace list's answer when it already has one.

## Verification

`tsc -b` clean, 393 tests passing (2 new). Release-note check passes. Not run in the app — worth a manual pass over the pairing flow and the removed-device case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)