### PR TITLE
fix(e2e): correct the Windows install paths, and document the Windows run

### DIFF
--- a/tests/end_to_end/README.md
+++ b/tests/end_to_end/README.md
@@ -116,6 +116,25 @@ check. `--fresh` wipes the profile so the run also covers first-launch bootstrap
 (portable node + core download, then every agent install from nothing); expect
 it to run for a long time and give it a generous `--install-timeout`.
 
+## Windows
+
+Same command, a few things that only bite there:
+
+- **Node 18+** must be on `PATH` (`node --version`). The CI images use 22.
+- **Until 0.9.23 ships**, the installed app has no driving endpoints — build from
+  source and point at the output:
+  `node tests\end_to_end\run.js --app=packages\launcher\out\main\index.js`
+- **Keep the profile path short.** `npm` trees plus a portable node runtime get
+  deep, and a path over 260 characters fails in ways that read like a broken
+  installer. `--home=C:\oa-e2e` avoids the whole question.
+- **Give installs more room**: `--install-timeout=30`. Defender scans every file
+  an installer writes, so the same install takes noticeably longer than on macOS.
+- **Hermes cannot install here yet** (upstream `uv` step); leave it out with
+  `--agents=` or a `skip` in the config until that is fixed.
+- **Over SSH there is no desktop session**, which is exactly what `--headless`
+  is for: no window is created and the whole run happens over the control
+  server. Only screenshots and GUI-level tests need an RDP session.
+
 ## Running it daily
 
 macOS / Linux (`crontab -e`):

--- a/tests/end_to_end/lib/launcher.js
+++ b/tests/end_to_end/lib/launcher.js
@@ -46,17 +46,22 @@ function installedCandidates() {
   if (process.platform === "win32") {
     const local =
       process.env.LOCALAPPDATA || path.join(home, "AppData", "Local")
+    const exe = "OpenAgents Launcher.exe"
+    // The NSIS installer is `oneClick: false` and lets the user pick a
+    // directory, so these are defaults rather than guarantees: per-user first
+    // (what most people get), then per-machine, which the MSI always uses.
     return [
-      path.join(
-        local,
-        "Programs",
-        "openagents-launcher",
-        "OpenAgents Launcher.exe",
-      ),
+      path.join(local, "Programs", "OpenAgents Launcher", exe),
+      path.join(local, "Programs", "openagents-launcher", exe),
       path.join(
         process.env["ProgramFiles"] || "C:\\Program Files",
         "OpenAgents Launcher",
-        "OpenAgents Launcher.exe",
+        exe,
+      ),
+      path.join(
+        process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)",
+        "OpenAgents Launcher",
+        exe,
       ),
     ]
   }


### PR DESCRIPTION
Follow-up to #644, from reading the Windows installer config after that merge.

## The bug

`installedCandidates()` looked for the per-user install at

```
%LOCALAPPDATA%\Programs\openagents-launcher\OpenAgents Launcher.exe
```

but electron-builder names that directory after `productName`, not the package
name, so the real path is `%LOCALAPPDATA%\Programs\OpenAgents Launcher\`. The
per-machine path was already right, which is why nothing looked obviously wrong.

The effect only shows up once 0.9.23 ships: auto-detection misses the installed
app and silently falls back to the local build, or fails with "no launcher
found" on a machine that has one. Every current run passes `--app` explicitly,
so this was invisible today and would have bitten the first person who ran it
without that flag.

Now checks, in order: per-user (`OpenAgents Launcher`), the old lowercase name
(harmless to keep — some electron-builder versions sanitize differently),
`%ProgramFiles%`, and `%ProgramFiles(x86)%`. The NSIS installer is
`oneClick: false` with `allowToChangeInstallationDirectory`, so these are
defaults rather than guarantees — `--app` remains the answer for a custom
location.

## Windows section in the README

Written from the config and the existing CI matrix rather than from a run — the
Windows box has not been exercised yet. It covers the four things that differ
there:

- **Long paths.** The default profile lands in `C:\Users\<name>\.openagents-e2e\home`;
  add a portable node runtime and npm trees and 260 characters goes fast, failing
  in ways that read like a broken installer. `--home=C:\oa-e2e` sidesteps it.
- **Defender.** It scans every file an installer writes, so `--install-timeout=30`
  is the realistic budget.
- **Hermes.** Its upstream `uv` install step is broken on Windows — the existing
  nightly matrix in `launcher-agent-e2e.yml` already excludes that cell.
- **SSH.** No desktop session is exactly what `--headless` is for; only
  screenshots and GUI-level tests need RDP.

## Why this is a separate PR

The commit was pushed straight to `develop` by mistake right after #644 merged.
`origin/develop` has been rolled back to the merge commit (`a5372444`) and the
change re-applied here as a fresh commit. Anyone who pulled `develop` in that
window should `git reset --hard origin/develop`.

## Tests

`node --test "tests/end_to_end/**/*.test.js"` — 24 passing. No behaviour change
on macOS or Linux; the touched function is Windows-only.
