### PR TITLE
fix(workspace): translate role names and replace the native selects

### DIFF
--- a/workspace/frontend/app/[workspaceId]/settings/integrations/page.tsx
+++ b/workspace/frontend/app/[workspaceId]/settings/integrations/page.tsx
@@ -12,8 +12,24 @@ import { ReadOnlyBanner, SectionHeader } from '@/components/settings/section-chr
 import { workspaceApi } from '@/lib/api';
 import type { IntegrationBinding, WorkspaceAgent } from '@/lib/types';
 import { useT } from '@/lib/i18n';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 type ConnectForm = 'telegram' | 'slack' | 'lark' | null;
+
+/**
+ * "No default agent", as a value a Select can hold.
+ *
+ * Radix refuses an empty string for an item — it reserves it for "nothing is
+ * selected" — so the absence has to travel under a name of its own and be
+ * turned back into '' at the edge, which is what the API stores.
+ */
+const NO_AGENT = '__none__';
 
 export default function IntegrationsSettingsPage() {
   const { workspace, me, refreshWorkspace } = useAdminSettings();
@@ -175,17 +191,23 @@ export default function IntegrationsSettingsPage() {
   };
 
   const agentPicker = (value: string, onChange: (v: string) => void) => (
-    <select
-      className="h-9 rounded-md border bg-background px-2 text-sm"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
+    <Select
+      value={value || NO_AGENT}
+      onValueChange={(v) => onChange(v === NO_AGENT ? '' : v)}
       disabled={!editable}
     >
-      <option value="">{t('admin.integrationNoDefaultAgent')}</option>
-      {agents.map((a) => (
-        <option key={a.agentName} value={a.agentName}>{a.agentName}</option>
-      ))}
-    </select>
+      <SelectTrigger className="h-9 w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={NO_AGENT}>{t('admin.integrationNoDefaultAgent')}</SelectItem>
+        {agents.map((a) => (
+          <SelectItem key={a.agentName} value={a.agentName}>
+            {a.agentName}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 
   return (

--- a/workspace/frontend/app/[workspaceId]/settings/layout.tsx
+++ b/workspace/frontend/app/[workspaceId]/settings/layout.tsx
@@ -12,6 +12,7 @@ import { workspaceApi } from '@/lib/api';
 import type { Workspace, WorkspaceMe } from '@/lib/types';
 import { useOpenAgentsAuth } from '@/lib/openagents-auth-context';
 import { goToCentralLogin } from '@/lib/auth-redirects';
+import { roleLabel } from '@/lib/roles';
 import { useT } from '@/lib/i18n';
 
 /** Read the workspace token persisted by the main workspace view (see
@@ -154,7 +155,10 @@ function SettingsShell({ workspaceId, children }: { workspaceId: string; childre
   }
 
   const roleBadge = ctxValue.me.role
-    ?? (ctxValue.me.tokenAccess ? t('admin.roleBadgeToken') : ctxValue.me.effectiveRole);
+    ? roleLabel(t, ctxValue.me.role)
+    : ctxValue.me.tokenAccess
+      ? t('admin.roleBadgeToken')
+      : roleLabel(t, ctxValue.me.effectiveRole);
 
   return (
     <AdminSettingsContext.Provider value={ctxValue}>

--- a/workspace/frontend/app/[workspaceId]/settings/members/page.tsx
+++ b/workspace/frontend/app/[workspaceId]/settings/members/page.tsx
@@ -8,6 +8,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useConfirm } from '@/components/ui/dialogs-provider';
 import { useAdminSettings, canAdminister } from '@/components/settings/admin-context';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { roleLabel } from '@/lib/roles';
 import { ReadOnlyBanner, SectionHeader } from '@/components/settings/section-chrome';
 import { workspaceApi } from '@/lib/api';
 import type { TeamInvite, TeamMember, WorkspaceRole } from '@/lib/types';
@@ -159,13 +167,21 @@ export default function MembersSettingsPage() {
               onKeyDown={(e) => { if (e.key === 'Enter') sendInvite(); }}
               className="flex-1"
             />
-            <select
-              className="h-9 rounded-md border bg-background px-2 text-sm"
+            <Select
               value={inviteRole}
-              onChange={(e) => setInviteRole(e.target.value as WorkspaceRole)}
+              onValueChange={(v) => setInviteRole(v as WorkspaceRole)}
             >
-              {INVITE_ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
-            </select>
+              <SelectTrigger className="h-9 w-32 shrink-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {INVITE_ROLES.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {roleLabel(t, r)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Button onClick={sendInvite} disabled={busy || !inviteEmail.trim()}>
               {busy ? <Loader2 className="size-4 animate-spin" /> : <Mail className="size-4" />}
               <span className="hidden sm:inline">{t('admin.inviteSend')}</span>
@@ -254,13 +270,21 @@ export default function MembersSettingsPage() {
                 </div>
                 {editable ? (
                   <>
-                    <select
-                      className="h-8 rounded-md border bg-background px-2 text-xs"
+                    <Select
                       value={m.role}
-                      onChange={(e) => changeRole(m.email, e.target.value as WorkspaceRole)}
+                      onValueChange={(v) => changeRole(m.email, v as WorkspaceRole)}
                     >
-                      {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
-                    </select>
+                      <SelectTrigger className="w-28 shrink-0">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ROLES.map((r) => (
+                          <SelectItem key={r} value={r}>
+                            {roleLabel(t, r)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <Button
                       variant="ghost"
                       size="icon"
@@ -272,7 +296,7 @@ export default function MembersSettingsPage() {
                   </>
                 ) : (
                   <span className="rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
-                    {m.role}
+                    {roleLabel(t, m.role)}
                   </span>
                 )}
               </div>

--- a/workspace/frontend/components/agents/agent-profile-panel.tsx
+++ b/workspace/frontend/components/agents/agent-profile-panel.tsx
@@ -13,6 +13,16 @@ import { agentLabel } from '@/lib/helpers';
 import { toast } from 'sonner';
 import type { CloudAgentConfig, AgentCatalogModel } from '@/lib/types';
 import { useT } from '@/lib/i18n';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+/** "Provider default", as a value a Select can hold. See NO_AGENT elsewhere. */
+const DEFAULT_MODEL = '__default__';
 
 export function AgentProfilePanel({ docked = false }: { docked?: boolean } = {}) {
   const {
@@ -432,20 +442,36 @@ export function AgentProfilePanel({ docked = false }: { docked?: boolean } = {})
                 {savingModel && <RefreshCw className="size-3 animate-spin text-muted-foreground ml-auto" />}
               </div>
               <div className="p-3 space-y-1.5">
-                <select
-                  value={currentModel}
-                  onChange={(e) => handleModelChange(e.target.value)}
+                <Select
+                  value={currentModel || DEFAULT_MODEL}
+                  onValueChange={(v) =>
+                    handleModelChange(v === DEFAULT_MODEL ? '' : v)
+                  }
                   disabled={savingModel || (isCloud && !cloudConfig)}
-                  className="w-full px-2 py-1.5 text-[13px] rounded-md border bg-background outline-none focus:ring-1 focus:ring-foreground/20 disabled:opacity-50"
                 >
-                  {!isCloud && <option value="">{t('agents.modelDefault')}</option>}
-                  {currentModel && !(modelOptions || []).some((m) => m.id === currentModel) && (
-                    <option value={currentModel}>{currentModel}</option>
-                  )}
-                  {(modelOptions || []).map((m) => (
-                    <option key={m.id} value={m.id}>{m.label || m.id}</option>
-                  ))}
-                </select>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {!isCloud && (
+                      <SelectItem value={DEFAULT_MODEL}>
+                        {t('agents.modelDefault')}
+                      </SelectItem>
+                    )}
+                    {/* A model the agent is on but the catalogue does not list
+                        — a hand-edited config, or one the provider dropped.
+                        Listing it is what keeps the picker from silently
+                        showing something the agent is not running. */}
+                    {currentModel && !(modelOptions || []).some((m) => m.id === currentModel) && (
+                      <SelectItem value={currentModel}>{currentModel}</SelectItem>
+                    )}
+                    {(modelOptions || []).map((m) => (
+                      <SelectItem key={m.id} value={m.id}>
+                        {m.label || m.id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
                 {!isCloud && (
                   <p className="text-[11px] text-muted-foreground leading-relaxed">{t('agents.modelHint')}</p>
                 )}

--- a/workspace/frontend/components/connect/connect-agent-view.tsx
+++ b/workspace/frontend/components/connect/connect-agent-view.tsx
@@ -24,6 +24,13 @@ import type { AgentCatalogEntry, CloudAgentConfig, CloudAgentProvider, Workspace
 import { AgentIcon, ProviderIcon } from '@/components/icons/agent-icons';
 import { AddModelAccessDialog } from '@/components/settings/model-access-dialog';
 import dynamic from 'next/dynamic';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 // The welcome film is ~2k lines of scene choreography only first-run users
 // ever see — load it on demand so the connect view's bundle stays lean.
@@ -78,6 +85,16 @@ function CategoryIcon({ category, className }: { category: string; className?: s
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
+
+/**
+ * Values a Select can hold for "nothing", which Radix reserves the empty string
+ * for. Each is turned back into '' at the edge, which is what the API stores.
+ * `__custom__` was already on the wire before this — it is a real choice ("let
+ * me type a model"), not an absence, and keeps its name.
+ */
+const NO_ACCESS = '__none__';
+const AUTO_MODEL = '__auto__';
+const CUSTOM_MODEL = '__custom__';
 
 export function ConnectAgentView({
   initialTab = 'node',
@@ -1788,16 +1805,22 @@ function AddAgentGallery({
 
               {/* Saved model access + add-new */}
               <div className="flex gap-2">
-                <select
-                  value={byokAccessId}
-                  onChange={(e) => pickAccess(e.target.value)}
-                  className="h-10 flex-1 rounded-md border bg-background px-3 text-sm"
+                <Select
+                  value={byokAccessId || NO_ACCESS}
+                  onValueChange={(v) => pickAccess(v === NO_ACCESS ? '' : v)}
                 >
-                  <option value="">{t('connect.byokProviderNone')}</option>
-                  {byokAccessOptions.map((a) => (
-                    <option key={a.id} value={a.id}>{a.label} · {a.apiKeyMasked}</option>
-                  ))}
-                </select>
+                  <SelectTrigger className="h-10 min-w-0 flex-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_ACCESS}>{t('connect.byokProviderNone')}</SelectItem>
+                    {byokAccessOptions.map((a) => (
+                      <SelectItem key={a.id} value={a.id}>
+                        {a.label} · {a.apiKeyMasked}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
                 <Button variant="outline" onClick={() => setShowAccessDialog(true)} className="h-10 shrink-0">
                   <Plus className="size-3.5 mr-1.5" />{t('connect.byokAddAccess')}
                 </Button>
@@ -1835,21 +1858,26 @@ function AddAgentGallery({
                   {/* Model — the ones this key can actually use */}
                   {byokModels && (
                     <div className="space-y-1.5">
-                      <select
-                        value={byokCustomModel ? '__custom__' : model}
-                        onChange={(e) => {
-                          if (e.target.value === '__custom__') { setByokCustomModel(true); setModel(''); }
-                          else { setByokCustomModel(false); setModel(e.target.value); }
+                      <Select
+                        value={byokCustomModel ? CUSTOM_MODEL : model || undefined}
+                        onValueChange={(v) => {
+                          if (v === CUSTOM_MODEL) { setByokCustomModel(true); setModel(''); }
+                          else { setByokCustomModel(false); setModel(v); }
                           setByokTest({ state: 'idle' });
                         }}
-                        className="w-full h-10 text-sm rounded-md border bg-background px-3"
                       >
-                        <option value="">{t('connect.byokChooseModel')}</option>
-                        {byokModels.map((m) => (
-                          <option key={m.id} value={m.id}>{m.label}</option>
-                        ))}
-                        <option value="__custom__">{t('connect.byokCustomModel')}</option>
-                      </select>
+                        <SelectTrigger className="h-10 w-full">
+                          <SelectValue placeholder={t('connect.byokChooseModel')} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {byokModels.map((m) => (
+                            <SelectItem key={m.id} value={m.id}>{m.label}</SelectItem>
+                          ))}
+                          <SelectItem value={CUSTOM_MODEL}>
+                            {t('connect.byokCustomModel')}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
                       {byokCustomModel && (
                         <Input
                           value={model}
@@ -1912,16 +1940,20 @@ function AddAgentGallery({
           {modelOptions && !(byok && byokAccessId) && !baseUrl.trim() && (
             <div className="space-y-1.5">
               <Label className="text-xs font-medium">{t('connect.nodeModel')}</Label>
-              <select
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="w-full h-10 text-sm rounded-md border bg-background px-3"
+              <Select
+                value={model || AUTO_MODEL}
+                onValueChange={(v) => setModel(v === AUTO_MODEL ? '' : v)}
               >
-                <option value="">{t('connect.nodeModelAuto')}</option>
-                {modelOptions.map((m) => (
-                  <option key={m.id} value={m.id}>{m.label}</option>
-                ))}
-              </select>
+                <SelectTrigger className="h-10 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={AUTO_MODEL}>{t('connect.nodeModelAuto')}</SelectItem>
+                  {modelOptions.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>{m.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           )}
 

--- a/workspace/frontend/components/settings/model-access-dialog.tsx
+++ b/workspace/frontend/components/settings/model-access-dialog.tsx
@@ -16,6 +16,13 @@ import { workspaceApi } from '@/lib/api';
 import type { CloudAgentProvider, ModelAccessEntry } from '@/lib/types';
 import { useT } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 export function AddModelAccessDialog({
   providers,
@@ -90,16 +97,25 @@ export function AddModelAccessDialog({
 
         <div className="space-y-1.5">
           <Label className="text-xs font-medium">{t('admin.modelAccessProvider')}</Label>
-          <select
-            value={provider}
-            onChange={(e) => { setProvider(e.target.value); setCheck({ state: 'idle' }); }}
-            className="w-full h-10 rounded-md border bg-background px-3 text-sm"
+          <Select
+            value={provider || undefined}
+            onValueChange={(v) => { setProvider(v); setCheck({ state: 'idle' }); }}
           >
-            <option value="">{t('admin.modelAccessPickProvider')}</option>
-            {options.map((p) => <option key={p.name} value={p.name}>{p.label}</option>)}
-            <option value="custom">{t('connect.byokProviderCustom')}</option>
-            <option value="custom-anthropic">{t('connect.byokProviderCustomAnthropic')}</option>
-          </select>
+            <SelectTrigger className="h-10 w-full">
+              {/* Nothing chosen yet is exactly what a placeholder is for, so
+                  unlike the other pickers this one needs no stand-in value. */}
+              <SelectValue placeholder={t('admin.modelAccessPickProvider')} />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((p) => (
+                <SelectItem key={p.name} value={p.name}>{p.label}</SelectItem>
+              ))}
+              <SelectItem value="custom">{t('connect.byokProviderCustom')}</SelectItem>
+              <SelectItem value="custom-anthropic">
+                {t('connect.byokProviderCustomAnthropic')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </div>
 
         {isCustomKind && (

--- a/workspace/frontend/components/settings/section-chrome.tsx
+++ b/workspace/frontend/components/settings/section-chrome.tsx
@@ -3,6 +3,7 @@
 import { Lock } from 'lucide-react';
 import { useT } from '@/lib/i18n';
 import { useAdminSettings } from './admin-context';
+import { roleLabel } from '@/lib/roles';
 
 /** Title + description header shared by every settings dashboard section. */
 export function SectionHeader({ title, description }: { title: string; description: string }) {
@@ -23,7 +24,9 @@ export function ReadOnlyBanner() {
   return (
     <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-300">
       <Lock className="size-3.5 shrink-0" />
-      {t('admin.readOnlyBanner', { role: me.effectiveRole ?? me.role ?? '?' })}
+      {t('admin.readOnlyBanner', {
+        role: roleLabel(t, me.effectiveRole ?? me.role) || '?',
+      })}
     </div>
   );
 }

--- a/workspace/frontend/lib/i18n/messages/en-US.ts
+++ b/workspace/frontend/lib/i18n/messages/en-US.ts
@@ -771,6 +771,10 @@ export const messages = {
     accessDeniedBody: "You don't have access to this workspace's settings.",
     readOnlyBanner: 'You are viewing as {role}. Only an owner or admin can change these settings.',
     roleBadgeToken: 'token access',
+    roleOwner: 'Owner',
+    roleAdmin: 'Admin',
+    roleMember: 'Member',
+    roleViewer: 'Viewer',
 
     navProfile: 'Profile',
     navGeneral: 'General',

--- a/workspace/frontend/lib/i18n/messages/zh-CN.ts
+++ b/workspace/frontend/lib/i18n/messages/zh-CN.ts
@@ -754,6 +754,10 @@ export const messages: Messages = {
     accessDeniedBody: '你没有权限访问此工作区的设置。',
     readOnlyBanner: '你当前的角色是 {role}。只有所有者或管理员才能修改这些设置。',
     roleBadgeToken: '令牌访问',
+    roleOwner: '所有者',
+    roleAdmin: '管理员',
+    roleMember: '成员',
+    roleViewer: '访客',
 
     navProfile: '个人资料',
     navGeneral: '常规',

--- a/workspace/frontend/lib/roles.ts
+++ b/workspace/frontend/lib/roles.ts
@@ -1,0 +1,26 @@
+import type { TranslateFn } from './i18n';
+import type { WorkspaceRole } from './types';
+
+/**
+ * Role names, in the reader's language.
+ *
+ * The API speaks `owner`/`admin`/`member`/`viewer` and every surface used to
+ * print those verbatim — a Chinese settings page with four English words in it,
+ * in a picker, a badge and a sentence.
+ *
+ * An unknown value comes through untranslated rather than blank: a role the UI
+ * has not heard of is still information, and hiding it would leave a member row
+ * looking as if it had no role at all.
+ */
+const ROLE_KEYS = {
+  owner: 'admin.roleOwner',
+  admin: 'admin.roleAdmin',
+  member: 'admin.roleMember',
+  viewer: 'admin.roleViewer',
+} as const;
+
+export function roleLabel(t: TranslateFn, role?: string | null): string {
+  if (!role) return '';
+  const key = ROLE_KEYS[role as WorkspaceRole];
+  return key ? t(key) : role;
+}


### PR DESCRIPTION
Two things the settings pages had in common, both visible on the members page.

## Role names were never translated

`owner` / `admin` / `member` / `viewer` came straight from the API and were
printed verbatim in three places — the pickers, the badge in the settings
header, and the sentence explaining why a section is read-only. A Chinese
settings page with four English words in it.

`lib/roles.ts` names them once; every surface reads from there. A role the UI
has not heard of comes through as itself rather than blank — an unfamiliar role
is still information, and hiding it would leave a member row looking as if it
had no role at all.

## The pickers were native `<select>`

They rendered in the OS's own style and matched nothing around them. All eight
in the app are now the `Select` the rest of the UI uses:

| File | Picker |
|---|---|
| `settings/members` | invite role, member role |
| `settings/integrations` | default agent |
| `settings/model-access-dialog` | provider |
| `agents/agent-profile-panel` | model |
| `connect/connect-agent-view` | saved access, BYOK model, node model |

One thing worth knowing for the next one of these: **five of them offered an
empty option** — "no default agent", "auto", "none" — and Radix refuses an
empty string on an item, because it reserves that for "nothing is selected".
Those absences now travel under a name inside the picker and are turned back
into `''` at the edge, which is what the API stores:

```tsx
value={model || AUTO_MODEL}
onValueChange={(v) => setModel(v === AUTO_MODEL ? '' : v)}
```

The provider picker is the exception — there, nothing-selected really is
nothing selected, so it uses a placeholder and needs no stand-in. `__custom__`
in the BYOK picker keeps its name: it is a real choice ("let me type a model"),
not an absence, and it was already on the wire.

Trigger heights are matched to the controls beside them rather than to the
component's defaults (the invite row is `h-9`, the member row `h-8`), and one
`text-[13px]` left over from styling the native select is gone.

## Checks

`next build` passes, tests pass, and no `<select>` remains in `app/` or
`components/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
