### PR TITLE
fix(test): plant detection fixtures where Windows actually looks

### DIFF
--- a/packages/agent-connector/test/agent-detection-matrix.test.js
+++ b/packages/agent-connector/test/agent-detection-matrix.test.js
@@ -87,6 +87,36 @@ const WHERE = {
   pi: [LOC.nvm20, 'npm -g under a non-default node version'],
 }
 
+/**
+ * The environment every probe child runs in: a synthetic HOME and the PATH a
+ * GUI launch is handed. Shared so a lookup and the assertion about that lookup
+ * can never disagree about where "installed" would even be visible.
+ */
+function childEnv(home) {
+  return {
+    HOME: home,
+    USERPROFILE: home,
+    PATH: IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin:/usr/sbin:/sbin',
+    SystemRoot: process.env.SystemRoot,
+    // Windows derives the npm/pnpm defaults from these; without them a
+    // synthetic HOME has no equivalent of those directories at all.
+    ...(IS_WINDOWS
+      ? {
+          APPDATA: path.join(home, 'AppData', 'Roaming'),
+          LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+        }
+      : {}),
+    // The shell probe is irrelevant here and would leak the developer's own
+    // PATH into the result, hiding a missing hardcoded dir.
+    OPENAGENTS_SKIP_SHELL_PATH: '1',
+  };
+}
+
+/** Substring test for a path, case-insensitive where the filesystem is. */
+function pathIncludes(full, part) {
+  return IS_WINDOWS ? full.toLowerCase().includes(part.toLowerCase()) : full.includes(part);
+}
+
 /** getInstallInfo() for one agent, in a child with a GUI-like PATH. */
 function installInfo(home, agentType) {
   const out = execFileSync(
@@ -98,27 +128,7 @@ function installInfo(home, agentType) {
        process.stdout.write(JSON.stringify(c.installer.getInstallInfo(process.argv[1])));`,
       agentType,
     ],
-    {
-      encoding: 'utf-8',
-      timeout: 30000,
-      env: {
-        HOME: home,
-        USERPROFILE: home,
-        PATH: IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin:/usr/sbin:/sbin',
-        SystemRoot: process.env.SystemRoot,
-        // Windows derives the npm/pnpm defaults from these; without them a
-        // synthetic HOME has no equivalent of those directories at all.
-        ...(IS_WINDOWS
-          ? {
-              APPDATA: path.join(home, 'AppData', 'Roaming'),
-              LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
-            }
-          : {}),
-        // The shell probe is irrelevant here and would leak the developer's own
-        // PATH into the result, hiding a missing hardcoded dir.
-        OPENAGENTS_SKIP_SHELL_PATH: '1',
-      },
-    },
+    { encoding: 'utf-8', timeout: 30000, env: childEnv(home) },
   );
   return JSON.parse(out);
 }
@@ -201,10 +211,21 @@ describe('Agent detection matrix', () => {
  * "Update" look like it did nothing.
  */
 describe('Managed vs global copy', () => {
+  // The user's own copy, in a place this platform really looks: an nvm version
+  // dir on Unix, the npm default prefix (%APPDATA%\npm) on Windows — where
+  // nvm's layout doesn't exist at all (nvm-for-windows is keyed off %NVM_HOME%
+  // and installs elsewhere). Planting it somewhere unscanned would test the
+  // fixture, not the lookup.
+  const GLOBAL_DIR = IS_WINDOWS
+    ? path.join('AppData', 'Roaming', 'npm')
+    : path.join('.nvm', 'versions', 'node', 'v22.16.0', 'bin');
+
   const plantGlobal = (home, text) => {
-    fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
-    fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), '22.16.0', 'utf-8');
-    const dir = path.join(home, '.nvm', 'versions', 'node', 'v22.16.0', 'bin');
+    if (!IS_WINDOWS) {
+      fs.mkdirSync(path.join(home, '.nvm', 'alias'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.nvm', 'alias', 'default'), '22.16.0', 'utf-8');
+    }
+    const dir = path.join(home, GLOBAL_DIR);
     fs.mkdirSync(dir, { recursive: true });
     const bin = path.join(dir, IS_WINDOWS ? 'opencode.cmd' : 'opencode');
     fs.writeFileSync(bin, IS_WINDOWS ? `@echo ${text}` : `#!/bin/sh\necho ${text}\n`, 'utf-8');
@@ -234,16 +255,7 @@ describe('Managed vs global copy', () => {
          const c=new AgentConnector({configDir: process.env.HOME + '/.openagents'});
          process.stdout.write(c.installer.which('opencode') || '');`,
       ],
-      {
-        encoding: 'utf-8',
-        timeout: 30000,
-        env: {
-          HOME: home, USERPROFILE: home,
-          PATH: IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin:/usr/sbin:/sbin',
-          SystemRoot: process.env.SystemRoot,
-          OPENAGENTS_SKIP_SHELL_PATH: '1',
-        },
-      },
+      { encoding: 'utf-8', timeout: 30000, env: childEnv(home) },
     );
 
   it('runs the launcher-installed copy when one is really installed', () => {
@@ -254,7 +266,7 @@ describe('Managed vs global copy', () => {
       const info = installInfo(home, 'opencode');
       assert.equal(info.location, 'runtime');
       assert.ok(
-        resolved(home).includes(path.join('.openagents', 'runtimes')),
+        pathIncludes(resolved(home), path.join('.openagents', 'runtimes')),
         'the binary that runs must be the one the UI describes',
       );
     } finally {
@@ -270,7 +282,10 @@ describe('Managed vs global copy', () => {
       plantGlobal(home, 'GLOBAL');
       plantManaged(home, { withPackage: false });
       assert.equal(installInfo(home, 'opencode').location, 'global');
-      assert.ok(resolved(home).includes('.nvm'));
+      assert.ok(
+        pathIncludes(resolved(home), GLOBAL_DIR),
+        `the global copy in ~/${GLOBAL_DIR} must be the one that runs`,
+      );
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/packages/agent-connector/test/binary-discovery.test.js
+++ b/packages/agent-connector/test/binary-discovery.test.js
@@ -36,6 +36,14 @@ function discover(extraEnv) {
         USERPROFILE: home,
         PATH: IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin:/usr/sbin:/sbin',
         SystemRoot: process.env.SystemRoot,
+        // Windows resolves the npm and pnpm defaults out of these; a synthetic
+        // HOME without them has no equivalent of those directories at all.
+        ...(IS_WINDOWS
+          ? {
+              APPDATA: path.join(home, 'AppData', 'Roaming'),
+              LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+            }
+          : {}),
         ...extraEnv,
       },
     },
@@ -74,7 +82,15 @@ describe('Binary discovery for GUI-launched processes', () => {
 
   it('finds CLIs installed with bun, pnpm and yarn, not just npm', () => {
     const bun = mk('.bun', 'bin');
-    const pnpm = mk(process.platform === 'darwin' ? 'Library' : '.local/share', 'pnpm');
+    // pnpm's global bin genuinely differs per platform: ~/Library/pnpm on
+    // macOS, ~/.local/share/pnpm on Linux, %LOCALAPPDATA%\pnpm on Windows.
+    const pnpm = mk(
+      ...(IS_WINDOWS
+        ? ['AppData', 'Local', 'pnpm']
+        : process.platform === 'darwin'
+          ? ['Library', 'pnpm']
+          : ['.local/share', 'pnpm']),
+    );
     const yarn = mk('.yarn', 'bin');
     const dirs = discover();
     assert.ok(dirs.includes(bun), 'bun global bin');


### PR DESCRIPTION
## Why

The `launcher-v0.9.25` tag build failed on every platform with:

```
npm error notarget No matching version found for @openagents-org/agent-launcher@0.2.175.
```

That version was never published: the Agent Connector `publish` job is gated on `test`, and the Windows leg of that matrix has been failing since the detection tests landed. npm is still on `0.2.173` while `packages/agent-connector/package.json` says `0.2.175`, and `packages/launcher` pins the exact version — so the tag pipeline cannot install its own dependency.

## What

Both Windows failures are fixture bugs, not product bugs — the tests planted binaries in Unix-only directories and then asserted a lookup that correctly does not search them on Windows.

- **`agent-detection-matrix`** — the "global copy" was planted under `~/.nvm/versions/node/<v>/bin`. nvm's layout does not exist on Windows (nvm-for-windows is keyed off `%NVM_HOME%`), so it now lands in the npm default prefix (`%APPDATA%\npm`) there, and the assertion checks that same directory instead of the literal `.nvm`. The child environment is built once and shared by both probes, so a lookup and the assertion about it can no longer disagree about where an install would even be visible. Path comparisons are case-insensitive on Windows.
- **`binary-discovery`** — pnpm's global bin was `Library` on macOS and `.local/share` everywhere else; on Windows it is `%LOCALAPPDATA%\pnpm`. The discovery child also needs `APPDATA`/`LOCALAPPDATA`, since a synthetic HOME without them has no equivalent of the npm/pnpm default directories at all.

No product code changes.

## Verification

Full suite green locally (macOS): 1332 passed, 0 failed. The Windows legs of this PR's Agent Connector run are the real check.

Once this merges, the push to `develop` publishes `agent-launcher@0.2.175` and the launcher tag build can be re-run.