### PR TITLE
feat(workspace): desktop build target, browser sign-in handoff, and honest probe failures

### DIFF
--- a/packages/agent-connector/src/probe.js
+++ b/packages/agent-connector/src/probe.js
@@ -30,7 +30,6 @@ const { spawn } = require('child_process');
 const { getEnhancedEnv } = require('./paths');
 const { shouldUseShellForBinary } = require('./adapters/health-status');
 const { formatAuthGuidance } = require('./auth-guidance');
-const { testLLMConnection } = require('./utils');
 
 const PROBE_PROMPT = 'hi';
 const DEFAULT_TIMEOUT_MS = 90_000;
@@ -90,7 +89,10 @@ function authFlavor(entry, agentEnv) {
  */
 /** Classify an error by its OUTPUT TEXT alone; null when nothing matches. */
 function classifyOutputText(text) {
-  if (/credit balance|insufficient[_ ]?(quota|credits|funds)|payment required|\b402\b|billing/.test(text)) return CODE.OUT_OF_CREDIT;
+  // Relays word this their own way and answer 403 rather than 402, so the
+  // English-and-402 pattern alone read "out of credit" as "bad credentials"
+  // — the one misreading that sends a user to re-authenticate a working key.
+  if (/credit balance|insufficient[_ ]?(quota|credits|funds)|payment required|\b402\b|billing|quota[_ ]?exceeded|exceeded your current quota|额度|余额|欠费|余额不足/.test(text)) return CODE.OUT_OF_CREDIT;
   if (/rate[- ]?limit|too many requests|\b429\b|overloaded|\b529\b/.test(text)) return CODE.RATE_LIMITED;
   if (/enotfound|econnrefused|econnreset|etimedout|eai_again|fetch failed|socket hang up|network error|self[- ]signed certificate|unable to get local issuer/.test(text)) return CODE.NETWORK;
   if (/api key.{0,24}(not set|not found|missing)|no api key|missing api key|environment variable.{0,40}(is )?(not set|required)/.test(text)) return CODE.MISSING_API_KEY;
@@ -169,6 +171,37 @@ function buildGuidance(code, entry, agentEnv, extra = {}) {
       break;
   }
   return lines;
+}
+
+/**
+ * Ask the model endpoint directly why an agent is not answering.
+ *
+ * Only ever used to REPLACE a verdict that explains nothing, and only when it
+ * can do better: a successful call means the endpoint is healthy and whatever
+ * ails the CLI is the CLI's own, which the caller's vaguer answer already says
+ * more honestly than "everything is fine" would. Likewise an unclassifiable
+ * error — swapping one shrug for another helps nobody.
+ */
+async function directApiVerdict(agentEnv, entry) {
+  // Required here rather than at the top so a test can stand in for it, and
+  // so a probe that never reaches this path never loads the HTTP client.
+  const { testLLMConnection } = require('./utils');
+  let res;
+  try {
+    res = await testLLMConnection(agentEnv);
+  } catch (e) {
+    res = { success: false, error: e.message };
+  }
+  if (!res || res.success) return null;
+  const code = classifyFailure(res.error, {});
+  if (code === CODE.CLI_ERROR) return null;
+  return {
+    ok: false,
+    method: 'llm_api',
+    code,
+    message: tail(res.error, OUTPUT_CAP),
+    guidance: buildGuidance(code, entry, agentEnv),
+  };
 }
 
 /** Run a CLI to completion with a hard timeout. Never rejects. */
@@ -266,6 +299,10 @@ async function probeAgentType(connector, type, opts = {}) {
     || (entry.probe && entry.probe.timeout_s ? entry.probe.timeout_s * 1000 : DEFAULT_TIMEOUT_MS);
   const env = { ...getEnhancedEnv(), ...agentEnv };
 
+  // Hoisted above the CLI tier: a failing CLI probe consults it too (below).
+  const hasApiKey = !!(agentEnv.LLM_API_KEY || agentEnv.OPENAI_API_KEY || agentEnv.ANTHROPIC_API_KEY
+    || agentEnv.ANTHROPIC_AUTH_TOKEN || agentEnv.KIMI_API_KEY || agentEnv.MOONSHOT_API_KEY);
+
   // ── Live tier 1: the agent's own CLI, when the registry declares how ──
   const probeArgs = entry.probe && Array.isArray(entry.probe.args) ? entry.probe.args : null;
   const altCheck = entry.check_ready && entry.check_ready.alt_check;
@@ -298,6 +335,19 @@ async function probeAgentType(connector, type, opts = {}) {
         guidance: buildGuidance(code, entry, agentEnv),
       });
     }
+    // A CLI verdict is not always the true one. A relay answering 403 "out of
+    // credit" makes Claude Code retry in silence until the probe's clock runs
+    // out, and all that reaches here is a timeout with an unrelated warning on
+    // stderr — which the guidance then reads as "it may be waiting for a login
+    // prompt", sending the user to a terminal to fix something that is not
+    // broken. Where the agent carries an endpoint and a key, ask the API the
+    // same question directly: one round trip, and it says why.
+    const unexplained = code === CODE.TIMEOUT || code === CODE.CLI_ERROR || code === CODE.EMPTY_RESPONSE;
+    if (unexplained && hasApiKey) {
+      const direct = await directApiVerdict(agentEnv, entry);
+      if (direct) return done(direct);
+    }
+
     return done({
       ok: false, method: 'cli', code,
       message: tail(res.stderr || res.stdout, OUTPUT_CAP) || (res.timedOut ? 'Timed out' : `Exited with code ${res.code}`),
@@ -306,9 +356,8 @@ async function probeAgentType(connector, type, opts = {}) {
   }
 
   // ── Live tier 2: direct LLM API call for API-key agents (e.g. OpenClaw) ──
-  const hasApiKey = !!(agentEnv.LLM_API_KEY || agentEnv.OPENAI_API_KEY || agentEnv.ANTHROPIC_API_KEY
-    || agentEnv.KIMI_API_KEY || agentEnv.MOONSHOT_API_KEY);
   if (hasApiKey || (entry.install && entry.install.api_only)) {
+    const { testLLMConnection } = require('./utils');
     let res;
     try { res = await testLLMConnection(agentEnv); } catch (e) { res = { success: false, error: e.message }; }
     if (res && res.success) {

--- a/packages/agent-connector/src/utils.js
+++ b/packages/agent-connector/src/utils.js
@@ -13,12 +13,20 @@ function testLLMConnection(env) {
   const http = require('http');
 
   const hasKimiConfig = !!(env.KIMI_API_KEY || env.MOONSHOT_API_KEY || env.KIMI_BASE_URL || env.KIMI_MODEL);
-  const apiKey = env.KIMI_API_KEY || env.MOONSHOT_API_KEY || env.LLM_API_KEY || env.OPENAI_API_KEY || env.ANTHROPIC_API_KEY || '';
+  const apiKey = env.KIMI_API_KEY || env.MOONSHOT_API_KEY || env.LLM_API_KEY || env.OPENAI_API_KEY
+    || env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY || '';
   if (!apiKey) return Promise.resolve({ success: false, error: 'No API key provided' });
 
   let baseUrl = (env.KIMI_BASE_URL || env.LLM_BASE_URL || env.OPENAI_BASE_URL || (hasKimiConfig ? 'https://api.moonshot.ai/v1' : 'https://api.openai.com/v1')).replace(/\/$/, '');
   const model = env.KIMI_MODEL || env.LLM_MODEL || env.OPENCLAW_MODEL || '';
-  const isAnthropic = baseUrl.includes('anthropic');
+  // An agent configured the Anthropic way is Anthropic-shaped wherever it
+  // points. Reading only the URL missed every relay whose host says nothing
+  // about the protocol it speaks — the common case for Claude Code, which is
+  // configured entirely through ANTHROPIC_* — and sent the test to OpenAI's
+  // default endpoint with an Anthropic key.
+  const hasAnthropicConfig = !hasKimiConfig && !env.LLM_API_KEY && !env.OPENAI_API_KEY
+    && !!(env.ANTHROPIC_BASE_URL || env.ANTHROPIC_MODEL || env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY);
+  const isAnthropic = hasAnthropicConfig || baseUrl.includes('anthropic');
 
   if (!isAnthropic && !baseUrl.endsWith('/v1')) {
     baseUrl += '/v1';
@@ -28,14 +36,25 @@ function testLLMConnection(env) {
     let url, headers, body;
 
     if (isAnthropic) {
-      url = 'https://api.anthropic.com/v1/messages';
+      // The configured endpoint, not the official one: a relay IS the API as
+      // far as this agent is concerned, and testing api.anthropic.com would
+      // report on a service the agent never talks to.
+      const base = (env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/+$/, '');
+      url = /\/v1$/.test(base) ? `${base}/messages` : `${base}/v1/messages`;
+      const token = env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY || apiKey;
       headers = {
-        'x-api-key': apiKey,
+        'x-api-key': token,
         'anthropic-version': '2023-06-01',
         'content-type': 'application/json',
       };
+      // Relays are split on which header they read, and Claude Code itself
+      // sends the bearer when pointed at one. Only off the official host: the
+      // real API has no use for it.
+      if (!/api\.anthropic\.com$/.test(new URL(url).hostname)) {
+        headers['authorization'] = `Bearer ${token}`;
+      }
       body = JSON.stringify({
-        model: model || 'claude-sonnet-4-20250514',
+        model: env.ANTHROPIC_MODEL || model || 'claude-sonnet-4-20250514',
         max_tokens: 32,
         messages: [{ role: 'user', content: 'Say hi in 5 words.' }],
       });

--- a/packages/agent-connector/test/probe.test.js
+++ b/packages/agent-connector/test/probe.test.js
@@ -191,3 +191,121 @@ describe('probeAgentType', () => {
     assert.equal(r.method, 'none');
   });
 });
+
+/**
+ * A CLI that hangs tells you nothing. The endpoint always knows why.
+ *
+ * Seen live: a relay answering 403 "预扣费额度失败" made Claude Code retry in
+ * silence for its whole 120s, leaving the probe with a timeout and an
+ * unrelated stderr warning — which the guidance read as "it may be waiting for
+ * a login prompt", sending the user to a terminal to fix a working install.
+ */
+describe('a CLI verdict that explains nothing defers to the endpoint', () => {
+  // `sleep 5` stands in for a CLI that hangs: the probe's clock is set well
+  // below it, so every case here starts from a genuine timeout.
+  const ENTRY = {
+    name: 'claude',
+    label: 'Claude Code CLI',
+    probe: { args: ['5'], timeout_s: 1 },
+  };
+
+  /** Stand in for the HTTP client probe.js lazily requires. */
+  function withLLM(answer, run) {
+    const path = require.resolve('../src/utils');
+    const original = require.cache[path];
+    require.cache[path] = {
+      id: path,
+      filename: path,
+      loaded: true,
+      exports: { testLLMConnection: async () => answer },
+    };
+    return run().finally(() => {
+      if (original) require.cache[path] = original;
+      else delete require.cache[path];
+    });
+  }
+
+  const hanging = fakeConnector({
+    entry: ENTRY,
+    health: { installed: true, ready: true, binary: 'sleep' },
+    env: { ANTHROPIC_API_KEY: 'sk-test', ANTHROPIC_BASE_URL: 'https://relay.example' },
+  });
+
+  it('reports the real reason the endpoint gives, not the timeout', async () => {
+    const answer = {
+      success: false,
+      error: 'HTTP 403: 预扣费额度失败, 用户剩余额度: $1.73, 需要预扣费额度: $3.50',
+    };
+    const r = await withLLM(answer, () => probeAgentType(hanging, 'claude', { timeoutMs: 400 }));
+
+    assert.equal(r.ok, false);
+    assert.equal(r.code, CODE.OUT_OF_CREDIT);
+    assert.equal(r.method, 'llm_api');
+    // The guidance the user acts on must be about money, not about terminals.
+    assert.match(r.guidance.join(' '), /credit|quota/i);
+    assert.doesNotMatch(r.guidance.join(' '), /interactive input|waiting/i);
+  });
+
+  it('keeps the CLI verdict when the endpoint is healthy', async () => {
+    // The endpoint answering means the CLI's own trouble is real and still
+    // unexplained; "everything is fine" would be a worse answer than vague.
+    const r = await withLLM({ success: true, response: 'hi' }, () =>
+      probeAgentType(hanging, 'claude', { timeoutMs: 400 }),
+    );
+
+    assert.equal(r.ok, false);
+    assert.equal(r.code, CODE.TIMEOUT);
+    assert.equal(r.method, 'cli');
+  });
+
+  it('keeps the CLI verdict when the endpoint fails just as vaguely', async () => {
+    const r = await withLLM({ success: false, error: 'something went wrong' }, () =>
+      probeAgentType(hanging, 'claude', { timeoutMs: 400 }),
+    );
+
+    assert.equal(r.method, 'cli');
+    assert.equal(r.code, CODE.TIMEOUT);
+  });
+
+  it('does not call the endpoint for an agent with no key', async () => {
+    let called = false;
+    const keyless = fakeConnector({
+      entry: ENTRY,
+      health: { installed: true, ready: true, binary: 'sleep' },
+      env: {},
+    });
+    const path = require.resolve('../src/utils');
+    const original = require.cache[path];
+    require.cache[path] = {
+      id: path, filename: path, loaded: true,
+      exports: { testLLMConnection: async () => { called = true; return { success: false }; } },
+    };
+    try {
+      const r = await probeAgentType(keyless, 'claude', { timeoutMs: 400 });
+      assert.equal(called, false);
+      assert.equal(r.method, 'cli');
+    } finally {
+      if (original) require.cache[path] = original;
+      else delete require.cache[path];
+    }
+  });
+});
+
+describe('out-of-credit is not only an English 402', () => {
+  it('reads a relay saying it in Chinese, and at 403', () => {
+    // The relay this came from answers 403 with its own wording; the original
+    // pattern matched neither, so it fell through to "invalid credentials" —
+    // which sends the user to re-authenticate a key that works.
+    assert.equal(
+      classifyFailure('HTTP 403: 预扣费额度失败, 用户剩余额度: $1.73'),
+      CODE.OUT_OF_CREDIT,
+    );
+    assert.equal(classifyFailure('余额不足，请充值'), CODE.OUT_OF_CREDIT);
+    assert.equal(classifyFailure('You exceeded your current quota'), CODE.OUT_OF_CREDIT);
+  });
+
+  it('still reads the English wording it always did', () => {
+    assert.equal(classifyFailure('Your credit balance is too low'), CODE.OUT_OF_CREDIT);
+    assert.equal(classifyFailure('402 payment required'), CODE.OUT_OF_CREDIT);
+  });
+});

--- a/workspace/frontend/.gitignore
+++ b/workspace/frontend/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 .next/
+
+# The desktop build's output (vite build). The launcher builds it from source
+# and ships it in the installer; it is never committed.
+dist-desktop/
 .env.local
 .vercelignore
 

--- a/workspace/frontend/app/auth/callback/page.tsx
+++ b/workspace/frontend/app/auth/callback/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react';
 
+import { isDesktopSignIn } from '@/lib/desktop-handoff';
+
 /**
  * Login handoff landing page.
  *
@@ -15,6 +17,13 @@ import { useEffect, useState } from 'react';
  * fails with auth/network-request-failed or just hangs. In that case we hand
  * the same custom token to our backend, which does the exchange server-side
  * and returns a workspace session JWT (see lib/workspace-session.ts).
+ *
+ * A sign-in belonging to the desktop launcher takes that server-side exchange
+ * FIRST, wherever Google stands. The app has to KEEP the credential, and a
+ * Firebase session cannot leave the page: its ID token lapses in an hour and
+ * its refresh token is not ours to hand over. Everything else about the flow
+ * is unchanged — same login, same callback, same destination. See
+ * lib/desktop-handoff.ts.
  */
 
 /** How long to give Firebase before assuming Google is unreachable. */
@@ -38,24 +47,30 @@ function AuthCallback() {
         const [{ signInWithCustomTokenValue }, { exchangeHandoffToken, clearWorkspaceSession }] =
           await Promise.all([import('@/lib/firebase'), import('@/lib/workspace-session')]);
 
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const firebaseTimeout = new Promise<never>((_, reject) => {
-          timer = setTimeout(
-            () => reject(new Error('auth/network-request-failed (timeout)')),
-            FIREBASE_TIMEOUT_MS,
-          );
-        });
-
-        try {
-          await Promise.race([signInWithCustomTokenValue(ct), firebaseTimeout]);
-          // Native Firebase session established — make sure no stale
-          // workspace session shadows it.
-          clearWorkspaceSession();
-        } catch (firebaseErr) {
-          console.warn('Firebase sign-in unavailable, using workspace session:', firebaseErr);
+        if (isDesktopSignIn(returnTo)) {
+          // The desktop app can only hold a workspace session, so this one is
+          // not raced against Firebase — it goes straight to the exchange.
           await exchangeHandoffToken(ct);
-        } finally {
-          if (timer) clearTimeout(timer);
+        } else {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const firebaseTimeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error('auth/network-request-failed (timeout)')),
+              FIREBASE_TIMEOUT_MS,
+            );
+          });
+
+          try {
+            await Promise.race([signInWithCustomTokenValue(ct), firebaseTimeout]);
+            // Native Firebase session established — make sure no stale
+            // workspace session shadows it.
+            clearWorkspaceSession();
+          } catch (firebaseErr) {
+            console.warn('Firebase sign-in unavailable, using workspace session:', firebaseErr);
+            await exchangeHandoffToken(ct);
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
         }
 
         // Only honour a same-origin returnTo (avoid open-redirects); else home.

--- a/workspace/frontend/app/auth/desktop/page.tsx
+++ b/workspace/frontend/app/auth/desktop/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  DESKTOP_AUTH_PATH,
+  forwardToDesktop,
+  parseDesktopHandoff,
+  type DesktopHandoff,
+} from '@/lib/desktop-handoff';
+import { loadWorkspaceSession } from '@/lib/workspace-session';
+
+/**
+ * The desktop launcher's sign-in landing.
+ *
+ * The launcher opens this page with the loopback port it is listening on. From
+ * here there are exactly two outcomes:
+ *
+ *  - a workspace session already exists on this origin → hand it to the port
+ *  - none does → send the user through the central login, with this page as
+ *    the returnTo, and take the first branch when they come back
+ *
+ * Deliberately an ordinary page rather than a branch of /auth/callback: the
+ * central login mints its one-time token and bounces through the callback ON
+ * THE WAY to returnTo, so a returnTo pointing at the callback is treated as the
+ * final destination and no token is ever minted. Being a normal destination
+ * keeps this on the same path every browser sign-in already takes.
+ */
+
+const CENTRAL = 'https://openagents.org';
+
+/** Set once we have been through the login; a second empty return is a failure,
+ *  not a reason to bounce again. */
+const RETRY_FLAG = 'retried';
+
+type Phase = 'working' | 'done' | 'failed';
+
+function DesktopAuth() {
+  const [phase, setPhase] = useState<Phase>('working');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const handoff = parseDesktopHandoff(window.location.search);
+    if (!handoff) {
+      setPhase('failed');
+      setError('This link is missing the information the desktop app needs.');
+      return;
+    }
+
+    const session = loadWorkspaceSession();
+    if (!session) {
+      if (params.get(RETRY_FLAG)) {
+        setPhase('failed');
+        setError('Signed in, but no desktop session was issued. Please try again.');
+        return;
+      }
+      window.location.replace(`${CENTRAL}/login?returnTo=${encodeURIComponent(returnUrl(handoff))}`);
+      return;
+    }
+
+    void (async () => {
+      try {
+        await forwardToDesktop(handoff, {
+          session: {
+            token: session.token,
+            email: session.email,
+            displayName: session.displayName,
+            expiresAt: session.expiresAt,
+          },
+        });
+        setPhase('done');
+      } catch (e) {
+        setPhase('failed');
+        setError(e instanceof Error ? e.message : 'Could not reach the desktop app.');
+      }
+    })();
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background">
+      <div className="flex flex-col items-center gap-5">
+        <img
+          src="/logo-icon.png"
+          alt="OpenAgents"
+          className={`size-16 dark:hidden ${phase === 'working' ? 'animate-[pulse_2s_ease-in-out_infinite]' : ''}`}
+        />
+        <img
+          src="/logo-white.png"
+          alt="OpenAgents"
+          className={`size-16 hidden dark:block ${phase === 'working' ? 'animate-[pulse_2s_ease-in-out_infinite]' : ''}`}
+        />
+        <div className="text-center max-w-md px-8">
+          <h1
+            className={`text-xl font-semibold tracking-tight ${phase === 'failed' ? 'text-destructive' : ''}`}
+          >
+            {phase === 'done'
+              ? 'You are signed in'
+              : phase === 'failed'
+                ? 'Sign-in failed'
+                : 'Signing you in…'}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {phase === 'done'
+              ? 'Return to OpenAgents Launcher to continue.'
+              : (error ?? 'OpenAgents Workspace')}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** This page's own URL, marked so a fruitless round trip cannot loop. */
+function returnUrl(handoff: DesktopHandoff): string {
+  const url = new URL(DESKTOP_AUTH_PATH, window.location.origin);
+  url.searchParams.set('port', String(handoff.port));
+  url.searchParams.set('state', handoff.state);
+  url.searchParams.set(RETRY_FLAG, '1');
+  return url.href;
+}
+
+export default function DesktopAuthPage() {
+  return <DesktopAuth />;
+}

--- a/workspace/frontend/desktop/app.tsx
+++ b/workspace/frontend/desktop/app.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useMemo } from 'react';
+import { ThemeProvider, useTheme } from 'next-themes';
+
+import { Toaster } from '@/components/ui/sonner';
+import { DialogsProvider } from '@/components/ui/dialogs-provider';
+import { OpenAgentsAuthProvider } from '@/lib/openagents-auth-context';
+import { I18nProvider, isLocale, useI18n, detectBrowserLocale } from '@/lib/i18n';
+
+import Home from '@/app/page';
+import NotFound from '@/app/not-found';
+import WorkspacePage from '@/app/[workspaceId]/page';
+import SettingsLayout from '@/app/[workspaceId]/settings/layout';
+import SettingsIndex from '@/app/[workspaceId]/settings/page';
+import SettingsApiCredits from '@/app/[workspaceId]/settings/api-credits/page';
+import SettingsDevices from '@/app/[workspaceId]/settings/devices/page';
+import SettingsGeneral from '@/app/[workspaceId]/settings/general/page';
+import SettingsIntegrations from '@/app/[workspaceId]/settings/integrations/page';
+import SettingsMembers from '@/app/[workspaceId]/settings/members/page';
+import SettingsModelAccess from '@/app/[workspaceId]/settings/model-access/page';
+import SettingsPreferences from '@/app/[workspaceId]/settings/preferences/page';
+import SettingsProfile from '@/app/[workspaceId]/settings/profile/page';
+import SettingsSecurity from '@/app/[workspaceId]/settings/security/page';
+import InvitePage from '@/app/invite/[token]/page';
+import SharePage from '@/app/share/[token]/page';
+
+import { DesktopRouter, type RouteTable } from './router';
+import { reportLocale, reportTheme, useHostAppearance } from './host';
+
+/**
+ * The desktop build's root.
+ *
+ * Stands in for `app/layout.tsx`, which cannot be reused as-is: it is a Server
+ * Component that resolves the locale from request headers and renders <html>
+ * and <body>. Everything BELOW that — the provider stack — is the same, in the
+ * same order, and every page component underneath is imported from `app/`
+ * untouched.
+ *
+ * The analytics snippets the web layout injects are deliberately absent: a
+ * signed desktop binary should not fetch and run third-party script at start-up.
+ */
+
+/**
+ * A promise `use()` can read without waiting.
+ *
+ * React reads `status`/`value` off a thenable and returns it synchronously
+ * when they are there — the convention Next.js itself follows for the params
+ * it hands a page. A bare `Promise.resolve()` has neither, so `use()` suspends
+ * instead; see Page below for why that is fatal here.
+ */
+type Fulfilled<T> = Promise<T> & { status: 'fulfilled'; value: T };
+
+function fulfilled<T>(value: T): Fulfilled<T> {
+  const promise = Promise.resolve(value) as Fulfilled<T>;
+  promise.status = 'fulfilled';
+  promise.value = value;
+  return promise;
+}
+
+/**
+ * Next's page components take `params` as a promise and unwrap it with `use()`.
+ *
+ * Handing them a plain resolved promise suspends the first render of every
+ * page that takes params, and there is no Suspense boundary above the router
+ * to catch it: React ends the render with "an unknown Component is an async
+ * Client Component" and the window goes blank. Every route except `/` takes
+ * params, so that was the whole app.
+ *
+ * Memoised on the values it carries — a fresh promise per render would be a
+ * fresh identity for `use()` on every pass.
+ */
+function Page({
+  params,
+  children,
+}: {
+  params: Record<string, string>;
+  children: (params: Promise<Record<string, string>>) => React.ReactNode;
+}): React.JSX.Element {
+  const key = JSON.stringify(params);
+  const promise = useMemo(() => fulfilled(params), [key]);
+  return <>{children(promise)}</>;
+}
+
+/**
+ * A settings page, inside the layout that gives it its rail and header.
+ *
+ * The page gets `params` as well as the layout. Most settings pages ignore it
+ * — they read the workspace from context — but the index page takes it and
+ * unwraps it with `use()`, and `use(undefined)` throws hard enough to blank
+ * the window. It only showed once the layout had LOADED, since a failing
+ * layout never renders its children, which is why "open workspace settings"
+ * was a white screen while every other route looked fine.
+ *
+ * Passing it to all of them costs nothing: a component that does not name the
+ * prop never sees it.
+ */
+function settingsRoute(
+  pattern: string,
+  Component: React.ComponentType<{ params: Promise<{ workspaceId: string }> }>,
+): RouteTable[number] {
+  return {
+    pattern,
+    render: (params) => (
+      <Page params={params}>
+        {(promise) => {
+          const workspaceParams = promise as Promise<{ workspaceId: string }>;
+          return (
+            <SettingsLayout params={workspaceParams}>
+              <Component params={workspaceParams} />
+            </SettingsLayout>
+          );
+        }}
+      </Page>
+    ),
+  };
+}
+
+/**
+ * The app's routes, mirroring the `app/` directory. Most specific first: the
+ * matcher takes the first pattern that fits, and `/:workspaceId` would
+ * otherwise swallow `/invite/abc`.
+ */
+const ROUTES: RouteTable = [
+  { pattern: '/', render: () => <Home /> },
+  {
+    pattern: '/invite/:token',
+    render: (params) => (
+      <Page params={params}>
+        {(promise) => <InvitePage params={promise as Promise<{ token: string }>} />}
+      </Page>
+    ),
+  },
+  {
+    pattern: '/share/:token',
+    render: (params) => (
+      <Page params={params}>
+        {(promise) => <SharePage params={promise as Promise<{ token: string }>} />}
+      </Page>
+    ),
+  },
+  settingsRoute('/:workspaceId/settings', SettingsIndex),
+  settingsRoute('/:workspaceId/settings/api-credits', SettingsApiCredits),
+  settingsRoute('/:workspaceId/settings/devices', SettingsDevices),
+  settingsRoute('/:workspaceId/settings/general', SettingsGeneral),
+  settingsRoute('/:workspaceId/settings/integrations', SettingsIntegrations),
+  settingsRoute('/:workspaceId/settings/members', SettingsMembers),
+  settingsRoute('/:workspaceId/settings/model-access', SettingsModelAccess),
+  settingsRoute('/:workspaceId/settings/preferences', SettingsPreferences),
+  settingsRoute('/:workspaceId/settings/profile', SettingsProfile),
+  settingsRoute('/:workspaceId/settings/security', SettingsSecurity),
+  {
+    pattern: '/:workspaceId',
+    render: (params) => (
+      <Page params={params}>
+        {(promise) => (
+          <WorkspacePage params={promise as Promise<{ workspaceId: string }>} />
+        )}
+      </Page>
+    ),
+  },
+];
+
+export default function App(): React.JSX.Element {
+  const host = useHostAppearance();
+
+  // The host's language when there is one; otherwise the machine's, since
+  // there is no server here to resolve it from a cookie and Accept-Language.
+  // `undefined` lets the provider fall back to its own default.
+  const initialLocale = useMemo(() => {
+    const fromHost = host?.locale;
+    if (fromHost && isLocale(fromHost)) return fromHost;
+    return detectBrowserLocale() ?? undefined;
+    // Deliberately only the first value: this is an INITIAL locale, and later
+    // changes are applied by AppearanceSync rather than by remounting the tree.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <I18nProvider initialLocale={initialLocale} hasStoredLocale={!!host}>
+        <AppearanceSync />
+        <OpenAgentsAuthProvider>
+          <DialogsProvider>
+            <DesktopRouter routes={ROUTES} notFound={<NotFound />} />
+          </DialogsProvider>
+        </OpenAgentsAuthProvider>
+        <Toaster />
+      </I18nProvider>
+    </ThemeProvider>
+  );
+}
+
+/**
+ * Keeps the two halves of the window agreeing about theme and language.
+ *
+ * Both directions, so a change made in the launcher's menu and one made in
+ * this app's own menu have the same effect. Each side only acts on a value
+ * that differs from what it already holds, which is what stops the two from
+ * handing a change back and forth forever.
+ *
+ * Renders nothing; it exists for the effects. On the web `useHostAppearance`
+ * returns null and every branch here is skipped.
+ */
+function AppearanceSync(): null {
+  const host = useHostAppearance();
+  const { theme, setTheme } = useTheme();
+  const { locale, setLocale } = useI18n();
+
+  // Host → app.
+  useEffect(() => {
+    if (!host) return;
+    if (host.theme && host.theme !== theme) setTheme(host.theme);
+    if (host.locale && host.locale !== locale && isLocale(host.locale)) {
+      setLocale(host.locale);
+    }
+  }, [host, theme, locale, setTheme, setLocale]);
+
+  // App → host. `theme` is undefined until next-themes has read storage.
+  useEffect(() => {
+    if (!host || !theme || theme === host.theme) return;
+    reportTheme(theme);
+  }, [host, theme]);
+
+  useEffect(() => {
+    if (!host || locale === host.locale) return;
+    reportLocale(locale);
+  }, [host, locale]);
+
+  return null;
+}

--- a/workspace/frontend/desktop/host.ts
+++ b/workspace/frontend/desktop/host.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * The launcher, as seen from inside the workspace.
+ *
+ * When the desktop build runs inside the launcher, its preload exposes this
+ * bridge. On the web there is nothing there, and every hook below falls back
+ * to the app's own behaviour — which is why the same components run in both
+ * places without knowing the difference.
+ *
+ * Only two settings cross: dark or light, and which language. They are one
+ * window, so those cannot disagree. Everything else — the accent colour, the
+ * launcher's skin, its UI scale — stays on its own side of the line: this app
+ * has its own design language, and repainting it in the host's would mean
+ * editing its design tokens.
+ */
+
+export interface HostAppearance {
+  theme: string;
+  locale: string;
+}
+
+interface HostBridge {
+  appearance: HostAppearance;
+  setTheme: (theme: string) => void;
+  setLocale: (locale: string) => void;
+  onAppearance: (cb: (next: HostAppearance) => void) => () => void;
+}
+
+function bridge(): HostBridge | null {
+  if (typeof window === 'undefined') return null;
+  return (window as unknown as { __oaHost__?: HostBridge }).__oaHost__ ?? null;
+}
+
+/** Whether this app is running inside the desktop launcher. */
+export function isHosted(): boolean {
+  return bridge() !== null;
+}
+
+/** What the host wants right now, or null when there is no host. */
+export function hostAppearance(): HostAppearance | null {
+  return bridge()?.appearance ?? null;
+}
+
+/** Tell the host the app changed one of the shared settings. */
+export function reportTheme(theme: string): void {
+  bridge()?.setTheme(theme);
+}
+
+export function reportLocale(locale: string): void {
+  bridge()?.setLocale(locale);
+}
+
+/**
+ * The host's appearance, kept current.
+ *
+ * Returns null off the desktop, so callers can tell "no host" from "host says
+ * system" — the first means leave everything alone, the second is a value.
+ */
+export function useHostAppearance(): HostAppearance | null {
+  const [appearance, setAppearance] = useState<HostAppearance | null>(hostAppearance);
+
+  useEffect(() => {
+    const host = bridge();
+    if (!host) return;
+    return host.onAppearance(setAppearance);
+  }, []);
+
+  return appearance;
+}

--- a/workspace/frontend/desktop/index.html
+++ b/workspace/frontend/desktop/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en" suppressHydrationWarning>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+    <title>OpenAgents Workspace</title>
+    <!-- Where the API lives. The bundle reads this in place of Next's
+         build-time NEXT_PUBLIC_API_URL (see vite.config.ts), so a self-hosted
+         deployment is a runtime setting rather than a rebuild: the launcher's
+         preload assigns it before this line runs. -->
+    <script>
+      window.__OA_API_URL__ = window.__OA_API_URL__ || 'https://workspace-endpoint.openagents.org';
+    </script>
+  </head>
+  <!-- Same classes app/layout.tsx puts on <body>, minus the generated font
+       class: the desktop build ships the family itself (see main.tsx). -->
+  <body class="bg-zinc-100 dark:bg-zinc-900">
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/workspace/frontend/desktop/main.tsx
+++ b/workspace/frontend/desktop/main.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+// Not globals.css directly: this wraps it with the source list Tailwind needs
+// when the build root is this folder. See styles.css.
+import './styles.css';
+import App from './app';
+
+/**
+ * Entry point for the desktop build of the workspace.
+ *
+ * The web build is a Next.js app and keeps being one; this is a second target
+ * over the same source, bundled by Vite into static files the launcher ships
+ * and loads locally. Nothing under `app/`, `components/` or `lib/` is aware of
+ * which target it is running in — the difference is confined to this folder
+ * (see app.tsx for the layout and routes, shims/ for the `next/*` modules).
+ */
+
+const container = document.getElementById('root');
+if (!container) throw new Error('#root is missing from index.html');
+
+createRoot(container).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/workspace/frontend/desktop/router.tsx
+++ b/workspace/frontend/desktop/router.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+/**
+ * The desktop build's router.
+ *
+ * The web app is a Next.js app-router application; the desktop build is the
+ * same components served from a file the app ships with. That rules out
+ * Next.js routing on two counts — there is no server to route, and the pages
+ * are loaded over file:, where `history.pushState` to a different path throws.
+ * So routing here is hash-based (`index.html#/acme/settings/members`) and the
+ * `next/navigation` hooks are re-implemented on top of it.
+ *
+ * Deliberately hand-written rather than react-router: what is needed is four
+ * hooks with Next.js's exact signatures, and matching a fixed table of routes.
+ * A router library would have to be adapted to those signatures anyway.
+ */
+
+export interface RouteMatch {
+  /** The matched pattern, e.g. `/:workspaceId/settings/:section`. */
+  pattern: string;
+  /** The path as it stands, e.g. `/acme/settings/members`. */
+  pathname: string;
+  params: Record<string, string>;
+  search: URLSearchParams;
+}
+
+interface RouterValue extends RouteMatch {
+  push: (href: string) => void;
+  replace: (href: string) => void;
+  back: () => void;
+  forward: () => void;
+  refresh: () => void;
+}
+
+const RouterContext = createContext<RouterValue | null>(null);
+
+/** Every route the desktop build serves, most specific first. */
+export type RouteTable = Array<{
+  pattern: string;
+  render: (params: Record<string, string>) => React.ReactNode;
+}>;
+
+/** Read the current location out of the hash, defaulting to the root. */
+function readLocation(): { pathname: string; search: URLSearchParams } {
+  const raw = window.location.hash.replace(/^#/, '') || '/';
+  const [pathname, query = ''] = raw.split('?');
+  return {
+    pathname: pathname.startsWith('/') ? pathname : `/${pathname}`,
+    search: new URLSearchParams(query),
+  };
+}
+
+/**
+ * Match a path against a pattern with `:name` segments.
+ *
+ * No wildcards and no optional segments: the table below is a fixed list of
+ * the app's own routes, and anything fancier would be a feature nothing asks
+ * for.
+ */
+function matchPattern(
+  pattern: string,
+  pathname: string,
+): Record<string, string> | null {
+  const patternParts = pattern.split('/').filter(Boolean);
+  const pathParts = pathname.split('/').filter(Boolean);
+  if (patternParts.length !== pathParts.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i++) {
+    const expected = patternParts[i];
+    const actual = pathParts[i];
+    if (expected.startsWith(':')) {
+      params[expected.slice(1)] = decodeURIComponent(actual);
+      continue;
+    }
+    if (expected !== actual) return null;
+  }
+  return params;
+}
+
+export function DesktopRouter({
+  routes,
+  notFound,
+}: {
+  routes: RouteTable;
+  notFound: React.ReactNode;
+}): React.JSX.Element {
+  const [location, setLocation] = useState(readLocation);
+
+  useEffect(() => {
+    const sync = (): void => setLocation(readLocation());
+    window.addEventListener('hashchange', sync);
+    // A hash-less first load (file:///…/index.html) is the root route.
+    if (!window.location.hash) window.location.replace('#/');
+    return () => window.removeEventListener('hashchange', sync);
+  }, []);
+
+  const navigate = useCallback((href: string, replace: boolean) => {
+    // Absolute URLs are not ours to route — the shell opens those externally.
+    const target = href.startsWith('#') ? href : `#${href.startsWith('/') ? href : `/${href}`}`;
+    if (replace) window.location.replace(target);
+    else window.location.hash = target.slice(1);
+  }, []);
+
+  const matched = useMemo(() => {
+    for (const route of routes) {
+      const params = matchPattern(route.pattern, location.pathname);
+      if (params) return { route, params };
+    }
+    return null;
+  }, [routes, location.pathname]);
+
+  const value = useMemo<RouterValue>(
+    () => ({
+      pattern: matched?.route.pattern ?? '',
+      pathname: location.pathname,
+      params: matched?.params ?? {},
+      search: location.search,
+      push: (href) => navigate(href, false),
+      replace: (href) => navigate(href, true),
+      back: () => window.history.back(),
+      forward: () => window.history.forward(),
+      // Next's refresh re-fetches server data; with no server, re-reading the
+      // location is the closest honest equivalent.
+      refresh: () => setLocation(readLocation()),
+    }),
+    [matched, location, navigate],
+  );
+
+  return (
+    <RouterContext.Provider value={value}>
+      {matched ? matched.route.render(matched.params) : notFound}
+    </RouterContext.Provider>
+  );
+}
+
+function useRouterValue(): RouterValue {
+  const value = useContext(RouterContext);
+  if (!value) throw new Error('Router hooks must be used inside DesktopRouter');
+  return value;
+}
+
+// ── The next/navigation surface the pages import ───────────────────────────
+// Same names, same shapes. `useRouter().push('/acme')` works unchanged.
+
+export function useRouter(): Pick<
+  RouterValue,
+  'push' | 'replace' | 'back' | 'forward' | 'refresh'
+> & { prefetch: (href: string) => void } {
+  const { push, replace, back, forward, refresh } = useRouterValue();
+  return useMemo(
+    // Nothing to prefetch when every route is already in the bundle.
+    () => ({ push, replace, back, forward, refresh, prefetch: () => {} }),
+    [push, replace, back, forward, refresh],
+  );
+}
+
+export function usePathname(): string {
+  return useRouterValue().pathname;
+}
+
+export function useSearchParams(): URLSearchParams {
+  return useRouterValue().search;
+}
+
+export function useParams<T = Record<string, string>>(): T {
+  return useRouterValue().params as T;
+}

--- a/workspace/frontend/desktop/shims/next-dynamic.ts
+++ b/workspace/frontend/desktop/shims/next-dynamic.ts
@@ -1,0 +1,19 @@
+import { lazy, type ComponentType } from 'react';
+
+/**
+ * `next/dynamic`, for the desktop build.
+ *
+ * Next's version exists mainly to keep a component out of the server render;
+ * with no server, what remains is React.lazy. `ssr: false` is accepted and
+ * ignored for the same reason. A `loading` component is honoured by wrapping —
+ * callers that pass one still get it.
+ */
+export default function dynamic<P extends object>(
+  loader: () => Promise<{ default: ComponentType<P> } | ComponentType<P>>,
+  _options?: { ssr?: boolean; loading?: ComponentType },
+): ComponentType<P> {
+  return lazy(async () => {
+    const loaded = await loader();
+    return 'default' in loaded ? loaded : { default: loaded };
+  }) as unknown as ComponentType<P>;
+}

--- a/workspace/frontend/desktop/shims/next-font-google.ts
+++ b/workspace/frontend/desktop/shims/next-font-google.ts
@@ -1,0 +1,24 @@
+/**
+ * `next/font/google`, for the desktop build.
+ *
+ * The web build downloads and self-hosts the font at build time and hands back
+ * a generated class name. The desktop build ships the family with the app (see
+ * desktop/index.html) and hands back the class that applies it — same call
+ * signature, so the layout code is unchanged.
+ */
+interface FontResult {
+  className: string;
+  style: { fontFamily: string };
+  variable: string;
+}
+
+function font(): FontResult {
+  return {
+    className: 'font-inter',
+    style: { fontFamily: 'Inter, system-ui, sans-serif' },
+    variable: '--font-inter',
+  };
+}
+
+export const Inter = font;
+export const Roboto = font;

--- a/workspace/frontend/desktop/shims/next-image.tsx
+++ b/workspace/frontend/desktop/shims/next-image.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+/**
+ * `next/image`, for the desktop build.
+ *
+ * Next's image component exists to serve resized, reformatted images from a
+ * server. There is no server here and every asset ships inside the app, so
+ * what is left of it is a plain `<img>` — the props that only describe the
+ * optimiser (`priority`, `quality`, `loader`, …) are accepted and dropped so
+ * call sites need no edit.
+ */
+export interface ImageProps
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src' | 'width' | 'height'> {
+  src: string | { src: string };
+  width?: number | string;
+  height?: number | string;
+  fill?: boolean;
+  priority?: boolean;
+  quality?: number;
+  unoptimized?: boolean;
+  placeholder?: string;
+  blurDataURL?: string;
+  loader?: unknown;
+  sizes?: string;
+}
+
+export default function Image({
+  src,
+  fill,
+  priority: _priority,
+  quality: _quality,
+  unoptimized: _unoptimized,
+  placeholder: _placeholder,
+  blurDataURL: _blurDataURL,
+  loader: _loader,
+  style,
+  ...props
+}: ImageProps): React.JSX.Element {
+  return (
+    <img
+      src={typeof src === 'string' ? src : src.src}
+      // `fill` means "cover the positioned parent", which is a handful of CSS
+      // properties rather than a feature of the optimiser.
+      style={
+        fill
+          ? { position: 'absolute', inset: 0, width: '100%', height: '100%', ...style }
+          : style
+      }
+      {...props}
+    />
+  );
+}

--- a/workspace/frontend/desktop/shims/next-link.tsx
+++ b/workspace/frontend/desktop/shims/next-link.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { useRouter } from '../router';
+
+/**
+ * `next/link`, for the desktop build.
+ *
+ * An anchor that routes instead of navigating: a real navigation would leave
+ * the app's own page for a file: URL that does not exist. Modified clicks and
+ * anything not left-button are left to the browser, so "open in new window"
+ * and the like behave as the platform expects.
+ */
+export default function Link({
+  href,
+  children,
+  onClick,
+  ...props
+}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }): React.JSX.Element {
+  const router = useRouter();
+  return (
+    <a
+      href={`#${href.startsWith('/') ? href : `/${href}`}`}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return;
+        event.preventDefault();
+        router.push(href);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}

--- a/workspace/frontend/desktop/shims/next-navigation.ts
+++ b/workspace/frontend/desktop/shims/next-navigation.ts
@@ -1,0 +1,12 @@
+/**
+ * `next/navigation`, for the desktop build.
+ *
+ * Aliased in vite.config.ts, so the pages' own imports resolve here without a
+ * line of theirs changing. The implementations live in the router next door.
+ */
+export {
+  useRouter,
+  usePathname,
+  useSearchParams,
+  useParams,
+} from '../router';

--- a/workspace/frontend/desktop/shims/next-script.tsx
+++ b/workspace/frontend/desktop/shims/next-script.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+/**
+ * `next/script`, for the desktop build — deliberately inert.
+ *
+ * Every call site is an analytics snippet loaded from a third party. The
+ * desktop app must not reach out to those hosts on its own: it ships as a
+ * signed binary, the pages are local files, and an outbound script tag would
+ * be both a privacy surprise and a thing that fails offline.
+ */
+export default function Script(_props: {
+  id?: string;
+  src?: string;
+  strategy?: string;
+  children?: React.ReactNode;
+  dangerouslySetInnerHTML?: { __html: string };
+}): null {
+  return null;
+}

--- a/workspace/frontend/desktop/styles.css
+++ b/workspace/frontend/desktop/styles.css
@@ -1,0 +1,20 @@
+/**
+ * The desktop build's stylesheet entry.
+ *
+ * Tailwind v4 works out what to generate from where its stylesheet sits, and
+ * Vite's root here is `desktop/` — so building through the shared
+ * styles/globals.css produced a stylesheet with the reset and none of the
+ * utilities: every page rendered as unstyled HTML. The pages themselves live a
+ * level up, and are named here so this build scans what the Next build already
+ * scans on its own.
+ *
+ * Declared in this file rather than in globals.css so the web build is left
+ * entirely alone — the same reason the shims exist.
+ */
+
+@import '../styles/globals.css';
+
+@source '../app';
+@source '../components';
+@source '../lib';
+@source './';

--- a/workspace/frontend/lib/desktop-handoff.test.ts
+++ b/workspace/frontend/lib/desktop-handoff.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { isDesktopReturn, isDesktopSignIn, parseDesktopHandoff } from './desktop-handoff';
+
+/**
+ * `isDesktopReturn` resolves `returnTo` against this page's own origin — the
+ * same-origin half of its answer is what stops it approving an open redirect.
+ * The runner has no DOM, and pulling one in for a single property would be a
+ * dependency and a lock-file churn for two assertions.
+ */
+const ORIGIN = 'https://workspace.openagents.org';
+
+beforeAll(() => {
+  vi.stubGlobal('window', { location: { origin: ORIGIN } });
+});
+
+describe('parseDesktopHandoff', () => {
+  it('reads the loopback target the launcher put in the link', () => {
+    expect(parseDesktopHandoff('?port=51234&state=abc')).toEqual({
+      port: 51234,
+      state: 'abc',
+    });
+  });
+
+  it('survives the extra parameters a round trip through login adds', () => {
+    expect(parseDesktopHandoff('?port=51234&state=abc&retried=1')?.state).toBe('abc');
+  });
+
+  it('refuses a port outside the range a loopback listener can hold', () => {
+    expect(parseDesktopHandoff('?port=80&state=abc')).toBeNull();
+    expect(parseDesktopHandoff('?port=99999&state=abc')).toBeNull();
+    expect(parseDesktopHandoff('?port=abc&state=abc')).toBeNull();
+  });
+
+  it('refuses a link with no state to check', () => {
+    expect(parseDesktopHandoff('?port=51234')).toBeNull();
+    expect(parseDesktopHandoff('?port=51234&state=')).toBeNull();
+  });
+});
+
+/**
+ * The callback page's one decision: a sign-in belonging to the launcher must be
+ * exchanged server-side, because a Firebase session cannot leave the page.
+ */
+describe('isDesktopReturn', () => {
+  it('recognises the desktop landing page, absolute or relative', () => {
+    expect(isDesktopReturn(`${ORIGIN}/auth/desktop?port=1&state=a`)).toBe(true);
+    expect(isDesktopReturn('/auth/desktop?port=1&state=a')).toBe(true);
+  });
+
+  it('leaves an ordinary browser sign-in alone', () => {
+    expect(isDesktopReturn('/inbox')).toBe(false);
+    expect(isDesktopReturn(null)).toBe(false);
+    expect(isDesktopReturn('not a url')).toBe(false);
+  });
+
+  // The callback redirects to whatever this approves, so a path match on some
+  // other origin would be an open redirect.
+  it('refuses the same path on another origin', () => {
+    expect(isDesktopReturn('https://elsewhere.example/auth/desktop?port=1&state=a')).toBe(false);
+  });
+});
+
+
+describe('isDesktopSignIn', () => {
+  const ua = navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+  });
+
+  function insideTheApp(): void {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: `${ua} OpenAgentsLauncher/1.0.0`,
+      configurable: true,
+    });
+  }
+
+  it('recognises a sign-in happening inside the desktop app', () => {
+    insideTheApp();
+    // No returnTo of its own: the in-app flow is the ordinary one, and the app
+    // is identified by the view it runs in.
+    expect(isDesktopSignIn('/inbox')).toBe(true);
+    expect(isDesktopSignIn(null)).toBe(true);
+  });
+
+  it('still recognises the browser round trip made on its behalf', () => {
+    expect(isDesktopSignIn('/auth/desktop?port=1&state=a')).toBe(true);
+  });
+
+  it('leaves an ordinary browser sign-in alone', () => {
+    expect(isDesktopSignIn('/inbox')).toBe(false);
+    expect(isDesktopSignIn(null)).toBe(false);
+  });
+});

--- a/workspace/frontend/lib/desktop-handoff.ts
+++ b/workspace/frontend/lib/desktop-handoff.ts
@@ -1,0 +1,131 @@
+// Login handoff for the desktop launcher.
+//
+// The launcher signs people in on this site's own pages, in a view inside the
+// app — so the ordinary flow (central login → /auth/callback → back here) is
+// what runs, and there is nothing desktop-specific about it except one thing:
+// the session has to be one the app can KEEP. A Firebase session lives in the
+// page; a workspace session (POST /v1/auth/session) is 30 days, minted
+// server-side, and readable by the app that hosts the view. So a sign-in
+// recognised as the launcher's takes that exchange first, wherever it happens.
+//
+// The loopback half below is for the accounts that cannot sign in inside an
+// app at all: Google and GitHub refuse to authenticate in an embedded view, so
+// those go out to the real browser, which has no way back into the app except
+// a port it can post to.
+//
+// The launcher opens /auth/desktop?port=&state= here. That page is an ordinary
+// page on this origin, which matters: the central login treats `returnTo` as
+// the destination to land on AFTER it has minted a custom token and bounced
+// through /auth/callback, so pointing returnTo at the callback itself skips the
+// token entirely. Landing on a normal page keeps the whole flow on the path the
+// web app already uses every day.
+//
+// What travels to the launcher is a workspace session (POST /v1/auth/session):
+// 30 days, minted server-side, no Google round-trip — so the desktop app stays
+// signed in, mainland China included. A Firebase ID token would not do: it
+// lapses in an hour and its refresh token never leaves the browser.
+
+export interface DesktopHandoff {
+  port: number;
+  state: string;
+}
+
+/** Where the launcher sends people to start a browser sign-in. */
+export const DESKTOP_AUTH_PATH = '/auth/desktop';
+
+/**
+ * The user agent the desktop app appends to this view's own (see the launcher's
+ * workspace-host). Present only inside the app, never in a browser.
+ */
+const LAUNCHER_UA_TAG = 'OpenAgentsLauncher';
+
+/** Whether this page is running inside the desktop app's own view. */
+export function isLauncherView(): boolean {
+  return (
+    typeof navigator !== 'undefined' && navigator.userAgent.includes(LAUNCHER_UA_TAG)
+  );
+}
+
+/**
+ * Whether the sign-in in progress belongs to the desktop app — either because
+ * it is happening inside it, or because it is a browser round trip on its
+ * behalf. Both need the session the app can keep.
+ */
+export function isDesktopSignIn(returnTo: string | null): boolean {
+  return isLauncherView() || isDesktopReturn(returnTo);
+}
+
+/** Anything above the privileged range; the launcher binds an ephemeral port. */
+const MIN_PORT = 1024;
+const MAX_PORT = 65535;
+
+/** Read the loopback target out of /auth/desktop's own query. */
+export function parseDesktopHandoff(search: string): DesktopHandoff | null {
+  const params = new URLSearchParams(search);
+  const port = Number(params.get('port'));
+  const state = params.get('state');
+  if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) return null;
+  if (!state) return null;
+  return { port, state };
+}
+
+/**
+ * Whether a login handoff is on its way back to the desktop app.
+ *
+ * The callback page asks this: a sign-in bound for the launcher must be
+ * exchanged server-side for a workspace session even where Firebase is
+ * perfectly reachable, because that is the only credential the app can keep.
+ *
+ * Same-origin is part of the question, not a detail: this answer decides that
+ * the callback may redirect straight to `returnTo`, and a path check alone
+ * would take https://elsewhere.example/auth/desktop for our own page.
+ */
+export function isDesktopReturn(returnTo: string | null): boolean {
+  if (!returnTo) return false;
+  try {
+    const url = new URL(returnTo, window.location.origin);
+    return url.origin === window.location.origin && url.pathname === DESKTOP_AUTH_PATH;
+  } catch {
+    return false;
+  }
+}
+
+interface ForwardPayload {
+  state: string;
+  session?: { token: string; email: string; displayName: string | null; expiresAt: number };
+  error?: string;
+}
+
+/**
+ * Hand the session to the launcher's loopback listener.
+ *
+ * A cross-origin POST it can read (the listener answers with our origin in
+ * Access-Control-Allow-Origin, and grants the private-network access Chrome
+ * requires of a public page reaching 127.0.0.1). Where the browser refuses that
+ * outright, fall back to navigating to the same endpoint with the payload in
+ * the query — a sign-in that completes beats one that is tidy.
+ */
+export async function forwardToDesktop(
+  handoff: DesktopHandoff,
+  payload: Omit<ForwardPayload, 'state'>,
+): Promise<void> {
+  const url = `http://127.0.0.1:${handoff.port}/desktop-auth`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: handoff.state, ...payload }),
+    });
+    if (!res.ok) throw new Error(`Launcher refused the sign-in (${res.status})`);
+  } catch {
+    const query = new URLSearchParams({ state: handoff.state });
+    if (payload.session) {
+      query.set('session_token', payload.session.token);
+      query.set('email', payload.session.email);
+      if (payload.session.displayName) query.set('display_name', payload.session.displayName);
+      query.set('expires_at', String(payload.session.expiresAt));
+    }
+    if (payload.error) query.set('error', payload.error);
+    window.location.replace(`${url}?${query.toString()}`);
+  }
+}

--- a/workspace/frontend/lib/openagents-auth-context.tsx
+++ b/workspace/frontend/lib/openagents-auth-context.tsx
@@ -19,7 +19,11 @@ interface OpenAgentsAuthContextValue {
   signOut: () => Promise<void>;
 }
 
-const OPENAGENTS_HOSTNAMES = ['workspace.openagents.org', 'localhost'];
+// `workspace` is the desktop build: the launcher serves the bundle from
+// openagents://workspace/, so that is this app's own host there — the same way
+// workspace.openagents.org is on the web. Without it the desktop app would
+// decide it was a third-party deployment and show the marketing landing page.
+const OPENAGENTS_HOSTNAMES = ['workspace.openagents.org', 'localhost', 'workspace'];
 
 const OpenAgentsAuthContext = createContext<OpenAgentsAuthContextValue | null>(null);
 

--- a/workspace/frontend/package-lock.json
+++ b/workspace/frontend/package-lock.json
@@ -34,12 +34,15 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.17",
+        "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^24.3.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.2.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.2",
+        "vite": "^7.3.6",
         "vitest": "^4.1.10"
       }
     },
@@ -67,6 +70,308 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -124,6 +429,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@firebase/ai": {
@@ -1355,6 +2102,26 @@
         "@chevrotain/types": "~11.1.1"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
@@ -1509,16 +2276,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3083,10 +3840,31 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
       "cpu": [
         "arm64"
       ],
@@ -3095,15 +3873,12 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
       "cpu": [
         "arm64"
       ],
@@ -3112,15 +3887,12 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
       "cpu": [
         "x64"
       ],
@@ -3129,15 +3901,26 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
       "cpu": [
         "x64"
       ],
@@ -3146,100 +3929,233 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
       "cpu": [
         "x64"
       ],
@@ -3247,33 +4163,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+        "openbsd"
+      ]
     },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
       "cpu": [
         "arm64"
       ],
@@ -3282,57 +4178,12 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
       "cpu": [
         "arm64"
       ],
@@ -3341,15 +4192,26 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
       "cpu": [
         "x64"
       ],
@@ -3358,17 +4220,21 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3657,6 +4523,570 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.23",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
@@ -3693,6 +5123,51 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/chai": {
@@ -3976,9 +5451,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -4075,6 +5550,27 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -4247,9 +5743,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4268,10 +5764,44 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5065,6 +6595,13 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5072,14 +6609,14 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -5101,6 +6638,48 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5265,6 +6844,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5501,13 +7090,46 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/katex": {
@@ -5848,6 +7470,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lucide-react": {
@@ -6909,6 +8541,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -7199,6 +8841,16 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -7366,38 +9018,50 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
-    "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
-        "@rolldown/pluginutils": "^1.0.0"
+        "@types/estree": "1.0.9"
       },
       "bin": {
-        "rolldown": "bin/cli.mjs"
+        "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/roughjs": {
@@ -7663,9 +9327,9 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7884,6 +9548,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -7991,17 +9686,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
-        "tinyglobby": "^0.2.17"
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8017,10 +9713,9 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -8033,16 +9728,13 @@
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
         "jiti": {
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -8066,267 +9758,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.33.0",
-        "lightningcss-darwin-arm64": "1.33.0",
-        "lightningcss-darwin-x64": "1.33.0",
-        "lightningcss-freebsd-x64": "1.33.0",
-        "lightningcss-linux-arm-gnueabihf": "1.33.0",
-        "lightningcss-linux-arm64-gnu": "1.33.0",
-        "lightningcss-linux-arm64-musl": "1.33.0",
-        "lightningcss-linux-x64-gnu": "1.33.0",
-        "lightningcss-linux-x64-musl": "1.33.0",
-        "lightningcss-win32-arm64-msvc": "1.33.0",
-        "lightningcss-win32-x64-msvc": "1.33.0"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-android-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/vitest": {
@@ -8490,6 +9921,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/workspace/frontend/package.json
+++ b/workspace/frontend/package.json
@@ -5,8 +5,11 @@
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build",
+    "build:desktop": "vite build",
+    "dev:desktop": "vite",
     "start": "next start -p 3000",
-    "test": "vitest run"
+    "test": "vitest run",
+    "build:desktop:debug": "vite build --mode development"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.23",
@@ -35,12 +38,15 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.17",
+    "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^24.3.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.2",
+    "vite": "^7.3.6",
     "vitest": "^4.1.10"
   }
 }

--- a/workspace/frontend/tsconfig.json
+++ b/workspace/frontend/tsconfig.json
@@ -38,6 +38,11 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    // Vite's own config, loaded by Vite (esbuild) and never by Next. It imports
+    // plugins that publish their types through package.json `exports`, which
+    // this project's `moduleResolution: node10` cannot follow — so `next build`
+    // failed type-checking a file it neither compiles nor ships.
+    "vite.config.ts"
   ]
 }

--- a/workspace/frontend/vite.config.ts
+++ b/workspace/frontend/vite.config.ts
@@ -1,0 +1,74 @@
+import { resolve } from 'node:path';
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+/**
+ * The desktop build of the workspace.
+ *
+ * A SECOND build target over the same source — `next build` is untouched and
+ * still produces the web app. This one bundles the same pages into static
+ * files the launcher ships inside its installer and loads from disk, so the
+ * desktop app opens instantly, works offline, and loads nothing from a remote
+ * origin.
+ *
+ * What makes that possible without forking the code is the alias table below:
+ * the handful of `next/*` modules the pages import resolve to small local
+ * equivalents (see desktop/shims). No page, component or lib file changes.
+ */
+export default defineConfig(({ mode }) => ({
+  root: resolve(__dirname, 'desktop'),
+  // The web app's own static files (logos, icons, the notification sound). Vite
+  // would otherwise look for them beside the entry, in desktop/, and the pages
+  // reference them by absolute path — `/logo-icon.png` — which is also why the
+  // launcher serves this bundle over a custom scheme rather than from file:.
+  publicDir: resolve(__dirname, 'public'),
+  // Relative, because the pages are loaded from a file: URL rather than served
+  // from the root of a host.
+  base: './',
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: [
+      { find: /^next\/navigation$/, replacement: resolve(__dirname, 'desktop/shims/next-navigation.ts') },
+      { find: /^next\/image$/, replacement: resolve(__dirname, 'desktop/shims/next-image.tsx') },
+      { find: /^next\/link$/, replacement: resolve(__dirname, 'desktop/shims/next-link.tsx') },
+      { find: /^next\/script$/, replacement: resolve(__dirname, 'desktop/shims/next-script.tsx') },
+      { find: /^next\/dynamic$/, replacement: resolve(__dirname, 'desktop/shims/next-dynamic.ts') },
+      { find: /^next\/font\/google$/, replacement: resolve(__dirname, 'desktop/shims/next-font-google.ts') },
+      // `@/` is the same project-root alias the web build uses (tsconfig paths).
+      { find: /^@\//, replacement: `${resolve(__dirname)}/` },
+    ],
+  },
+  // `process.env.NEXT_PUBLIC_*` is a Next.js build-time substitution; Vite
+  // leaves it alone and the page dies on `process is not defined`. These put
+  // the same values back — with the API base left resolvable at RUN time, so a
+  // self-hosted deployment can be pointed at without a rebuild: the launcher's
+  // preload sets `globalThis.__OA_API_URL__` before the page's first script.
+  define: {
+    // A bare identifier, not an expression: esbuild's `define` takes only
+    // entity names and literals. index.html gives it a default, and the
+    // launcher's preload — which runs before any page script — can set it to
+    // a self-hosted endpoint first.
+    'process.env.NEXT_PUBLIC_API_URL': '__OA_API_URL__',
+    // Analytics is deliberately off in the desktop build; see shims/next-script.
+    'process.env.NEXT_PUBLIC_POSTHOG_KEY': 'undefined',
+    'process.env.NEXT_PUBLIC_POSTHOG_HOST': 'undefined',
+    'process.env.NEXT_PUBLIC_GA_ID': 'undefined',
+    // `--mode development` keeps React's development build, whose errors are
+    // sentences rather than "Minified React error #NNN" — the difference
+    // between an afternoon and a minute when the app only breaks once bundled.
+    'process.env.NODE_ENV': JSON.stringify(
+      mode === 'development' ? 'development' : 'production',
+    ),
+  },
+  build: {
+    outDir: resolve(__dirname, 'dist-desktop'),
+    emptyOutDir: true,
+    // The launcher ships this; a source map would double the installer for a
+    // stack trace nobody can act on in a signed build.
+    sourcemap: false,
+    // Readable names in a development build, for the same reason.
+    minify: mode !== 'development',
+  },
+}));


### PR DESCRIPTION
Splits the workspace-side half of the desktop launcher work out of
`feat/launcher-workspace-dual-mode` so it can be merged and **deployed** on its
own. No launcher code here.

## Why this needs to be deployed, not just merged

The launcher checks for `workspace.openagents.org/auth/desktop` **before** it
opens a browser, and refuses the sign-in when it 404s — otherwise the user
completes a login with no way back into the app. Until this is live, Google /
GitHub / Apple sign-in shows "needs a workspace-side update". Email + password
already works and does not depend on this page.

## What is in it

**Desktop build target** — the same source builds twice. `next build` keeps
producing the web app; a second Vite target bundles `app/`, `components/` and
`lib/` into static files the installer ships and loads from disk. Nothing under
those directories knows which target it runs in: the difference lives in
`desktop/`, where the `next/*` modules the pages import resolve to local
equivalents. **The Next build is untouched.**

**The sign-in page.** Electron has no http origin an OAuth provider will
redirect to, and Google refuses to authenticate inside an embedded view — so
the sign-in happens in the user's own browser and `/auth/desktop` hands the
result back over loopback. It has to be an ordinary page: a `returnTo` aimed
straight at `/auth/callback` is taken as the final destination and no handoff
token is minted at all.

`/auth/callback` takes the server-side exchange **first** for those sign-ins,
wherever Google stands: a Firebase session cannot leave the page, since its ID
token lapses in an hour and its refresh token is not ours to hand over.
**Browser sign-ins keep the existing Firebase-then-fallback path exactly as it
was** — the whole change is inside one `if`.

**Probe diagnostics** (`packages/agent-connector`) — a probe that timed out
reported that the CLI "may be waiting for interactive input" and sent the user
to a terminal. Live case: a relay answering 403 for an account short of credit
makes Claude Code retry silently for the full 120s, printing only an unrelated
warning. The user was told to fix an install that works. Now, when a CLI
verdict explains nothing and the agent has an endpoint and a key, the API is
asked directly — one round trip, and it names the cause.

`testLLMConnection` could not make that call for a Claude agent: it read
neither `ANTHROPIC_BASE_URL` nor `ANTHROPIC_MODEL` and hardcoded
`api.anthropic.com`, so an agent pointed at a relay was tested against a
service it never talks to. Out-of-credit detection also matched only English
wording and 402, while relays word it their own way and answer 403 — which
fell through to `invalid_api_key`, the one misreading that sends a user to
re-authenticate a working key.

## Risk to the web app

Confined to additions. The only edits to existing files are the `if` in
`/auth/callback`, and `workspace` joining the auth context's own-hostname list
(the bundle is served from `openagents://workspace/`). Tailwind sources are
declared in `desktop/styles.css` rather than in `globals.css`, so the web
build's stylesheet is byte-identical.

## Tests

`agent-connector` 1523 pass / 0 fail (6 new, including the real 403 payload).
`workspace/frontend` 16 pass — two of them were failing before this: the
implementation reads `window.location` for its same-origin check and the runner
has no DOM, so they now stub the one property that matters rather than pulling
in jsdom.

## After merging

Deploy the workspace front end. Nothing else — no backend change, no launcher
change.

One thing we cannot test from here: whether openagents.org's `returnTo`
allowlist accepts `https://workspace.openagents.org/auth/desktop?port=..&state=..`
(a workspace-domain URL carrying a query). If it strips the query, the loopback
handoff lands without its port and the sign-in ends on the landing page instead
of returning to the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
