### PR TITLE
feat(launcher): drive the whole agent journey headlessly, and test it daily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ lib/
 !packages/launcher/src/renderer/lib/**
 !workspace/frontend/lib/
 !workspace/frontend/lib/**
+!tests/end_to_end/lib/
+!tests/end_to_end/lib/**
 !packages/go/web/lib/
 !packages/go/web/lib/**
 lib64/
@@ -277,3 +279,6 @@ deploy/
 # APNs auth keys (Apple Push Notification service .p8 private keys)
 workspace/backend/secrets/
 *.p8
+
+# End-to-end test credentials (tests/end_to_end/agents.example.json is the template)
+tests/end_to_end/agents.config.json

--- a/packages/launcher/changelog/0.9.23.json
+++ b/packages/launcher/changelog/0.9.23.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.9.23",
+  "date": "2026-08-27",
+  "entries": [
+    {
+      "type": "improvement",
+      "title": {
+        "en": "Every supported agent is now tested end to end, every day",
+        "zh": "每个受支持的 Agent 每天都会跑一遍端到端测试"
+      },
+      "description": {
+        "en": "A new automated suite pairs a workspace, installs each agent from nothing, configures and connects it, then asks it a question and checks the answer — on macOS, Windows and Linux. A setup path that breaks upstream is now caught the same day rather than by the next person who tries it.",
+        "zh": "新增的自动化测试会完整走一遍流程：配对工作区、从零安装每个 Agent、完成配置与连接，再发一条消息核对回复，macOS、Windows、Linux 三端每天各跑一次。上游变动导致的安装或连接问题当天即可发现，不必等用户先踩到。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.19",
+  "version": "0.9.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.9.19",
+      "version": "0.9.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4485,6 +4485,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/control-server.test.ts
+++ b/packages/launcher/src/main/control-server.test.ts
@@ -32,6 +32,19 @@ function deps(overrides: Partial<ControlDeps> = {}): ControlDeps {
     screenshot: async () => null,
     window: () => true,
     logFiles: () => ({}),
+    catalog: async () => ({ supported: ["opencode"] }),
+    envFields: async () => [{ name: "LLM_API_KEY", required: true }],
+    install: async () => ({ ok: true }),
+    createAgent: async () => ({ success: true }),
+    saveEnv: async () => ({ success: true }),
+    connectWorkspace: async () => ({ success: true }),
+    startAgent: async () => ({ success: true }),
+    stopAgent: async () => ({ success: true }),
+    removeAgent: async () => ({ success: true }),
+    workspaces: () => [{ id: "ws1", slug: "acme" }],
+    sendChat: async () => ({ success: true, messageId: "m1" }),
+    chatMessages: async () => [],
+    quit: () => {},
     tokenDir: dir,
     ...overrides,
   }
@@ -171,6 +184,198 @@ describe("startControlServer", () => {
     })
     expect(invalid.status).toBe(400)
     expect(seen).toEqual(["create"])
+  })
+
+  it("drives the agent lifecycle through the injected deps", async () => {
+    const calls: string[] = []
+    const srv = await start({
+      createAgent: async (o) => {
+        calls.push(`create:${o.name}:${o.type}:${o.path}`)
+        return { success: true }
+      },
+      saveEnv: async (o) => {
+        calls.push(`env:${o.name || o.type}:${JSON.stringify(o.env)}`)
+        return { success: true }
+      },
+      connectWorkspace: async (n, w) => {
+        calls.push(`connect:${n}:${w}`)
+        return { success: true }
+      },
+      startAgent: async (n) => {
+        calls.push(`start:${n}`)
+        return { success: true }
+      },
+      stopAgent: async (n) => {
+        calls.push(`stop:${n}`)
+        return { success: true }
+      },
+      removeAgent: async (n) => {
+        calls.push(`remove:${n}`)
+        return { success: true }
+      },
+    })
+    const post = (route: string, body: unknown): Promise<Response> =>
+      call(srv, route, { method: "POST", body: JSON.stringify(body) })
+
+    expect(
+      (
+        await post("/agents/create", {
+          name: "e2e-1",
+          type: "opencode",
+          path: "/tmp/x",
+        })
+      ).status,
+    ).toBe(200)
+    // Non-string env values are dropped rather than coerced.
+    await post("/agents/env", { name: "e2e-1", env: { KEY: "sk-1", N: 7 } })
+    await post("/agents/connect", { name: "e2e-1", workspace: "acme" })
+    await post("/agents/start", { name: "e2e-1" })
+    await post("/agents/stop", { name: "e2e-1" })
+    await post("/agents/remove", { name: "e2e-1" })
+
+    expect(calls).toEqual([
+      "create:e2e-1:opencode:/tmp/x",
+      'env:e2e-1:{"KEY":"sk-1"}',
+      "connect:e2e-1:acme",
+      "start:e2e-1",
+      "stop:e2e-1",
+      "remove:e2e-1",
+    ])
+
+    // Required fields are enforced before any dep runs.
+    expect((await post("/agents/create", { name: "only-name" })).status).toBe(
+      400,
+    )
+    expect((await post("/agents/connect", { name: "e2e-1" })).status).toBe(400)
+    expect((await post("/agents/start", {})).status).toBe(400)
+    expect(calls).toHaveLength(6)
+  })
+
+  it("POST /install runs in the background and GET /install reports the outcome", async () => {
+    let release: (() => void) | null = null
+    const srv = await start({
+      install: (type, onData) =>
+        new Promise((resolve, reject) => {
+          onData(`installing ${type}\n`)
+          release = (): void =>
+            type === "boom"
+              ? reject(new Error("installer exploded"))
+              : resolve({})
+        }),
+    })
+    const post = (body: unknown): Promise<Response> =>
+      call(srv, "/install", { method: "POST", body: JSON.stringify(body) })
+
+    // Nothing started yet.
+    expect(await (await call(srv, "/install?type=opencode")).json()).toEqual({
+      type: "opencode",
+      state: "idle",
+    })
+
+    const started = await post({ type: "opencode" })
+    expect(started.status).toBe(202)
+    expect((await started.json()) as { state: string }).toMatchObject({
+      state: "running",
+    })
+
+    // A second POST joins the running job instead of starting a rival installer.
+    const again = await post({ type: "opencode" })
+    expect(((await again.json()) as { state: string }).state).toBe("running")
+
+    release!()
+    await new Promise((r) => setTimeout(r, 20))
+    const done = (await (await call(srv, "/install?type=opencode")).json()) as {
+      state: string
+      log: string
+    }
+    expect(done.state).toBe("done")
+    expect(done.log).toContain("installing opencode")
+
+    expect((await post({})).status).toBe(400)
+  })
+
+  it("GET /install surfaces an installer failure as state:error", async () => {
+    const srv = await start({
+      install: async () => {
+        throw new Error("installer exploded")
+      },
+    })
+    await call(srv, "/install", {
+      method: "POST",
+      body: JSON.stringify({ type: "hermes" }),
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    const job = (await (await call(srv, "/install?type=hermes")).json()) as {
+      state: string
+      error: string
+    }
+    expect(job.state).toBe("error")
+    expect(job.error).toMatch(/installer exploded/)
+  })
+
+  it("serves the workspace + chat surface the respond check needs", async () => {
+    let sent: Record<string, unknown> | null = null
+    const srv = await start({
+      sendChat: async (input) => {
+        sent = input as unknown as Record<string, unknown>
+        return { success: true, messageId: "m1" }
+      },
+      chatMessages: async (ws, ch, limit) => [{ ws, ch, limit }],
+    })
+    expect(await (await call(srv, "/workspaces")).json()).toEqual({
+      workspaces: [{ id: "ws1", slug: "acme" }],
+    })
+
+    const res = await call(srv, "/chat/send", {
+      method: "POST",
+      body: JSON.stringify({
+        workspace: "ws1",
+        channel: "e2e",
+        agent: "e2e-1",
+        content: "What is 2+2?",
+      }),
+    })
+    expect(res.status).toBe(200)
+    expect(sent).toEqual({
+      workspaceId: "ws1",
+      channelName: "e2e",
+      agentId: "e2e-1",
+      content: "What is 2+2?",
+    })
+
+    expect(
+      await (
+        await call(srv, "/chat/messages?workspace=ws1&channel=e2e&limit=5")
+      ).json(),
+    ).toEqual({ messages: [{ ws: "ws1", ch: "e2e", limit: 5 }] })
+
+    expect((await call(srv, "/chat/messages")).status).toBe(400)
+    expect(
+      (await call(srv, "/chat/send", { method: "POST", body: "{}" })).status,
+    ).toBe(400)
+  })
+
+  it("answers 503 while the core is still loading, 500 for real failures", async () => {
+    const srv = await start({
+      workspaces: () => {
+        throw new Error("core not loaded yet — retry shortly")
+      },
+      catalog: async () => {
+        throw new Error("registry unreachable")
+      },
+    })
+    expect((await call(srv, "/workspaces")).status).toBe(503)
+    expect((await call(srv, "/catalog")).status).toBe(500)
+  })
+
+  it("POST /quit answers before the app goes away", async () => {
+    let quit = 0
+    const srv = await start({ quit: () => quit++ })
+    const res = await call(srv, "/quit", { method: "POST" })
+    expect(await res.json()).toEqual({ quitting: true })
+    expect(quit).toBe(0) // deferred so the response can flush
+    await new Promise((r) => setTimeout(r, 80))
+    expect(quit).toBe(1)
   })
 
   it("unknown routes list what exists", async () => {

--- a/packages/launcher/src/main/control-server.ts
+++ b/packages/launcher/src/main/control-server.ts
@@ -39,6 +39,57 @@ export interface ControlDeps {
   window: (action: "create" | "show" | "hide") => boolean
   /** Absolute paths of log files exposed by GET /logs. */
   logFiles: () => Record<string, string>
+
+  // ── Driving surface ────────────────────────────────────────────────────
+  // What tests/end_to_end/run.js needs to walk an agent from "nothing
+  // installed" to "answered a message", through the same AgentManager calls
+  // the renderer reaches over IPC. Each throws while the core is still
+  // loading; the server answers 503 for that so a script can just retry.
+
+  /** Core info + supported types + installed types (GET /catalog). */
+  catalog: () => Promise<unknown>
+  /** The fields the Configure dialog would show (GET /agents/env-fields). */
+  envFields: (type: string) => Promise<unknown[]>
+  /** Install an agent type, streaming installer output to `onData` (POST /install). */
+  install: (type: string, onData: (chunk: string) => void) => Promise<unknown>
+  /** Register an agent instance (POST /agents/create). */
+  createAgent: (opts: {
+    name: string
+    type: string
+    path?: string
+  }) => Promise<unknown>
+  /** Save env for one instance (`name`) or a whole type (`type`) (POST /agents/env). */
+  saveEnv: (opts: {
+    name?: string
+    type?: string
+    env: Record<string, string>
+  }) => Promise<unknown>
+  /** Bind an agent to a paired workspace (POST /agents/connect). */
+  connectWorkspace: (name: string, workspace: string) => Promise<unknown>
+  /** Ask the daemon to start one agent (POST /agents/start). */
+  startAgent: (name: string) => Promise<unknown>
+  /** Ask the daemon to stop one agent (POST /agents/stop). */
+  stopAgent: (name: string) => Promise<unknown>
+  /** Delete an agent instance (POST /agents/remove). */
+  removeAgent: (name: string) => Promise<unknown>
+  /** Workspaces registered on this device (GET /workspaces). */
+  workspaces: () => unknown[]
+  /** Post a chat message as the user (POST /chat/send). */
+  sendChat: (input: {
+    workspaceId: string
+    channelName?: string
+    agentId?: string
+    content: string
+  }) => Promise<unknown>
+  /** Recent messages in a channel (GET /chat/messages). */
+  chatMessages: (
+    workspaceId: string,
+    channelName: string | undefined,
+    limit: number,
+  ) => Promise<unknown[]>
+  /** Quit the app — teardown for a test run (POST /quit). */
+  quit: () => void
+
   /** Where control.token is written. Defaults to ~/.openagents. */
   tokenDir?: string
 }
@@ -102,6 +153,57 @@ function extractToken(req: http.IncomingMessage, url: URL): string {
   return url.searchParams.get("token") || ""
 }
 
+/** A trimmed string field from a JSON body, '' when absent or the wrong type. */
+function str(v: unknown): string {
+  return typeof v === "string" ? v.trim() : ""
+}
+
+/** A string map from a JSON body — non-string values are dropped, not coerced. */
+function envRecord(v: unknown): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!v || typeof v !== "object") return out
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof val === "string") out[k] = val
+  }
+  return out
+}
+
+/**
+ * An agent install runs for minutes and streams as it goes, so POST /install
+ * starts it and returns immediately; GET /install?type= reports how it went.
+ * One job per type (installs are per-type and idempotent), kept in memory for
+ * the life of the app — a test that loses its connection can poll again.
+ */
+interface InstallJob {
+  type: string
+  state: "running" | "done" | "error"
+  startedAt: number
+  endedAt: number | null
+  log: string
+  error: string | null
+}
+
+/** Installer output is unbounded; keep the tail, which is where failures are. */
+const INSTALL_LOG_MAX = 64 * 1024
+
+function appendLog(job: InstallJob, chunk: string): void {
+  job.log = (job.log + chunk).slice(-INSTALL_LOG_MAX)
+}
+
+function jobView(job: InstallJob): Record<string, unknown> {
+  return {
+    type: job.type,
+    state: job.state,
+    startedAt: new Date(job.startedAt).toISOString(),
+    endedAt: job.endedAt ? new Date(job.endedAt).toISOString() : null,
+    durationSeconds: Math.round(
+      ((job.endedAt || Date.now()) - job.startedAt) / 1000,
+    ),
+    error: job.error,
+    log: job.log,
+  }
+}
+
 /** Constant-time comparison — a control token must not be guessable byte-by-byte. */
 function tokenMatches(presented: string, expected: string): boolean {
   const a = Buffer.from(presented)
@@ -119,6 +221,8 @@ export function startControlServer(
   const tokenFile = path.join(tokenDir, "control.token")
   fs.mkdirSync(tokenDir, { recursive: true })
   fs.writeFileSync(tokenFile, token, { mode: 0o600 })
+
+  const installs = new Map<string, InstallJob>()
 
   const server = http.createServer(async (req, res) => {
     let url: URL
@@ -197,6 +301,152 @@ export function startControlServer(
           return json(res, 200, { windowOpen })
         }
 
+        case "GET /catalog":
+          return json(res, 200, await deps.catalog())
+
+        case "GET /agents/env-fields": {
+          const type = url.searchParams.get("type") || ""
+          if (!type) return json(res, 400, { error: "missing 'type'" })
+          return json(res, 200, { type, fields: await deps.envFields(type) })
+        }
+
+        case "POST /install": {
+          const body = await readBody(req)
+          const type = str(body.type)
+          if (!type) return json(res, 400, { error: "missing 'type'" })
+          const running = installs.get(type)
+          // Already installing — hand back the job instead of starting a
+          // second installer over the top of the first.
+          if (running && running.state === "running") {
+            return json(res, 202, jobView(running))
+          }
+          const job: InstallJob = {
+            type,
+            state: "running",
+            startedAt: Date.now(),
+            endedAt: null,
+            log: "",
+            error: null,
+          }
+          installs.set(type, job)
+          deps
+            .install(type, (chunk) => appendLog(job, chunk))
+            .then(() => {
+              job.state = "done"
+              job.endedAt = Date.now()
+            })
+            .catch((err: unknown) => {
+              job.state = "error"
+              job.endedAt = Date.now()
+              job.error = (err as Error)?.message || String(err)
+            })
+          return json(res, 202, jobView(job))
+        }
+
+        case "GET /install": {
+          const type = url.searchParams.get("type") || ""
+          if (!type) return json(res, 400, { error: "missing 'type'" })
+          const job = installs.get(type)
+          if (!job) return json(res, 200, { type, state: "idle" })
+          return json(res, 200, jobView(job))
+        }
+
+        case "POST /agents/create": {
+          const body = await readBody(req)
+          const name = str(body.name)
+          const type = str(body.type)
+          if (!name || !type)
+            return json(res, 400, { error: "missing 'name' or 'type'" })
+          const result = await deps.createAgent({
+            name,
+            type,
+            path: str(body.path) || undefined,
+          })
+          return json(res, 200, { result })
+        }
+
+        case "POST /agents/env": {
+          const body = await readBody(req)
+          const name = str(body.name)
+          const type = str(body.type)
+          if (!name && !type)
+            return json(res, 400, { error: "missing 'name' or 'type'" })
+          const result = await deps.saveEnv({
+            name: name || undefined,
+            type: type || undefined,
+            env: envRecord(body.env),
+          })
+          return json(res, 200, { result })
+        }
+
+        case "POST /agents/connect": {
+          const body = await readBody(req)
+          const name = str(body.name)
+          const workspace = str(body.workspace)
+          if (!name || !workspace)
+            return json(res, 400, { error: "missing 'name' or 'workspace'" })
+          const result = await deps.connectWorkspace(name, workspace)
+          return json(res, 200, { result })
+        }
+
+        case "POST /agents/start":
+        case "POST /agents/stop":
+        case "POST /agents/remove": {
+          const body = await readBody(req)
+          const name = str(body.name)
+          if (!name) return json(res, 400, { error: "missing 'name'" })
+          const action = url.pathname.split("/").pop()
+          const result =
+            action === "start"
+              ? await deps.startAgent(name)
+              : action === "stop"
+                ? await deps.stopAgent(name)
+                : await deps.removeAgent(name)
+          return json(res, 200, { result })
+        }
+
+        case "GET /workspaces":
+          return json(res, 200, { workspaces: deps.workspaces() })
+
+        case "POST /chat/send": {
+          const body = await readBody(req)
+          const workspaceId = str(body.workspace) || str(body.workspaceId)
+          const content = typeof body.content === "string" ? body.content : ""
+          if (!workspaceId || !content)
+            return json(res, 400, { error: "missing 'workspace' or 'content'" })
+          const result = await deps.sendChat({
+            workspaceId,
+            channelName: str(body.channel) || undefined,
+            agentId: str(body.agent) || undefined,
+            content,
+          })
+          return json(res, 200, { result })
+        }
+
+        case "GET /chat/messages": {
+          const workspaceId = url.searchParams.get("workspace") || ""
+          if (!workspaceId)
+            return json(res, 400, { error: "missing 'workspace'" })
+          const limit = Math.min(
+            500,
+            Math.max(1, Number(url.searchParams.get("limit")) || 100),
+          )
+          const messages = await deps.chatMessages(
+            workspaceId,
+            url.searchParams.get("channel") || undefined,
+            limit,
+          )
+          return json(res, 200, { messages })
+        }
+
+        case "POST /quit": {
+          // Answer before quitting: app.quit() tears down this server, so a
+          // reply written afterwards would never reach the caller.
+          json(res, 200, { quitting: true })
+          setTimeout(() => deps.quit(), 50)
+          return
+        }
+
         default:
           return json(res, 404, {
             error: `no route ${route}`,
@@ -205,13 +455,33 @@ export function startControlServer(
               "GET /agents",
               "GET /logs?file=<name>&tail=N",
               "GET /screenshot",
+              "GET /catalog",
+              "GET /agents/env-fields?type=<type>",
+              "GET /install?type=<type>",
+              "GET /workspaces",
+              "GET /chat/messages?workspace=<id>&channel=<name>&limit=N",
               "POST /pair {code}",
               "POST /window {action}",
+              "POST /install {type}",
+              "POST /agents/create {name, type, path?}",
+              "POST /agents/env {name|type, env}",
+              "POST /agents/connect {name, workspace}",
+              "POST /agents/start {name}",
+              "POST /agents/stop {name}",
+              "POST /agents/remove {name}",
+              "POST /chat/send {workspace, content, channel?, agent?}",
+              "POST /quit",
             ],
           })
       }
     } catch (err) {
-      return json(res, 500, { error: (err as Error)?.message || String(err) })
+      const message = (err as Error)?.message || String(err)
+      // The core loads asynchronously after the app starts, so every driving
+      // route is unavailable for the first minutes of a cold boot. That is a
+      // "try again shortly", not a server fault — say so with the status code
+      // rather than making callers pattern-match on the message.
+      const code = /^core not loaded/i.test(message) ? 503 : 500
+      return json(res, code, { error: message })
     }
   })
 

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -2443,9 +2443,19 @@ app.whenReady().then(async () => {
   const controlPort = configuredControlPort()
   if (controlPort !== null) {
     const appStartedAt = Date.now()
+    // Every driving endpoint needs the core, which finishes loading minutes
+    // after start on a cold boot. One shared guard whose message the control
+    // server turns into a 503 ("retry shortly") rather than a 500.
+    const withCore = (): AgentManager => {
+      if (!agentManager) throw new Error("core not loaded yet — retry shortly")
+      return agentManager
+    }
     startControlServer(controlPort, {
       getStatus: () => ({
-        version: app.getVersion(),
+        // Not app.getVersion(): running the unpackaged build (which is what a
+        // pre-release end-to-end run does) makes Electron report ITS version,
+        // so the test's report would file the results under "42.3.3".
+        version: getLauncherVersion(),
         platform: process.platform,
         arch: process.arch,
         headless: isHeadless,
@@ -2456,10 +2466,36 @@ app.whenReady().then(async () => {
         node: agentManager ? agentManager.getNodeStatus() : null,
       }),
       getAgents: () => (agentManager ? agentManager.getAgents() : []),
-      pair: (code) => {
-        if (!agentManager) throw new Error("core not loaded yet — retry shortly")
-        return agentManager.connectNode(code, {})
-      },
+      pair: (code) => withCore().connectNode(code, {}),
+      catalog: async () => ({
+        core: withCore().getCoreInfo(),
+        supported: withCore().getSupportedAgentTypes(),
+        installed: withCore().listInstalledAgents(),
+        catalog: await withCore().getCatalog(false),
+      }),
+      envFields: (type) => withCore().getEnvFields(type),
+      install: (type, onData) =>
+        withCore().installAgentTypeStreaming(type, onData),
+      createAgent: (opts) =>
+        withCore().addAgent({
+          name: opts.name,
+          type: opts.type,
+          path: opts.path,
+        }),
+      saveEnv: async (opts) =>
+        opts.name
+          ? withCore().saveAgentInstanceEnv(opts.name, opts.env)
+          : withCore().saveAgentEnv(opts.type as string, opts.env),
+      connectWorkspace: (name, workspace) =>
+        withCore().connectWorkspace(name, workspace),
+      startAgent: (name) => withCore().startAgent(name),
+      stopAgent: (name) => withCore().stopAgent(name),
+      removeAgent: (name) => withCore().removeAgent(name),
+      workspaces: () => withCore().getNetworks(),
+      sendChat: (input) => withCore().sendChatMessage(input),
+      chatMessages: (workspaceId, channelName, limit) =>
+        withCore().getChatMessages(workspaceId, channelName, limit),
+      quit: () => app.quit(),
       screenshot: async () => {
         if (!mainWindow || mainWindow.isDestroyed()) return null
         const image = await mainWindow.webContents.capturePage()

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,6 +126,20 @@ The test suite is organized into several categories:
 - Network launcher functionality
 - Async network initialization
 
+### Suites pytest does not run
+
+Two directories here are Node scripts rather than pytest modules — they drive
+real installs against a real workspace, so they are run on demand, not in the
+unit suite:
+
+- **`end_to_end/`** — the desktop launcher, end to end: pair a workspace,
+  install each supported agent from nothing, configure and connect it, then
+  message it and check the answer. One entry point for macOS, Linux and
+  Windows (`node tests/end_to_end/run.js`), intended to run daily. See
+  [`end_to_end/README.md`](end_to_end/README.md).
+- **`e2e/`** — the same journey through the `agn` CLI instead of the launcher
+  (`node tests/e2e/agent-smoke.js`). See [`e2e/README.md`](e2e/README.md).
+
 ## Test Configuration
 
 Tests are configured via `pyproject.toml` with the following settings:

--- a/tests/end_to_end/README.md
+++ b/tests/end_to_end/README.md
@@ -1,0 +1,161 @@
+# Launcher end-to-end test
+
+One script, three platforms. It walks the desktop launcher through the whole
+user journey, per agent, on the machine it runs on:
+
+```
+pair a workspace → install the agent → create an instance → configure its
+credentials → connect it to the workspace → start it → send it a message →
+read its answer
+```
+
+```bash
+node tests/end_to_end/run.js                 # every agent in the config file
+node tests/end_to_end/run.js --agents=claude # just one
+node tests/end_to_end/run.js --fresh         # from an empty profile (slow, thorough)
+```
+
+Exit code is `0` only when every agent that had credentials passed. Results land
+in `~/.openagents-e2e/runs/<timestamp>/` (`results.json`, `summary.md`,
+`run.log`, plus per-agent diagnostics for anything that failed) and the newest
+run is always copied to `~/.openagents-e2e/latest.json`.
+
+## How it drives the app
+
+Through the launcher's **control server** — a loopback HTTP surface the app
+opens when started with `--control-port=N` (see
+`packages/launcher/src/main/control-server.ts`). Behind it sits the same
+`AgentManager` the UI calls over IPC, so a green run means the desktop path
+works, not that some parallel CLI does.
+
+No display is involved: the run starts the app `--headless`, which is what makes
+a scheduled job on a Windows box over SSH — where there is no desktop session at
+all — possible. GUI-level coverage lives in `packages/launcher/e2e/` (Playwright)
+and is a different job.
+
+Each run gets its own `HOME` (`~/.openagents-e2e/home` by default), so
+`~/.openagents` — portable node, core library, daemon config, agent runtimes —
+and the Electron profile are the test's, not yours. Your own launcher can stay
+open while a run is in progress.
+
+## What the isolated profile does and does not cover
+
+The run gets its own `HOME`, so `~/.openagents` and the Electron profile are the
+test's. It does **not** get its own `PATH`: an agent CLI installed globally on
+the machine is visible to the launcher inside the run, and the catalog reports
+it as already installed — so its install step is skipped even under `--fresh`.
+That matches what the launcher itself would see on that machine, but it means a
+box where you develop is not the place to prove the from-nothing install path.
+Use a machine that has no agent CLIs of its own for that (which is what a
+dedicated daily runner is).
+
+## Configuration
+
+Copy the example and fill it in — the file is gitignored:
+
+```bash
+cp tests/end_to_end/agents.example.json tests/end_to_end/agents.config.json
+```
+
+The config file **is** the matrix: an agent is tested because it has an entry,
+skipped (with the reason in the report) when it carries a `skip`, and skipped
+too when its required credentials are missing. `apiKey` / `baseUrl` / `model`
+are mapped onto whatever variables the launcher's own Configure dialog asks for
+(`GET /agents/env-fields` → `*_API_KEY`, `*_BASE_URL`, `*_MODEL`), so a registry
+change lands here without an edit. Anything off that convention goes in `env`;
+agents that read a file instead of the environment (Hermes) use `files`.
+
+`workspace.token` must be an owner/admin credential — it is what mints the
+pairing code.
+
+Everything can come from the environment instead, which is what a CI or a
+scheduled job usually wants:
+
+| Variable | Meaning |
+| --- | --- |
+| `OA_E2E_WS_API` | Workspace API base (default `https://workspace-endpoint.openagents.org`) |
+| `OA_E2E_WS_TOKEN` | Workspace token (owner/admin) |
+| `OA_E2E_WS_ID` | Workspace id or slug |
+| `OA_E2E_<AGENT>_API_KEY` | Per-agent key, e.g. `OA_E2E_CLAUDE_API_KEY` |
+| `OA_E2E_<AGENT>_BASE_URL` | Per-agent base URL |
+| `OA_E2E_<AGENT>_MODEL` | Per-agent model |
+| `OA_E2E_CONFIG` | Config file path |
+| `OA_LAUNCHER_BIN` | Launcher binary to test |
+
+Precedence is flag → environment → config file.
+
+## Options
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--agents=a,b` | every configured agent | Narrow the matrix |
+| `--config=<file>` | `tests/end_to_end/agents.config.json` | Config file |
+| `--app=<path>` | installed app, then `packages/launcher/out/main/index.js` | Which launcher to test |
+| `--home=<dir>` | `~/.openagents-e2e/home` | Profile the run uses as `HOME` |
+| `--out=<dir>` | `~/.openagents-e2e/runs` | Results and diagnostics |
+| `--fresh` | off | Delete the profile first — proves the from-nothing path |
+| `--attach` | off | Use a launcher already running under `--home` |
+| `--reinstall` | off | Install even when the agent is already installed |
+| `--keep` | off | Leave the created agents behind |
+| `--json` | off | Print only the results JSON |
+| `--boot-timeout` / `--install-timeout` / `--start-timeout` / `--reply-timeout` | 12 / 20 / 3 / 6 min | Patience, in minutes |
+
+By default the run tests the **installed** launcher — the artifact users get. To
+test a working copy instead, build it first and point at the output:
+
+```bash
+cd packages/launcher && npm install && npm run build
+node tests/end_to_end/run.js --app=packages/launcher/out/main/index.js
+```
+
+## Warm vs fresh
+
+The default profile is reused between runs, so installs are warm and a full
+matrix takes minutes rather than hours — the right trade for a daily regression
+check. `--fresh` wipes the profile so the run also covers first-launch bootstrap
+(portable node + core download, then every agent install from nothing); expect
+it to run for a long time and give it a generous `--install-timeout`.
+
+## Running it daily
+
+macOS / Linux (`crontab -e`):
+
+```cron
+30 3 * * * cd /path/to/openagents && /usr/bin/node tests/end_to_end/run.js >> ~/.openagents-e2e/cron.log 2>&1
+```
+
+Windows (Task Scheduler, daily):
+
+```powershell
+schtasks /create /tn "OpenAgents E2E" /sc daily /st 03:30 ^
+  /tr "node C:\path\to\openagents\tests\end_to_end\run.js"
+```
+
+`~/.openagents-e2e/latest.json` holds the last run's machine-readable status —
+`summary`, `ok`, and a per-agent breakdown — for whatever collects it.
+
+## Reading a failure
+
+Each agent result names the step that failed (`install`, `create`, `configure`,
+`connect`, `start`, `respond`) and keeps the evidence in
+`<run>/<agent>/`: `daemon.log`, `startup.log`, `install.log`, `agents.json`,
+`status.json`. Secrets are redacted from everything written to disk.
+
+Common ones:
+
+- **`install` fails** — read `install.log`; it is the installer's own output.
+- **`start` times out** — the agent never reached a running state; `daemon.log`
+  says why (missing binary, bad credentials, unsupported adapter).
+- **`respond` times out** — the agent started but never answered: usually a
+  wrong model name or an LLM endpoint that rejects the key. `daemon.log` again.
+
+## Testing the harness
+
+```bash
+node --test "tests/end_to_end/**/*.test.js"
+```
+
+Covers the pure logic — credential mapping, reply detection, config precedence,
+the control client's error handling — so a broken harness fails in a second
+instead of forty minutes into a nightly. The control server's own endpoints are
+covered by `packages/launcher/src/main/control-server.test.ts`.

--- a/tests/end_to_end/agents.example.json
+++ b/tests/end_to_end/agents.example.json
@@ -1,0 +1,67 @@
+{
+  "_comment": [
+    "Copy to agents.config.json (gitignored) and fill in. This file IS the test",
+    "matrix: an agent is tested because it has an entry here. Credentials can also",
+    "come from the environment (OA_E2E_WS_TOKEN, OA_E2E_<AGENT>_API_KEY, ...) —",
+    "see README.md.",
+    "",
+    "apiKey / baseUrl / model are mapped onto whatever env vars the launcher's",
+    "Configure dialog asks for (*_API_KEY, *_BASE_URL, *_MODEL). Anything that",
+    "doesn't follow that convention goes in `env`, which is applied last."
+  ],
+
+  "workspace": {
+    "apiBase": "https://workspace-endpoint.openagents.org",
+    "id": "your-workspace-slug",
+    "token": "the workspace token (owner/admin — it mints the pairing code)"
+  },
+
+  "defaults": {
+    "apiKey": "sk-... (an OpenAI-compatible gateway key most agents can share)",
+    "baseUrl": "https://your-gateway.example.com/v1"
+  },
+
+  "prompt": "What is 2+2? Reply with just the number.",
+  "expect": "4",
+
+  "agents": {
+    "openclaw": { "model": "deepseek-v4-flash" },
+    "opencode": { "model": "gpt-5-mini" },
+    "codex": { "model": "gpt-5-mini" },
+    "kimi": { "model": "kimi-k2" },
+    "deepseek": { "model": "deepseek-chat" },
+
+    "claude": {
+      "model": "claude-sonnet-4-6",
+      "apiKey": "sk-ant-... (Anthropic key or a relay token)",
+      "baseUrl": "https://api.anthropic.com"
+    },
+
+    "gemini": {
+      "model": "gemini-3.5-flash",
+      "apiKey": "AIza...",
+      "env": { "GOOGLE_GEMINI_BASE_URL": "https://your-gateway.example.com" }
+    },
+
+    "pi": {
+      "model": "claude-sonnet-4-6",
+      "env": { "PI_PROVIDER": "anthropic", "PI_API_FORMAT": "anthropic" }
+    },
+
+    "amp": {
+      "apiKey": "amp key",
+      "env": { "AMP_URL": "https://ampcode.com" }
+    },
+
+    "hermes": {
+      "model": "deepseek-v4-flash",
+      "files": {
+        "~/.hermes/.env": "OPENAI_API_KEY=${apiKey}\n",
+        "~/.hermes/config.yaml": "model:\n  default: ${model}\n  provider: custom\n  base_url: ${baseUrl}\n  api_key: ${apiKey}\n"
+      }
+    },
+
+    "cursor": { "skip": "authenticates only against Cursor's own cloud — needs a real cursor.com key" },
+    "antigravity": { "skip": "Google browser sign-in only — no unattended path yet" }
+  }
+}

--- a/tests/end_to_end/harness.test.js
+++ b/tests/end_to_end/harness.test.js
@@ -1,0 +1,368 @@
+"use strict"
+
+/**
+ * Unit tests for the harness itself — `node --test tests/end_to_end/`.
+ *
+ * The end-to-end run is slow, credentialed and machine-dependent; these cover
+ * the pure logic inside it (credential mapping, reply detection, config
+ * precedence, the control client's error handling) so a broken harness is
+ * caught in a second rather than 40 minutes into a nightly.
+ */
+
+const assert = require("node:assert")
+const fs = require("node:fs")
+const http = require("node:http")
+const os = require("node:os")
+const path = require("node:path")
+const { test } = require("node:test")
+
+const {
+  buildEnv,
+  missingRequired,
+  isAnswer,
+  agentError,
+  containsAnswer,
+  instanceName,
+} = require("./lib/scenario")
+const { buildConfig, validate, secretsOf } = require("./lib/config")
+const { Control, readControlPort, startupLogSize } = require("./lib/control")
+const { summarize, renderMarkdown } = require("./lib/report")
+const { makeRedactor, renderTable } = require("./lib/util")
+
+const FIELDS = [
+  { name: "LLM_API_KEY", required: true },
+  {
+    name: "LLM_BASE_URL",
+    required: false,
+    default: "https://api.openai.com/v1",
+  },
+  { name: "LLM_MODEL", required: false },
+]
+
+test("buildEnv maps credentials onto the launcher's own field names", () => {
+  const env = buildEnv(FIELDS, {
+    apiKey: "sk-1",
+    baseUrl: "https://gw/v1",
+    model: "m-1",
+    env: {},
+  })
+  assert.deepStrictEqual(env, {
+    LLM_API_KEY: "sk-1",
+    LLM_BASE_URL: "https://gw/v1",
+    LLM_MODEL: "m-1",
+  })
+})
+
+test("buildEnv falls back to a field's default and lets explicit env win", () => {
+  const env = buildEnv(FIELDS, {
+    apiKey: "sk-1",
+    baseUrl: "",
+    model: "",
+    env: { LLM_MODEL: "override", EXTRA: "1" },
+  })
+  assert.strictEqual(env.LLM_BASE_URL, "https://api.openai.com/v1")
+  assert.strictEqual(env.LLM_MODEL, "override")
+  assert.strictEqual(env.EXTRA, "1")
+})
+
+test("missingRequired names only the required fields with nothing to put in them", () => {
+  assert.deepStrictEqual(missingRequired(FIELDS, { LLM_MODEL: "m" }), [
+    "LLM_API_KEY",
+  ])
+  assert.deepStrictEqual(missingRequired(FIELDS, { LLM_API_KEY: "sk" }), [])
+})
+
+test("isAnswer ignores our own message, thinking chatter, and other agents", () => {
+  const mine = (over) => ({
+    messageId: "1",
+    senderType: "agent",
+    senderName: "e2e-openclaw-mac-x",
+    content: "4",
+    ...over,
+  })
+  assert.strictEqual(isAnswer(mine(), "e2e-openclaw-mac-x"), true)
+  assert.strictEqual(
+    isAnswer(mine({ senderType: "human" }), "e2e-openclaw-mac-x"),
+    false,
+  )
+  assert.strictEqual(
+    isAnswer(mine({ messageType: "thinking" }), "e2e-openclaw-mac-x"),
+    false,
+  )
+  assert.strictEqual(
+    isAnswer(mine({ content: "  " }), "e2e-openclaw-mac-x"),
+    false,
+  )
+  assert.strictEqual(
+    isAnswer(mine({ content: "Thinking..." }), "e2e-openclaw-mac-x"),
+    false,
+  )
+  assert.strictEqual(
+    isAnswer(
+      { ...mine(), senderType: "system", senderName: "other-agent" },
+      "e2e-x",
+    ),
+    false,
+  )
+})
+
+test("agentError catches an adapter's failure text posted as a chat message", () => {
+  // The false positive this exists for: an error naming the model contains the
+  // digit the arithmetic answer was checked against, so a substring test on
+  // "4" reported a broken agent as passing.
+  assert.ok(
+    agentError(
+      "Error processing message: CLI exited 1: candidate_failed requested=custom/deepseek-4-flash",
+    ),
+  )
+  assert.ok(agentError("Agent error: boom"))
+  assert.ok(
+    agentError("codex CLI not found. Install with: npm i -g @openai/codex"),
+  )
+  assert.ok(agentError("Working directory does not exist: /nope"))
+  // Real answers, including one that merely mentions the word.
+  assert.strictEqual(agentError("4"), null)
+  assert.strictEqual(agentError("The answer is 4."), null)
+  assert.strictEqual(agentError("I get 4 as the error-free answer"), null)
+})
+
+test("containsAnswer matches the answer as a token, not inside a model name", () => {
+  // Both halves came from real runs. The first is the false positive that made
+  // a broken agent pass; the second is Hermes, which prints a warning banner
+  // and then the answer — rejecting it would have been the opposite mistake.
+  assert.strictEqual(
+    containsAnswer(
+      "Error processing message: CLI exited 1: candidate_failed requested=custom/deepseek-4-flash",
+      "4",
+    ),
+    false,
+  )
+  assert.strictEqual(containsAnswer("gpt-4-turbo is not available", "4"), false)
+  assert.strictEqual(containsAnswer("Pi error: Connection error.", "4"), false)
+
+  assert.strictEqual(containsAnswer("4", "4"), true)
+  assert.strictEqual(containsAnswer("The answer is 4.", "4"), true)
+  assert.strictEqual(containsAnswer("2+2 = 4", "4"), true)
+  assert.strictEqual(
+    containsAnswer("⚠ scanner unavailable — pattern matching only\n4", "4"),
+    true,
+  )
+  // Regex metacharacters in `expect` are literal, not a pattern.
+  assert.strictEqual(containsAnswer("the total is 1.5", "1.5"), true)
+  assert.strictEqual(containsAnswer("the total is 155", "1.5"), false)
+})
+
+test("instanceName is unique, tagged with the platform, and short", () => {
+  const a = instanceName("openclaw")
+  assert.match(a, /^e2e-openclaw-(mac|win|lx)-[a-z0-9]+$/)
+  assert.ok(a.length <= 38, `${a} is too long`)
+})
+
+test("config resolves file → env → flags, in that order of precedence", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oa-e2e-cfg-"))
+  const file = path.join(dir, "config.json")
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      workspace: {
+        id: "from-file",
+        token: "tok-file",
+        apiBase: "https://file",
+      },
+      defaults: { apiKey: "sk-default", baseUrl: "https://gw/v1" },
+      agents: { openclaw: { model: "m-1" }, cursor: { skip: "no key" } },
+    }),
+  )
+  const saved = { ...process.env }
+  process.env.OA_E2E_WS_ID = "from-env"
+  process.env.OA_E2E_OPENCLAW_API_KEY = "sk-env"
+  try {
+    const config = buildConfig([
+      `--config=${file}`,
+      "--ws-token=tok-flag",
+      "--agents=openclaw",
+    ])
+    assert.strictEqual(config.workspace.id, "from-env") // env beats the file
+    assert.strictEqual(config.workspace.token, "tok-flag") // a flag beats both
+    assert.strictEqual(config.agents.length, 1) // --agents narrows the matrix
+    assert.strictEqual(config.agents[0].apiKey, "sk-env")
+    assert.strictEqual(config.agents[0].baseUrl, "https://gw/v1") // from defaults
+    assert.deepStrictEqual(validate(config), [])
+    assert.ok(secretsOf(config).includes("sk-env"))
+  } finally {
+    process.env = saved
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("config refuses to start without a workspace or an agent", () => {
+  const saved = { ...process.env }
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("OA_E2E_")) delete process.env[key]
+  }
+  delete process.env.WORKSPACE_API_BASE_URL
+  try {
+    const problems = validate(
+      buildConfig(["--config=" + path.join(os.tmpdir(), "nope.json")]),
+    )
+    assert.ok(false, `expected a missing-config error, got ${problems}`)
+  } catch (err) {
+    assert.match(err.message, /config file not found/)
+  } finally {
+    process.env = saved
+  }
+})
+
+test("readControlPort ignores a previous run's port line", () => {
+  // The regression that cost a warm-profile run its whole boot timeout: the
+  // reused log still ended with yesterday's (dead) port, and the app writes its
+  // token file before it logs today's.
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oa-e2e-home2-"))
+  fs.mkdirSync(path.join(home, ".openagents"), { recursive: true })
+  const log = path.join(home, ".openagents", "startup.log")
+  fs.writeFileSync(
+    log,
+    "2026-01-01Z Control server on 127.0.0.1:64354 (token: x)\n",
+  )
+
+  const baseline = startupLogSize(home)
+  assert.strictEqual(
+    readControlPort(home, baseline),
+    null,
+    "stale line must not count",
+  )
+
+  fs.appendFileSync(log, "2026-01-02Z booting\n")
+  assert.strictEqual(readControlPort(home, baseline), null)
+
+  fs.appendFileSync(
+    log,
+    "2026-01-02Z Control server on 127.0.0.1:50487 (token: x)\n",
+  )
+  assert.strictEqual(readControlPort(home, baseline), 50487)
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+test("readControlPort takes the port from the newest startup-log line", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oa-e2e-home-"))
+  fs.mkdirSync(path.join(home, ".openagents"), { recursive: true })
+  const log = path.join(home, ".openagents", "startup.log")
+  assert.strictEqual(readControlPort(home), null)
+  fs.writeFileSync(
+    log,
+    [
+      "2026-01-01T00:00:00Z Control server on 127.0.0.1:4599 (token: x)",
+      "2026-01-01T00:05:00Z something else",
+      "2026-01-02T00:00:00Z Control server on 127.0.0.1:51234 (token: x)",
+      "",
+    ].join("\n"),
+  )
+  assert.strictEqual(readControlPort(home), 51234)
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+test("the control client sends the token and surfaces server errors", async () => {
+  const seen = []
+  const server = http.createServer((req, res) => {
+    seen.push([req.method, req.url, req.headers.authorization])
+    if (req.url === "/status") {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      return res.end(JSON.stringify({ coreReady: true }))
+    }
+    res.writeHead(503, { "Content-Type": "application/json" })
+    res.end(JSON.stringify({ error: "core not loaded yet — retry shortly" }))
+  })
+  await new Promise((r) => server.listen(0, "127.0.0.1", r))
+  const control = new Control({ port: server.address().port, token: "tok" })
+  try {
+    assert.deepStrictEqual(await control.status(), { coreReady: true })
+    assert.deepStrictEqual(seen[0], ["GET", "/status", "Bearer tok"])
+    await assert.rejects(control.workspaces(), /503: core not loaded/)
+
+    // waitFor rides out failing probes until the deadline, then says what it saw.
+    await assert.rejects(
+      control.waitFor(() => control.workspaces(), {
+        timeoutMs: 300,
+        intervalMs: 100,
+        label: "workspaces",
+      }),
+      /timed out .* waiting for workspaces .*core not loaded/,
+    )
+  } finally {
+    server.close()
+  }
+})
+
+test("the report counts outcomes and shows the step that failed", () => {
+  const run = {
+    startedAt: "2026-08-27T00:00:00.000Z",
+    durationMs: 60_000,
+    platform: "darwin",
+    arch: "arm64",
+    launcherVersion: "0.9.23",
+    coreVersion: "0.2.173",
+    workspace: { id: "w1", slug: "acme" },
+    results: [
+      {
+        type: "openclaw",
+        status: "pass",
+        durationMs: 30_000,
+        reply: "4",
+        steps: [],
+      },
+      {
+        type: "codex",
+        status: "fail",
+        durationMs: 20_000,
+        reason: 'answer did not contain "4"',
+        steps: [
+          { name: "install", status: "ok", durationMs: 1000 },
+          {
+            name: "respond",
+            status: "fail",
+            durationMs: 19_000,
+            detail: "no reply",
+          },
+        ],
+      },
+      {
+        type: "cursor",
+        status: "skip",
+        durationMs: 0,
+        reason: "no key",
+        steps: [],
+      },
+    ],
+  }
+  assert.deepStrictEqual(summarize(run.results), {
+    total: 3,
+    pass: 1,
+    fail: 1,
+    skip: 1,
+  })
+  const md = renderMarkdown(run)
+  assert.match(md, /\| codex \| FAIL \|/)
+  assert.match(md, /### codex \(respond\)/)
+})
+
+test("secrets are redacted everywhere output is written", () => {
+  const redact = makeRedactor(["sk-super-secret-value", "short", ""])
+  assert.strictEqual(redact("key=sk-super-secret-value done"), "key=*** done")
+  assert.strictEqual(redact("short stays"), "short stays") // too short to be a key
+})
+
+test("renderTable pads columns to the widest cell", () => {
+  const table = renderTable(
+    ["A", "BB"],
+    [
+      ["1", "2"],
+      ["333", "4"],
+    ],
+  )
+  assert.deepStrictEqual(table.split("\n"), [
+    "A    BB",
+    "---  --",
+    "1    2",
+    "333  4",
+  ])
+})

--- a/tests/end_to_end/lib/config.js
+++ b/tests/end_to_end/lib/config.js
@@ -1,0 +1,205 @@
+"use strict"
+
+/**
+ * Run configuration: CLI flags, then environment, then the config file.
+ *
+ * The config file IS the agent matrix — an agent is tested because it has an
+ * entry with credentials, and skipped (with a reason in the report) when it
+ * doesn't. That keeps "which agents can we test today" in one reviewable file
+ * per machine instead of spread across a dozen environment variables.
+ */
+
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+const DEFAULT_API_BASE = "https://workspace-endpoint.openagents.org"
+const DEFAULT_PROMPT = "What is 2+2? Reply with just the number."
+const DEFAULT_EXPECT = "4"
+
+const DEFAULTS = {
+  bootTimeoutMin: 12,
+  installTimeoutMin: 20,
+  startTimeoutMin: 3,
+  replyTimeoutMin: 6,
+  settleSec: 15,
+  pollSec: 10,
+}
+
+function parseArgs(argv) {
+  const flags = {}
+  for (const arg of argv) {
+    if (!arg.startsWith("--")) continue
+    const [key, ...rest] = arg.slice(2).split("=")
+    flags[key] = rest.length ? rest.join("=") : true
+  }
+  return flags
+}
+
+function readConfigFile(file) {
+  if (!file) return {}
+  if (!fs.existsSync(file)) {
+    throw new Error(`config file not found: ${file}`)
+  }
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8"))
+  } catch (err) {
+    throw new Error(`config file ${file} is not valid JSON: ${err.message}`)
+  }
+}
+
+function defaultConfigFile(flags) {
+  if (flags.config) return path.resolve(String(flags.config))
+  if (process.env.OA_E2E_CONFIG) return path.resolve(process.env.OA_E2E_CONFIG)
+  const local = path.join(__dirname, "..", "agents.config.json")
+  return fs.existsSync(local) ? local : null
+}
+
+/** Per-agent credentials from the environment, for a keyless config file. */
+function envCred(type) {
+  const upper = type.toUpperCase().replace(/[^A-Z0-9]/g, "_")
+  const pick = (suffix) => process.env[`OA_E2E_${upper}_${suffix}`] || ""
+  const cred = {}
+  if (pick("API_KEY")) cred.apiKey = pick("API_KEY")
+  if (pick("BASE_URL")) cred.baseUrl = pick("BASE_URL")
+  if (pick("MODEL")) cred.model = pick("MODEL")
+  return cred
+}
+
+function minutes(value, fallbackMin) {
+  const n = Number(value)
+  return (Number.isFinite(n) && n > 0 ? n : fallbackMin) * 60_000
+}
+
+function seconds(value, fallbackSec) {
+  const n = Number(value)
+  return (Number.isFinite(n) && n >= 0 ? n : fallbackSec) * 1_000
+}
+
+function buildConfig(argv) {
+  const flags = parseArgs(argv)
+  const file = defaultConfigFile(flags)
+  const doc = readConfigFile(file)
+
+  const workspace = {
+    apiBase:
+      flags["ws-api"] ||
+      process.env.OA_E2E_WS_API ||
+      process.env.WORKSPACE_API_BASE_URL ||
+      (doc.workspace && doc.workspace.apiBase) ||
+      DEFAULT_API_BASE,
+    token:
+      flags["ws-token"] ||
+      process.env.OA_E2E_WS_TOKEN ||
+      (doc.workspace && doc.workspace.token) ||
+      "",
+    id:
+      flags["ws-id"] ||
+      process.env.OA_E2E_WS_ID ||
+      (doc.workspace && (doc.workspace.id || doc.workspace.slug)) ||
+      "",
+  }
+
+  const defaults = doc.defaults || {}
+  const configured = doc.agents || {}
+  // `--agents=a,b` narrows the matrix; without it every configured agent runs.
+  const requested = flags.agents
+    ? String(flags.agents)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : Object.keys(configured)
+
+  const agents = requested.map((type) => {
+    const entry = { ...(configured[type] || {}) }
+    const fromEnv = envCred(type)
+    return {
+      type,
+      label: entry.label || type,
+      model: fromEnv.model || entry.model || defaults.model || "",
+      apiKey: fromEnv.apiKey || entry.apiKey || defaults.apiKey || "",
+      baseUrl: fromEnv.baseUrl || entry.baseUrl || defaults.baseUrl || "",
+      env: { ...(defaults.env || {}), ...(entry.env || {}) },
+      files: entry.files || {},
+      prompt: entry.prompt || doc.prompt || DEFAULT_PROMPT,
+      expect: entry.expect || doc.expect || DEFAULT_EXPECT,
+      skip: entry.skip || null,
+    }
+  })
+
+  const homeDir = path.resolve(
+    flags.home ||
+      process.env.OA_E2E_HOME ||
+      path.join(os.homedir(), ".openagents-e2e", "home"),
+  )
+
+  return {
+    configFile: file,
+    workspace,
+    agents,
+    homeDir,
+    outDir: path.resolve(
+      flags.out ||
+        process.env.OA_E2E_OUT ||
+        path.join(os.homedir(), ".openagents-e2e", "runs"),
+    ),
+    appPath: flags.app ? String(flags.app) : process.env.OA_LAUNCHER_BIN || "",
+    fresh: !!flags.fresh,
+    attach: !!flags.attach,
+    keep: !!flags.keep,
+    reinstall: !!flags.reinstall,
+    json: !!flags.json,
+    timeouts: {
+      boot: minutes(flags["boot-timeout"], DEFAULTS.bootTimeoutMin),
+      install: minutes(flags["install-timeout"], DEFAULTS.installTimeoutMin),
+      start: minutes(flags["start-timeout"], DEFAULTS.startTimeoutMin),
+      reply: minutes(flags["reply-timeout"], DEFAULTS.replyTimeoutMin),
+      // A just-started agent needs a moment to join the workspace and begin
+      // reading its channel; a message posted before that is simply missed.
+      settle: seconds(flags.settle, DEFAULTS.settleSec),
+      // How often the slow waits ask again. Installs run for minutes; polling
+      // them every second buys nothing and floods the log.
+      poll: seconds(flags.poll, DEFAULTS.pollSec),
+    },
+    help: !!flags.help,
+  }
+}
+
+/** Everything the run must have before it starts doing slow things. */
+function validate(config) {
+  const problems = []
+  if (!config.workspace.token) {
+    problems.push(
+      "no workspace token — set workspace.token in the config file or OA_E2E_WS_TOKEN",
+    )
+  }
+  if (!config.workspace.id) {
+    problems.push(
+      "no workspace — set workspace.id in the config file or OA_E2E_WS_ID",
+    )
+  }
+  if (!config.agents.length) {
+    problems.push(
+      config.configFile
+        ? `no agents configured in ${config.configFile}`
+        : "no config file found — copy tests/end_to_end/agents.example.json and fill it in",
+    )
+  }
+  return problems
+}
+
+/** Every secret this run knows, for redacting logs before they hit disk. */
+function secretsOf(config) {
+  return [
+    config.workspace.token,
+    ...config.agents.flatMap((a) => [a.apiKey, ...Object.values(a.env)]),
+  ]
+}
+
+module.exports = {
+  buildConfig,
+  validate,
+  secretsOf,
+  DEFAULT_PROMPT,
+  DEFAULT_EXPECT,
+}

--- a/tests/end_to_end/lib/control.js
+++ b/tests/end_to_end/lib/control.js
@@ -1,0 +1,287 @@
+"use strict"
+
+/**
+ * Client for the launcher's local control server — the HTTP surface defined in
+ * packages/launcher/src/main/control-server.ts.
+ *
+ * Everything the end-to-end run does to the launcher goes through here: it is
+ * the same AgentManager the UI drives over IPC, reached without a display. That
+ * matters on the machines this suite runs on daily — a Windows box over SSH has
+ * no desktop session, so a GUI driver (Playwright) cannot see the app at all.
+ */
+
+const fs = require("fs")
+const path = require("path")
+
+const { sleep } = require("./util")
+
+class ControlError extends Error {
+  constructor(message, status, body) {
+    super(message)
+    this.name = "ControlError"
+    this.status = status
+    this.body = body
+  }
+}
+
+/** Where the running launcher writes its per-start token, under the test HOME. */
+function tokenFile(homeDir) {
+  return path.join(homeDir, ".openagents", "control.token")
+}
+
+/** The token, or null while the app has not written it yet. */
+function readToken(homeDir) {
+  try {
+    const token = fs.readFileSync(tokenFile(homeDir), "utf-8").trim()
+    return token || null
+  } catch {
+    return null
+  }
+}
+
+/** Current size of the startup log — the baseline a boot reads forward from. */
+function startupLogSize(homeDir) {
+  try {
+    return fs.statSync(startupLog(homeDir)).size
+  } catch {
+    return 0
+  }
+}
+
+function startupLog(homeDir) {
+  return path.join(homeDir, ".openagents", "startup.log")
+}
+
+/**
+ * The port the control server chose, from the startup log.
+ *
+ * We start the app with `--control-port=0` so a run can never collide with
+ * another launcher (the user's own, or yesterday's leftover). The app logs the
+ * port it landed on, and `fromOffset` is what keeps us from reading YESTERDAY's
+ * line: on a reused profile the log already ends with a port that is now dead,
+ * and the app writes its token file before it logs the new port — so a naive
+ * "last line wins" latches onto the old port and then waits out the whole boot
+ * timeout against a closed socket. Pass the log's size from just before the
+ * spawn and only this run's lines are considered.
+ */
+function readControlPort(homeDir, fromOffset = 0) {
+  let text
+  try {
+    const fd = fs.openSync(startupLog(homeDir), "r")
+    try {
+      const size = fs.fstatSync(fd).size
+      if (size <= fromOffset) return null
+      const buf = Buffer.alloc(size - fromOffset)
+      fs.readSync(fd, buf, 0, buf.length, fromOffset)
+      text = buf.toString("utf-8")
+    } finally {
+      fs.closeSync(fd)
+    }
+  } catch {
+    return null
+  }
+  const matches = [...text.matchAll(/Control server on 127\.0\.0\.1:(\d+)/g)]
+  if (!matches.length) return null
+  return Number(matches[matches.length - 1][1])
+}
+
+class Control {
+  constructor({ port, token, log = () => {} }) {
+    this.port = port
+    this.token = token
+    this.log = log
+  }
+
+  async request(method, route, { body, timeoutMs = 30_000 } = {}) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    let res
+    try {
+      res = await fetch(`http://127.0.0.1:${this.port}${route}`, {
+        method,
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      })
+    } catch (err) {
+      if (err.name === "AbortError") {
+        throw new ControlError(
+          `${method} ${route} timed out after ${Math.round(timeoutMs / 1000)}s`,
+          0,
+          null,
+        )
+      }
+      throw new ControlError(
+        `${method} ${route} failed: ${err.message}`,
+        0,
+        null,
+      )
+    } finally {
+      clearTimeout(timer)
+    }
+
+    const text = await res.text()
+    let parsed = null
+    try {
+      parsed = text ? JSON.parse(text) : null
+    } catch {
+      parsed = { raw: text }
+    }
+    if (!res.ok) {
+      const detail = (parsed && parsed.error) || text.slice(0, 300)
+      throw new ControlError(
+        `${method} ${route} → ${res.status}: ${detail}`,
+        res.status,
+        parsed,
+      )
+    }
+    return parsed
+  }
+
+  get(route, opts) {
+    return this.request("GET", route, opts)
+  }
+
+  post(route, body, opts) {
+    return this.request("POST", route, { ...opts, body: body || {} })
+  }
+
+  // ── Read ────────────────────────────────────────────────────────────────
+  status() {
+    return this.get("/status", { timeoutMs: 10_000 })
+  }
+
+  agents() {
+    return this.get("/agents").then((r) => r.agents || [])
+  }
+
+  catalog() {
+    return this.get("/catalog", { timeoutMs: 60_000 })
+  }
+
+  envFields(type) {
+    return this.get(`/agents/env-fields?type=${encodeURIComponent(type)}`).then(
+      (r) => r.fields || [],
+    )
+  }
+
+  workspaces() {
+    return this.get("/workspaces").then((r) => r.workspaces || [])
+  }
+
+  logs(file, tail = 200) {
+    return this.get(`/logs?file=${encodeURIComponent(file)}&tail=${tail}`).then(
+      (r) => r[file] || "",
+    )
+  }
+
+  // ── Drive ───────────────────────────────────────────────────────────────
+  pair(code) {
+    return this.post("/pair", { code }, { timeoutMs: 60_000 })
+  }
+
+  startInstall(type) {
+    return this.post("/install", { type })
+  }
+
+  installStatus(type) {
+    return this.get(`/install?type=${encodeURIComponent(type)}`)
+  }
+
+  createAgent(name, type, workdir) {
+    return this.post("/agents/create", { name, type, path: workdir })
+  }
+
+  saveInstanceEnv(name, env) {
+    return this.post("/agents/env", { name, env })
+  }
+
+  saveTypeEnv(type, env) {
+    return this.post("/agents/env", { type, env })
+  }
+
+  connect(name, workspace) {
+    return this.post(
+      "/agents/connect",
+      { name, workspace },
+      { timeoutMs: 60_000 },
+    )
+  }
+
+  start(name) {
+    return this.post("/agents/start", { name }, { timeoutMs: 60_000 })
+  }
+
+  stop(name) {
+    return this.post("/agents/stop", { name }, { timeoutMs: 60_000 })
+  }
+
+  remove(name) {
+    return this.post("/agents/remove", { name }, { timeoutMs: 60_000 })
+  }
+
+  sendChat(workspace, channel, agent, content) {
+    return this.post(
+      "/chat/send",
+      { workspace, channel, agent, content },
+      { timeoutMs: 60_000 },
+    ).then((r) => r.result)
+  }
+
+  chatMessages(workspace, channel, limit = 100) {
+    const qs = new URLSearchParams({ workspace, limit: String(limit) })
+    if (channel) qs.set("channel", channel)
+    return this.get(`/chat/messages?${qs}`, { timeoutMs: 60_000 }).then(
+      (r) => r.messages || [],
+    )
+  }
+
+  quit() {
+    return this.post("/quit", {}, { timeoutMs: 10_000 }).catch(() => null)
+  }
+
+  /**
+   * Poll `probe` until it returns a truthy value.
+   *
+   * Transport errors are swallowed on purpose: a 503 means the core is still
+   * loading and a dropped connection means the app is busy — both are states
+   * this suite waits through, not failures. `describe` turns the last seen
+   * value into the timeout message so a failure says what it was stuck on.
+   */
+  async waitFor(probe, { timeoutMs, intervalMs = 3_000, label, describe }) {
+    const deadline = Date.now() + timeoutMs
+    let last = null
+    let lastError = null
+    while (Date.now() < deadline) {
+      try {
+        const value = await probe()
+        last = value
+        if (value) return value
+        lastError = null
+      } catch (err) {
+        lastError = err
+      }
+      await sleep(intervalMs)
+    }
+    const detail = lastError
+      ? lastError.message
+      : describe
+        ? describe(last)
+        : JSON.stringify(last)
+    throw new Error(
+      `timed out after ${Math.round(timeoutMs / 1000)}s waiting for ${label} (last: ${detail})`,
+    )
+  }
+}
+
+module.exports = {
+  Control,
+  ControlError,
+  readToken,
+  readControlPort,
+  startupLogSize,
+  tokenFile,
+}

--- a/tests/end_to_end/lib/launcher.js
+++ b/tests/end_to_end/lib/launcher.js
@@ -1,0 +1,284 @@
+"use strict"
+
+/**
+ * Start (or attach to) the desktop launcher and hand back a control client.
+ *
+ * The app runs `--headless --control-port=0`: no window is created, and the
+ * control server binds a free loopback port it writes to the startup log. Both
+ * matter for the daily run — a headless app needs no desktop session (Windows
+ * over SSH has none), and a random port never collides with the launcher the
+ * developer already has open.
+ *
+ * The run gets its own HOME. `~/.openagents` (portable node, core lib, daemon
+ * config, agent runtimes) and the Electron profile all hang off it, so a test
+ * run never touches — or is polluted by — the real installation, and `--fresh`
+ * is a single directory removal.
+ */
+
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { spawn } = require("child_process")
+
+const {
+  Control,
+  readToken,
+  readControlPort,
+  startupLogSize,
+} = require("./control")
+const { sleep, ensureDir } = require("./util")
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..")
+const LAUNCHER_DIR = path.join(REPO_ROOT, "packages", "launcher")
+
+/** Installed-app locations per platform, in the order a user would have them. */
+function installedCandidates() {
+  const home = os.homedir()
+  if (process.platform === "darwin") {
+    return [
+      "/Applications/OpenAgents Launcher.app/Contents/MacOS/OpenAgents Launcher",
+      path.join(
+        home,
+        "Applications/OpenAgents Launcher.app/Contents/MacOS/OpenAgents Launcher",
+      ),
+    ]
+  }
+  if (process.platform === "win32") {
+    const local =
+      process.env.LOCALAPPDATA || path.join(home, "AppData", "Local")
+    return [
+      path.join(
+        local,
+        "Programs",
+        "openagents-launcher",
+        "OpenAgents Launcher.exe",
+      ),
+      path.join(
+        process.env["ProgramFiles"] || "C:\\Program Files",
+        "OpenAgents Launcher",
+        "OpenAgents Launcher.exe",
+      ),
+    ]
+  }
+  return [
+    "/opt/OpenAgents Launcher/openagents-launcher",
+    "/usr/bin/openagents-launcher",
+    path.join(home, "Applications", "OpenAgents Launcher.AppImage"),
+  ]
+}
+
+/** The electron binary from the launcher's own node_modules, or null. */
+function electronBinary() {
+  let electron
+  try {
+    electron = require(path.join(LAUNCHER_DIR, "node_modules", "electron"))
+  } catch {
+    return null
+  }
+  return typeof electron === "string" && fs.existsSync(electron)
+    ? electron
+    : null
+}
+
+/** The electron-vite build output plus the electron binary that can run it. */
+function devCandidate(mainEntry) {
+  const main = mainEntry || path.join(LAUNCHER_DIR, "out", "main", "index.js")
+  if (!fs.existsSync(main)) return null
+  const electron = electronBinary()
+  if (!electron) return null
+  return { command: electron, args: [main], kind: "dev build" }
+}
+
+/**
+ * What to run, in order of trust: an explicit path, then an installed app (what
+ * the user actually ships), then the local build. A daily run should be testing
+ * the shipped artifact, so the build is the fallback, never the default.
+ */
+function resolveLauncher(explicit) {
+  if (explicit) {
+    if (!fs.existsSync(explicit)) {
+      throw new Error(`--app ${explicit} does not exist`)
+    }
+    if (!explicit.endsWith(".js")) {
+      return { command: explicit, args: [], kind: "installed app" }
+    }
+    // A build output, not an executable — it needs electron to run it, and
+    // `npm install` in packages/launcher is what puts electron there.
+    const dev = devCandidate(path.resolve(explicit))
+    if (!dev) {
+      throw new Error(
+        `${explicit} needs electron to run it — run \`npm install\` in packages/launcher first`,
+      )
+    }
+    return dev
+  }
+  for (const candidate of installedCandidates()) {
+    if (fs.existsSync(candidate)) {
+      return { command: candidate, args: [], kind: "installed app" }
+    }
+  }
+  const dev = devCandidate()
+  if (dev) return dev
+  throw new Error(
+    "no launcher found — install the app, run `npm run build` in packages/launcher, " +
+      "or pass --app <path to the launcher binary>",
+  )
+}
+
+class LauncherHandle {
+  constructor({ control, child, homeDir, logPath, attached }) {
+    this.control = control
+    this.child = child
+    this.homeDir = homeDir
+    this.logPath = logPath
+    this.attached = attached
+  }
+
+  /** Quit the app the way the tray menu does, so the daemon is stopped too. */
+  async stop() {
+    if (this.attached || !this.child) return
+    await this.control.quit()
+    for (let i = 0; i < 40 && this.child.exitCode === null; i++)
+      await sleep(250)
+    if (this.child.exitCode === null) {
+      this.child.kill()
+      await sleep(1_000)
+      if (this.child.exitCode === null) this.child.kill("SIGKILL")
+    }
+  }
+}
+
+/** Attach to a launcher that is already running under the given HOME. */
+async function attachLauncher({ homeDir, log }) {
+  const token = readToken(homeDir)
+  const port = readControlPort(homeDir)
+  if (!token || !port) {
+    throw new Error(
+      `no running launcher found for HOME=${homeDir} — start it with ` +
+        "`--control-port=0` (or drop --attach to have this script start one)",
+    )
+  }
+  const control = new Control({ port, token, log })
+  await control.status() // fails loudly if the token is stale
+  return new LauncherHandle({
+    control,
+    child: null,
+    homeDir,
+    logPath: null,
+    attached: true,
+  })
+}
+
+async function startLauncher({ appPath, homeDir, outDir, bootTimeoutMs, log }) {
+  const target = resolveLauncher(appPath)
+  ensureDir(homeDir)
+  const appData = ensureDir(path.join(homeDir, "AppData", "Roaming"))
+  const localAppData = ensureDir(path.join(homeDir, "AppData", "Local"))
+  const logPath = path.join(ensureDir(outDir), "launcher.out.log")
+  const logStream = fs.createWriteStream(logPath, { flags: "a" })
+
+  log(`launcher: ${target.command} (${target.kind})`)
+  log(`profile HOME: ${homeDir}`)
+
+  // Where this run's startup log begins. Everything already in the file is a
+  // PREVIOUS run's — including its (now dead) control port.
+  const logBaseline = startupLogSize(homeDir)
+
+  const args = [...target.args, "--headless", "--control-port=0"]
+  // AppImage/deb on a headless box often has no usable sandbox (no user
+  // namespaces under some kernels/containers); the app would exit before the
+  // control server ever starts.
+  if (process.platform === "linux") args.push("--no-sandbox")
+
+  const child = spawn(target.command, args, {
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      APPDATA: appData,
+      LOCALAPPDATA: localAppData,
+      // Keep the runner's own Electron/npm settings out of the app's way.
+      ELECTRON_RUN_AS_NODE: undefined,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  child.stdout.pipe(logStream)
+  child.stderr.pipe(logStream)
+
+  let exited = null
+  child.on("exit", (code, signal) => {
+    exited = { code, signal }
+  })
+
+  // 1. The app writes control.token and logs its port once the server is up.
+  const deadline = Date.now() + bootTimeoutMs
+  let token = null
+  let port = null
+  while (Date.now() < deadline) {
+    if (exited) {
+      throw new Error(
+        `launcher exited (code ${exited.code}, signal ${exited.signal}) before the ` +
+          `control server started — see ${logPath}`,
+      )
+    }
+    token = readToken(homeDir)
+    port = readControlPort(homeDir, logBaseline)
+    // Both have to answer before we trust them: a killed run can leave a token
+    // file behind, and the app writes the token before it logs the port.
+    if (token && port) {
+      const probe = new Control({ port, token })
+      const reachable = await probe.status().then(
+        () => true,
+        () => false,
+      )
+      if (reachable) break
+    }
+    token = null
+    port = null
+    await sleep(1_000)
+  }
+  if (!token || !port) {
+    throw new Error(
+      `control server did not come up within ${Math.round(bootTimeoutMs / 1000)}s — see ${logPath}`,
+    )
+  }
+  log(`control server: 127.0.0.1:${port}`)
+
+  const control = new Control({ port, token, log })
+  const handle = new LauncherHandle({
+    control,
+    child,
+    homeDir,
+    logPath,
+    attached: false,
+  })
+
+  // 2. On a cold profile the app downloads a portable node runtime and the core
+  //    library before AgentManager exists — minutes, not seconds.
+  await control.waitFor(
+    async () => {
+      if (exited) {
+        throw new Error(
+          `launcher exited (code ${exited.code}) while loading the core — see ${logPath}`,
+        )
+      }
+      const status = await control.status()
+      return status.coreReady ? status : null
+    },
+    {
+      timeoutMs: Math.max(0, deadline - Date.now()),
+      intervalMs: 5_000,
+      label: "the core to finish loading (GET /status coreReady)",
+    },
+  )
+  log("core ready")
+  return handle
+}
+
+module.exports = {
+  startLauncher,
+  attachLauncher,
+  resolveLauncher,
+  REPO_ROOT,
+  LAUNCHER_DIR,
+}

--- a/tests/end_to_end/lib/report.js
+++ b/tests/end_to_end/lib/report.js
@@ -1,0 +1,109 @@
+"use strict"
+
+/**
+ * What the run leaves behind: a table on the terminal for whoever is watching,
+ * results.json for whatever collects the daily status, and summary.md to paste
+ * into an issue when a cell goes red.
+ */
+
+const path = require("path")
+
+const { renderTable, formatDuration, writeFileSafe } = require("./util")
+
+const MARK = { pass: "PASS", fail: "FAIL", skip: "SKIP" }
+
+function summarize(results) {
+  return {
+    total: results.length,
+    pass: results.filter((r) => r.status === "pass").length,
+    fail: results.filter((r) => r.status === "fail").length,
+    skip: results.filter((r) => r.status === "skip").length,
+  }
+}
+
+/** The step that ended the run for this agent — the useful half of a failure. */
+function failedStep(result) {
+  const step = (result.steps || []).find((s) => s.status === "fail")
+  return step ? step.name : null
+}
+
+function detailOf(result) {
+  if (result.status === "pass") {
+    return result.reply ? JSON.stringify(String(result.reply).slice(0, 60)) : ""
+  }
+  const step = failedStep(result)
+  const reason = String(result.reason || "")
+    .split("\n")[0]
+    .slice(0, 90)
+  return step ? `${step}: ${reason}` : reason
+}
+
+function renderConsole(run) {
+  const counts = summarize(run.results)
+  const rows = run.results.map((r) => [
+    r.type,
+    MARK[r.status] || r.status,
+    formatDuration(r.durationMs),
+    detailOf(r),
+  ])
+  return [
+    "",
+    renderTable(["AGENT", "STATUS", "TIME", "DETAIL"], rows),
+    "",
+    `${counts.pass} passed, ${counts.fail} failed, ${counts.skip} skipped ` +
+      `in ${formatDuration(run.durationMs)} ` +
+      `(${run.platform}/${run.arch}, launcher ${run.launcherVersion || "?"})`,
+  ].join("\n")
+}
+
+function renderMarkdown(run) {
+  const counts = summarize(run.results)
+  const lines = [
+    `# Launcher end-to-end — ${run.startedAt}`,
+    "",
+    `- Host: \`${run.platform}/${run.arch}\``,
+    `- Launcher: \`${run.launcherVersion || "?"}\` (core \`${run.coreVersion || "?"}\`)`,
+    `- Workspace: \`${run.workspace.slug || run.workspace.id}\``,
+    `- Result: **${counts.pass} passed, ${counts.fail} failed, ${counts.skip} skipped** in ${formatDuration(run.durationMs)}`,
+    "",
+    "| Agent | Status | Time | Detail |",
+    "| --- | --- | --- | --- |",
+  ]
+  for (const r of run.results) {
+    lines.push(
+      `| ${r.type} | ${MARK[r.status] || r.status} | ${formatDuration(r.durationMs)} | ${detailOf(r).replace(/\|/g, "\\|")} |`,
+    )
+  }
+  const failures = run.results.filter((r) => r.status === "fail")
+  if (failures.length) {
+    lines.push("", "## Failures", "")
+    for (const r of failures) {
+      lines.push(
+        `### ${r.type} (${failedStep(r) || "?"})`,
+        "",
+        "```",
+        String(r.reason || ""),
+        "```",
+        "",
+      )
+      lines.push(
+        ...(r.steps || []).map(
+          (s) =>
+            `- ${s.name}: ${s.status} (${formatDuration(s.durationMs)})${s.detail ? ` — ${String(s.detail).split("\n")[0]}` : ""}`,
+        ),
+        "",
+      )
+    }
+  }
+  return lines.join("\n")
+}
+
+function writeArtifacts(run, outDir, redact) {
+  const jsonPath = path.join(outDir, "results.json")
+  const mdPath = path.join(outDir, "summary.md")
+  writeFileSafe(jsonPath, redact(JSON.stringify(run, null, 2)))
+  writeFileSafe(mdPath, redact(renderMarkdown(run)))
+  return { jsonPath, mdPath }
+}
+
+module.exports = { summarize, renderConsole, renderMarkdown, writeArtifacts }

--- a/tests/end_to_end/lib/scenario.js
+++ b/tests/end_to_end/lib/scenario.js
@@ -1,0 +1,456 @@
+"use strict"
+
+/**
+ * One agent, end to end: install → create → configure → connect → start → ask
+ * it something and read the answer back.
+ *
+ * Every step goes through the launcher's control server, which is the same
+ * AgentManager the UI calls over IPC — so a green run means the desktop path
+ * works on this machine today, not that some parallel CLI does.
+ */
+
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+const { sleep, ensureDir, formatDuration } = require("./util")
+const { removeMember } = require("./workspace")
+
+const RUNNING_STATES = /^(running|online|idle|active)$/i
+/** Status/thinking chatter the agent posts before its real answer. */
+const NON_ANSWER_TYPES = new Set(["thinking", "status", "tool", "tool_call"])
+
+/**
+ * How an adapter reports that it could not answer.
+ *
+ * These arrive as ordinary chat messages — `sendError` in the core's adapter
+ * base sets no distinguishing message_type — so the text is the only signal.
+ * Catching them matters more than it looks: a substring check for the expected
+ * answer can PASS on an error, which is how "CLI exited 1: ... requested=
+ * custom/deepseek-4-flash" once counted as the answer to "what is 2+2".
+ * Prefixes collected from the adapters' own sendError call sites.
+ */
+const AGENT_ERRORS = [
+  /^error(:| processing message)/i,
+  /^agent error:/i,
+  /^configuration error:/i,
+  /^failed to (run|start)\b/i,
+  /^working directory does not exist:/i,
+  /^the agent hit an error/i,
+  /\bCLI not found\b/i,
+  /became unresponsive and was res/i,
+  /timed out before producing a resp/i,
+  /^⚠️/,
+]
+
+/** The agent's own error text, or null when the message is a real answer. */
+function agentError(text) {
+  const body = String(text || "").trim()
+  return AGENT_ERRORS.some((re) => re.test(body)) ? body : null
+}
+
+/**
+ * Does the reply contain the expected answer as a TOKEN, rather than as a
+ * fragment of a longer word?
+ *
+ * A plain `includes("4")` matched the "4" inside "deepseek-4-flash" and so
+ * passed an agent whose only message was a failure naming that model.
+ * Excluding hyphen and underscore neighbours — the characters that hold model
+ * and package names together — separates that from a real answer, including
+ * one that arrives after a warning banner, which is how Hermes answers.
+ */
+function containsAnswer(reply, expected) {
+  const needle = String(expected == null ? "" : expected).trim()
+  if (!needle) return true
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return new RegExp(`(^|[^\\w-])${escaped}([^\\w-]|$)`, "i").test(String(reply))
+}
+
+/** A short, unique, filesystem- and workspace-safe instance name. */
+function instanceName(type) {
+  const tag =
+    process.platform === "win32"
+      ? "win"
+      : process.platform === "darwin"
+        ? "mac"
+        : "lx"
+  return `e2e-${type}-${tag}-${Date.now().toString(36)}`
+}
+
+/**
+ * Map this agent's credentials onto the env vars the Configure dialog asks for.
+ *
+ * The field list comes from the launcher itself (GET /agents/env-fields), so a
+ * registry change lands in the test without an edit here — we only have to know
+ * the three shapes a field can have. Explicit `env` entries win: they are the
+ * escape hatch for an agent whose variables don't follow the convention.
+ */
+function buildEnv(fields, agent) {
+  const env = {}
+  for (const field of fields) {
+    const name = field && field.name
+    if (!name) continue
+    if (/_API_KEY$/.test(name) && agent.apiKey) env[name] = agent.apiKey
+    else if (/_BASE_URL$/.test(name) && agent.baseUrl) env[name] = agent.baseUrl
+    else if (/_MODEL$/.test(name) && agent.model) env[name] = agent.model
+    else if (field.default) env[name] = String(field.default)
+  }
+  return { ...env, ...agent.env }
+}
+
+/** Required fields the credentials can't fill — the reason to skip, not fail. */
+function missingRequired(fields, env) {
+  return fields
+    .filter((f) => f && f.required && !String(env[f.name] || "").trim())
+    .map((f) => f.name)
+}
+
+/**
+ * Config an agent reads from disk rather than the environment (Hermes keeps its
+ * key in ~/.hermes/.env, the way `hermes setup` writes it). Declared per agent
+ * in the config file so this stays data, not a growing if-chain.
+ */
+function writeConfigFiles(agent, homeDir) {
+  const written = []
+  for (const [rawPath, rawBody] of Object.entries(agent.files || {})) {
+    const target = path.resolve(
+      rawPath.startsWith("~/") ? path.join(homeDir, rawPath.slice(2)) : rawPath,
+    )
+    const body = String(rawBody)
+      .replace(/\$\{apiKey\}/g, agent.apiKey)
+      .replace(/\$\{baseUrl\}/g, agent.baseUrl)
+      .replace(/\$\{model\}/g, agent.model)
+    ensureDir(path.dirname(target))
+    fs.writeFileSync(target, body)
+    written.push(target)
+  }
+  return written
+}
+
+function isAnswer(message, agentName) {
+  if (!message) return false
+  if (message.senderType === "human") return false
+  if (NON_ANSWER_TYPES.has(String(message.messageType || "").toLowerCase()))
+    return false
+  const text = String(message.content || "").trim()
+  if (!text || text.toLowerCase() === "thinking...") return false
+  // A workspace can hold other agents; only this run's agent counts.
+  const sender = String(message.senderName || "")
+  return (
+    sender === agentName ||
+    sender.includes(agentName) ||
+    message.senderType === "agent"
+  )
+}
+
+class StepRecorder {
+  constructor(log) {
+    this.steps = []
+    this.log = log
+  }
+
+  async run(name, fn) {
+    const startedAt = Date.now()
+    this.log(`  · ${name}`)
+    try {
+      const detail = await fn()
+      const step = {
+        name,
+        status: "ok",
+        durationMs: Date.now() - startedAt,
+        detail: detail || null,
+      }
+      this.steps.push(step)
+      this.log(
+        `    ✓ ${name} (${formatDuration(step.durationMs)})${detail ? ` — ${detail}` : ""}`,
+      )
+      return detail
+    } catch (err) {
+      this.steps.push({
+        name,
+        status: "fail",
+        durationMs: Date.now() - startedAt,
+        detail: err.message,
+      })
+      throw err
+    }
+  }
+
+  skipped(name, reason) {
+    this.steps.push({ name, status: "skipped", durationMs: 0, detail: reason })
+    this.log(`    – ${name} skipped — ${reason}`)
+  }
+}
+
+/** Install the type if it isn't there, polling the background install job. */
+async function ensureInstalled({
+  control,
+  type,
+  timeoutMs,
+  pollMs,
+  reinstall,
+  step,
+  log,
+}) {
+  // An unreachable marketplace must not stop the run: installing is idempotent,
+  // so "we could not tell" resolves to "install it".
+  const catalog = await control.catalog().catch((err) => {
+    log(`    ! could not read the catalog (${err.message}) — installing anyway`)
+    return null
+  })
+  const entry =
+    catalog && (catalog.catalog || []).find((c) => c && c.name === type)
+  if (entry && entry.installed && !reinstall) {
+    step.skipped("install", `${type} already installed`)
+    return
+  }
+  await step.run("install", async () => {
+    await control.startInstall(type)
+    const job = await control.waitFor(
+      async () => {
+        const state = await control.installStatus(type)
+        return state.state === "running" ? null : state
+      },
+      {
+        timeoutMs,
+        intervalMs: pollMs,
+        label: `the ${type} installer to finish`,
+        describe: () => "still running",
+      },
+    )
+    if (job.state !== "done") {
+      const tail = String(job.log || "")
+        .split("\n")
+        .slice(-12)
+        .join("\n")
+      throw new Error(`installer failed: ${job.error || "unknown"}\n${tail}`)
+    }
+    return formatDuration(job.durationSeconds * 1000)
+  })
+}
+
+async function runAgent({
+  control,
+  config,
+  agent,
+  workspace,
+  log,
+  outDir,
+  redact,
+}) {
+  const startedAt = Date.now()
+  const step = new StepRecorder(log)
+  const name = instanceName(agent.type)
+  const result = {
+    type: agent.type,
+    instance: name,
+    status: "fail",
+    reason: null,
+    reply: null,
+    steps: step.steps,
+    durationMs: 0,
+  }
+
+  if (agent.skip) {
+    result.status = "skip"
+    result.reason = agent.skip
+    result.durationMs = Date.now() - startedAt
+    log(`  – skipped: ${agent.skip}`)
+    return result
+  }
+
+  try {
+    await ensureInstalled({
+      control,
+      type: agent.type,
+      timeoutMs: config.timeouts.install,
+      pollMs: config.timeouts.poll,
+      reinstall: config.reinstall,
+      step,
+      log,
+    })
+
+    // The working directory is the agent's spawn cwd; a missing one makes the
+    // daemon's spawn fail with an error that reads like a broken agent.
+    const workdir = ensureDir(path.join(config.homeDir, "e2e-work", name))
+    await step.run("create", async () => {
+      await control.createAgent(name, agent.type, workdir)
+      const agents = await control.agents()
+      if (!agents.some((a) => a.name === name)) {
+        throw new Error("the runtime did not persist the agent")
+      }
+      return name
+    })
+
+    const fields = await control.envFields(agent.type)
+    const env = buildEnv(fields, agent)
+    const missing = missingRequired(fields, env)
+    if (missing.length) {
+      result.status = "skip"
+      result.reason = `no credential for ${missing.join(", ")}`
+      step.skipped("configure", result.reason)
+      await cleanup({ control, config, name, workspace, step, log })
+      result.durationMs = Date.now() - startedAt
+      return result
+    }
+
+    await step.run("configure", async () => {
+      const files = writeConfigFiles(agent, config.homeDir)
+      if (Object.keys(env).length) await control.saveInstanceEnv(name, env)
+      const vars = Object.keys(env).join(", ") || "no env fields"
+      return files.length ? `${vars} (+${files.length} config file(s))` : vars
+    })
+
+    await step.run("connect", async () => {
+      await control.connect(name, workspace.slug)
+      return workspace.slug
+    })
+
+    await step.run("start", async () => {
+      await control.start(name)
+      // Remembered outside the probe so a timeout can say what the agent was
+      // stuck AT — "state=error: no binary" beats "it never started".
+      let seen = null
+      const row = await control.waitFor(
+        async () => {
+          const agents = await control.agents()
+          seen = agents.find((a) => a.name === name) || null
+          return seen && RUNNING_STATES.test(String(seen.state || ""))
+            ? seen
+            : null
+        },
+        {
+          timeoutMs: config.timeouts.start,
+          intervalMs: 3_000,
+          label: `${name} to reach a running state`,
+          describe: () =>
+            seen
+              ? `state=${seen.state}${seen.lastError ? ` — ${seen.lastError}` : ""}`
+              : "the agent is not in the daemon's list",
+        },
+      )
+      return `state=${row.state}`
+    })
+
+    await step.run("respond", async () => {
+      const channel = name
+      const before = new Set(
+        (await control.chatMessages(workspace.id, channel, 100)).map(
+          (m) => m.messageId,
+        ),
+      )
+      await sleep(config.timeouts.settle)
+      await control.sendChat(workspace.id, channel, name, agent.prompt)
+
+      const answer = await control.waitFor(
+        async () => {
+          const messages = await control.chatMessages(
+            workspace.id,
+            channel,
+            100,
+          )
+          return (
+            messages.find(
+              (m) => !before.has(m.messageId) && isAnswer(m, name),
+            ) || null
+          )
+        },
+        {
+          timeoutMs: config.timeouts.reply,
+          intervalMs: 5_000,
+          label: `${name} to answer`,
+          describe: () => "no agent message in the channel yet",
+        },
+      )
+      result.reply = String(answer.content || "").slice(0, 400)
+      if (!containsAnswer(answer.content, agent.expect)) {
+        // Only now ask whether this was the adapter reporting a failure: a real
+        // answer can arrive behind a warning banner, and checking the error
+        // shape first would fail it.
+        const failed = agentError(answer.content)
+        throw new Error(
+          failed
+            ? `the agent reported an error: ${failed.slice(0, 300)}`
+            : `answer did not contain "${agent.expect}": ${JSON.stringify(
+                result.reply.slice(0, 200),
+              )}`,
+        )
+      }
+      return JSON.stringify(result.reply.slice(0, 80))
+    })
+
+    result.status = "pass"
+  } catch (err) {
+    result.reason = err.message
+    log(`    ✗ ${err.message.split("\n")[0]}`)
+    await collectDiagnostics({ control, agent, name, outDir, redact, log })
+  }
+
+  await cleanup({ control, config, name, workspace, step, log })
+  result.durationMs = Date.now() - startedAt
+  return result
+}
+
+/**
+ * Leave both sides as we found them so tomorrow's run starts from the same
+ * state: the agent goes from the daemon AND its membership row goes from the
+ * workspace. Skipping the second half leaves a dead member behind every day.
+ */
+async function cleanup({ control, config, name, workspace, step, log }) {
+  if (config.keep) {
+    step.skipped("cleanup", "--keep")
+    return
+  }
+  try {
+    await control.stop(name)
+    // The daemon stops asynchronously; removing under it leaves a stray process.
+    await sleep(Math.min(2_000, config.timeouts.poll))
+    await control.remove(name)
+  } catch (err) {
+    // A leftover agent is worth knowing about but never turns a green run red.
+    log(`    ! cleanup of ${name} failed: ${err.message}`)
+  }
+  if (config.workspace && !(await removeMember(config.workspace, name))) {
+    log(`    ! ${name} is still listed as a workspace member`)
+  }
+}
+
+/** Everything needed to tell WHY a cell failed, without a second run. */
+async function collectDiagnostics({
+  control,
+  agent,
+  name,
+  outDir,
+  redact,
+  log,
+}) {
+  const dir = ensureDir(path.join(outDir, agent.type))
+  const write = (file, body) => {
+    try {
+      fs.writeFileSync(path.join(dir, file), redact(String(body || "")))
+    } catch {
+      /* diagnostics are best-effort */
+    }
+  }
+  try {
+    write("daemon.log", await control.logs("daemon", 400))
+    write("startup.log", await control.logs("startup", 200))
+    write("agents.json", JSON.stringify(await control.agents(), null, 2))
+    write("status.json", JSON.stringify(await control.status(), null, 2))
+    const job = await control.installStatus(agent.type).catch(() => null)
+    if (job && job.log) write("install.log", job.log)
+    log(`    → diagnostics in ${dir}`)
+  } catch (err) {
+    log(`    ! could not collect diagnostics: ${err.message}`)
+  }
+}
+
+module.exports = {
+  runAgent,
+  buildEnv,
+  missingRequired,
+  isAnswer,
+  agentError,
+  containsAnswer,
+  instanceName,
+}

--- a/tests/end_to_end/lib/util.js
+++ b/tests/end_to_end/lib/util.js
@@ -1,0 +1,76 @@
+"use strict"
+
+/** Small shared helpers. No dependencies — this suite runs with bare node. */
+
+const fs = require("fs")
+const path = require("path")
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+/** "4m12s" / "38s" — durations in a results table are read, not computed. */
+function formatDuration(ms) {
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, "0")}s`
+}
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)
+}
+
+/**
+ * Hide every secret this run knows about in `text`.
+ *
+ * Logs and daemon output are written to disk and pasted into chat when a run
+ * fails, and both can echo an API key back verbatim.
+ */
+function makeRedactor(secrets) {
+  const values = [
+    ...new Set(secrets.filter((s) => typeof s === "string" && s.length >= 8)),
+  ]
+  values.sort((a, b) => b.length - a.length)
+  return (text) => {
+    if (!text) return text
+    let out = String(text)
+    for (const v of values) out = out.split(v).join("***")
+    return out
+  }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function writeFileSafe(file, contents) {
+  ensureDir(path.dirname(file))
+  fs.writeFileSync(file, contents)
+}
+
+/** Fixed-width text table — the run summary on a terminal with no deps. */
+function renderTable(headers, rows) {
+  const all = [headers, ...rows]
+  const widths = headers.map((_, i) =>
+    Math.max(...all.map((r) => String(r[i] ?? "").length)),
+  )
+  const line = (cells) =>
+    cells
+      .map((c, i) => String(c ?? "").padEnd(widths[i]))
+      .join("  ")
+      .trimEnd()
+  return [
+    line(headers),
+    line(widths.map((w) => "-".repeat(w))),
+    ...rows.map(line),
+  ].join("\n")
+}
+
+module.exports = {
+  sleep,
+  formatDuration,
+  nowStamp,
+  makeRedactor,
+  ensureDir,
+  writeFileSafe,
+  renderTable,
+}

--- a/tests/end_to_end/lib/workspace.js
+++ b/tests/end_to_end/lib/workspace.js
@@ -1,0 +1,136 @@
+"use strict"
+
+/**
+ * The workspace side of the run: mint the pairing code the launcher redeems.
+ *
+ * Workspaces are created on the web and reach a device by pairing — the
+ * launcher has no "create workspace" path any more — so an automated run has to
+ * start where a person would: ask the workspace for a code, then hand it to the
+ * app. `POST /v1/workspaces/{id}/pairing-codes` is the same call the web UI
+ * makes behind "Connect a device".
+ */
+
+const API_ENVELOPE_HINT =
+  "expected {code, message, data} from the workspace API — check the base URL"
+
+/**
+ * One HTTP call to the workspace, retried through a flaky connection.
+ *
+ * Only transport failures are retried, never an HTTP status: a 404 or a 403 is
+ * an answer and means the same thing the second time. A dropped TLS handshake
+ * is not — and a daily job that reports every agent red because one connection
+ * blipped is a job people stop reading.
+ */
+async function apiCall(base, route, opts) {
+  const attempts = 3
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await apiCallOnce(base, route, opts)
+    } catch (err) {
+      if (!err.transient || attempt >= attempts) throw err
+      await new Promise((r) => setTimeout(r, attempt * 2_000))
+    }
+  }
+}
+
+async function apiCallOnce(
+  base,
+  route,
+  { method = "GET", token, body, timeoutMs = 30_000 },
+) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  let res
+  try {
+    res = await fetch(`${base.replace(/\/$/, "")}${route}`, {
+      method,
+      signal: controller.signal,
+      headers: {
+        "X-Workspace-Token": token,
+        Authorization: `Bearer ${token}`,
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    })
+  } catch (err) {
+    const failure = new Error(
+      err.name === "AbortError"
+        ? `${method} ${route} timed out after ${Math.round(timeoutMs / 1000)}s`
+        : `${method} ${route} failed: ${err.message}`,
+    )
+    failure.transient = true
+    throw failure
+  } finally {
+    clearTimeout(timer)
+  }
+
+  const text = await res.text()
+  let parsed = null
+  try {
+    parsed = text ? JSON.parse(text) : null
+  } catch {
+    throw new Error(
+      `${method} ${route} → ${res.status}: not JSON (${API_ENVELOPE_HINT})`,
+    )
+  }
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${route} → ${res.status}: ${(parsed && parsed.message) || text.slice(0, 200)}`,
+    )
+  }
+  return parsed && parsed.data !== undefined ? parsed.data : parsed
+}
+
+/**
+ * A fresh single-use pairing code (XXXX-XXXX, 30-minute TTL).
+ *
+ * Needs an owner/admin credential for the workspace: the workspace token works,
+ * which is what the daily runner is configured with.
+ */
+async function mintPairingCode({ apiBase, token, id }) {
+  const route = `/v1/workspaces/${encodeURIComponent(id)}/pairing-codes`
+  const data = await apiCall(apiBase, route, {
+    method: "POST",
+    token,
+    body: {},
+  })
+  const code = data && data.code
+  if (!code) {
+    throw new Error(`workspace returned no pairing code (${API_ENVELOPE_HINT})`)
+  }
+  return { code, expiresAt: data.expiresAt || null }
+}
+
+/**
+ * Drop the agent's membership row from the workspace.
+ *
+ * Removing the agent on the launcher side does NOT do this: the core's
+ * `disconnectWorkspace` only clears the local binding, so the workspace keeps
+ * showing the agent as a (permanently offline) member. Left alone, a daily run
+ * files a fresh corpse in the members list every day.
+ *
+ * Best effort by design — a 404 means someone already cleaned it up, and no
+ * cleanup failure should turn a passing agent red.
+ */
+async function removeMember({ apiBase, token, id }, agentName) {
+  const route = `/v1/workspaces/${encodeURIComponent(id)}/members/${encodeURIComponent(agentName)}`
+  try {
+    await apiCall(apiBase, route, { method: "DELETE", token })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Fail early and clearly when the endpoint or token is wrong. */
+async function checkWorkspace({ apiBase, token, id }) {
+  const route = `/v1/workspaces/${encodeURIComponent(id)}`
+  const data = await apiCall(apiBase, route, { token })
+  return {
+    id: (data && (data.id || data.workspaceId)) || id,
+    slug: (data && data.slug) || id,
+    name: (data && data.name) || id,
+  }
+}
+
+module.exports = { mintPairingCode, checkWorkspace, removeMember, apiCall }

--- a/tests/end_to_end/run.js
+++ b/tests/end_to_end/run.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+"use strict"
+
+/**
+ * Launcher end-to-end test — one entry point, three platforms.
+ *
+ *   node tests/end_to_end/run.js [--agents=claude,codex] [--fresh] [--attach]
+ *
+ * What it proves, per agent, on the machine it runs on:
+ *
+ *   pair a workspace → install the agent → create an instance → configure its
+ *   credentials → connect it to the workspace → start it → send it a message
+ *   → read its answer.
+ *
+ * It drives the desktop launcher headlessly through the control server
+ * (packages/launcher/src/main/control-server.ts) — the same AgentManager the UI
+ * calls over IPC — so it needs no display and runs the same way from a terminal,
+ * an SSH session, or a scheduled job. Exit code is 0 only when every agent that
+ * had credentials passed.
+ *
+ * See README.md for configuration and the daily-run setup.
+ */
+
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+const { buildConfig, validate, secretsOf } = require("./lib/config")
+const { startLauncher, attachLauncher } = require("./lib/launcher")
+const { mintPairingCode, checkWorkspace } = require("./lib/workspace")
+const { runAgent } = require("./lib/scenario")
+const { renderConsole, writeArtifacts, summarize } = require("./lib/report")
+const {
+  ensureDir,
+  nowStamp,
+  makeRedactor,
+  writeFileSafe,
+  formatDuration,
+} = require("./lib/util")
+
+const USAGE = `
+Launcher end-to-end test
+
+  node tests/end_to_end/run.js [options]
+
+Options
+  --agents=a,b          Only these agent types (default: every agent in the config file)
+  --config=<file>       Config file (default: tests/end_to_end/agents.config.json)
+  --app=<path>          Launcher binary to test (default: the installed app, then the local build)
+  --home=<dir>          Profile directory the run uses as HOME (default: ~/.openagents-e2e/home)
+  --out=<dir>           Where results and diagnostics go (default: ~/.openagents-e2e/runs)
+  --fresh               Delete the profile first — proves the from-nothing path (slow)
+  --attach              Use a launcher that is already running under --home
+  --reinstall           Install the agent even when it is already installed
+  --keep                Leave the created agents behind (for debugging)
+  --json                Print only the results JSON
+  --boot-timeout=<min>  Wait for the core to load (default 12)
+  --install-timeout=<min>  Per-agent install (default 20)
+  --start-timeout=<min>    Agent reaching a running state (default 3)
+  --reply-timeout=<min>    Agent answering (default 6)
+  --settle=<sec>        Wait after start before messaging the agent (default 15)
+  --poll=<sec>          How often the slow waits re-check (default 10)
+  --help
+`
+
+async function main() {
+  const config = buildConfig(process.argv.slice(2))
+  if (config.help) {
+    process.stdout.write(USAGE)
+    return 0
+  }
+
+  const problems = validate(config)
+  if (problems.length) {
+    process.stderr.write(
+      `Cannot start:\n${problems.map((p) => `  - ${p}`).join("\n")}\n`,
+    )
+    return 2
+  }
+
+  const redact = makeRedactor(secretsOf(config))
+  const startedAt = new Date()
+  const outDir = ensureDir(path.join(config.outDir, nowStamp()))
+  const logFile = path.join(outDir, "run.log")
+  const log = (line) => {
+    const text = redact(String(line))
+    if (!config.json) process.stdout.write(`${text}\n`)
+    fs.appendFileSync(logFile, `${new Date().toISOString()} ${text}\n`)
+  }
+
+  log(`Launcher end-to-end — ${startedAt.toISOString()}`)
+  log(`host: ${process.platform}/${process.arch}, node ${process.version}`)
+  if (config.configFile) log(`config: ${config.configFile}`)
+  log(`output: ${outDir}`)
+
+  if (config.fresh && !config.attach) {
+    // --fresh deletes a directory tree. A --home that is (or contains) the real
+    // home would take the user's account with it, so refuse rather than trust
+    // the flag.
+    const real = path.resolve(os.homedir())
+    const target = path.resolve(config.homeDir)
+    if (target === real || real.startsWith(`${target}${path.sep}`)) {
+      process.stderr.write(
+        `Refusing --fresh: ${target} is your real home directory (or contains it).\n` +
+          "Point --home at a dedicated profile directory.\n",
+      )
+      return 2
+    }
+    log(`fresh run — removing ${target}`)
+    fs.rmSync(target, { recursive: true, force: true })
+  }
+
+  const run = {
+    startedAt: startedAt.toISOString(),
+    finishedAt: null,
+    durationMs: 0,
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    host: os.hostname(),
+    launcherVersion: null,
+    coreVersion: null,
+    fresh: config.fresh,
+    workspace: { id: config.workspace.id, slug: null },
+    results: [],
+    ok: false,
+    outDir,
+  }
+
+  let launcher = null
+  try {
+    // 1. The workspace has to exist and the token has to work before we spend
+    //    ten minutes booting a launcher.
+    const remote = await checkWorkspace(config.workspace)
+    log(`workspace: ${remote.name} (${remote.slug})`)
+
+    // 2. Boot the app (or attach to one already running). Ctrl-C from here on
+    //    must still take the launcher down — a stranded headless Electron is
+    //    invisible and would hold the profile for the next run.
+    process.once("SIGINT", () => {
+      process.stderr.write("\ninterrupted — stopping the launcher\n")
+      const stop = launcher ? launcher.stop() : Promise.resolve()
+      stop.finally(() => process.exit(130))
+    })
+    launcher = config.attach
+      ? await attachLauncher({ homeDir: config.homeDir, log })
+      : await startLauncher({
+          appPath: config.appPath,
+          homeDir: config.homeDir,
+          outDir,
+          bootTimeoutMs: config.timeouts.boot,
+          log,
+        })
+    const control = launcher.control
+    const status = await control.status()
+    run.launcherVersion = status.version || null
+    log(`launcher ${status.version} (headless=${status.headless})`)
+
+    // 3. Pair this device with the workspace — where a person starts, and the
+    //    only way a workspace reaches the launcher.
+    // Retried with a FRESH code each time: codes are single-use, so a redeem
+    // that failed after the server consumed it cannot be repeated. Worth the
+    // retry because the failure seen in practice is a dropped TLS handshake on
+    // the way out — one blip should not paint a whole nightly red.
+    for (let attempt = 1; ; attempt++) {
+      const { code } = await mintPairingCode(config.workspace)
+      log(`pairing with code ${code.slice(0, 2)}**-****`)
+      try {
+        await control.pair(code)
+        break
+      } catch (err) {
+        if (attempt >= 3) throw err
+        log(`pairing failed (${err.message}) — retrying`)
+        await new Promise((r) => setTimeout(r, attempt * 5_000))
+      }
+    }
+    const local = (await control.workspaces()).find(
+      (w) => w && (w.id === remote.id || w.slug === remote.slug),
+    )
+    if (!local) {
+      throw new Error(
+        `pairing reported success but ${remote.slug} is not registered on this device`,
+      )
+    }
+    run.workspace = {
+      id: local.id || remote.id,
+      slug: local.slug || remote.slug,
+    }
+    log(`paired: ${run.workspace.slug}`)
+
+    const catalog = await control.catalog().catch(() => null)
+    run.coreVersion = (catalog && catalog.core && catalog.core.version) || null
+    const supported = new Set((catalog && catalog.supported) || [])
+
+    // 4. Each agent, in turn.
+    for (const agent of config.agents) {
+      log("")
+      log(`── ${agent.type} ${"─".repeat(Math.max(0, 40 - agent.type.length))}`)
+      if (supported.size && !supported.has(agent.type) && !agent.skip) {
+        agent.skip = `not in this core's adapter map (core ${run.coreVersion || "?"})`
+      }
+      const result = await runAgent({
+        control,
+        config,
+        agent,
+        workspace: run.workspace,
+        log,
+        outDir,
+        redact,
+      })
+      run.results.push(result)
+    }
+  } catch (err) {
+    log(`\nrun aborted: ${err.message}`)
+    run.error = err.message
+  } finally {
+    if (launcher) {
+      log("")
+      log("stopping the launcher")
+      await launcher
+        .stop()
+        .catch((err) => log(`could not stop cleanly: ${err.message}`))
+    }
+  }
+
+  run.finishedAt = new Date().toISOString()
+  run.durationMs = Date.now() - startedAt.getTime()
+  const counts = summarize(run.results)
+  run.ok = !run.error && counts.fail === 0 && counts.total > 0
+  run.summary = counts
+
+  const { jsonPath, mdPath } = writeArtifacts(run, outDir, redact)
+  // A fixed path the daily job can read without knowing the run's timestamp.
+  writeFileSafe(
+    path.join(config.outDir, "latest.json"),
+    redact(JSON.stringify(run, null, 2)),
+  )
+
+  if (config.json) {
+    process.stdout.write(`${redact(JSON.stringify(run, null, 2))}\n`)
+  } else {
+    process.stdout.write(`${renderConsole(run)}\n`)
+    process.stdout.write(`\nresults: ${jsonPath}\nsummary: ${mdPath}\n`)
+    if (run.error) process.stdout.write(`run aborted: ${run.error}\n`)
+  }
+  return run.ok ? 0 : 1
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code
+    // Let stdout drain (it is a pipe under cron/Task Scheduler, where writes are
+    // asynchronous and process.exit would truncate the report), but never hang:
+    // an unref'd timer forces the exit if something keeps the loop alive.
+    setTimeout(() => process.exit(code), 5_000).unref()
+  })
+  .catch((err) => {
+    process.stderr.write(`${err && err.stack ? err.stack : err}\n`)
+    process.exit(1)
+  })

--- a/tests/end_to_end/run.test.js
+++ b/tests/end_to_end/run.test.js
@@ -1,0 +1,180 @@
+"use strict"
+
+/**
+ * The entry point itself, against stubbed services.
+ *
+ * Runs `run.js --attach` as a real child process with a stub control server and
+ * a stub workspace API behind it, so the orchestration — config, attach,
+ * pairing, the per-agent loop, the report and the exit code — is covered
+ * without a launcher, a workspace, or a single API key.
+ */
+
+const assert = require("node:assert")
+const fs = require("node:fs")
+const os = require("node:os")
+const path = require("node:path")
+const { execFile } = require("node:child_process")
+const { test } = require("node:test")
+
+const { stubLauncher, stubWorkspaceApi, listen } = require("./stub-launcher")
+
+const RUN_JS = path.join(__dirname, "run.js")
+
+/** A HOME that looks like one a launcher is already running under. */
+function fakeProfile(port) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oa-e2e-attach-"))
+  const dir = path.join(home, ".openagents")
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, "control.token"), "tok")
+  fs.writeFileSync(
+    path.join(dir, "startup.log"),
+    `2026-08-27T00:00:00Z Control server on 127.0.0.1:${port} (token: x)\n`,
+  )
+  return home
+}
+
+function writeConfig(home, agents) {
+  const file = path.join(home, "agents.config.json")
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      defaults: { apiKey: "sk-secret-key-value", baseUrl: "https://gw/v1" },
+      agents,
+    }),
+  )
+  return file
+}
+
+function runScript(args) {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [RUN_JS, ...args],
+      // A clean OA_E2E_* environment: the developer running these tests may
+      // have their own credentials exported.
+      {
+        env: Object.fromEntries(
+          Object.entries(process.env).filter(([k]) => !k.startsWith("OA_E2E_")),
+        ),
+      },
+      (err, stdout, stderr) => {
+        resolve({ code: err ? err.code : 0, stdout, stderr })
+      },
+    )
+  })
+}
+
+async function withStubs(opts, fn) {
+  const launcher = stubLauncher(opts)
+  const workspace = stubWorkspaceApi({ workspaceId: "acme" })
+  const l = await listen(launcher.server)
+  const w = await listen(workspace.server)
+  const home = fakeProfile(l.port)
+  try {
+    return await fn({ home, launcher, workspace, wsPort: w.port })
+  } finally {
+    l.close()
+    w.close()
+    fs.rmSync(home, { recursive: true, force: true })
+  }
+}
+
+function baseArgs({ home, wsPort, config }) {
+  return [
+    "--attach",
+    `--home=${home}`,
+    `--out=${path.join(home, "out")}`,
+    `--config=${config}`,
+    `--ws-api=http://127.0.0.1:${wsPort}`,
+    "--ws-token=wst-secret-token",
+    "--ws-id=acme",
+    "--settle=0",
+    "--poll=0.1",
+    "--json",
+  ]
+}
+
+test("a green run pairs, tests every agent, and exits 0", async () => {
+  await withStubs({}, async ({ home, launcher, workspace, wsPort }) => {
+    const config = writeConfig(home, {
+      openclaw: { model: "m-1" },
+      cursor: { skip: "no unattended login" },
+    })
+    const { code, stdout } = await runScript(baseArgs({ home, wsPort, config }))
+    assert.strictEqual(code, 0, stdout)
+
+    const run = JSON.parse(stdout)
+    assert.strictEqual(run.ok, true)
+    assert.deepStrictEqual(run.summary, { total: 2, pass: 1, fail: 0, skip: 1 })
+    assert.strictEqual(run.results[0].type, "openclaw")
+    assert.strictEqual(run.results[0].status, "pass")
+    assert.strictEqual(run.results[1].status, "skip")
+    assert.strictEqual(run.launcherVersion, "0.9.23")
+    assert.strictEqual(run.workspace.slug, "acme")
+
+    // It really did pair, with a code it minted for this run.
+    assert.strictEqual(launcher.state.paired, workspace.state.minted[0])
+    // Cleanup covers BOTH sides: the daemon's agent and the workspace's member
+    // row. Only removing the first leaves a dead member behind on every run.
+    assert.deepStrictEqual(workspace.state.removedMembers, [
+      run.results[0].instance,
+    ])
+    // Attach mode leaves the launcher running — it is not ours to quit.
+    assert.strictEqual(launcher.state.quit, 0)
+
+    // Secrets never reach the results, and the summary is on disk for the job
+    // that collects it.
+    assert.ok(!stdout.includes("sk-secret-key-value"))
+    assert.ok(!stdout.includes("wst-secret-token"))
+    const latest = JSON.parse(
+      fs.readFileSync(path.join(home, "out", "latest.json"), "utf-8"),
+    )
+    assert.strictEqual(latest.ok, true)
+  })
+})
+
+test("a wrong answer makes the run exit 1", async () => {
+  await withStubs({ reply: "no idea" }, async ({ home, wsPort }) => {
+    const config = writeConfig(home, { openclaw: { model: "m-1" } })
+    const { code, stdout } = await runScript(baseArgs({ home, wsPort, config }))
+    assert.strictEqual(code, 1)
+    const run = JSON.parse(stdout)
+    assert.strictEqual(run.ok, false)
+    assert.strictEqual(run.results[0].status, "fail")
+  })
+})
+
+test("an agent the installed core cannot run is skipped, not failed", async () => {
+  await withStubs({}, async ({ home, wsPort }) => {
+    // The stub core supports openclaw and codex only.
+    const config = writeConfig(home, { hermes: { model: "m-1" } })
+    const { code, stdout } = await runScript(baseArgs({ home, wsPort, config }))
+    assert.strictEqual(code, 0)
+    const run = JSON.parse(stdout)
+    assert.strictEqual(run.results[0].status, "skip")
+    assert.match(run.results[0].reason, /adapter map/)
+  })
+})
+
+test("a workspace that cannot be reached aborts before touching the launcher", async () => {
+  await withStubs({}, async ({ home, wsPort, launcher }) => {
+    const config = writeConfig(home, { openclaw: { model: "m-1" } })
+    const args = baseArgs({ home, wsPort, config }).map((a) =>
+      a.startsWith("--ws-id=") ? "--ws-id=missing" : a,
+    )
+    const { code, stdout } = await runScript(args)
+    assert.strictEqual(code, 1)
+    const run = JSON.parse(stdout)
+    assert.match(run.error, /404/)
+    assert.deepStrictEqual(run.results, [])
+    assert.ok(!launcher.state.calls.includes("POST /pair"))
+  })
+})
+
+test("missing credentials stop the run before anything slow happens", async () => {
+  const { code, stderr } = await runScript([
+    "--config=/nonexistent/config.json",
+  ])
+  assert.strictEqual(code, 1)
+  assert.match(stderr, /config file not found/)
+})

--- a/tests/end_to_end/scenario.test.js
+++ b/tests/end_to_end/scenario.test.js
@@ -1,0 +1,174 @@
+"use strict"
+
+/**
+ * The per-agent scenario against a stub control server.
+ *
+ * It exercises the real sequence — install → create → configure → connect →
+ * start → respond → cleanup — including the polling and the exact routes and
+ * payloads, so a wiring mistake between the harness and the control server is
+ * caught here instead of forty minutes into a nightly run. What it cannot
+ * prove is the launcher's half of those routes; that is
+ * packages/launcher/src/main/control-server.test.ts.
+ */
+
+const assert = require("node:assert")
+const fs = require("node:fs")
+const os = require("node:os")
+const path = require("node:path")
+const { test } = require("node:test")
+
+const { Control } = require("./lib/control")
+const { runAgent } = require("./lib/scenario")
+const { stubLauncher, listen } = require("./stub-launcher")
+
+function fixture() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oa-e2e-run-"))
+  const config = {
+    homeDir: home,
+    keep: false,
+    reinstall: false,
+    timeouts: {
+      install: 20_000,
+      start: 4_000,
+      reply: 8_000,
+      settle: 0,
+      poll: 100,
+    },
+  }
+  const agent = {
+    type: "openclaw",
+    apiKey: "sk-secret-key-value",
+    baseUrl: "https://gw/v1",
+    model: "m-1",
+    env: {},
+    files: { "~/.stub/config": "key=${apiKey}\n" },
+    prompt: "What is 2+2? Reply with just the number.",
+    expect: "4",
+    skip: null,
+  }
+  return { home, config, agent }
+}
+
+async function withStub(opts, fn) {
+  const { server, state } = stubLauncher(opts)
+  const { port, close } = await listen(server)
+  const control = new Control({ port, token: "tok" })
+  try {
+    return await fn({ control, state })
+  } finally {
+    close()
+  }
+}
+
+test("a full agent scenario passes and leaves nothing behind", async () => {
+  const { home, config, agent } = fixture()
+  const result = await withStub({}, async ({ control, state }) => {
+    const result = await runAgent({
+      control,
+      config,
+      agent,
+      workspace: { id: "w1", slug: "acme" },
+      log: () => {},
+      outDir: path.join(home, "out"),
+      redact: (s) => s,
+    })
+    assert.deepStrictEqual(state.env.env, {
+      LLM_API_KEY: "sk-secret-key-value",
+      LLM_BASE_URL: "https://gw/v1",
+    })
+    assert.strictEqual(state.connected.workspace, "acme")
+    assert.strictEqual(state.sent.content, agent.prompt)
+    assert.strictEqual(
+      state.agents.length,
+      0,
+      "the agent should be removed at the end",
+    )
+    // Config files declared for the agent land under the run's HOME.
+    assert.strictEqual(
+      fs.readFileSync(path.join(home, ".stub", "config"), "utf-8"),
+      "key=sk-secret-key-value\n",
+    )
+    return result
+  })
+
+  assert.strictEqual(result.status, "pass", result.reason || "")
+  assert.match(result.reply, /4/)
+  assert.deepStrictEqual(
+    result.steps.map((s) => `${s.name}:${s.status}`),
+    [
+      "install:ok",
+      "create:ok",
+      "configure:ok",
+      "connect:ok",
+      "start:ok",
+      "respond:ok",
+    ],
+  )
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+test("a wrong answer fails at `respond` and writes diagnostics", async () => {
+  const { home, config, agent } = fixture()
+  const outDir = path.join(home, "out")
+  const result = await withStub(
+    { reply: "I cannot help with that." },
+    ({ control }) =>
+      runAgent({
+        control,
+        config,
+        agent,
+        workspace: { id: "w1", slug: "acme" },
+        log: () => {},
+        outDir,
+        redact: (s) => s.split("sk-secret-key-value").join("***"),
+      }),
+  )
+  assert.strictEqual(result.status, "fail")
+  assert.match(result.reason, /did not contain "4"/)
+  assert.strictEqual(
+    result.steps.find((s) => s.status === "fail").name,
+    "respond",
+  )
+  assert.ok(fs.existsSync(path.join(outDir, "openclaw", "daemon.log")))
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+test("an agent that never starts fails at `start`, not at `respond`", async () => {
+  const { home, config, agent } = fixture()
+  const result = await withStub({ failStart: true }, ({ control }) =>
+    runAgent({
+      control,
+      config,
+      agent,
+      workspace: { id: "w1", slug: "acme" },
+      log: () => {},
+      outDir: path.join(home, "out"),
+      redact: (s) => s,
+    }),
+  )
+  assert.strictEqual(result.status, "fail")
+  assert.strictEqual(
+    result.steps.find((s) => s.status === "fail").name,
+    "start",
+  )
+  assert.match(result.reason, /state=stopped/)
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+test("a missing credential skips the agent instead of failing it", async () => {
+  const { home, config, agent } = fixture()
+  const result = await withStub({}, ({ control }) =>
+    runAgent({
+      control,
+      config,
+      agent: { ...agent, apiKey: "" },
+      workspace: { id: "w1", slug: "acme" },
+      log: () => {},
+      outDir: path.join(home, "out"),
+      redact: (s) => s,
+    }),
+  )
+  assert.strictEqual(result.status, "skip")
+  assert.match(result.reason, /no credential for LLM_API_KEY/)
+  fs.rmSync(home, { recursive: true, force: true })
+})

--- a/tests/end_to_end/stub-launcher.js
+++ b/tests/end_to_end/stub-launcher.js
@@ -1,0 +1,173 @@
+"use strict"
+
+/**
+ * Test doubles for the two services the run talks to: the launcher's control
+ * server and the workspace API. Shared by the harness tests — not part of the
+ * suite itself (`node --test` only picks up *.test.js).
+ */
+
+const http = require("node:http")
+
+function jsonServer(handler) {
+  return http.createServer((req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1")
+    let body = ""
+    req.on("data", (c) => (body += c))
+    req.on("end", () => {
+      const send = (code, value) => {
+        res.writeHead(code, { "Content-Type": "application/json" })
+        res.end(JSON.stringify(value))
+      }
+      handler({
+        route: `${req.method} ${url.pathname}`,
+        url,
+        input: body ? JSON.parse(body) : {},
+        send,
+      })
+    })
+  })
+}
+
+/** A control server with just enough behaviour to walk an agent through. */
+function stubLauncher({ reply = "The answer is 4.", failStart = false } = {}) {
+  const state = {
+    agents: [],
+    messages: [],
+    calls: [],
+    env: null,
+    installs: new Set(),
+    quit: 0,
+  }
+  const server = jsonServer(({ route, url, input, send }) => {
+    state.calls.push(route)
+    switch (route) {
+      case "GET /status":
+        return send(200, { coreReady: true, version: "0.9.23", headless: true })
+      case "GET /catalog":
+        return send(200, {
+          core: { version: "0.2.173" },
+          supported: ["openclaw", "codex"],
+          catalog: [{ name: "openclaw", installed: false }],
+        })
+      case "POST /install":
+        state.installs.add(input.type)
+        return send(202, { type: input.type, state: "running" })
+      case "GET /install":
+        // Report "running" once, then done — the harness must poll, not assume.
+        return send(200, {
+          type: url.searchParams.get("type"),
+          state: state.installs.has("polled")
+            ? "done"
+            : (state.installs.add("polled"), "running"),
+          durationSeconds: 3,
+          log: "installed",
+        })
+      case "GET /agents/env-fields":
+        return send(200, {
+          fields: [
+            { name: "LLM_API_KEY", required: true },
+            { name: "LLM_BASE_URL", required: false },
+          ],
+        })
+      case "POST /agents/create":
+        state.agents.push({
+          name: input.name,
+          type: input.type,
+          state: "stopped",
+        })
+        return send(200, { result: { success: true } })
+      case "GET /agents":
+        return send(200, { agents: state.agents })
+      case "POST /agents/env":
+        state.env = input
+        return send(200, { result: { success: true } })
+      case "POST /agents/connect":
+        state.connected = input
+        return send(200, { result: { success: true } })
+      case "POST /agents/start":
+        if (!failStart && state.agents[0]) state.agents[0].state = "running"
+        return send(200, { result: { success: true } })
+      case "POST /agents/stop":
+      case "POST /agents/remove":
+        state.agents = []
+        return send(200, { result: { success: true } })
+      case "POST /pair":
+        state.paired = input.code
+        return send(200, { result: { paired: true } })
+      case "GET /workspaces":
+        return send(200, {
+          workspaces: [{ id: "w1", slug: "acme", name: "Acme" }],
+        })
+      case "POST /chat/send":
+        state.sent = input
+        state.messages.push({
+          messageId: `m${state.messages.length}`,
+          senderType: "human",
+          senderName: "user",
+          content: input.content,
+        })
+        // The agent answers on the next poll, after a thinking placeholder the
+        // harness has to skip.
+        state.messages.push({
+          messageId: "thinking",
+          senderType: "agent",
+          senderName: input.agent,
+          messageType: "thinking",
+          content: "Thinking...",
+        })
+        state.messages.push({
+          messageId: "answer",
+          senderType: "agent",
+          senderName: input.agent,
+          content: reply,
+        })
+        return send(200, { result: { success: true } })
+      case "GET /chat/messages":
+        return send(200, { messages: state.messages })
+      case "GET /logs":
+        return send(200, { [url.searchParams.get("file")]: "log" })
+      case "POST /quit":
+        state.quit++
+        return send(200, { quitting: true })
+      default:
+        return send(404, { error: `no route ${route}` })
+    }
+  })
+  return { server, state }
+}
+
+/** The workspace API: enough to look a workspace up and mint a pairing code. */
+function stubWorkspaceApi({ workspaceId = "acme" } = {}) {
+  const state = { minted: [], removedMembers: [] }
+  const server = jsonServer(({ route, send }) => {
+    const removal = route.match(
+      new RegExp(`^DELETE /v1/workspaces/${workspaceId}/members/(.+)$`),
+    )
+    if (removal) {
+      state.removedMembers.push(decodeURIComponent(removal[1]))
+      return send(200, { code: 0, message: "ok", data: { removed: true } })
+    }
+    if (route === `GET /v1/workspaces/${workspaceId}`) {
+      return send(200, {
+        code: 0,
+        message: "ok",
+        data: { id: "w1", slug: workspaceId, name: "Acme" },
+      })
+    }
+    if (route === `POST /v1/workspaces/${workspaceId}/pairing-codes`) {
+      const code = `ABCD-${String(1000 + state.minted.length)}`
+      state.minted.push(code)
+      return send(200, { code: 0, message: "ok", data: { code } })
+    }
+    return send(404, { code: 404, message: "not found", data: null })
+  })
+  return { server, state }
+}
+
+/** Start a stub and hand back its port plus a close function. */
+async function listen(server) {
+  await new Promise((r) => server.listen(0, "127.0.0.1", r))
+  return { port: server.address().port, close: () => server.close() }
+}
+
+module.exports = { stubLauncher, stubWorkspaceApi, listen }


### PR DESCRIPTION
## Why

We can look at a machine and see the launcher's state — `/status`, `/agents`, `/logs` — but we cannot ask it to *do* anything. Installing an agent, configuring credentials, connecting it to a workspace and getting an answer back happen only through the UI, so nothing checks daily that the path a new user walks still works.

The obvious answer, driving the GUI with Playwright, does not survive contact with where we need to run this. On a Windows box reached over SSH there is no desktop session for a browser driver to attach to — and that machine is exactly the one that should be running this every day. Driving the `agn` CLI instead would test the CLI: install, configure and connect all bypass the desktop code path, so the launcher could be broken and the run would stay green.

So the launcher tells us itself, through a local HTTP surface backed by the same `AgentManager` the renderer calls over IPC.

## What this adds

**1. The control server becomes drivable** (`src/main/control-server.ts`)

| Route | Purpose |
| --- | --- |
| `GET /catalog` | core info, supported types, what is installed |
| `GET /agents/env-fields?type=` | the fields the Configure dialog would ask for |
| `POST /install` · `GET /install?type=` | start an install, poll how it went |
| `POST /agents/create` | the New Agent form |
| `POST /agents/env` | Configure → Save (instance env, as the dialog does) |
| `POST /agents/connect` | bind to a paired workspace |
| `POST /agents/start` · `/stop` · `/remove` | lifecycle |
| `GET /workspaces` | workspaces registered on this device |
| `POST /chat/send` · `GET /chat/messages` | the launcher's own chat |
| `POST /quit` | teardown (goes through `before-quit`, so the daemon stops too) |

Two details worth reviewing:

- **503, not 500, while the core loads.** On a cold boot `AgentManager` does not exist for minutes. That is "try again shortly", not a server fault, and a script should not have to pattern-match an error string to tell the difference.
- **Installs are a background job.** They run for 10+ minutes; `POST /install` returns immediately and `GET /install?type=` reports `running` / `done` / `error` with the installer's own log tail. A run that loses its connection can poll again.

Auth and binding are unchanged: loopback only, per-start random token.

**2. `tests/end_to_end/` — one entry point, three platforms**

```bash
node tests/end_to_end/run.js                 # every agent in the config file
node tests/end_to_end/run.js --agents=claude # one of them
node tests/end_to_end/run.js --fresh         # from an empty profile
```

Per agent: **pair a workspace → install → create → configure → connect → start → send a message → check the answer → clean up**. Pairing is where a person starts, so the run starts there too: it mints a code from the workspace API and redeems it through `POST /pair`.

Plain Node, no `npm install`. The app is started `--headless` with its own `HOME`, so the run cannot disturb — or be disturbed by — the launcher you already have open.

Three design points:

- **The config file is the matrix.** An agent is tested because it has an entry, and skipped *with a reason in the report* when its credentials are missing. Adding an agent is a JSON edit.
- **No agent's env vars are hardcoded.** The field list comes from the launcher (`GET /agents/env-fields`) and is filled by convention (`*_API_KEY`, `*_BASE_URL`, `*_MODEL`), with an `env` escape hatch. A registry change lands without touching the test — deepseek's `DSH_PERMISSION_MODE` was picked up from its declared default with no code change.
- **A failure has to be diagnosable the same day.** The report names the step that failed and keeps `daemon.log`, `install.log`, `agents.json` and `status.json` next to it. Secrets are redacted from everything written to disk.

Exit code is 0 only when every agent that had credentials passed. `~/.openagents-e2e/latest.json` always holds the newest machine-readable result for whatever collects it; README has the cron and Task Scheduler snippets.

## Verified on real hardware

Full matrix on macOS against a live workspace — **9/9 agents that can authenticate unattended passed**:

```
openclaw ✅  opencode ✅  kimi ✅  deepseek ✅  hermes ✅
pi ✅        claude ✅    codex ✅  gemini ✅
cursor ⊘ (Cursor's own cloud only)   antigravity ⊘ (Google browser sign-in only)
```

Cold profile: ~17 min for the full matrix. Warm: ~40 s per agent.

## Five bugs the real runs found

None of these are reachable from unit tests. They are the reason this PR is worth more than its diff.

1. **Stale control port.** On a reused profile the startup log still ends with the previous run's port, and the app writes its token file *before* it logs the new one — so the harness latched onto a closed socket and waited out the full 12-minute boot timeout. Certain to happen every day; the first cold run cannot reproduce it. Fixed by reading only lines written after the spawn, and by probing `/status` before trusting the pair.

2. **A false pass.** Adapter errors are posted as ordinary chat messages (`sendError` sets no distinguishing `message_type`), and `"Error processing message: … requested=custom/deepseek-4-flash"` contains a `4` — so a substring check for the arithmetic answer reported a broken agent as **passing**. The worst failure mode a regression suite can have.

3. **The over-correction that would have caused the opposite bug.** Hermes answers `⚠ tirith security scanner enabled but not available …\n4`. Rejecting anything error-shaped would have failed a genuine pass. The verdict now checks the answer as a *token* first (excluding hyphen/underscore neighbours, which is what separates `4` from `deepseek-4-flash`) and only asks about the error shape when that check fails.

4. **A network blip painted the whole run red.** A dropped TLS handshake during pairing aborted everything after 5 s. Now retried — but only transport failures, never an HTTP status, because a 404 means the same thing the second time; and each attempt mints a **fresh** code, since pairing codes are single-use.

5. **Cleanup only did half the job.** Removing the agent locally leaves its workspace membership row behind — the core's `disconnectWorkspace` only clears the local binding. A daily run would file a fresh corpse in the members list every day (10 had already accumulated during development). Cleanup now removes the member too, best-effort so it can never turn a passing agent red.

Each has a regression test built from the actual message that exposed it.

## Known limit

The profile isolates `HOME`, not `PATH`: an agent CLI installed globally on the machine is visible inside the run and reports as already installed, so its install step is skipped even under `--fresh`. That matches what the launcher itself would see, but it means a development box cannot prove the from-nothing install path — a dedicated runner can. Documented in the README.

## Tests

- `packages/launcher`: 399 passing (16 new, covering every added route, the install job's states, and the 503/500 split)
- `tests/end_to_end`: 24 passing via `node --test`, including the full scenario and the entry point itself driven against stub services — no launcher, workspace or API key needed

## Notes for the reviewer

- `packages/launcher/package-lock.json` was regenerated: it was stale at 0.9.19 and had missing optional-dependency entries.
- `tests/end_to_end/agents.config.json` (real credentials) is gitignored; `agents.example.json` is the template.
- Version bumped to 0.9.23 with release notes.
