### PR TITLE
fix(kimi): make Kimi Code CLI actually reachable — in the launcher, the registry, and the Python adapter

### DIFF
--- a/packages/agent-connector/icons/kimi.svg
+++ b/packages/agent-connector/icons/kimi.svg
@@ -1,11 +1,6 @@
-<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#141821"/>
-      <stop offset="0.52" stop-color="#2f6df6"/>
-      <stop offset="1" stop-color="#49d2ff"/>
-    </linearGradient>
-  </defs>
-  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
-  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 112 112" role="img" style="flex:none;line-height:1">
+<title>Kimi Code CLI</title>
+<rect width="112" height="112" rx="28" fill="#000"/>
+<path d="M30 34 38 34 38 56 39 57 63 34 75 34 53 57 65 66 77 73 77 81 73 81 67 78 46 63 38 71 38 81 30 81Z" fill="#fff"/>
+<circle cx="86" cy="28" r="5.5" fill="#1783FF"/>
 </svg>

--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.175",
+  "version": "0.2.176",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/registry.json
+++ b/packages/agent-connector/registry.json
@@ -876,11 +876,12 @@
   },
   {
     "name": "kimi",
-    "label": "Kimi",
+    "label": "Kimi Code CLI",
     "description": "Kimi Code CLI — Moonshot AI's terminal coding agent.",
     "homepage": "https://moonshotai.github.io/kimi-code",
     "tags": [
       "coding",
+      "cli",
       "moonshot",
       "open-source"
     ],

--- a/packages/agent-connector/src/registry.js
+++ b/packages/agent-connector/src/registry.js
@@ -101,7 +101,16 @@ class Registry {
         // day-old) cached remote copy, same as install.
         if (b.resolve_env) entry.resolve_env = b.resolve_env;
         if (b.install) entry.install = { ...b.install };
-        if (!entry.check_ready && b.check_ready) entry.check_ready = b.check_ready;
+        // check_ready is the auth/readiness contract of the adapter shipping in
+        // THIS core, so the bundled fields win over a remote copy that may be a
+        // release behind — the same rule as install, and for the same reason.
+        // Kimi is what proved it: the CLI rewrite added `login_command: kimi
+        // login`, but the server was still serving the API-key-only entry, and
+        // "fill it in only when absent" meant the sign-in never appeared.
+        // Spread rather than replace so anything the server adds on its own
+        // (auth_detected_labels and friends) survives.
+        if (b.check_ready)
+          entry.check_ready = { ...(entry.check_ready || {}), ...b.check_ready };
         if (!entry.launch && b.launch) entry.launch = b.launch;
         if (!entry.probe && b.probe) entry.probe = b.probe;
         // Always take featured/order/support from bundled (source of truth for ordering)
@@ -148,7 +157,8 @@ class Registry {
     const b = bundled.find((e) => e.name === agentType);
     if (b) {
       if (b.install) entry.install = { ...b.install };
-      if (!entry.check_ready && b.check_ready) entry.check_ready = b.check_ready;
+      if (b.check_ready)
+        entry.check_ready = { ...(entry.check_ready || {}), ...b.check_ready };
       if (!entry.launch && b.launch) entry.launch = b.launch;
       if (!entry.probe && b.probe) entry.probe = b.probe;
       if ((!entry.env_config || !entry.env_config.length) && b.env_config?.length) entry.env_config = b.env_config;

--- a/packages/agent-connector/test/registry.test.js
+++ b/packages/agent-connector/test/registry.test.js
@@ -127,6 +127,31 @@ describe('Registry', () => {
     assert.match(cursor.install.windows, /WindowsPowerShell\\v1\.0\\powershell\.exe/);
   });
 
+  it('bundled check_ready overrides a stale cached copy', () => {
+    // The kimi failure: the served catalog still described the API-key-only
+    // agent, so an entry that HAD a check_ready never picked up the
+    // `kimi login` the CLI rewrite introduced — and the launcher had no
+    // sign-in to offer.
+    const staleKimi = [{
+      name: 'kimi',
+      label: 'Kimi',
+      check_ready: {
+        env_vars: ['KIMI_API_KEY'],
+        not_ready_message: 'No API key — press e to configure',
+        auth_detected_labels: { api_key: 'API key detected' },
+      },
+    }];
+    fs.writeFileSync(path.join(tmpDir, 'agent_catalog.json'), JSON.stringify(staleKimi), 'utf-8');
+
+    const reg = new Registry(tmpDir);
+    const kimi = reg.getEntry('kimi');
+
+    assert.equal(kimi.check_ready.login_command, 'kimi login');
+    assert.match(kimi.check_ready.not_ready_message, /kimi login/);
+    // Fields only the server knows about are kept, not clobbered.
+    assert.deepEqual(kimi.check_ready.auth_detected_labels, { api_key: 'API key detected' });
+  });
+
   it('ignores expired cache', () => {
     const reg = new Registry(tmpDir);
     const fakeEntry = [{ name: 'old-agent' }];

--- a/packages/agent-connector/test/registry.test.js
+++ b/packages/agent-connector/test/registry.test.js
@@ -41,7 +41,8 @@ describe('Registry', () => {
     const reg = new Registry(tmpDir);
     const entry = reg.getEntry('kimi');
     assert.ok(entry, 'bundled registry should have kimi');
-    assert.equal(entry.label, 'Kimi');
+    assert.equal(entry.label, 'Kimi Code CLI');
+    assert.ok(entry.tags.includes('cli'), 'kimi drives a CLI and must be tagged as one');
     assert.ok(entry.adapter);
     assert.equal(entry.adapter.class, 'KimiAdapter');
 

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -911,7 +911,16 @@ export class AgentManager extends EventEmitter {
           (x) => x.name === e.name,
         )
         if (b) {
-          if (!e.check_ready && b.check_ready) e.check_ready = b.check_ready
+          // Bundled check_ready wins field-by-field, mirroring registry.js —
+          // it is the auth/readiness contract of the adapter this core ships,
+          // and the served copy can be a release behind. Filling it in only
+          // when absent is what kept `kimi login` off the Configure dialog
+          // after Kimi moved to the real CLI.
+          if (b.check_ready)
+            e.check_ready = {
+              ...((e.check_ready as Record<string, unknown>) || {}),
+              ...(b.check_ready as Record<string, unknown>),
+            }
           if (
             (!e.env_config || !(e.env_config as unknown[]).length) &&
             (b.env_config as unknown[] | undefined)?.length

--- a/packages/launcher/src/main/agents/daemon-process.ts
+++ b/packages/launcher/src/main/agents/daemon-process.ts
@@ -15,10 +15,9 @@ import {
   DAEMON_LOG_FILE,
   DAEMON_PID_FILE,
   DAEMON_STATUS_FILE,
-  LOCAL_CORE,
   PORTABLE_NODE_DIR,
 } from "./paths"
-import { resolveWorkingNode } from "./runtime"
+import { coreTiers, resolveWorkingNode, unpackedPath } from "./runtime"
 
 /** Launcher-side note in the daemon's own log, so both sides share a timeline. */
 export function appendDaemonLog(message: string): void {
@@ -195,39 +194,24 @@ export function startDaemon(connector: Record<string, unknown> | null): {
     path.delimiter,
   )
 
-  // Bundled fallback CLI: the copy of @openagents-org/agent-launcher we ship
-  // inside the app (asarUnpack'd, so it's a real on-disk file the spawned
-  // node can execute rather than a virtual path inside app.asar). This lets
-  // the daemon start even when the runtime-downloaded GLOBAL core never
-  // landed (offline / AV-blocked) — the same failure that used to strand
-  // Windows users at "Daemon failed to start".
-  let bundledCli: string | null = null
-  try {
-    const pkg = require.resolve("@openagents-org/agent-launcher/package.json")
-    let p = path.join(path.dirname(pkg), "bin", "agent-connector.js")
-    if (p.includes("app.asar") && !p.includes("app.asar.unpacked"))
-      p = p.replace("app.asar", "app.asar.unpacked")
-    bundledCli = p
-  } catch (e) {
-    // Not fatal — the LOCAL/portable candidates below may still resolve. But
-    // if none do, knowing the bundled copy was unresolvable is what explains
-    // the "CLI not found" that follows.
-    appendDaemonLog(`bundled agent-launcher CLI unresolvable: ${String(e)}`)
-  }
+  // The daemon runs the same core the app does — newest first, see coreTiers.
+  // That ordering matters as much here as in-process: the daemon is what
+  // actually drives the adapters, so a runtime-downloaded core older than the
+  // one packaged with the app would keep running yesterday's agents.
+  //
+  // Paths are rewritten out of app.asar because the packaged copy has to be a
+  // real on-disk file the spawned node can execute. Having it at all is what
+  // lets the daemon start when the downloaded core never landed (offline /
+  // AV-blocked) — the failure that used to strand Windows users at "Daemon
+  // failed to start".
+  const tiers = coreTiers()
+  if (!tiers.some((t) => t.source === "bundled"))
+    appendDaemonLog("bundled agent-launcher CLI unresolvable")
 
   let cliPath: string | null = null
-  const cliCandidates = [
-    path.join(LOCAL_CORE, "bin", "agent-connector.js"),
-    path.join(
-      portableNodeDir,
-      "node_modules",
-      "@openagents-org",
-      "agent-launcher",
-      "bin",
-      "agent-connector.js",
-    ),
-    ...(bundledCli ? [bundledCli] : []),
-  ]
+  const cliCandidates = tiers.map((t) =>
+    unpackedPath(path.join(t.dir, "bin", "agent-connector.js")),
+  )
   for (const c of cliCandidates) {
     try {
       if (fs.existsSync(c)) {

--- a/packages/launcher/src/main/agents/runtime.test.ts
+++ b/packages/launcher/src/main/agents/runtime.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import { orderCoreTiers, unpackedPath, type CoreTier } from "./runtime"
+
+const tier = (
+  source: CoreTier["source"],
+  version: string | null,
+): CoreTier => ({ dir: `/${source}`, version, source })
+
+describe("orderCoreTiers", () => {
+  it("runs the app's own core when npm's latest trails it", () => {
+    // The exact state that hid Kimi Code CLI: an app built against 0.2.175
+    // downloading — and then running — the 0.2.173 that npm still called
+    // latest, whose registry describes kimi as an API-only agent.
+    const order = orderCoreTiers([
+      null,
+      tier("global", "0.2.173"),
+      tier("bundled", "0.2.175"),
+    ])
+    expect(order.map((t) => t.source)).toEqual(["bundled", "global"])
+  })
+
+  it("still lets a downloaded core newer than the app win", () => {
+    const order = orderCoreTiers([
+      null,
+      tier("global", "0.2.180"),
+      tier("bundled", "0.2.175"),
+    ])
+    expect(order.map((t) => t.source)).toEqual(["global", "bundled"])
+  })
+
+  it("keeps the monorepo copy first in dev, whatever the versions say", () => {
+    const order = orderCoreTiers([
+      tier("local", "0.0.0"),
+      tier("global", "9.9.9"),
+      tier("bundled", "0.2.175"),
+    ])
+    expect(order.map((t) => t.source)).toEqual(["local", "global", "bundled"])
+  })
+
+  it("prefers the downloaded core on a tie, as it always did", () => {
+    const order = orderCoreTiers([
+      null,
+      tier("global", "0.2.175"),
+      tier("bundled", "0.2.175"),
+    ])
+    expect(order.map((t) => t.source)).toEqual(["global", "bundled"])
+  })
+
+  it("sorts an unreadable version below a readable one", () => {
+    expect(
+      orderCoreTiers([null, tier("global", null), tier("bundled", "0.2.175")]),
+    ).toEqual([tier("bundled", "0.2.175"), tier("global", null)])
+    // Two unreadable versions are not comparable — discovery order stands.
+    expect(
+      orderCoreTiers([null, tier("global", null), tier("bundled", null)]).map(
+        (t) => t.source,
+      ),
+    ).toEqual(["global", "bundled"])
+  })
+
+  it("drops tiers that are not installed", () => {
+    expect(orderCoreTiers([null, null, null])).toEqual([])
+    expect(
+      orderCoreTiers([null, null, tier("bundled", "0.2.175")]).map(
+        (t) => t.source,
+      ),
+    ).toEqual(["bundled"])
+  })
+
+  it("compares a non-semver version by falling back to discovery order", () => {
+    const order = orderCoreTiers([
+      null,
+      tier("global", "nightly"),
+      tier("bundled", "0.2.175"),
+    ])
+    expect(order.map((t) => t.source)).toEqual(["global", "bundled"])
+  })
+})
+
+describe("unpackedPath", () => {
+  it("redirects an asar path to the copy on disk", () => {
+    expect(
+      unpackedPath("/App/Resources/app.asar/node_modules/x/bin/y.js"),
+    ).toBe("/App/Resources/app.asar.unpacked/node_modules/x/bin/y.js")
+  })
+
+  it("leaves an already-unpacked or plain path alone", () => {
+    const unpacked = "/App/Resources/app.asar.unpacked/node_modules/x/bin/y.js"
+    expect(unpackedPath(unpacked)).toBe(unpacked)
+    expect(
+      unpackedPath("/home/me/repo/packages/agent-connector/bin/y.js"),
+    ).toBe("/home/me/repo/packages/agent-connector/bin/y.js")
+  })
+})

--- a/packages/launcher/src/main/agents/runtime.ts
+++ b/packages/launcher/src/main/agents/runtime.ts
@@ -6,6 +6,7 @@ import path from "path"
 import fs from "fs"
 import { spawnSync } from "child_process"
 import { withPathEnv } from "../env"
+import { compareVersions } from "../../shared/version-compare"
 import { CONFIG_DIR, GLOBAL_CORE, LOCAL_CORE } from "./paths"
 
 /** The install-command key for this OS, as the shared registry spells it. */
@@ -15,49 +16,130 @@ export function platformKey(): "macos" | "linux" | "windows" {
   return "linux"
 }
 
+/** Which copy of the core a tier refers to. */
+export type CoreSource = "local" | "global" | "bundled"
+
+export interface CoreTier {
+  /** Package root — the directory holding the core's package.json. */
+  dir: string
+  /** Its version, or null when package.json is unreadable. */
+  version: string | null
+  source: CoreSource
+}
+
+/** A path inside app.asar rewritten to its unpacked twin (see build.asarUnpack). */
+export function unpackedPath(p: string): string {
+  return p.includes("app.asar") && !p.includes("app.asar.unpacked")
+    ? p.replace("app.asar", "app.asar.unpacked")
+    : p
+}
+
+/** The core packaged with the app, located however the bundler laid it out. */
+export function bundledCoreDir(): string | null {
+  try {
+    return path.dirname(
+      require.resolve("@openagents-org/agent-launcher/package.json"),
+    )
+  } catch {
+    return null
+  }
+}
+
+function coreVersionAt(dir: string): string | null {
+  try {
+    const v = JSON.parse(
+      fs.readFileSync(path.join(dir, "package.json"), "utf-8"),
+    ).version
+    return typeof v === "string" && v ? v : null
+  } catch {
+    return null
+  }
+}
+
+function tierAt(dir: string | null, source: CoreSource): CoreTier | null {
+  if (!dir) return null
+  try {
+    if (!fs.existsSync(path.join(dir, "package.json"))) return null
+  } catch {
+    return null
+  }
+  return { dir, version: coreVersionAt(dir), source }
+}
+
 /**
- * Load the agent-launcher core, preferring the monorepo copy (dev), then the
- * one the runtime bootstrap installed, then the copy bundled with the app.
+ * Every core we could run, best first.
+ *
+ * Three copies exist: the monorepo's (dev), the one the runtime bootstrap
+ * downloads from npm, and the one packaged inside the app. The downloaded copy
+ * used to win outright, which pinned every user to whatever npm's `latest`
+ * dist-tag happened to be — so an app built against a newer core still ran the
+ * older one, and anything shipping IN the core (an adapter, and the registry
+ * entry describing it) stayed invisible until a publish went out.
+ *
+ * Kimi Code CLI was exactly that: the app shipped core 0.2.175, npm's latest
+ * was still 0.2.173, and 0.2.173 describes kimi as an API-only agent with no
+ * installer and no `kimi login`. The marketplace faithfully showed the old
+ * agent while the new one sat unused in the app bundle.
+ *
+ * So the monorepo copy still wins in dev, and otherwise the NEWEST of the
+ * downloaded and packaged copies does. A core newer than the app still takes
+ * effect — that is what the bootstrap is for — but one older than the app can
+ * no longer downgrade it. Ties and unreadable versions keep the previous
+ * precedence (downloaded before packaged), because sort is stable.
+ */
+export function coreTiers(): CoreTier[] {
+  return orderCoreTiers([
+    tierAt(LOCAL_CORE, "local"),
+    tierAt(GLOBAL_CORE, "global"),
+    tierAt(bundledCoreDir(), "bundled"),
+  ])
+}
+
+/**
+ * The ordering rule on its own, so it can be exercised without three real
+ * install trees on disk. Pass the tiers in discovery order (local, global,
+ * bundled): a tie keeps that order, since sort is stable.
+ */
+export function orderCoreTiers(tiers: Array<CoreTier | null>): CoreTier[] {
+  const present = tiers.filter((t): t is CoreTier => t !== null)
+  return [
+    ...present.filter((t) => t.source === "local"),
+    ...present
+      .filter((t) => t.source !== "local")
+      .sort((a, b) => compareCoreVersions(b.version, a.version)),
+  ]
+}
+
+/** Semver order, with an unreadable version sorting below a readable one. */
+function compareCoreVersions(a: string | null, b: string | null): number {
+  if (!a && !b) return 0
+  if (!a) return -1
+  if (!b) return 1
+  return compareVersions(a, b) ?? 0
+}
+
+/**
+ * Load the agent-launcher core — the newest one available (see coreTiers),
+ * falling through to the next tier if a load throws.
  */
 export function loadCore(): Record<string, unknown> | null {
-  if (fs.existsSync(path.join(LOCAL_CORE, "package.json"))) {
+  for (const tier of coreTiers()) {
     try {
-      return require(LOCAL_CORE)
+      return require(tier.dir)
     } catch (e) {
-      console.error("Failed to load local core:", e)
+      console.error(`Failed to load ${tier.source} core:`, e)
     }
   }
-  if (fs.existsSync(path.join(GLOBAL_CORE, "package.json"))) {
-    try {
-      return require(GLOBAL_CORE)
-    } catch (e) {
-      console.error("Failed to load global core:", e)
-    }
-  }
-  try {
-    return require("@openagents-org/agent-launcher")
-  } catch (e) {
-    console.error("Failed to load bundled core:", e)
-  }
-  // All three tiers failed. Callers surface this as "core not ready", but
-  // without the errors above that state is impossible to diagnose from a user's
-  // log — this is the single most common failure mode on Windows.
+  // Every tier failed. Callers surface this as "core not ready", but without
+  // the errors above that state is impossible to diagnose from a user's log —
+  // this is the single most common failure mode on Windows.
   console.error("loadCore: no core package could be loaded")
   return null
 }
 
-/** The version of whichever core tier loadCore would pick, or null. */
+/** Version of the core we would run — the first tier that declares one. */
 export function readCoreVersion(): string | null {
-  for (const dir of [LOCAL_CORE, GLOBAL_CORE]) {
-    try {
-      const pkg = path.join(dir, "package.json")
-      if (fs.existsSync(pkg))
-        return JSON.parse(fs.readFileSync(pkg, "utf-8")).version
-    } catch {}
-  }
-  try {
-    return require("@openagents-org/agent-launcher/package.json").version
-  } catch {}
+  for (const tier of coreTiers()) if (tier.version) return tier.version
   return null
 }
 

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -92,6 +92,7 @@ import { attachRendererLogging, rendererLogPath } from "./renderer-log"
 import {
   applyDownloadRegion,
   applyProxyFromSettings,
+  adoptSystemProxyForChildren,
   tuneNpmRegistry,
 } from "./net-config"
 import { hardenWebContents, openExternalSafely } from "./web-security"
@@ -1494,6 +1495,9 @@ function setupIPC(): void {
     }
     if (key === "httpProxy" || key === "httpsProxy" || key === "noProxy") {
       applyProxyFromSettings(store)
+      // Clearing the Settings proxy deletes the env vars; re-adopt so children
+      // fall back to the OS proxy rather than to nothing.
+      void adoptSystemProxyForChildren(store)
     }
     // Download acceleration: re-point npm (and therefore core/agent installs)
     // at the mirror without needing a restart. Node dist URLs are resolved per
@@ -2581,6 +2585,9 @@ app.whenReady().then(async () => {
   // them take effect).
   applyStartOnBoot()
   applyProxyFromSettings(store)
+  // Resolving the OS proxy needs a session, so it cannot be synchronous. It
+  // settles in milliseconds, well before the first agent CLI is spawned.
+  void adoptSystemProxyForChildren(store)
 
   // Restore the UI language before the tray is built or any startup
   // notification fires, so main's strings match the renderer from the first

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -75,6 +75,7 @@ import {
   type NotificationPrefs,
 } from "./notifications"
 import { PORTABLE_NODE_DIR } from "./agents/paths"
+import { bundledCoreDir, readCoreVersion } from "./agents/runtime"
 import {
   markUiReached,
   reportStartupError,
@@ -297,6 +298,20 @@ let _updateSplash:
   | ((msg: string, pct: number, detail?: string) => void)
   | null = null
 
+/** Version of the core packaged inside the app, or null if unreadable. */
+function bundledCoreVersion(): string | null {
+  const dir = bundledCoreDir()
+  if (!dir) return null
+  try {
+    const v = JSON.parse(
+      fs.readFileSync(path.join(dir, "package.json"), "utf-8"),
+    ).version
+    return typeof v === "string" && v ? v : null
+  } catch {
+    return null
+  }
+}
+
 async function ensureCoreLibrary(): Promise<void> {
   const corePkgPath = path.join(GLOBAL_MODULES, CORE_PKG, "package.json")
   let installedVersion: string | null = null
@@ -321,7 +336,22 @@ async function ensureCoreLibrary(): Promise<void> {
     const latestVersion = meta?.version
     if (!latestVersion) throw new Error("core latest lookup failed")
 
-    if (!installedVersion) {
+    // Never spend a download on a core we would then ignore. The app ships its
+    // own copy and runs whichever is newer (see coreTiers), so an npm `latest`
+    // that trails the packaged core is not an update — it is a downgrade the
+    // loader would discard anyway. This is the registry's normal state in the
+    // window between a core landing in the app and its publish going out.
+    const bundledVersion = bundledCoreVersion()
+    const npmIsUpgrade =
+      !bundledVersion || isUpgradeAvailable(bundledVersion, latestVersion)
+
+    if (!npmIsUpgrade) {
+      slog(
+        `Core library: keeping the v${bundledVersion} bundled with the app (npm latest is v${latestVersion})`,
+      )
+      if (_updateSplash)
+        _updateSplash("Core library ready", 80, "v" + bundledVersion)
+    } else if (!installedVersion) {
       slog("Core library not found — installing v" + latestVersion + "...")
       if (_updateSplash)
         _updateSplash("Installing core library...", 65, "v" + latestVersion)
@@ -339,7 +369,10 @@ async function ensureCoreLibrary(): Promise<void> {
         _updateSplash("Core library up to date", 80, "v" + installedVersion)
     }
 
-    if (!installedVersion || latestVersion !== installedVersion) {
+    if (
+      npmIsUpgrade &&
+      (!installedVersion || latestVersion !== installedVersion)
+    ) {
       const tgzPath = path.join(
         os.tmpdir(),
         `agent-launcher-${latestVersion}.tgz`,
@@ -390,7 +423,7 @@ async function ensureCoreLibrary(): Promise<void> {
     }
   } catch (e: unknown) {
     slog("Core update failed: " + (e as Error).message)
-    if (!installedVersion) {
+    if (!installedVersion && !bundledCoreVersion()) {
       slog("Falling back to npm...")
       const npmCmd = findNpmCommand()
       if (npmCmd) {
@@ -428,7 +461,9 @@ async function ensureCoreLibrary(): Promise<void> {
     }
   }
 
-  coreVersion = installedVersion
+  // What the app will actually load, which is not necessarily what sits in the
+  // portable prefix — see coreTiers.
+  coreVersion = readCoreVersion() || installedVersion
 
   const npmCheck = path.join(
     PORTABLE_NODE_DIR,
@@ -2098,10 +2133,10 @@ function setupIPC(): void {
           ),
         },
       )
-      const corePkgPath = path.join(GLOBAL_MODULES, CORE_PKG, "package.json")
-      try {
-        coreVersion = JSON.parse(fs.readFileSync(corePkgPath, "utf-8")).version
-      } catch {}
+      // Report what will actually load, not merely what npm just wrote: when
+      // the published core trails the one packaged with the app, the app's copy
+      // is still the one that runs. See coreTiers.
+      coreVersion = readCoreVersion()
       if (agentManager) {
         try {
           await agentManager.stopAll()

--- a/packages/launcher/src/main/net-config.test.ts
+++ b/packages/launcher/src/main/net-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("electron", () => ({
+  session: {
+    defaultSession: {
+      resolveProxy: (): Promise<string> => Promise.resolve(resolveProxyResult),
+      setProxy: (): Promise<void> => Promise.resolve(),
+    },
+    fromPartition: () => ({ setProxy: (): Promise<void> => Promise.resolve() }),
+  },
+}))
+
+let resolveProxyResult = "DIRECT"
+
+import { adoptSystemProxyForChildren, firstProxyUrl } from "./net-config"
+import type { Store } from "./store"
+
+const emptyStore = { get: () => undefined } as unknown as Store
+const storeWith = (values: Record<string, string>): Store =>
+  ({ get: (k: string) => values[k] }) as unknown as Store
+
+const PROXY_KEYS = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+]
+
+function clearProxyEnv(): void {
+  for (const k of PROXY_KEYS) delete process.env[k]
+}
+
+describe("firstProxyUrl", () => {
+  it("reads a PAC list and skips DIRECT", () => {
+    expect(firstProxyUrl("PROXY 127.0.0.1:7897")).toBe("http://127.0.0.1:7897")
+    expect(firstProxyUrl("DIRECT;PROXY 10.0.0.1:8080")).toBe(
+      "http://10.0.0.1:8080",
+    )
+    expect(firstProxyUrl("HTTPS gw.corp:443")).toBe("https://gw.corp:443")
+  })
+
+  it("returns null when there is nothing usable", () => {
+    expect(firstProxyUrl("DIRECT")).toBeNull()
+    expect(firstProxyUrl("")).toBeNull()
+    expect(firstProxyUrl("PROXY")).toBeNull()
+  })
+
+  it("skips SOCKS, which undici cannot use from HTTPS_PROXY", () => {
+    // Exporting one would swap a working direct connection for a broken tunnel.
+    expect(firstProxyUrl("SOCKS5 127.0.0.1:7897")).toBeNull()
+    expect(firstProxyUrl("SOCKS5 127.0.0.1:7897;PROXY 127.0.0.1:7890")).toBe(
+      "http://127.0.0.1:7890",
+    )
+  })
+})
+
+describe("adoptSystemProxyForChildren", () => {
+  it("hands the OS proxy to child processes when nothing else is set", async () => {
+    clearProxyEnv()
+    resolveProxyResult = "PROXY 127.0.0.1:7897"
+    await adoptSystemProxyForChildren(emptyStore)
+    // Electron follows the system proxy on its own; a spawned CLI reads only
+    // these. Without them `kimi login` went direct while the browser half of
+    // the same sign-in went through the tunnel.
+    expect(process.env.HTTPS_PROXY).toBe("http://127.0.0.1:7897")
+    expect(process.env.https_proxy).toBe("http://127.0.0.1:7897")
+    expect(process.env.HTTP_PROXY).toBe("http://127.0.0.1:7897")
+  })
+
+  it("never tunnels localhost — the daemon and control server live there", async () => {
+    clearProxyEnv()
+    resolveProxyResult = "PROXY 127.0.0.1:7897"
+    await adoptSystemProxyForChildren(emptyStore)
+    expect(process.env.NO_PROXY).toContain("127.0.0.1")
+    expect(process.env.NO_PROXY).toContain("localhost")
+  })
+
+  it("stays out of the way when Settings already specifies a proxy", async () => {
+    clearProxyEnv()
+    resolveProxyResult = "PROXY 127.0.0.1:7897"
+    await adoptSystemProxyForChildren(
+      storeWith({ httpsProxy: "http://corp:8080" }),
+    )
+    expect(process.env.HTTPS_PROXY).toBeUndefined()
+  })
+
+  it("sets nothing when the OS reports a direct connection", async () => {
+    clearProxyEnv()
+    resolveProxyResult = "DIRECT"
+    await adoptSystemProxyForChildren(emptyStore)
+    expect(process.env.HTTPS_PROXY).toBeUndefined()
+    expect(process.env.NO_PROXY).toBeUndefined()
+  })
+})

--- a/packages/launcher/src/main/net-config.test.ts
+++ b/packages/launcher/src/main/net-config.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest"
+import { createServer, type Server } from "node:net"
+import { afterAll, describe, expect, it, vi } from "vitest"
 
 vi.mock("electron", () => ({
   session: {
@@ -56,22 +57,51 @@ describe("firstProxyUrl", () => {
   })
 })
 
+/** A real listener, so the liveness check has something to connect to. */
+let live: Server
+let livePort = 0
+const listening = new Promise<void>((resolve) => {
+  live = createServer()
+  live.listen(0, "127.0.0.1", () => {
+    livePort = (live.address() as { port: number }).port
+    resolve()
+  })
+})
+afterAll(() => live?.close())
+
+/** A port nothing is bound to — the "OS names a proxy that died" case. */
+const DEAD_PORT = 9
+
 describe("adoptSystemProxyForChildren", () => {
   it("hands the OS proxy to child processes when nothing else is set", async () => {
+    await listening
     clearProxyEnv()
-    resolveProxyResult = "PROXY 127.0.0.1:7897"
+    resolveProxyResult = `PROXY 127.0.0.1:${livePort}`
     await adoptSystemProxyForChildren(emptyStore)
     // Electron follows the system proxy on its own; a spawned CLI reads only
     // these. Without them `kimi login` went direct while the browser half of
     // the same sign-in went through the tunnel.
-    expect(process.env.HTTPS_PROXY).toBe("http://127.0.0.1:7897")
-    expect(process.env.https_proxy).toBe("http://127.0.0.1:7897")
-    expect(process.env.HTTP_PROXY).toBe("http://127.0.0.1:7897")
+    expect(process.env.HTTPS_PROXY).toBe(`http://127.0.0.1:${livePort}`)
+    expect(process.env.https_proxy).toBe(`http://127.0.0.1:${livePort}`)
+    expect(process.env.HTTP_PROXY).toBe(`http://127.0.0.1:${livePort}`)
+  })
+
+  it("leaves children direct when the OS names a proxy that is not running", async () => {
+    // A tunnelling client in TUN mode keeps working after its HTTP listener
+    // dies: direct connections still go through, but System Settings still
+    // advertises the dead port. Exporting it would trade a working direct
+    // connection for ECONNREFUSED in every spawned CLI.
+    clearProxyEnv()
+    resolveProxyResult = `PROXY 127.0.0.1:${DEAD_PORT}`
+    await adoptSystemProxyForChildren(emptyStore)
+    expect(process.env.HTTPS_PROXY).toBeUndefined()
+    expect(process.env.HTTP_PROXY).toBeUndefined()
   })
 
   it("never tunnels localhost — the daemon and control server live there", async () => {
+    await listening
     clearProxyEnv()
-    resolveProxyResult = "PROXY 127.0.0.1:7897"
+    resolveProxyResult = `PROXY 127.0.0.1:${livePort}`
     await adoptSystemProxyForChildren(emptyStore)
     expect(process.env.NO_PROXY).toContain("127.0.0.1")
     expect(process.env.NO_PROXY).toContain("localhost")

--- a/packages/launcher/src/main/net-config.ts
+++ b/packages/launcher/src/main/net-config.ts
@@ -8,6 +8,7 @@
  * configuration.
  */
 import { session } from "electron"
+import { connect } from "node:net"
 import {
   setRegionPreference,
   useChinaMirror,
@@ -140,6 +141,41 @@ export function firstProxyUrl(rule: string): string | null {
   return null
 }
 
+/**
+ * Does anything actually answer at this proxy?
+ *
+ * An OS proxy setting outlives the program that served it. A machine running a
+ * tunnelling client in TUN mode keeps working when its HTTP listener dies —
+ * DNS still resolves into the tunnel and direct connections still go through —
+ * so System Settings goes on advertising a port with nothing behind it. Seen
+ * exactly that: nothing on 127.0.0.1:7897, yet direct requests to the same
+ * hosts returned 200. Exporting that address would have swapped a working
+ * direct connection for ECONNREFUSED in every CLI we spawn, which is worse than
+ * the gap this whole function exists to close.
+ */
+function proxyIsListening(url: string, timeoutMs = 700): Promise<boolean> {
+  let host: string
+  let port: number
+  try {
+    const u = new URL(url)
+    host = u.hostname
+    port = Number(u.port) || (u.protocol === "https:" ? 443 : 80)
+  } catch {
+    return Promise.resolve(false)
+  }
+  return new Promise((resolve) => {
+    const socket = connect({ host, port })
+    const done = (ok: boolean): void => {
+      socket.destroy()
+      resolve(ok)
+    }
+    socket.setTimeout(timeoutMs)
+    socket.once("connect", () => done(true))
+    socket.once("timeout", () => done(false))
+    socket.once("error", () => done(false))
+  })
+}
+
 /** Localhost must never be tunnelled — the daemon and control server live there. */
 const LOCAL_BYPASS = "localhost,127.0.0.1,::1"
 
@@ -178,6 +214,11 @@ export async function adoptSystemProxyForChildren(store: Store): Promise<void> {
       )
       const url = firstProxyUrl(rule)
       if (!url) return
+      // The OS can name a proxy that is no longer running — see proxyIsListening.
+      if (!(await proxyIsListening(url))) {
+        slog(`system proxy ${url} is not accepting connections — leaving children direct`)
+        return
+      }
       http = https = url
     } catch (err) {
       slog(`could not resolve the system proxy: ${(err as Error).message}`)

--- a/packages/launcher/src/main/net-config.ts
+++ b/packages/launcher/src/main/net-config.ts
@@ -108,6 +108,94 @@ export async function tuneNpmRegistry(
 //     only fast with the system proxy on" was the reported experience.
 // node's core https (our Node/npm bootstrap downloads) doesn't read these, but
 // those already go through regional mirrors so proxy coverage there is moot.
+/**
+ * Proxy variables this process actually inherited, captured before anything
+ * below rewrites them. A proxy the user exported in their own environment is
+ * theirs; applyProxyFromSettings deletes the vars when Settings is empty, and
+ * this is what lets us put them back.
+ */
+const INHERITED_PROXY = {
+  http: process.env.HTTP_PROXY || process.env.http_proxy || "",
+  https: process.env.HTTPS_PROXY || process.env.https_proxy || "",
+  no: process.env.NO_PROXY || process.env.no_proxy || "",
+}
+
+/**
+ * First usable proxy in a `session.resolveProxy` result.
+ *
+ * The format is a `;`-separated PAC list: `DIRECT`, `PROXY host:port`,
+ * `HTTPS host:port`, `SOCKS5 host:port`. SOCKS is deliberately skipped —
+ * undici (Node's fetch, and therefore most agent CLIs) cannot use a SOCKS
+ * proxy from HTTPS_PROXY, so exporting one would swap a working direct
+ * connection for a broken tunnel.
+ */
+export function firstProxyUrl(rule: string): string | null {
+  for (const part of (rule || "").split(";")) {
+    const [scheme, hostport] = part.trim().split(/\s+/)
+    if (!hostport) continue
+    const s = scheme.toUpperCase()
+    if (s === "PROXY") return `http://${hostport}`
+    if (s === "HTTPS") return `https://${hostport}`
+  }
+  return null
+}
+
+/** Localhost must never be tunnelled — the daemon and control server live there. */
+const LOCAL_BYPASS = "localhost,127.0.0.1,::1"
+
+/**
+ * Give spawned CLIs the proxy the OS is configured with.
+ *
+ * Electron follows the system proxy on its own (`{ mode: "system" }` below), so
+ * the app's own requests work on a machine whose proxy lives in System Settings
+ * rather than in a shell profile. A child process sees none of that: Node reads
+ * only HTTP(S)_PROXY, and a GUI-launched Electron inherits no shell exports.
+ *
+ * That gap is how `kimi login` failed with "Client network socket disconnected
+ * before secure TLS connection was established" on a machine where the sign-in
+ * page had just succeeded — the browser half went through the tunnel, the CLI's
+ * token exchange went direct. Kimi Code, like most agent CLIs, honours these
+ * variables (undici's EnvHttpProxyAgent), so handing them over is all it takes.
+ *
+ * Only ever fills a gap: an explicit Settings proxy already won, and a proxy
+ * the user exported themselves is restored rather than replaced.
+ */
+export async function adoptSystemProxyForChildren(store: Store): Promise<void> {
+  const explicit =
+    ((store.get("httpProxy") as string) || "").trim() ||
+    ((store.get("httpsProxy") as string) || "").trim()
+  if (explicit) return
+
+  let http = INHERITED_PROXY.http
+  let https = INHERITED_PROXY.https
+  if (!http && !https) {
+    if (!session?.defaultSession) return
+    try {
+      // Resolved against a host the launcher genuinely talks to, so a PAC file
+      // that routes by destination gives an answer that applies to our traffic.
+      const rule = await session.defaultSession.resolveProxy(
+        "https://registry.npmjs.org",
+      )
+      const url = firstProxyUrl(rule)
+      if (!url) return
+      http = https = url
+    } catch (err) {
+      slog(`could not resolve the system proxy: ${(err as Error).message}`)
+      return
+    }
+  }
+
+  const set = (name: string, value: string): void => {
+    if (!value) return
+    process.env[name] = value
+    process.env[name.toLowerCase()] = value
+  }
+  set("HTTP_PROXY", http)
+  set("HTTPS_PROXY", https)
+  set("NO_PROXY", INHERITED_PROXY.no || LOCAL_BYPASS)
+  slog(`child processes will use proxy ${https || http}`)
+}
+
 export function applyProxyFromSettings(store: Store): void {
   const http = ((store.get("httpProxy") as string) || "").trim()
   const https = ((store.get("httpsProxy") as string) || "").trim()

--- a/packages/launcher/src/renderer/public/icons/kimi.svg
+++ b/packages/launcher/src/renderer/public/icons/kimi.svg
@@ -1,11 +1,6 @@
-<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#141821"/>
-      <stop offset="0.52" stop-color="#2f6df6"/>
-      <stop offset="1" stop-color="#49d2ff"/>
-    </linearGradient>
-  </defs>
-  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
-  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 112 112" role="img" style="flex:none;line-height:1">
+<title>Kimi Code CLI</title>
+<rect width="112" height="112" rx="28" fill="#000"/>
+<path d="M30 34 38 34 38 56 39 57 63 34 75 34 53 57 65 66 77 73 77 81 73 81 67 78 46 63 38 71 38 81 30 81Z" fill="#fff"/>
+<circle cx="86" cy="28" r="5.5" fill="#1783FF"/>
 </svg>

--- a/registry/icons/kimi.svg
+++ b/registry/icons/kimi.svg
@@ -1,11 +1,6 @@
-<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#141821"/>
-      <stop offset="0.52" stop-color="#2f6df6"/>
-      <stop offset="1" stop-color="#49d2ff"/>
-    </linearGradient>
-  </defs>
-  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
-  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 112 112" role="img" style="flex:none;line-height:1">
+<title>Kimi Code CLI</title>
+<rect width="112" height="112" rx="28" fill="#000"/>
+<path d="M30 34 38 34 38 56 39 57 63 34 75 34 53 57 65 66 77 73 77 81 73 81 67 78 46 63 38 71 38 81 30 81Z" fill="#fff"/>
+<circle cx="86" cy="28" r="5.5" fill="#1783FF"/>
 </svg>

--- a/registry/kimi.json
+++ b/registry/kimi.json
@@ -1,10 +1,11 @@
 {
   "name": "kimi",
-  "label": "Kimi",
+  "label": "Kimi Code CLI",
   "description": "Kimi Code CLI — Moonshot AI's terminal coding agent.",
   "homepage": "https://moonshotai.github.io/kimi-code",
   "tags": [
     "coding",
+    "cli",
     "moonshot",
     "open-source"
   ],

--- a/sdk/src/openagents/adapters/kimi.py
+++ b/sdk/src/openagents/adapters/kimi.py
@@ -1,29 +1,144 @@
 """
-Kimi adapter for OpenAgents workspace — Moonshot AI OpenAI-compatible API.
+Kimi adapter for OpenAgents workspace — drives Moonshot's Kimi Code CLI
+(npm ``@moonshot-ai/kimi-code``) in print mode, with a direct-API fallback.
 
-Mirrors packages/agent-connector/src/adapters/kimi.js. Reuses the streaming
-chat-completions client from LlmDirectAdapter but applies Kimi-specific
-defaults (base URL https://api.moonshot.ai/v1, model kimi-k2.6) and accepts
-KIMI_API_KEY / MOONSHOT_API_KEY in addition to the generic LLM_*/OPENAI_*
-variables.
+Mirrors packages/agent-connector/src/adapters/kimi.js:
+
+  - CLI mode (preferred): ``kimi -p <prompt> --output-format stream-json``,
+    JSONL-parsed via :mod:`openagents.adapters.kimi_stream`, with real session
+    continuity per channel via ``-S <session_id>``.
+  - auth: the saved KIMI_API_KEY / KIMI_BASE_URL / KIMI_MODEL are mapped onto
+    the CLI's env-provider contract (KIMI_MODEL_API_KEY / KIMI_MODEL_BASE_URL /
+    KIMI_MODEL_NAME); with no key configured the CLI's own ``kimi login``
+    credentials apply.
+  - direct-API fallback: when the CLI is not installed (or the wrong product,
+    the legacy Python ``kimi-cli`` 1.x, is on PATH) the adapter falls back to
+    the OpenAI-compatible chat-completions path it has always used, so agents
+    configured before CLI support keep working unchanged.
 
 Priority for every value: UI-saved env > process env > default.
+
+Deliberate difference from the Node port: no cross-turn channel recap is
+prepended when starting a fresh session. The Python WorkspaceClient exposes no
+recent-messages read, and no other Python adapter builds one either; session
+resume (``-S``) carries the history in the normal case.
 """
 
+import asyncio
+import hashlib
+import json
 import logging
 import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
 
+from openagents.adapters.kimi_stream import (
+    DEFAULT_KIMI_MODEL,
+    KimiStreamParser,
+    build_kimi_args,
+    build_kimi_env,
+    classify_kimi_error,
+    classify_kimi_version,
+    interpret_kimi_message,
+    redact_args,
+    redact_secrets,
+)
 from openagents.adapters.llm_direct import LlmDirectAdapter
+from openagents.adapters.utils import format_attachments_for_prompt
 from openagents.workspace_client import DEFAULT_ENDPOINT
 
 logger = logging.getLogger(__name__)
 
+IS_WINDOWS = os.name == "nt"
+
 DEFAULT_BASE_URL = "https://api.moonshot.ai/v1"
-DEFAULT_MODEL = "kimi-k2.6"
+DEFAULT_MODEL = DEFAULT_KIMI_MODEL
+
+# Kill a run that has produced nothing for this long, nudging the channel once
+# on the way. Kimi's provider retry backoff can reach ~1 min between attempts,
+# so the ceiling is generous.
+_WATCHDOG_INTERVAL = 15.0
+_WATCHDOG_NUDGE_AT = 4      # ~60s of silence → "Still working..."
+_WATCHDOG_MAX = 20          # ~5min of silence → treat as hung
+_STDERR_CAP = 64 * 1024
+
+# `kimi --version` costs a process spawn; cache the answer per resolved binary
+# path with a TTL so repeated messages don't re-run it, yet an install/upgrade
+# is still re-detected.
+_VERSION_CACHE_TTL = 5 * 60.0
+_version_cache: dict = {}
+
+
+def find_kimi_binary() -> Optional[str]:
+    """Locate the ``kimi`` CLI across platforms.
+
+    Tiers mirror the Node adapter: the launcher's isolated runtime prefix first
+    (so a launcher-managed install always wins over whatever is on PATH), then
+    the package's own ``dist/main.mjs``, then PATH, then the well-known install
+    locations a GUI/daemon PATH tends to miss — including ``~/.kimi-code/bin``,
+    where the npm package's postinstall drops a native build.
+    """
+    home = Path.home()
+    ext = ".cmd" if IS_WINDOWS else ""
+
+    # Tier 0: launcher-managed prefixes.
+    for root in (
+        home / ".openagents" / "runtimes" / "kimi",
+        home / ".openagents" / "nodejs",
+    ):
+        cand = root / "node_modules" / ".bin" / f"kimi{ext}"
+        if cand.is_file():
+            return str(cand)
+        pkg_bin = root / "node_modules" / "@moonshot-ai" / "kimi-code" / "dist" / "main.mjs"
+        if pkg_bin.is_file():
+            return str(pkg_bin)
+
+    # Tier 1: PATH.
+    for name in (("kimi.cmd", "kimi.exe", "kimi") if IS_WINDOWS else ("kimi",)):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    # Tier 2: common install locations.
+    if IS_WINDOWS:
+        candidates = [
+            Path(os.environ.get("APPDATA", "")) / "npm" / "kimi.cmd",
+            home / ".kimi-code" / "bin" / "kimi.exe",
+        ]
+    else:
+        candidates = [
+            home / ".kimi-code" / "bin" / "kimi",
+            home / ".local" / "bin" / "kimi",
+            home / ".npm-global" / "bin" / "kimi",
+            Path("/opt/homebrew/bin/kimi"),
+            Path("/usr/local/bin/kimi"),
+        ]
+    for cand in candidates:
+        try:
+            if cand.is_file() and (IS_WINDOWS or os.access(cand, os.X_OK)):
+                return str(cand)
+        except OSError:
+            continue
+    return None
+
+
+def kimi_sessions_file(workspace_id: str, agent_name: str) -> Path:
+    """Where this agent's channel→session map lives (same layout as the Node port)."""
+    safe = hashlib.sha256(f"{workspace_id}|{agent_name}".encode("utf-8")).hexdigest()[:16]
+    return Path.home() / ".openagents" / "sessions" / f"kimi_{safe}.json"
+
+
+def clear_version_cache() -> None:
+    """Drop the cached ``kimi --version`` answers (test hook; also after upgrade)."""
+    _version_cache.clear()
 
 
 class KimiAdapter(LlmDirectAdapter):
-    """Kimi (Moonshot) adapter — OpenAI-compatible chat completions."""
+    """Kimi Code CLI adapter, falling back to Moonshot's OpenAI-compatible API."""
 
     def __init__(
         self,
@@ -45,6 +160,10 @@ class KimiAdapter(LlmDirectAdapter):
             working_dir,
         )
 
+        # LlmDirectAdapter accepts working_dir but does not keep it — the CLI
+        # path needs it as the process cwd, so hold it here.
+        self.working_dir = working_dir
+
         self._direct_api_key = (
             os.environ.get("KIMI_API_KEY")
             or os.environ.get("MOONSHOT_API_KEY")
@@ -65,12 +184,530 @@ class KimiAdapter(LlmDirectAdapter):
         )
         self._direct_mode = bool(self._direct_api_key and self._direct_base_url)
 
-        if self._direct_mode:
+        # CLI-mode state.
+        self._channel_sessions: dict = {}   # channel → {"session_id", "working_dir"}
+        self._channel_processes: dict = {}  # channel → in-flight process
+        self._stopping_channels: set = set()
+        self._logged_fallback = False
+        self._sessions_file = kimi_sessions_file(workspace_id, agent_name)
+        self._load_sessions()
+
+        if find_kimi_binary():
+            logger.info("Kimi Code CLI detected — running in CLI mode")
+        elif self._direct_mode:
             logger.info(
-                f"Kimi mode: {self._direct_base_url} model={self._direct_model}"
+                "Kimi direct API mode: %s model=%s (install Kimi Code CLI for full "
+                "agent mode: npm install -g @moonshot-ai/kimi-code)",
+                self._direct_base_url, self._direct_model,
             )
         else:
             logger.warning(
-                "Kimi adapter started without API key. "
-                "Set KIMI_API_KEY (or MOONSHOT_API_KEY) via the Launcher Configure screen."
+                "Kimi adapter started without CLI or API key. Install the CLI "
+                "(npm install -g @moonshot-ai/kimi-code) and/or set KIMI_API_KEY."
             )
+
+    # ------------------------------------------------------------------
+    # Session persistence (real Kimi session ids, bound to working dir)
+    # ------------------------------------------------------------------
+
+    def _load_sessions(self):
+        try:
+            if self._sessions_file.exists():
+                data = json.loads(self._sessions_file.read_text())
+                if isinstance(data, dict):
+                    self._channel_sessions.update(
+                        {k: v for k, v in data.items() if isinstance(v, dict)}
+                    )
+                    logger.info("Loaded %d Kimi session(s)", len(self._channel_sessions))
+        except Exception:
+            logger.debug("Could not load Kimi sessions file, starting fresh")
+
+    def _save_sessions(self):
+        try:
+            self._sessions_file.parent.mkdir(parents=True, exist_ok=True)
+            self._sessions_file.write_text(json.dumps(self._channel_sessions))
+        except Exception:
+            logger.debug("Could not save Kimi sessions file")
+
+    def _resumable_session(self, channel: str, working_dir: str) -> Optional[str]:
+        """A saved session id for this channel, or None.
+
+        Only resume when the saved working dir matches the current one — a
+        session carries the project it was started in, and crossing projects
+        gives the model a history that does not describe the files it sees.
+        """
+        entry = self._channel_sessions.get(channel)
+        if not isinstance(entry, dict):
+            return None
+        session_id = entry.get("session_id")
+        if not session_id:
+            return None
+        saved_dir = entry.get("working_dir")
+        if saved_dir and working_dir and saved_dir != working_dir:
+            return None
+        return session_id
+
+    def _clear_session(self, channel: str):
+        if channel in self._channel_sessions:
+            del self._channel_sessions[channel]
+            self._save_sessions()
+
+    # ------------------------------------------------------------------
+    # Version / product preflight (cached)
+    # ------------------------------------------------------------------
+
+    def _read_version_raw(self, kimi_bin: str) -> str:
+        """Run ``kimi --version`` and return its raw output. Isolated for testing."""
+        cmd = self._spawn_cmd(kimi_bin, ["--version"])
+        return subprocess.run(
+            cmd, capture_output=True, text=True, timeout=8,
+        ).stdout.strip()
+
+    def _check_version(self, kimi_bin: str):
+        """Resolve the installed product identity, cached per binary path."""
+        now = time.time()
+        cached = _version_cache.get(kimi_bin)
+        if cached and (now - cached[1]) < _VERSION_CACHE_TTL:
+            return cached[0]
+        try:
+            result = classify_kimi_version(self._read_version_raw(kimi_bin))
+        except Exception:
+            # `kimi --version` failed → undetermined; proceed leniently.
+            result = classify_kimi_version(None)
+        _version_cache[kimi_bin] = (result, now)
+        return result
+
+    # ------------------------------------------------------------------
+    # Spawn helpers
+    # ------------------------------------------------------------------
+
+    def _spawn_cmd(self, kimi_bin: str, args: list) -> list:
+        """Resolve ``[cmd, *args]``, routing a bare ``.mjs``/``.js`` through node.
+
+        Kimi Code's package bin IS ``dist/main.mjs``, so a path landing on one
+        has to run under node rather than being exec'd directly.
+        """
+        if kimi_bin.endswith((".mjs", ".js")):
+            return [self._node_bin(), kimi_bin, *args]
+        if IS_WINDOWS and kimi_bin.lower().endswith(".cmd"):
+            return ["cmd.exe", "/c", kimi_bin, *args]
+        return [kimi_bin, *args]
+
+    @staticmethod
+    def _node_bin() -> str:
+        """The launcher's portable node when present, else whatever is on PATH."""
+        home = Path.home()
+        candidates = (
+            [home / ".openagents" / "nodejs" / "node.exe"]
+            if IS_WINDOWS
+            else [
+                home / ".openagents" / "nodejs" / "node",
+                home / ".openagents" / "nodejs" / "bin" / "node",
+            ]
+        )
+        for c in candidates:
+            if c.is_file():
+                return str(c)
+        return shutil.which("node") or "node"
+
+    def _resolve_cwd(self) -> str:
+        """The directory the CLI runs in. Never silently cross into another project."""
+        if not self.working_dir:
+            d = Path.home() / ".openagents" / "workspaces" / _safe_name(self.agent_name)
+            d.mkdir(parents=True, exist_ok=True)
+            return str(d)
+        p = Path(self.working_dir)
+        if not p.is_dir():
+            raise NotADirectoryError(f"Working directory does not exist: {self.working_dir}")
+        return str(p)
+
+    # ------------------------------------------------------------------
+    # Prompt assembly
+    # ------------------------------------------------------------------
+
+    def _context_header(self, channel: str) -> str:
+        """A compact context header.
+
+        Kimi Code keeps its own coding system prompt; we add only workspace
+        identity and (soft) plan-mode framing — print mode cannot take the CLI's
+        ``--plan`` flag.
+        """
+        lines = [
+            f'[OpenAgents workspace] You are "{self.agent_name}", a coding agent '
+            f'in workspace channel "{channel}".'
+        ]
+        if self._mode == "plan":
+            lines.append(
+                "You are in PLAN mode: investigate and propose a plan; do not modify files."
+            )
+        lines.append(
+            "Work in the current working directory. Reply concisely. "
+            "The user request follows:"
+        )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Control actions (stop / restart)
+    # ------------------------------------------------------------------
+
+    async def _on_control_action(self, action: Optional[str], payload: dict):
+        channel = payload.get("channel") if isinstance(payload, dict) else None
+
+        if action == "stop":
+            if channel and channel in self._channel_processes:
+                self._stopping_channels.add(channel)
+                await self._stop_process(self._channel_processes.pop(channel))
+                await self._send_response(channel, "Execution stopped by user.")
+                return
+            if self._channel_processes:
+                await self._stop_all_processes("Execution stopped by user.")
+                return
+            # No CLI runs in flight — fall through to the direct-API stop.
+            await super()._on_control_action(action, payload)
+            return
+
+        if action == "restart":
+            if channel:
+                proc = self._channel_processes.pop(channel, None)
+                if proc:
+                    await self._stop_process(proc)
+                self._clear_session(channel)
+                await self._send_status(
+                    channel,
+                    "Session restarted — next message starts a fresh Kimi session.",
+                )
+            else:
+                self._channel_sessions = {}
+                self._save_sessions()
+                await self._stop_all_processes("Execution stopped.")
+            return
+
+        await super()._on_control_action(action, payload)
+
+    async def _stop_all_processes(self, message: str = "Execution stopped."):
+        entries = list(self._channel_processes.items())
+        if not entries:
+            return
+        logger.info("Stopping %d running Kimi process(es)...", len(entries))
+        for channel, proc in entries:
+            self._stopping_channels.add(channel)
+            await self._stop_process(proc)
+            self._channel_processes.pop(channel, None)
+            try:
+                await self._send_response(channel, message)
+            except Exception:
+                pass
+
+    async def _stop_process(self, proc):
+        """Terminate a kimi process tree gracefully, then forcefully.
+
+        POSIX: signal the whole process group (the CLI's shell tools share it
+        because we spawn with ``start_new_session=True``). Windows:
+        ``taskkill /F /T`` kills the tree.
+        """
+        if not proc or proc.returncode is not None:
+            return
+        if IS_WINDOWS:
+            try:
+                proc.send_signal(signal.SIGINT)
+            except Exception:
+                pass
+            if await _exited(proc, 1.5):
+                return
+            try:
+                killer = await asyncio.create_subprocess_exec(
+                    "taskkill", "/F", "/T", "/PID", str(proc.pid),
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await asyncio.wait_for(killer.wait(), timeout=5)
+            except Exception:
+                _safe_kill(proc)
+            await _exited(proc, 2)
+            return
+
+        for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(os.getpgid(proc.pid), sig)
+            except Exception:
+                _safe_kill(proc)
+            if await _exited(proc, 1.5):
+                return
+
+    # ------------------------------------------------------------------
+    # Message handling
+    # ------------------------------------------------------------------
+
+    async def _handle_message(self, msg: dict):
+        kimi_bin = find_kimi_binary()
+        channel = msg.get("sessionId") or self.channel_name
+
+        if not kimi_bin:
+            # Legacy direct-API fallback: agents configured before CLI support
+            # keep working exactly as they did.
+            if self._direct_mode:
+                self._log_fallback(
+                    "Kimi Code CLI not found — using direct API fallback "
+                    "(npm install -g @moonshot-ai/kimi-code for full agent mode)"
+                )
+                await super()._handle_message(msg)
+                return
+            await self._send_error(
+                channel,
+                "Kimi Code CLI not found. Install it with: "
+                "npm install -g @moonshot-ai/kimi-code "
+                "(or set KIMI_API_KEY for direct API mode).",
+            )
+            return
+
+        ver = self._check_version(kimi_bin)
+        if ver.product == "legacy":
+            # Wrong product on PATH: the wound-down Python kimi-cli (1.x) has a
+            # different headless interface.
+            if self._direct_mode:
+                self._log_fallback(
+                    f"Legacy kimi-cli {ver.version} detected — using direct API "
+                    "fallback. Install Kimi Code CLI: npm install -g @moonshot-ai/kimi-code"
+                )
+                await super()._handle_message(msg)
+                return
+            await self._send_error(
+                channel,
+                f"Found the legacy Python kimi-cli ({ver.version}), which is not "
+                "supported. Install the real Kimi Code CLI with: "
+                "npm install -g @moonshot-ai/kimi-code",
+            )
+            return
+
+        await self._handle_message_cli(msg, kimi_bin)
+
+    def _log_fallback(self, message: str):
+        if not self._logged_fallback:
+            self._logged_fallback = True
+            logger.info(message)
+
+    async def _handle_message_cli(self, msg: dict, kimi_bin: str):
+        content = (msg.get("content") or "").strip()
+        att_text = format_attachments_for_prompt(msg.get("attachments") or [])
+        if att_text:
+            content = f"{content}{att_text}" if content else att_text.strip()
+        if not content:
+            return
+
+        channel = msg.get("sessionId") or self.channel_name
+        self._stopping_channels.discard(channel)
+        sender = msg.get("senderName") or msg.get("senderType") or "user"
+        logger.info(
+            "Processing message from %s in %s: %s...",
+            sender, channel, redact_secrets(content[:80]),
+        )
+
+        try:
+            working_dir = self._resolve_cwd()
+        except NotADirectoryError as e:
+            await self._send_error(channel, str(e))
+            return
+
+        await self._auto_title_channel(channel, content)
+        await self._send_status(channel, "thinking...")
+
+        # One retry: if resuming a stale session fails, retry once fresh.
+        for attempt in range(2):
+            resume_id = self._resumable_session(channel, working_dir) if attempt == 0 else None
+
+            # Resuming → Kimi already has the history, send the bare turn.
+            prompt = content if resume_id else f"{self._context_header(channel)}\n\n{content}"
+            args = build_kimi_args(prompt, resume_id)
+            result = await self._run_kimi(channel, kimi_bin, args, working_dir)
+
+            if result["user_stopped"]:
+                return
+
+            # Stale-session handling: a resume that died with nothing useful →
+            # clear it and retry fresh once.
+            if resume_id and not result["ok"] and not result["any_output"] and attempt == 0:
+                logger.info("Resume of session %s failed — retrying fresh", resume_id)
+                self._clear_session(channel)
+                continue
+
+            if result["session_id"]:
+                self._channel_sessions[channel] = {
+                    "session_id": result["session_id"],
+                    "working_dir": working_dir,
+                }
+                self._save_sessions()
+
+            if result["ok"] and result["final_text"]:
+                await self._send_response(channel, result["final_text"])
+            elif not result["ok"]:
+                await self._send_error(
+                    channel,
+                    classify_kimi_error(
+                        code=result["exit_code"],
+                        signal=result["exit_signal"],
+                        stderr_text=result["stderr_text"],
+                        retry_message=result["retry_message"],
+                    ).user_message,
+                )
+            else:
+                await self._send_response(
+                    channel, "No response generated. Please try again."
+                )
+            return
+
+    async def _run_kimi(self, channel: str, kimi_bin: str, args: list, working_dir: str) -> dict:
+        """Spawn one ``kimi -p … --output-format stream-json`` run and summarize it.
+
+        ``ok`` is exit code 0; ``final_text`` is the LAST assistant text of the turn.
+        """
+        env, _ = build_kimi_env(os.environ)
+        cmd = self._spawn_cmd(kimi_bin, args)
+        logger.info(
+            "Spawning kimi in %s: %s",
+            working_dir, " ".join(redact_args([kimi_bin, *args])),
+        )
+
+        state = {
+            "ok": False,
+            "final_text": "",
+            "session_id": None,
+            "any_output": False,
+            "user_stopped": False,
+            "exit_code": None,
+            "exit_signal": None,
+            "stderr_text": "",
+            "retry_message": "",
+        }
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=working_dir,
+                env=env,
+                limit=10 * 1024 * 1024,  # big tool output lines
+                start_new_session=not IS_WINDOWS,  # own process group for tree kill
+            )
+        except Exception as e:
+            state["stderr_text"] = f"error: failed to start Kimi Code CLI: {e}"
+            return state
+
+        self._channel_processes[channel] = proc
+        loop = asyncio.get_running_loop()
+        last_activity = loop.time()
+
+        async def read_stdout():
+            nonlocal last_activity
+            parser = KimiStreamParser()
+            while True:
+                try:
+                    chunk = await proc.stdout.read(65536)
+                except Exception:
+                    break
+                if not chunk:
+                    break
+                last_activity = loop.time()
+                for parsed in parser.push(chunk):
+                    await self._dispatch_event(channel, parsed, state)
+            for parsed in parser.flush():
+                await self._dispatch_event(channel, parsed, state)
+
+        async def read_stderr():
+            nonlocal last_activity
+            while True:
+                try:
+                    line = await proc.stderr.readline()
+                except Exception:
+                    break
+                if not line:
+                    break
+                last_activity = loop.time()
+                if len(state["stderr_text"]) < _STDERR_CAP:
+                    state["stderr_text"] += line.decode("utf-8", errors="replace")
+
+        async def watchdog():
+            silences = 0
+            while proc.returncode is None:
+                await asyncio.sleep(_WATCHDOG_INTERVAL)
+                if proc.returncode is not None:
+                    return
+                if loop.time() - last_activity < _WATCHDOG_INTERVAL:
+                    silences = 0
+                    continue
+                silences += 1
+                if silences == _WATCHDOG_NUDGE_AT:
+                    await self._send_status(channel, "Still working...")
+                if silences >= _WATCHDOG_MAX:
+                    logger.warning("Watchdog: kimi silent on %s — killing", channel)
+                    if not state["stderr_text"]:
+                        state["stderr_text"] = (
+                            "error: Kimi became unresponsive and was stopped."
+                        )
+                    await self._stop_process(proc)
+                    return
+
+        dog = asyncio.ensure_future(watchdog())
+        try:
+            await asyncio.gather(read_stdout(), read_stderr())
+            await proc.wait()
+        finally:
+            dog.cancel()
+            self._channel_processes.pop(channel, None)
+
+        code = proc.returncode
+        # A negative return code is POSIX shorthand for "killed by signal N".
+        if code is not None and code < 0:
+            state["exit_signal"] = signal.Signals(-code).name
+        state["exit_code"] = code
+        state["ok"] = code == 0
+        if channel in self._stopping_channels:
+            state["user_stopped"] = True
+        return state
+
+    async def _dispatch_event(self, channel: str, parsed: dict, state: dict):
+        """Turn one parsed stream message into workspace activity + run state."""
+        for e in interpret_kimi_message(parsed):
+            kind = e["kind"]
+            if kind == "text":
+                state["any_output"] = True
+                # The Python BaseAdapter has no separate "thinking" channel, so
+                # interim prose is surfaced as transient status; the final text
+                # is what gets posted as the reply.
+                state["final_text"] = e["text"]
+                await self._send_status(channel, e["text"])
+            elif kind == "tool_start":
+                state["any_output"] = True
+                preview = e.get("preview")
+                await self._send_status(
+                    channel, f"{e['name']}: {preview}" if preview else e["name"]
+                )
+            elif kind == "session":
+                state["session_id"] = e["session_id"]
+            elif kind == "retrying":
+                state["retry_message"] = e.get("message") or state["retry_message"]
+                await self._send_status(
+                    channel,
+                    f"Provider error — retrying ({e['attempt']}/{e['max_attempts']})...",
+                )
+
+
+async def _exited(proc, timeout: float) -> bool:
+    """Wait up to ``timeout`` for the process to exit; True when it did."""
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+        return True
+    except asyncio.TimeoutError:
+        return proc.returncode is not None
+
+
+def _safe_kill(proc):
+    try:
+        proc.kill()
+    except (ProcessLookupError, OSError):
+        pass
+
+
+def _safe_name(name: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in (name or "agent"))

--- a/sdk/src/openagents/adapters/kimi_stream.py
+++ b/sdk/src/openagents/adapters/kimi_stream.py
@@ -1,0 +1,425 @@
+"""
+Pure, side-effect-free helpers for the Kimi Code CLI adapter.
+
+Everything here is I/O-free and deterministic so it can be unit-tested without
+spawning the ``kimi`` binary or touching the network: the JSONL stream parser,
+the message interpreter, secret redaction, error/version classification, the
+argument builder, and the env mapping that turns the launcher's ``KIMI_*``
+fields into the CLI's ``KIMI_MODEL_*`` provider variables.
+
+Kept behaviourally identical to the Node port
+(``packages/agent-connector/src/adapters/kimi-stream.js``), which was verified
+against Kimi Code CLI v0.39.1 (``kimi -p --output-format stream-json``). The
+stream is JSONL on stdout where each line is a message::
+
+    {role:"assistant", content, tool_calls?:[{type:"function",id,function:{name,arguments}}]}
+    {role:"tool", tool_call_id, content}
+    {role:"meta", type:"system.version", version}
+    {role:"meta", type:"session.resume_hint", session_id, command, content}
+    {role:"meta", type:"turn.step.retrying", failed_attempt, next_attempt,
+                  max_attempts, delay_ms, error_name, error_message}
+
+Fatal errors arrive on stderr as ``error: ...`` lines. Exit codes: 0 success,
+1 permanent failure (config/auth/quota), 75 transient (retryable).
+
+IMPORTANT product distinction: two Moonshot products install a ``kimi`` binary.
+Kimi Code CLI (npm ``@moonshot-ai/kimi-code``) versions are 0.x; the legacy
+Python ``kimi-cli`` (PyPI) is 1.x and has a DIFFERENT headless interface. A 1.x
+``kimi --version`` therefore means the WRONG product.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, NamedTuple, Optional
+
+# Hard cap on a single un-terminated line we will buffer before dropping it.
+# Guards against a pathological stream pinning memory (same rationale as the
+# Goose parser next door).
+_MAX_LINE_BYTES = 8 * 1024 * 1024
+
+DEFAULT_KIMI_MODEL = "kimi-k2.6"
+# The CLI defaults max_completion_tokens to the model's full context size
+# (262144), which OpenAI-compatible gateways reject (input+output > context).
+# A fixed, generous output budget works against both Moonshot and gateways.
+DEFAULT_MAX_COMPLETION_TOKENS = "32768"
+
+# Kimi Code CLI's documented exit codes.
+EXIT_PERMANENT = 1
+EXIT_TRANSIENT = 75
+
+
+# ---------------------------------------------------------------------------
+# Version / product classification
+# ---------------------------------------------------------------------------
+
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)(?:[-.][0-9A-Za-z.]+)?")
+
+
+class KimiVersion(NamedTuple):
+    """``version`` is the dotted string; ``product`` identifies which CLI it is.
+
+    ``"kimi-code"`` → the real Kimi Code CLI (0.x) this adapter drives
+    ``"legacy"``    → the wound-down Python kimi-cli (1.x) — incompatible
+    ``None``        → undetermined (unparseable output); proceed leniently
+    """
+
+    version: Optional[str]
+    product: Optional[str]
+
+
+def parse_kimi_version(raw: Optional[str]) -> Optional[str]:
+    """Pull a dotted version (e.g. ``0.39.1``) out of ``kimi --version`` output."""
+    if not raw or not isinstance(raw, str):
+        return None
+    m = _VERSION_RE.search(raw)
+    return m.group(0) if m else None
+
+
+def classify_kimi_version(raw_version: Optional[str]) -> KimiVersion:
+    """Classify ``kimi --version`` output into a product identity."""
+    version = parse_kimi_version(raw_version)
+    if not version:
+        return KimiVersion(None, None)
+    major = int(version.split(".")[0])
+    return KimiVersion(version, "kimi-code" if major == 0 else "legacy")
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction (same patterns as the other CLI adapters)
+# ---------------------------------------------------------------------------
+
+_SECRET_PATTERNS = [
+    re.compile(r"\bsk-[A-Za-z0-9._-]{8,}\b"),
+    re.compile(r"\b(?:or|rk|gsk|ghp|gho|ghu|ghs|github_pat)[-_][A-Za-z0-9._-]{12,}\b"),
+    re.compile(r"\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}", re.IGNORECASE),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+_REDACTED = "«redacted»"
+
+
+def redact_secrets(text: Any) -> Any:
+    """Redact obvious secret material from a free-text string."""
+    if text is None:
+        return text
+    out = str(text)
+    for pattern in _SECRET_PATTERNS:
+        out = pattern.sub(_REDACTED, out)
+    return out
+
+
+def redact_args(args: list) -> list:
+    """Redact an argv list for logging. The prompt (arg after ``-p``) is elided."""
+    out: list = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a in ("-p", "--prompt"):
+            out.append(a)
+            out.append("«prompt»")
+            i += 2
+            continue
+        out.append(redact_secrets(a))
+        i += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# JSONL stream parser
+# ---------------------------------------------------------------------------
+
+
+def _parse_lines(lines) -> list:
+    out = []
+    for line in lines:
+        t = line.strip()
+        if not t or not t.startswith("{"):
+            continue
+        try:
+            obj = json.loads(t)
+        except (ValueError, TypeError):
+            # Partial or non-JSON diagnostic line — skip.
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+class KimiStreamParser:
+    """Line-buffered JSONL parser. ``push()`` returns complete parsed messages."""
+
+    def __init__(self) -> None:
+        self._buf = ""
+
+    def push(self, chunk) -> list:
+        if isinstance(chunk, (bytes, bytearray)):
+            chunk = chunk.decode("utf-8", errors="replace")
+        self._buf += chunk
+        lines = self._buf.split("\n")
+        self._buf = lines.pop()
+        if len(self._buf) > _MAX_LINE_BYTES:
+            # A single line this long is not a message we can use; drop it
+            # rather than growing without bound.
+            self._buf = ""
+        return _parse_lines(lines)
+
+    def flush(self) -> list:
+        rest = self._buf
+        self._buf = ""
+        return _parse_lines([rest])
+
+
+# ---------------------------------------------------------------------------
+# Message interpretation
+# ---------------------------------------------------------------------------
+
+
+def content_text(content: Any) -> str:
+    """Flatten a message ``content`` (string or list of text blocks) to a string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "".join(parts)
+    return ""
+
+
+# Argument keys worth surfacing in a tool-status preview, best first.
+_PREVIEW_KEYS = (
+    "command",
+    "path",
+    "file_path",
+    "pattern",
+    "url",
+    "query",
+    "prompt",
+    "description",
+)
+
+
+def tool_preview(args_json: Any) -> str:
+    """A short, redacted human preview for a tool call's JSON arguments."""
+    if not isinstance(args_json, str):
+        return ""
+    try:
+        args = json.loads(args_json)
+    except (ValueError, TypeError):
+        return ""
+    if not isinstance(args, dict):
+        return ""
+    for key in _PREVIEW_KEYS:
+        v = args.get(key)
+        if isinstance(v, str) and v.strip():
+            one = redact_secrets(" ".join(v.split()))
+            return one[:80] + "…" if len(one) > 80 else one
+    return ""
+
+
+def interpret_kimi_message(msg: Any) -> list:
+    """Map one parsed stream message to zero or more adapter events.
+
+    ``{"kind": "text", "text": ...}``                            assistant prose
+    ``{"kind": "tool_start", "name": ..., "preview": ...}``       a tool call was issued
+    ``{"kind": "tool_result", "id": ..., "text": ...}``           a tool finished
+    ``{"kind": "session", "session_id": ...}``                    resume hint
+    ``{"kind": "retrying", "attempt", "max_attempts", "message"}``provider retry
+    ``{"kind": "version", "version": ...}``                       stream preamble
+    """
+    if not isinstance(msg, dict):
+        return []
+    events: list = []
+    role = msg.get("role")
+
+    if role == "assistant":
+        text = content_text(msg.get("content")).strip()
+        if text:
+            events.append({"kind": "text", "text": text})
+        tool_calls = msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tc in tool_calls:
+                fn = tc.get("function") if isinstance(tc, dict) else None
+                name = fn.get("name") if isinstance(fn, dict) else None
+                events.append(
+                    {
+                        "kind": "tool_start",
+                        "name": name if isinstance(name, str) else "tool",
+                        "preview": tool_preview(fn.get("arguments") if isinstance(fn, dict) else None),
+                    }
+                )
+        return events
+
+    if role == "tool":
+        tool_call_id = msg.get("tool_call_id")
+        events.append(
+            {
+                "kind": "tool_result",
+                "id": tool_call_id if isinstance(tool_call_id, str) else "",
+                "text": content_text(msg.get("content")),
+            }
+        )
+        return events
+
+    if role == "meta":
+        mtype = msg.get("type")
+        session_id = msg.get("session_id")
+        if mtype == "session.resume_hint" and isinstance(session_id, str) and session_id:
+            events.append({"kind": "session", "session_id": session_id})
+        elif mtype == "turn.step.retrying":
+            attempt = msg.get("failed_attempt")
+            max_attempts = msg.get("max_attempts")
+            error_message = msg.get("error_message")
+            events.append(
+                {
+                    "kind": "retrying",
+                    "attempt": attempt if isinstance(attempt, int) else 0,
+                    "max_attempts": max_attempts if isinstance(max_attempts, int) else 0,
+                    "message": redact_secrets(error_message) if isinstance(error_message, str) else "",
+                }
+            )
+        elif mtype == "system.version":
+            version = msg.get("version")
+            events.append({"kind": "version", "version": version if isinstance(version, str) else ""})
+        return events
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Argument + environment builders
+# ---------------------------------------------------------------------------
+
+
+def build_kimi_args(prompt: str, session_id: Optional[str] = None) -> list:
+    """Build the argv for one non-interactive run.
+
+    Print mode (``-p``) already auto-approves tools — the CLI REJECTS combining
+    it with ``--yolo``/``--auto``/``--plan`` (verified v0.39.1), so permission
+    and plan flags must never be added here.
+    """
+    args: list = []
+    if session_id:
+        args.extend(["-S", session_id])
+    args.extend(["-p", prompt, "--output-format", "stream-json"])
+    return args
+
+
+def build_kimi_env(agent_env: Optional[dict]) -> tuple:
+    """Map the saved ``KIMI_*`` fields onto Kimi Code CLI's env-provider contract.
+
+    Setting ``KIMI_MODEL_NAME`` synthesizes an in-memory provider from
+    ``KIMI_MODEL_API_KEY`` (required) + ``KIMI_MODEL_BASE_URL`` +
+    ``KIMI_MODEL_PROVIDER_TYPE``, bypassing ``kimi login``.
+
+    With no API key configured the env is passed through untouched, so the CLI's
+    own ``kimi login`` credentials / config.toml apply.
+
+    :returns: ``(env, via_env_provider)``
+    """
+    env = dict(agent_env or {})
+    api_key = (
+        env.get("KIMI_MODEL_API_KEY")
+        or env.get("KIMI_API_KEY")
+        or env.get("MOONSHOT_API_KEY")
+        or ""
+    )
+    if not api_key:
+        return env, False
+
+    env["KIMI_MODEL_API_KEY"] = api_key
+    if not env.get("KIMI_MODEL_NAME"):
+        env["KIMI_MODEL_NAME"] = env.get("KIMI_MODEL") or DEFAULT_KIMI_MODEL
+    base_url = env.get("KIMI_MODEL_BASE_URL") or env.get("KIMI_BASE_URL")
+    if base_url:
+        env["KIMI_MODEL_BASE_URL"] = base_url.rstrip("/")
+    if not env.get("KIMI_MODEL_PROVIDER_TYPE"):
+        env["KIMI_MODEL_PROVIDER_TYPE"] = "kimi"
+    if not env.get("KIMI_MODEL_MAX_COMPLETION_TOKENS"):
+        env["KIMI_MODEL_MAX_COMPLETION_TOKENS"] = DEFAULT_MAX_COMPLETION_TOKENS
+    return env, True
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+_STDERR_ERROR_RE = re.compile(r"^\s*error:\s*(.+)$", re.IGNORECASE)
+_WRAPPER_PREFIX_RE = re.compile(r"^failed to run prompt:\s*", re.IGNORECASE)
+
+
+def extract_stderr_error(stderr_text: Optional[str]) -> str:
+    """Extract the message from ``error: ...`` lines on stderr (last one wins)."""
+    if not stderr_text:
+        return ""
+    last = ""
+    for line in str(stderr_text).split("\n"):
+        m = _STDERR_ERROR_RE.match(line)
+        if m:
+            last = m.group(1).strip()
+    # Strip the CLI's wrapper prefix so the user sees the actual cause.
+    return redact_secrets(_WRAPPER_PREFIX_RE.sub("", last))
+
+
+class KimiError(NamedTuple):
+    kind: str
+    user_message: str
+
+
+_AUTH_RE = re.compile(
+    r"auth_error|401|unauthorized|invalid.{0,20}(api.?key|token)|credential", re.IGNORECASE
+)
+_CONFIG_RE = re.compile(
+    r"no model configured|llm not set|kimi_model_api_key is missing", re.IGNORECASE
+)
+_RATE_RE = re.compile(r"rate.?limit|429|quota|insufficient.{0,20}balance", re.IGNORECASE)
+_CONTEXT_RE = re.compile(r"context length|maximum context|too many tokens", re.IGNORECASE)
+
+
+def classify_kimi_error(
+    code: Optional[int] = None,
+    signal: Optional[str] = None,
+    stderr_text: Optional[str] = None,
+    retry_message: Optional[str] = None,
+) -> KimiError:
+    """Classify a failed run into a user-facing message."""
+    detail = extract_stderr_error(stderr_text) or redact_secrets(retry_message or "")
+
+    if _AUTH_RE.search(detail):
+        return KimiError(
+            "auth",
+            "Kimi authentication failed. Check KIMI_API_KEY in the launcher, "
+            "or run `kimi login` in a terminal."
+            + (f"\n\nDetails: {detail}" if detail else ""),
+        )
+    if _CONFIG_RE.search(detail):
+        return KimiError(
+            "config",
+            "Kimi Code CLI is not configured. Set KIMI_API_KEY (plus optional "
+            "KIMI_BASE_URL / KIMI_MODEL) in the launcher, or run `kimi login` in a terminal.",
+        )
+    if _RATE_RE.search(detail):
+        return KimiError(
+            "rate_limit",
+            "Kimi hit a rate/quota limit. Please retry shortly."
+            + (f"\n\nDetails: {detail}" if detail else ""),
+        )
+    if _CONTEXT_RE.search(detail):
+        return KimiError(
+            "context",
+            "The request exceeded the model's context limits."
+            + (f"\n\nDetails: {detail}" if detail else ""),
+        )
+    if code == EXIT_TRANSIENT:
+        return KimiError(
+            "transient",
+            "Kimi hit a temporary provider error — please try again."
+            + (f"\n\nDetails: {detail}" if detail else ""),
+        )
+    if detail:
+        return KimiError("error", f"Kimi failed: {detail}")
+    why = f"terminated by signal {signal}" if signal else f"exited with code {code}"
+    return KimiError("error", f"Kimi Code CLI {why}.")

--- a/sdk/src/openagents/registry/kimi.yaml
+++ b/sdk/src/openagents/registry/kimi.yaml
@@ -1,8 +1,8 @@
 name: kimi
-label: Kimi
+label: Kimi Code CLI
 description: Kimi Code CLI — Moonshot AI's terminal coding agent.
 homepage: https://moonshotai.github.io/kimi-code
-tags: [coding, moonshot, open-source]
+tags: [coding, cli, moonshot, open-source]
 featured: true
 order: 7
 support:

--- a/tests/agents/test_kimi_adapter.py
+++ b/tests/agents/test_kimi_adapter.py
@@ -1,0 +1,611 @@
+"""Unit tests for the Kimi adapter, its stream helpers, and registry wiring.
+
+No real Kimi Code CLI is installed and no model credits are used: a fake ``kimi``
+executable plus monkeypatching cover binary discovery, product classification,
+the JSONL stream parser, the env-provider mapping, CLI-vs-direct routing, session
+resume, and an end-to-end stream-json run. Mirrors
+packages/agent-connector/test/kimi.test.js.
+
+Run:
+    pytest tests/agents/test_kimi_adapter.py -v
+"""
+
+import asyncio
+import functools
+import json
+import stat
+
+import pytest
+
+import openagents.registry.loader as loader
+from openagents.adapters import kimi as kimi_mod
+from openagents.adapters.kimi import KimiAdapter, find_kimi_binary
+from openagents.adapters.kimi_stream import (
+    DEFAULT_KIMI_MODEL,
+    KimiStreamParser,
+    build_kimi_args,
+    build_kimi_env,
+    classify_kimi_error,
+    classify_kimi_version,
+    extract_stderr_error,
+    interpret_kimi_message,
+    redact_args,
+    tool_preview,
+)
+
+
+def _aiorun(coro_fn):
+    """Run an async test body via asyncio.run so the suite doesn't depend on a
+    pytest async plugin being installed (pytest still injects fixtures via the
+    preserved signature)."""
+
+    @functools.wraps(coro_fn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(coro_fn(*args, **kwargs))
+
+    return wrapper
+
+
+def _kimi_data():
+    return next(d for d in loader.load_registry_yamls() if d.get("name") == "kimi")
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_kimi_is_builtin_and_points_at_this_adapter(self):
+        data = _kimi_data()
+        assert data.get("builtin") is True
+        assert data["adapter"]["module"] == "openagents.adapters.kimi"
+        assert data["adapter"]["class"] == "KimiAdapter"
+
+    def test_registry_describes_the_cli_product(self):
+        data = _kimi_data()
+        # The entry must advertise the CLI this adapter actually drives, not the
+        # API-only agent kimi used to be.
+        assert data["label"] == "Kimi Code CLI"
+        assert "cli" in data["tags"]
+        assert "@moonshot-ai/kimi-code" in data["install"]["macos"]
+        assert data["check_ready"]["login_command"] == "kimi login"
+
+    def test_api_key_is_optional_now_that_kimi_login_exists(self):
+        fields = {f["name"]: f for f in _kimi_data()["env_config"]}
+        assert fields["KIMI_API_KEY"]["required"] is False
+        assert fields["KIMI_API_KEY"].get("password") is True
+
+    def test_plugin_creates_this_adapter(self):
+        plugin = loader._make_plugin_from_yaml(_kimi_data())
+        adapter = plugin.create_adapter("ws", "chan", "tok", "agent", "http://x")
+        assert isinstance(adapter, KimiAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Binary discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    return home
+
+
+def _make_executable(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+class TestBinaryDiscovery:
+    def test_none_when_nothing_installed(self, isolated_home):
+        assert find_kimi_binary() is None
+
+    def test_launcher_runtime_prefix_wins_over_path(self, isolated_home, monkeypatch, tmp_path):
+        managed = _make_executable(
+            isolated_home / ".openagents" / "runtimes" / "kimi" / "node_modules" / ".bin" / "kimi"
+        )
+        on_path = _make_executable(tmp_path / "path-bin" / "kimi")
+        monkeypatch.setenv("PATH", str(on_path.parent))
+        # A launcher-managed install must win: it is the one the launcher
+        # installs, updates and knows the version of.
+        assert find_kimi_binary() == str(managed)
+
+    def test_finds_the_packages_own_mjs_entry(self, isolated_home):
+        pkg_bin = (
+            isolated_home / ".openagents" / "runtimes" / "kimi" / "node_modules"
+            / "@moonshot-ai" / "kimi-code" / "dist" / "main.mjs"
+        )
+        pkg_bin.parent.mkdir(parents=True, exist_ok=True)
+        pkg_bin.write_text("// entry\n")
+        assert find_kimi_binary() == str(pkg_bin)
+
+    def test_finds_the_postinstall_native_build(self, isolated_home):
+        native = _make_executable(isolated_home / ".kimi-code" / "bin" / "kimi")
+        assert find_kimi_binary() == str(native)
+
+    def test_finds_kimi_on_path(self, isolated_home, monkeypatch, tmp_path):
+        bindir = tmp_path / "bin"
+        found = _make_executable(bindir / "kimi")
+        monkeypatch.setenv("PATH", str(bindir))
+        assert find_kimi_binary() == str(found)
+
+
+# ---------------------------------------------------------------------------
+# Stream helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionClassification:
+    def test_kimi_code_vs_legacy_python_cli(self):
+        # Two Moonshot products install a `kimi` binary; only 0.x is the one
+        # this adapter can drive.
+        assert classify_kimi_version("kimi 0.39.1") == ("0.39.1", "kimi-code")
+        assert classify_kimi_version("0.40.0-beta.2") == ("0.40.0-beta.2", "kimi-code")
+        assert classify_kimi_version("kimi-cli 1.44.0") == ("1.44.0", "legacy")
+
+    def test_unparseable_output_stays_undetermined(self):
+        # Lenient on purpose: an unreadable --version must not block a working
+        # install.
+        assert classify_kimi_version("no version here") == (None, None)
+        assert classify_kimi_version(None) == (None, None)
+
+
+class TestStreamParser:
+    def test_parses_jsonl_across_chunk_boundaries(self):
+        parser = KimiStreamParser()
+        assert parser.push('{"role":"assistant","content":"hel') == []
+        msgs = parser.push('lo"}\n{"role":"meta","type":"system.version","version":"0.39.1"}\n')
+        assert [m.get("content") or m.get("version") for m in msgs] == ["hello", "0.39.1"]
+
+    def test_flush_returns_the_unterminated_tail(self):
+        parser = KimiStreamParser()
+        parser.push('{"role":"assistant","content":"tail"}')
+        assert parser.push("") == []
+        assert parser.flush() == [{"role": "assistant", "content": "tail"}]
+
+    def test_skips_non_json_diagnostics_without_dying(self):
+        parser = KimiStreamParser()
+        msgs = parser.push(
+            'warming up\n{"role":"assistant","content":"ok"}\nnot json at all\n'
+        )
+        assert msgs == [{"role": "assistant", "content": "ok"}]
+
+    def test_accepts_bytes(self):
+        parser = KimiStreamParser()
+        assert parser.push(b'{"role":"assistant","content":"b"}\n')[0]["content"] == "b"
+
+
+class TestMessageInterpretation:
+    def test_assistant_text_and_tool_calls(self):
+        events = interpret_kimi_message(
+            {
+                "role": "assistant",
+                "content": "working on it",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "1",
+                        "function": {"name": "Bash", "arguments": '{"command":"ls -la"}'},
+                    }
+                ],
+            }
+        )
+        assert events[0] == {"kind": "text", "text": "working on it"}
+        assert events[1] == {"kind": "tool_start", "name": "Bash", "preview": "ls -la"}
+
+    def test_content_blocks_are_flattened(self):
+        events = interpret_kimi_message(
+            {"role": "assistant", "content": [{"text": "a"}, {"text": "b"}]}
+        )
+        assert events == [{"kind": "text", "text": "ab"}]
+
+    def test_whitespace_only_filler_produces_no_text_event(self):
+        events = interpret_kimi_message(
+            {
+                "role": "assistant",
+                "content": "   \n ",
+                "tool_calls": [{"function": {"name": "Read", "arguments": "{}"}}],
+            }
+        )
+        assert [e["kind"] for e in events] == ["tool_start"]
+
+    def test_session_and_retry_meta(self):
+        assert interpret_kimi_message(
+            {"role": "meta", "type": "session.resume_hint", "session_id": "sess-1"}
+        ) == [{"kind": "session", "session_id": "sess-1"}]
+
+        retry = interpret_kimi_message(
+            {
+                "role": "meta",
+                "type": "turn.step.retrying",
+                "failed_attempt": 1,
+                "max_attempts": 3,
+                "error_message": "upstream 502",
+            }
+        )
+        assert retry == [
+            {"kind": "retrying", "attempt": 1, "max_attempts": 3, "message": "upstream 502"}
+        ]
+
+    def test_unknown_roles_and_meta_types_are_ignored(self):
+        assert interpret_kimi_message({"role": "user", "content": "echo"}) == []
+        assert interpret_kimi_message({"role": "meta", "type": "something.new"}) == []
+        assert interpret_kimi_message("not a dict") == []
+
+    def test_tool_result_carries_its_id(self):
+        assert interpret_kimi_message(
+            {"role": "tool", "tool_call_id": "abc", "content": "done"}
+        ) == [{"kind": "tool_result", "id": "abc", "text": "done"}]
+
+    def test_tool_preview_redacts_and_truncates(self):
+        assert "«redacted»" in tool_preview('{"command":"export K=sk-abcdefghijklmnop"}')
+        long = tool_preview(json.dumps({"command": "x" * 200}))
+        assert long.endswith("…") and len(long) == 81
+        assert tool_preview("not json") == ""
+        assert tool_preview(None) == ""
+
+
+class TestArgsAndEnv:
+    def test_print_mode_args_with_resume_only_when_resuming(self):
+        assert build_kimi_args("do it") == [
+            "-p", "do it", "--output-format", "stream-json",
+        ]
+        assert build_kimi_args("do it", "sess-1") == [
+            "-S", "sess-1", "-p", "do it", "--output-format", "stream-json",
+        ]
+
+    def test_args_never_carry_permission_or_plan_flags(self):
+        # Print mode auto-approves tools and the CLI REJECTS combining -p with
+        # --yolo/--auto/--plan (verified v0.39.1).
+        args = build_kimi_args("do it", "sess-1")
+        assert not {"--yolo", "--auto", "--plan"} & set(args)
+
+    def test_logged_argv_elides_the_prompt(self):
+        assert redact_args(["kimi", "-p", "secret business", "--output-format"]) == [
+            "kimi", "-p", "«prompt»", "--output-format",
+        ]
+
+    def test_maps_launcher_fields_onto_the_env_provider_contract(self):
+        env, via = build_kimi_env(
+            {
+                "KIMI_API_KEY": "sk-test",
+                "KIMI_BASE_URL": "https://relay.example.com/v1/",
+                "KIMI_MODEL": "kimi-k2.7-code",
+            }
+        )
+        assert via is True
+        assert env["KIMI_MODEL_API_KEY"] == "sk-test"
+        assert env["KIMI_MODEL_NAME"] == "kimi-k2.7-code"
+        # Trailing slash stripped — the CLI concatenates paths onto this.
+        assert env["KIMI_MODEL_BASE_URL"] == "https://relay.example.com/v1"
+        assert env["KIMI_MODEL_PROVIDER_TYPE"] == "kimi"
+        # Gateways reject the CLI's default (the model's full context size).
+        assert env["KIMI_MODEL_MAX_COMPLETION_TOKENS"] == "32768"
+
+    def test_accepts_the_moonshot_alias_and_default_model(self):
+        env, via = build_kimi_env({"MOONSHOT_API_KEY": "sk-alias"})
+        assert via is True
+        assert env["KIMI_MODEL_API_KEY"] == "sk-alias"
+        assert env["KIMI_MODEL_NAME"] == DEFAULT_KIMI_MODEL
+
+    def test_never_overrides_explicit_kimi_model_variables(self):
+        env, _ = build_kimi_env(
+            {
+                "KIMI_API_KEY": "sk-test",
+                "KIMI_MODEL_NAME": "custom",
+                "KIMI_MODEL_PROVIDER_TYPE": "openai",
+                "KIMI_MODEL_MAX_COMPLETION_TOKENS": "999",
+            }
+        )
+        assert env["KIMI_MODEL_NAME"] == "custom"
+        assert env["KIMI_MODEL_PROVIDER_TYPE"] == "openai"
+        assert env["KIMI_MODEL_MAX_COMPLETION_TOKENS"] == "999"
+
+    def test_no_key_passes_env_through_for_the_kimi_login_path(self):
+        env, via = build_kimi_env({"PATH": "/usr/bin", "KIMI_MODEL": "kimi-k3"})
+        assert via is False
+        # Untouched: the CLI's own `kimi login` credentials must apply.
+        assert env == {"PATH": "/usr/bin", "KIMI_MODEL": "kimi-k3"}
+
+
+class TestErrorClassification:
+    def test_extracts_and_strips_the_cli_wrapper(self):
+        assert extract_stderr_error(
+            "noise\nerror: failed to run prompt: auth_error 401\n"
+        ) == "auth_error 401"
+        assert extract_stderr_error("") == ""
+
+    def test_auth_config_rate_and_context_failures(self):
+        assert classify_kimi_error(code=1, stderr_text="error: auth_error 401").kind == "auth"
+        assert classify_kimi_error(
+            code=1, stderr_text="error: KIMI_MODEL_API_KEY is missing"
+        ).kind == "config"
+        assert classify_kimi_error(code=1, stderr_text="error: 429 rate limit").kind == "rate_limit"
+        assert classify_kimi_error(
+            code=1, stderr_text="error: maximum context exceeded"
+        ).kind == "context"
+
+    def test_transient_exit_code_is_retryable(self):
+        assert classify_kimi_error(code=75, stderr_text="").kind == "transient"
+
+    def test_generic_failure_names_the_exit_or_signal(self):
+        assert "exited with code 3" in classify_kimi_error(code=3).user_message
+        assert "signal SIGKILL" in classify_kimi_error(code=None, signal="SIGKILL").user_message
+
+    def test_falls_back_to_the_last_provider_retry_error(self):
+        # Nothing on stderr, but the stream reported a retry — use that.
+        result = classify_kimi_error(code=1, stderr_text="", retry_message="upstream 401 unauthorized")
+        assert result.kind == "auth"
+
+    def test_auth_message_offers_both_sign_in_paths(self):
+        msg = classify_kimi_error(code=1, stderr_text="error: auth_error 401").user_message
+        assert "KIMI_API_KEY" in msg and "kimi login" in msg
+
+
+# ---------------------------------------------------------------------------
+# Adapter: direct-API configuration (the pre-CLI behaviour, still supported)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for key in (
+        "KIMI_API_KEY", "MOONSHOT_API_KEY", "LLM_API_KEY", "OPENAI_API_KEY",
+        "KIMI_BASE_URL", "LLM_BASE_URL", "OPENAI_BASE_URL", "KIMI_MODEL", "LLM_MODEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _adapter(tmp_path, **kwargs):
+    proj = tmp_path / "project"
+    proj.mkdir(exist_ok=True)
+    return KimiAdapter("ws1", "general", "tok", "agentA", "http://x",
+                       working_dir=str(proj), **kwargs)
+
+
+class TestDirectApiConfig:
+    def test_moonshot_defaults_with_only_a_key(self, tmp_path, clean_env, monkeypatch):
+        monkeypatch.setenv("KIMI_API_KEY", "sk-test")
+        a = _adapter(tmp_path)
+        assert a._direct_mode is True
+        assert a._direct_base_url == "https://api.moonshot.ai/v1"
+        assert a._direct_model == DEFAULT_KIMI_MODEL
+
+    def test_moonshot_api_key_alias(self, tmp_path, clean_env, monkeypatch):
+        monkeypatch.setenv("MOONSHOT_API_KEY", "sk-alias")
+        assert _adapter(tmp_path)._direct_api_key == "sk-alias"
+
+    def test_base_url_and_model_overrides(self, tmp_path, clean_env, monkeypatch):
+        monkeypatch.setenv("KIMI_API_KEY", "sk-test")
+        monkeypatch.setenv("KIMI_BASE_URL", "https://relay.example.com/v1/")
+        monkeypatch.setenv("KIMI_MODEL", "kimi-k3")
+        a = _adapter(tmp_path)
+        assert a._direct_base_url == "https://relay.example.com/v1"
+        assert a._direct_model == "kimi-k3"
+
+    def test_no_key_means_no_direct_mode(self, tmp_path, clean_env):
+        assert _adapter(tmp_path)._direct_mode is False
+
+
+# ---------------------------------------------------------------------------
+# Adapter: CLI vs direct routing
+# ---------------------------------------------------------------------------
+
+
+class TestCliRouting:
+    @_aiorun
+    async def test_asks_to_install_when_neither_cli_nor_key_exists(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setattr(kimi_mod, "find_kimi_binary", lambda: None)
+        a = _adapter(tmp_path)
+        errors = []
+        a._send_error = lambda ch, text: _record(errors, text)
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+        assert len(errors) == 1
+        assert "@moonshot-ai/kimi-code" in errors[0]
+
+    @_aiorun
+    async def test_rejects_the_legacy_python_cli_with_no_fallback(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setattr(kimi_mod, "find_kimi_binary", lambda: "/fake/kimi")
+        a = _adapter(tmp_path)
+        a._check_version = lambda _bin: classify_kimi_version("kimi-cli 1.44.0")
+        errors = []
+        a._send_error = lambda ch, text: _record(errors, text)
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+        assert len(errors) == 1
+        assert "legacy Python kimi-cli (1.44.0)" in errors[0]
+        assert "@moonshot-ai/kimi-code" in errors[0]
+
+    @_aiorun
+    async def test_falls_back_to_direct_api_when_cli_is_missing_but_key_is_set(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setenv("KIMI_API_KEY", "sk-test")
+        monkeypatch.setattr(kimi_mod, "find_kimi_binary", lambda: None)
+        a = _adapter(tmp_path)
+        seen = []
+
+        async def fake_direct(msg):
+            seen.append(msg["content"])
+
+        # Reaching the inherited direct path IS the assertion.
+        monkeypatch.setattr(
+            kimi_mod.LlmDirectAdapter, "_handle_message",
+            lambda _self, msg: fake_direct(msg),
+        )
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+        assert seen == ["hello"]
+
+    @_aiorun
+    async def test_legacy_cli_also_falls_back_when_a_key_exists(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setenv("KIMI_API_KEY", "sk-test")
+        monkeypatch.setattr(kimi_mod, "find_kimi_binary", lambda: "/fake/kimi")
+        a = _adapter(tmp_path)
+        a._check_version = lambda _bin: classify_kimi_version("kimi-cli 1.44.0")
+        seen = []
+
+        async def fake_direct(msg):
+            seen.append(msg["content"])
+
+        monkeypatch.setattr(
+            kimi_mod.LlmDirectAdapter, "_handle_message",
+            lambda _self, msg: fake_direct(msg),
+        )
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+        assert seen == ["hello"]
+
+
+def _record(bucket, text):
+    bucket.append(text)
+
+    async def _noop():
+        return None
+
+    return _noop()
+
+
+# ---------------------------------------------------------------------------
+# Adapter: sessions
+# ---------------------------------------------------------------------------
+
+
+class TestSessions:
+    def test_resumes_only_within_the_same_working_dir(self, tmp_path, clean_env, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        a = _adapter(tmp_path)
+        a._channel_sessions["thread"] = {"session_id": "s1", "working_dir": "/proj/a"}
+        assert a._resumable_session("thread", "/proj/a") == "s1"
+        # A session carries the project it started in — crossing projects would
+        # hand the model a history that does not describe the files it sees.
+        assert a._resumable_session("thread", "/proj/b") is None
+        assert a._resumable_session("other", "/proj/a") is None
+
+    def test_sessions_round_trip_through_disk(self, tmp_path, clean_env, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        a = _adapter(tmp_path)
+        a._channel_sessions["thread"] = {"session_id": "s1", "working_dir": "/proj/a"}
+        a._save_sessions()
+
+        b = _adapter(tmp_path)
+        assert b._resumable_session("thread", "/proj/a") == "s1"
+
+    def test_sessions_are_per_agent(self, tmp_path, clean_env, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        a = _adapter(tmp_path)
+        a._channel_sessions["thread"] = {"session_id": "s1", "working_dir": "/proj/a"}
+        a._save_sessions()
+
+        other = KimiAdapter("ws1", "general", "tok", "agentB", "http://x",
+                            working_dir=str(tmp_path / "project"))
+        assert other._resumable_session("thread", "/proj/a") is None
+
+
+# ---------------------------------------------------------------------------
+# Adapter: an end-to-end run against a fake CLI
+# ---------------------------------------------------------------------------
+
+
+FAKE_CLI = """#!/bin/sh
+cat <<'EOF'
+{"role":"meta","type":"system.version","version":"0.39.1"}
+{"role":"assistant","content":"looking","tool_calls":[{"function":{"name":"Read","arguments":"{\\"path\\":\\"a.txt\\"}"}}]}
+{"role":"tool","tool_call_id":"1","content":"file body"}
+{"role":"assistant","content":"all done"}
+{"role":"meta","type":"session.resume_hint","session_id":"sess-42"}
+EOF
+exit 0
+"""
+
+FAILING_CLI = """#!/bin/sh
+echo 'error: failed to run prompt: auth_error 401 unauthorized' >&2
+exit 1
+"""
+
+
+def _install_fake_cli(tmp_path, body, monkeypatch):
+    binary = tmp_path / "fake-kimi"
+    binary.write_text(body)
+    binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setattr(kimi_mod, "find_kimi_binary", lambda: str(binary))
+    return binary
+
+
+class TestEndToEndRun:
+    @_aiorun
+    async def test_streams_a_turn_and_captures_the_session(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        _install_fake_cli(tmp_path, FAKE_CLI, monkeypatch)
+        a = _adapter(tmp_path)
+        a._check_version = lambda _bin: classify_kimi_version("kimi 0.39.1")
+
+        statuses, responses, errors = [], [], []
+        a._send_status = lambda ch, text: _record(statuses, text)
+        a._send_response = lambda ch, text: _record(responses, text)
+        a._send_error = lambda ch, text: _record(errors, text)
+        a._auto_title_channel = lambda ch, text: _record([], text)
+
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+
+        assert errors == []
+        # The LAST assistant text is the reply; earlier prose is interim status.
+        assert responses == ["all done"]
+        assert "Read: a.txt" in statuses
+        assert "looking" in statuses
+        # The session id arrives inline and must persist for the next turn.
+        assert a._resumable_session("thread", str(tmp_path / "project")) == "sess-42"
+
+    @_aiorun
+    async def test_reports_a_classified_error_instead_of_raw_stderr(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        _install_fake_cli(tmp_path, FAILING_CLI, monkeypatch)
+        a = _adapter(tmp_path)
+        a._check_version = lambda _bin: classify_kimi_version("kimi 0.39.1")
+
+        responses, errors = [], []
+        a._send_status = lambda ch, text: _record([], text)
+        a._send_response = lambda ch, text: _record(responses, text)
+        a._send_error = lambda ch, text: _record(errors, text)
+        a._auto_title_channel = lambda ch, text: _record([], text)
+
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+
+        assert responses == []
+        assert len(errors) == 1
+        assert "authentication failed" in errors[0]
+        assert "kimi login" in errors[0]
+
+    @_aiorun
+    async def test_refuses_a_working_dir_that_does_not_exist(
+        self, tmp_path, clean_env, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        _install_fake_cli(tmp_path, FAKE_CLI, monkeypatch)
+        a = KimiAdapter("ws1", "general", "tok", "agentA", "http://x",
+                        working_dir=str(tmp_path / "nope"))
+        a._check_version = lambda _bin: classify_kimi_version("kimi 0.39.1")
+        errors = []
+        a._send_error = lambda ch, text: _record(errors, text)
+
+        await a._handle_message({"content": "hello", "sessionId": "thread"})
+
+        assert len(errors) == 1
+        assert "Working directory does not exist" in errors[0]

--- a/workspace/backend/registry/icons/kimi.svg
+++ b/workspace/backend/registry/icons/kimi.svg
@@ -1,11 +1,6 @@
-<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#141821"/>
-      <stop offset="0.52" stop-color="#2f6df6"/>
-      <stop offset="1" stop-color="#49d2ff"/>
-    </linearGradient>
-  </defs>
-  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
-  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 112 112" role="img" style="flex:none;line-height:1">
+<title>Kimi Code CLI</title>
+<rect width="112" height="112" rx="28" fill="#000"/>
+<path d="M30 34 38 34 38 56 39 57 63 34 75 34 53 57 65 66 77 73 77 81 73 81 67 78 46 63 38 71 38 81 30 81Z" fill="#fff"/>
+<circle cx="86" cy="28" r="5.5" fill="#1783FF"/>
 </svg>

--- a/workspace/backend/registry/kimi.json
+++ b/workspace/backend/registry/kimi.json
@@ -1,10 +1,11 @@
 {
   "name": "kimi",
-  "label": "Kimi",
+  "label": "Kimi Code CLI",
   "description": "Kimi Code CLI — Moonshot AI's terminal coding agent.",
   "homepage": "https://moonshotai.github.io/kimi-code",
   "tags": [
     "coding",
+    "cli",
     "moonshot",
     "open-source"
   ],

--- a/workspace/frontend/public/icons/agents/kimi.svg
+++ b/workspace/frontend/public/icons/agents/kimi.svg
@@ -1,11 +1,6 @@
-<svg viewBox="0 0 24 24" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <linearGradient id="kimi-g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#141821"/>
-      <stop offset="0.52" stop-color="#2f6df6"/>
-      <stop offset="1" stop-color="#49d2ff"/>
-    </linearGradient>
-  </defs>
-  <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#kimi-g)"/>
-  <path d="M7 6.5h2.6v4.1l4.2-4.1H17l-4.7 4.7 5 6.3h-3.2l-3.6-4.7-.9.9v3.8H7z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 112 112" role="img" style="flex:none;line-height:1">
+<title>Kimi Code CLI</title>
+<rect width="112" height="112" rx="28" fill="#000"/>
+<path d="M30 34 38 34 38 56 39 57 63 34 75 34 53 57 65 66 77 73 77 81 73 81 67 78 46 63 38 71 38 81 30 81Z" fill="#fff"/>
+<circle cx="86" cy="28" r="5.5" fill="#1783FF"/>
 </svg>


### PR DESCRIPTION
## Why nothing about Kimi Code CLI showed up on screen

The CLI rewrite (7b044d43) was complete and correct. It just never reached a user, for three independent reasons — this PR fixes all three.

**1. The launcher ran a core older than the one it shipped.** Three copies of the agent-launcher core exist: the monorepo's (dev), the one the runtime bootstrap downloads from npm, and the one packaged inside the app. The downloaded copy won outright, pinning every user to whatever npm's `latest` happened to be. With `NPM_TOKEN` expired, that was 0.2.173 — which describes kimi as an API-only agent with no installer and no `kimi login`. The marketplace faithfully showed the old agent while the new one sat unused in the app bundle.

Measured before the fix, on a dev machine:

| source | kimi entry |
|---|---|
| app-bundled registry (0.2.175) | npm installer, `kimi login`, key optional |
| `~/.openagents/nodejs/.../agent-launcher` | **0.2.173** — `api_only: true`, no login |
| `~/.openagents/agent_catalog.json` (live cache) | `api_only: true`, no login |
| `GET /v1/agent-registry` (production) | `api_only: true`, no login |

**2. A served entry could out-rank the core's own auth contract.** `_mergeBundled` filled `check_ready` in only when absent, so a backend a release behind kept `login_command` out of the catalog entirely — and that field is what the Configure dialog, the Install detail page and the setup wizard read to offer a CLI sign-in.

**3. The Python adapter was never ported.** `openagents.adapters.kimi` — the module the registry's own `adapter.module` names — stayed a 76-line `LlmDirectAdapter` subclass talking to Moonshot's API directly, while the entry beside it advertised "Kimi Code CLI — Moonshot AI's terminal coding agent".

## What changed

- **`fix(kimi)`** — kimi is labelled `Kimi Code CLI` and tagged `cli` in all four registry copies. Every other CLI-driven agent already carries its product name; kimi was also missing from the Install page's CLI category chip.
- **`fix(launcher)`** — `coreTiers()` picks the monorepo copy in dev, else the **newest** of the downloaded and packaged copies. A core newer than the app still wins (that is what the bootstrap is for); an older one can no longer downgrade it. The daemon resolves its CLI through the same ordering, `ensureCoreLibrary` skips a download it would then ignore, and `coreVersion` reports what will load. Plus: bundled `check_ready` now wins field-by-field over a served copy, matching the rule `install` has always followed (spread, so server-only fields survive).
- **`feat(kimi)`** — the Python adapter reaches parity with the Node one: `kimi -p … --output-format stream-json`, per-channel session continuity via `-S` bound to the working dir, launcher-managed-install-first binary discovery, and classified failures instead of raw stderr. Pure half split into `kimi_stream.py`, mirroring the goose/goose_stream split.
- **`chore(core)`** — 0.2.176. The publish job skips a version already on npm, so without this the registry merge fix would never ship (0.2.175 published earlier today, without it).

## Not in this PR

- **The launcher app version stays 0.9.25.** The existing 0.9.25 release note already promises "Kimi now runs Moonshot's Kimi Code CLI" — this PR is what makes that sentence true.
- **The launcher's core pin stays 0.2.175.** Pointing it at a version npm does not have yet breaks the launcher build; it moves in a follow-up once CI publishes 0.2.176 — same ordering used for 0.2.169 and 0.2.175.
- **The backend still needs a deploy.** `label` and `tags` are served fields that no merge rule overrides, so the workspace UI keeps showing "Kimi" until `workspace/backend/registry/` redeploys. The launcher card is unaffected — it overlays its own translated description.

## Testing

- `agent-connector`: 1333 pass / 0 fail (run exactly as CI does, mini excluded). New case: a stale cached `check_ready` no longer suppresses `kimi login`.
- `launcher`: `tsc -b` clean, 425/425 vitest. New `runtime.test.ts` covers the tier ordering, including the exact 0.2.175-app / 0.2.173-npm case.
- Python: new `tests/agents/test_kimi_adapter.py`, 49/49 — stream parsing, env-provider mapping, error classification, CLI-vs-direct routing, session isolation, and two end-to-end runs against a fake `kimi` binary. `ruff` clean.
- Backwards compatibility is asserted, not assumed: with no CLI installed, or with the wound-down Python `kimi-cli` 1.x on PATH, both adapters fall back to the direct-API path, and the key resolution order is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
