### PR TITLE
fix(e2e): fill the API key on the tab that actually holds it

### DIFF
--- a/packages/launcher/e2e/fixtures.ts
+++ b/packages/launcher/e2e/fixtures.ts
@@ -158,10 +158,22 @@ export const test = base.extend<LauncherFixtures>({
     const localAppData = path.join(homeDir, "AppData", "Local")
     mkdirSync(appData, { recursive: true })
     mkdirSync(localAppData, { recursive: true })
+    // HOMEDRIVE + HOMEPATH as well as USERPROFILE: a Windows tool that resolves
+    // the home directory from the older pair lands in the REAL profile whatever
+    // USERPROFILE says, and the isolation is only as good as its leakiest
+    // reader. openclaw's auth store was found under C:\Users\Administrator
+    // during a run whose HOME was a temp dir, which is the shape of exactly
+    // this. Windows-only: the pair means nothing elsewhere, and homeDir is
+    // always drive-lettered there (mkdtemp under %TEMP%).
+    const winHome =
+      process.platform === "win32" && /^[A-Za-z]:/.test(homeDir)
+        ? { HOMEDRIVE: homeDir.slice(0, 2), HOMEPATH: homeDir.slice(2) }
+        : {}
     const env = {
       ...process.env,
       HOME: homeDir,
       USERPROFILE: homeDir,
+      ...winHome,
       APPDATA: appData,
       LOCALAPPDATA: localAppData,
     } as Record<string, string>

--- a/packages/launcher/e2e/respond.spec.ts
+++ b/packages/launcher/e2e/respond.spec.ts
@@ -248,9 +248,10 @@ test.describe("launcher full flow", () => {
     await page.getByTestId("new-agent-create").click()
 
     // 3. Configure LLM — the dialog auto-opens after create. Agents with GUI key
-    //    fields (openclaw/opencode/codex/gemini) get filled + Saved. Agents with
-    //    no key field (claude no-config; cursor/hermes login-only) get their env
-    //    injected via IPC, then the dialog is closed (→ Connect dialog opens).
+    //    fields get filled + Saved: openclaw/opencode show one plain form, while
+    //    the dual-auth ones (claude/codex/gemini) put it behind the API-key tab.
+    //    Agents with no key field at all (cursor/hermes, login-only) get their
+    //    env injected via IPC, then the dialog is closed (→ Connect opens).
     const save = page.getByTestId("cfg-save")
     // getEnvFields (IPC → core) can be slow right after install, esp. on Windows.
     const hasKeyFields = await save
@@ -264,19 +265,40 @@ test.describe("launcher full flow", () => {
     if (hasKeyFields) {
       await expect(async () => {
         if (await connectDialog.isVisible().catch(() => false)) return
+        // Dual-auth agents (claude/codex/gemini) open on the CLI sign-in tab,
+        // and Radix unmounts the tab that isn't selected — so the key form is
+        // not in the DOM to be found, and the only `agent-config-*` inputs
+        // here are the CLI tab's model fields. Save writes every field's
+        // default whatever the tab, so this used to save an EMPTY key and the
+        // provider's stock base URL and still close the dialog: connect passed
+        // and the agent then started with no credential at all.
+        const keyTab = page.getByTestId("auth-tab-key")
+        if (await keyTab.isVisible().catch(() => false)) await keyTab.click()
+
         const fieldIds = await page.evaluate(() =>
           Array.from(document.querySelectorAll('[id^="agent-config-"]')).map(
             (e) => e.id,
           ),
         )
+        let filledKey = false
         for (const id of fieldIds) {
           const varName = id.replace("agent-config-", "")
           let val: string | undefined
           if (varName.endsWith("_API_KEY")) val = cred.key
           else if (varName.endsWith("_BASE_URL")) val = cred.base
           else if (varName.endsWith("_MODEL")) val = cred.model
-          if (val) await page.locator(`[id="${id}"]`).fill(val)
+          if (!val) continue
+          await page.locator(`[id="${id}"]`).fill(val)
+          if (varName.endsWith("_API_KEY")) filledKey = true
         }
+        // Saving without a key is not a failure the dialog reports — the field
+        // is optional for an agent that could also be signed in — so assert it
+        // here. Without this the run reaches the reply check with nothing to
+        // authenticate, and reads as a gateway or model problem.
+        if (!filledKey)
+          throw new Error(
+            `no *_API_KEY input found for ${SLUG}; saw [${fieldIds.join(", ")}]`,
+          )
         await save.click().catch(() => {})
         await expect(connectDialog).toBeVisible({ timeout: 6_000 })
       }).toPass({ timeout: 60_000 })
@@ -354,12 +376,26 @@ test.describe("launcher full flow", () => {
     } catch (e) {
       // Attach the daemon log/status so a non-reply is diagnosable (why the
       // agent didn't answer: LLM error, join failure, wrong model, etc.).
+      //
+      // Redacted rather than attached as-is: daemon.yaml holds the instance env
+      // verbatim, so the raw file would put the gateway key and the workspace
+      // token into artifacts that outlive the run and get copied around. Only
+      // the values this test knows are secret are masked — everything else is
+      // left alone so the attachment stays diagnosable.
       const fs = await import("node:fs")
       const p = await import("node:path")
+      const secrets = [cred.key, process.env.E2E_WS_TOKEN].filter(
+        (v): v is string => !!v,
+      )
+      const redact = (text: string): string =>
+        secrets.reduce((acc, v) => acc.split(v).join("***REDACTED***"), text)
       for (const rel of ["daemon.log", "daemon.status.json", "daemon.yaml"]) {
         const fp = p.join(homeDir, ".openagents", rel)
         if (fs.existsSync(fp)) {
-          await test.info().attach(rel, { path: fp })
+          await test.info().attach(rel, {
+            body: redact(fs.readFileSync(fp, "utf8")),
+            contentType: "text/plain",
+          })
         }
       }
       throw e

--- a/packages/launcher/src/main/agents/daemon-process.ts
+++ b/packages/launcher/src/main/agents/daemon-process.ts
@@ -266,12 +266,26 @@ export function startDaemon(connector: Record<string, unknown> | null): {
       env: withPathEnv(enhancedPath, daemonEnv),
       windowsHide: true,
     })
+    const spawnedAt = Date.now()
     proc.once("error", (err: Error) => {
       appendDaemonLog(`daemon spawn error: ${err.message}`)
     })
     proc.once("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+      // "early" used to be asserted rather than measured: this handler lives as
+      // long as the process, so a deliberate stop minutes in logged the very
+      // same line as a spawn that died on the spot. Every daemon.log therefore
+      // carried an alarming-looking exit that nothing could date. Print the age
+      // instead and let the reader tell the two apart.
+      const how =
+        `after ${Date.now() - spawnedAt}ms: ` +
+        `code=${code ?? "null"} signal=${signal ?? "null"}`
+      // Word the two cases apart: the Logs page classifies a line as an error
+      // by its text, so a clean stop must not read like a crash — and a
+      // non-zero exit still has to.
       appendDaemonLog(
-        `daemon process exited early: code=${code ?? "null"} signal=${signal ?? "null"}`,
+        code
+          ? `daemon process failed and exited ${how}`
+          : `daemon process exited ${how}`,
       )
     })
     proc.unref()

--- a/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/configure-dialog.tsx
@@ -448,11 +448,15 @@ export function ConfigureDialog({
                 onValueChange={(v) => setAuthTab(v as "cli" | "key")}
               >
                 <TabsList className="grid w-full grid-cols-2">
-                  <TabsTrigger value="cli" className="text-xs">
+                  {/* Handles, not labels: the tab names are translated, and the
+                      key form only exists in the DOM while its tab is the
+                      selected one — the e2e matrix has to be able to select
+                      it. */}
+                  <TabsTrigger value="cli" className="text-xs" data-testid="auth-tab-cli">
                     <Terminal />
                     {t("agents.list.health.cliLogin")}
                   </TabsTrigger>
-                  <TabsTrigger value="key" className="text-xs">
+                  <TabsTrigger value="key" className="text-xs" data-testid="auth-tab-key">
                     <KeyRound />
                     {t("agents.list.health.apiKey")}
                   </TabsTrigger>


### PR DESCRIPTION
Follow-up to #662. That one got `connect` to 5/6 — the first run to reach an actual LLM call — which is what exposed this.

## The respond 0/6 root cause is in the spec, not in the adapters

The run's `daemon.yaml` (the env each agent process was really handed):

| agent | injected | |
|---|---|---|
| openclaw | `LLM_API_KEY` + `LLM_BASE_URL=<gateway>` + `LLM_MODEL` | ✅ |
| opencode | same | ✅ |
| codex | `OPENAI_BASE_URL=https://api.openai.com/v1` + model, **no key** | ❌ |
| claude | `ANTHROPIC_BASE_URL=https://api.anthropic.com` + model, **no key** | ❌ |
| gemini | `GOOGLE_GEMINI_BASE_URL=https://generativelanguage.googleapis.com`, **no key** | ❌ |

Those three are exactly the dual-auth agents, and their Configure dialog opens on the **CLI sign-in tab** (`useState<"cli" | "key">("cli")`). Radix unmounts the tab that is not selected, so the API-key form is not in the DOM: the spec enumerates `[id^="agent-config-"]`, finds only the CLI tab's model fields, and fills no key.

`save()` then writes every field's stored default whatever the tab shows — which is where the official base URLs came from — and the key field is `required: false` on an agent that could equally be signed in, so the required-field guard did not object either. The dialog closed, connect passed, and the agent started with no credential.

Two rounds of reports read this as a gateway problem. It never was: those three requests never left the machine.

**Fix:** select the API-key tab before enumerating, and throw when no `*_API_KEY` input was filled. Saving an empty key silently is the part that cost the time, so it is now a loud failure with the field ids it did see.

Product side for this is two `data-testid` attributes on the tab triggers — the tab labels are translated, so there was no stable handle.

## Also here, all from the same run's evidence

- **Attachments are redacted.** `daemon.yaml` carries the instance env verbatim, so the raw attachment put the gateway key and the workspace token into artifacts that outlive the run. Only the values this test knows are secret are masked, so the attachment stays diagnosable.
- **`HOMEDRIVE`/`HOMEPATH` alongside `USERPROFILE`** in the isolated HOME. openclaw's auth store turned up under the real profile during a run whose HOME was a temp dir, and a Windows tool resolving home from the older pair is the shape of that. Unproven — it is hardening in the right place, not a confirmed diagnosis.
- **The daemon exit log now says how long the process lived**, and words a clean stop apart from a failure. `exited early` was asserted, not measured: the handler outlives the spawn, so a deliberate stop minutes in printed the same alarming line as a spawn that died on the spot — which is why every `daemon.log` in the run carried one with nothing to date it. The failure wording keeps matching `log-parser`'s error regex; a clean stop deliberately no longer does.

## Testing

- `npm run typecheck` — clean
- `npx vitest run` — 48 files, 476 tests, all passing

## Still open after this

- **opencode** reaches the gateway, declares the provider, opens a session, then neither errors nor replies until the 300s timeout. The same model answers a direct `/v1/chat/completions` in under a second, so this one needs its own investigation.
- **openclaw** fails inside its own CLI: `requires legacy credential migration; run openclaw doctor --fix`. Whether the `HOMEDRIVE` change removes it is a question for the next run.
- **gemini**'s `Approval mode overridden to "default" because the current folder is not trusted` is untouched; its `Invalid auth method selected` should go with the key fix.
- The self-hosted orchestrator greps `daemon.log`. If anything there matches `exited early`, that string is gone now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
