### PR TITLE
feat(skills) add Hypit to the Skill Hub catalog

### DIFF
--- a/workspace/backend/app/skill_catalog.py
+++ b/workspace/backend/app/skill_catalog.py
@@ -699,6 +699,19 @@ SKILL_CATALOG: List[dict] = [
         "source_path": "skills/sn-md-to-html-report",
         "author": "SenseNova",
     },
+    # -------------------------------------------------------------------------
+    # Hypit
+    # -------------------------------------------------------------------------
+    {
+        "id": "hypit",
+        "name": "Hypit",
+        "description": "Produce complete videos with AI agents — author, preview, build and batch-expand Hypit/SVML projects",
+        "category": "ai-ml",
+        "icon": "video",
+        "source_repo": "hypit-ai/hypit",
+        "source_path": "skills/hypit",
+        "author": "Hypit",
+    },
 ]
 
 # Keep the workspace-module helpers for backward compatibility with the launcher

--- a/workspace/frontend/components/skills/skills-view.tsx
+++ b/workspace/frontend/components/skills/skills-view.tsx
@@ -105,6 +105,7 @@ const SKILLS: Skill[] = [
   { id: 'mcp-builder', name: 'MCP Builder', category: 'ai-ml', logo: `${SI}/anthropic.svg`, tags: ['mcp', 'tools', 'protocol'], sourceRepo: 'anthropics/skills', sourcePath: 'skills/mcp-builder', author: 'Anthropic', featured: true },
   { id: 'skill-creator', name: 'Skill Creator', category: 'ai-ml', logo: `${SI}/anthropic.svg`, tags: ['meta', 'evals', 'authoring'], sourceRepo: 'anthropics/skills', sourcePath: 'skills/skill-creator', author: 'Anthropic' },
   { id: 'ai-sdk', name: 'Vercel AI SDK', category: 'ai-ml', logo: `${SI}/vercel.svg`, tags: ['streaming', 'react', 'rag'], sourceRepo: 'TerminalSkills/skills', sourcePath: 'skills/ai-sdk', author: 'Community' },
+  { id: 'hypit', name: 'Hypit', category: 'ai-ml', logo: 'https://avatars.githubusercontent.com/u/274059971', tags: ['video', 'svml', 'authoring'], sourceRepo: 'hypit-ai/hypit', sourcePath: 'skills/hypit', author: 'Hypit' },
   // Frontend
   { id: 'nextjs', name: 'Next.js', category: 'frontend', logo: `${SI}/nextdotjs.svg`, tags: ['react', 'ssr', 'app-router'], sourceRepo: 'TerminalSkills/skills', sourcePath: 'skills/nextjs', author: 'Community', featured: true },
   { id: 'angular', name: 'Angular', category: 'frontend', logo: `${SI}/angular.svg`, tags: ['typescript', 'spa', 'rxjs'], sourceRepo: 'TerminalSkills/skills', sourcePath: 'skills/angular', author: 'Community' },

--- a/workspace/frontend/lib/i18n/messages/en-US.ts
+++ b/workspace/frontend/lib/i18n/messages/en-US.ts
@@ -1712,6 +1712,8 @@ export const messages = {
         'End-to-end Excel data analysis — cleaning, filtering, aggregation, charts, and export',
       'sn-image-base': 'Image generation, recognition (VLM), and text optimization APIs',
       'sn-md-to-html-report': 'Convert Markdown research reports to polished HTML with charts and styling',
+      hypit:
+        'Produce complete videos with AI agents — author, preview, review and build Hypit/SVML projects, then batch-expand them into variants',
     },
   },
 

--- a/workspace/frontend/lib/i18n/messages/zh-CN.ts
+++ b/workspace/frontend/lib/i18n/messages/zh-CN.ts
@@ -1669,6 +1669,7 @@ export const messages: Messages = {
       'sn-da-excel-workflow': '端到端 Excel 数据分析 —— 清洗、筛选、聚合、图表与导出',
       'sn-image-base': '图像生成、图像识别(VLM)与文本优化 API',
       'sn-md-to-html-report': '将 Markdown 研究报告转换为带图表与样式的精美 HTML',
+      hypit: '用 AI agent 完成整支视频 —— 创作、预览、审校与构建 Hypit/SVML 项目，并批量扩展出多个变体',
     },
   },
 


### PR DESCRIPTION
## What

Adds Hypit to the Skill Hub catalog. Hypit is a video authoring toolkit for AI agents,
distributed as an Agent Skill rather than as an agent of its own, so it enters through the
catalog and not the agent registry. The entry points at `hypit-ai/hypit`, path `skills/hypit`.

## Why that path only works now

The skill used to live at `.agents/skills/hypit`. `_assertSafeSourcePath` requires every
segment of a `source_path` to begin with `[A-Za-z0-9]`, so a dot-prefixed path is rejected
outright and the skill could not be addressed at all. Hypit has since moved it to a dot-free
repository source, which lets us fetch it unchanged.

## Four places carry a catalog skill

| File | Change |
|---|---|
| `workspace/backend/app/skill_catalog.py` | the entry the installer resolves through `find_skill` |
| `workspace/frontend/components/skills/skills-view.tsx` | the Skill Hub grid keeps its own list |
| `workspace/frontend/lib/i18n/messages/{en-US,zh-CN}.ts` | the `skills.catalog.hypit` description |

`packages/agent-connector/src/skill-catalog.js` is the workspace *module* catalog and is
unrelated — third-party skills do not go there.

## Category

`ai-ml`, following the closest precedent in the file: SenseNova Image Gen is also a generation
skill and is filed there. A category of its own is worth doing once more Hypit skills land; one
entry does not justify a filter tab with a single card in it.

## Verification

Installed through the real Skill Hub UI on two platforms, using this exact entry.

**Linux.** The install lands 56 files in `<workingDir>/.claude/skills/hypit`,
`listInstalledSkills` reports it, and uninstall leaves the directory clean — checked for both
`claude` and `codex` agent types. A Claude agent then discovered the skill on its own, followed
its environment gate, selected a Distribution, established a project boundary, wrote a runtime
profile and drove the real Hypit CLI. It stopped at credential resolution, which is a Hypit
platform limit rather than an integration failure: `packages/credential-store-os` throws on
anything that is not darwin or win32, and Hypit's own `environment.md` lists only macOS 13+ and
Windows 10/11 as supported hosts.

**Windows.** Same install path, then the step Linux could not reach — HypiHub OAuth completed
and the credential was written to the OS credential store, FFmpeg 9.0.1 went on PATH, and
`hypit runtime up` began provisioning. The chain works end to end on a supported host.

The backend catalog loads with 67 entries and unique ids; the frontend typechecks
(`tsc --noEmit`, exit 0).

## Merge timing

`hypit-ai/hypit` is still private and the installer clones over anonymous HTTPS, so an install
fails today for anyone whose git has no read access to it. Hypit expects to open the repository
within days. Until then this entry only works where such access is configured, so it is worth
holding the merge until the repository is public rather than shipping a catalog card that cannot
install.

## Follow-ups found while testing

Not fixed here — separate PRs. All are in the install path and all are reproducible:

1. `installSkill` fetches with `execFileSync`, freezing the entire daemon event loop for the
   length of the clone (15s in one run). Every other adapter's poll and heartbeat then dies with
   `socket hang up` at the moment the loop resumes.
2. `git clone --sparse` fails on older git, which reports `cannot change to '<url>'` and
   installs nothing. A `--no-checkout` + `sparse-checkout` + `checkout` sequence gives an
   identical result at the same speed and works on every version.
3. `installSkill` clears its destination with readdir + rmSync, both of which follow symlinks,
   so installing into a repository that symlink-shares its skills directory deletes the real
   source files.
4. Unrelated failures collapse into one line. A mirror rewrite conflict, an old git, a reset
   connection and a missing git on the daemon's PATH all surface as `could not fetch skill`,
   with git's own stderr swallowed. The health probe has the same shape of problem: a silently
   retried auth failure is reported as "may be waiting for interactive input".
5. #631 now has a live reproduction. A working Windows agent is reported as `Not logged in`
   because `check_ready.creds_file` points at `~/.claude/sessions`, which is session bookkeeping
   rather than credentials.
