### PR TITLE
fix(sdk): lazily load optional gRPC transport

### DIFF
--- a/sdk/src/openagents/sdk/topology.py
+++ b/sdk/src/openagents/sdk/topology.py
@@ -444,7 +444,7 @@ class CentralizedTopology(NetworkTopology):
 
                     transport = WebSocketTransport(transport_config.config)
                 elif transport_type == TransportType.GRPC:
-                    from .transports import GRPCTransport
+                    from .transports.grpc import GRPCTransport
 
                     transport = GRPCTransport(transport_config.config)
                 elif transport_type == TransportType.MCP:
@@ -718,7 +718,7 @@ class DecentralizedTopology(NetworkTopology):
 
                     transport = WebSocketTransport(transport_config.get("config", {}))
                 elif transport_type == TransportType.GRPC:
-                    from .transports import GRPCTransport
+                    from .transports.grpc import GRPCTransport
 
                     transport = GRPCTransport(transport_config.get("config", {}))
                 else:

--- a/sdk/src/openagents/sdk/transports/__init__.py
+++ b/sdk/src/openagents/sdk/transports/__init__.py
@@ -5,26 +5,35 @@ This package provides transport implementations for agent communication.
 Includes WebSocket, gRPC, and base transport abstractions.
 """
 
+from importlib import import_module
+from typing import Any
+
+# Import transport types and models
+from openagents.models.event import Event
+
 # Import base classes
-from .base import Transport, Message
+from openagents.models.network_context import NetworkContext
+from openagents.models.transport import (
+    AgentConnection,
+    ConnectionInfo,
+    ConnectionState,
+    PeerMetadata,
+    TransportType,
+)
+
+from .a2a import A2ATransport, create_a2a_transport
+from .base import Message, Transport
+from .http import HttpTransport
+from .mcp import MCPTransport, create_mcp_transport
 
 # Import transport implementations
 from .websocket import WebSocketTransport, create_websocket_transport
-from .grpc import GRPCTransport, OpenAgentsGRPCServicer, create_grpc_transport
-from .http import HttpTransport
-from .mcp import MCPTransport, create_mcp_transport
-from .a2a import A2ATransport, create_a2a_transport
-from openagents.models.network_context import NetworkContext
 
-# Import transport types and models
-from openagents.models.transport import (
-    TransportType,
-    ConnectionState,
-    PeerMetadata,
-    ConnectionInfo,
-    AgentConnection,
-)
-from openagents.models.event import Event
+_GRPC_EXPORTS = {
+    "GRPCTransport",
+    "OpenAgentsGRPCServicer",
+    "create_grpc_transport",
+}
 
 # Simplified exports - only working transports
 __all__ = [
@@ -39,7 +48,6 @@ __all__ = [
     "MCPTransport",
     "A2ATransport",
     "NetworkContext",
-    "OpenAgentsGRPCServicer",
     # Convenience functions
     "create_websocket_transport",
     "create_grpc_transport",
@@ -51,4 +59,16 @@ __all__ = [
     "PeerMetadata",
     "ConnectionInfo",
     "AgentConnection",
+    "OpenAgentsGRPCServicer",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Load gRPC exports only when callers explicitly request them."""
+    if name not in _GRPC_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    grpc_module = import_module(f"{__name__}.grpc")
+    value = getattr(grpc_module, name)
+    globals()[name] = value
+    return value

--- a/tests/test_optional_grpc.py
+++ b/tests/test_optional_grpc.py
@@ -1,0 +1,46 @@
+"""Verify non-gRPC transports work without the SDK's grpcio dependency."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_http_transport_import_does_not_require_grpcio():
+    """A base install can import HTTP transport without grpcio installed."""
+    sdk_src = Path(__file__).parents[1] / "sdk" / "src"
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        class BlockGrpc(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "grpc" or fullname.startswith("grpc."):
+                    raise ModuleNotFoundError("grpc blocked for optional dependency test")
+                return None
+
+        sys.meta_path.insert(0, BlockGrpc())
+        from openagents.sdk.transports import HttpTransport
+        assert HttpTransport.__name__ == "HttpTransport"
+        assert "grpc" not in sys.modules
+
+        try:
+            from openagents.sdk.transports import GRPCTransport
+        except ImportError as exc:
+            assert "pip install openagents[sdk]" in str(exc)
+        else:
+            raise AssertionError(f"unexpected gRPC transport: {GRPCTransport}")
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(sdk_src)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- Keep non-gRPC SDK transports importable without the optional `grpcio` dependency.
- Load gRPC exports only when callers explicitly request them.
- Preserve the existing installation guidance when gRPC is explicitly selected.

This PR addresses the current SDK optional-dependency contract on `develop`. Issue #563 described an obsolete Docker image path and is not claimed as the active bug basis.

## Validation

- Current `develop` baseline reproduces an import failure without `grpcio`.
- Focused optional-gRPC regression passes after the change.
- Explicit gRPC import still returns the existing `pip install openagents[sdk]` guidance.
- Ruff passes for the changed transport module and regression test.
- `compileall` passes for all changed files.

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
