### PR TITLE
fix(core): find agent CLIs the user installed themselves

### DIFF
--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.178",
+  "version": "0.2.179",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -19,21 +19,27 @@ const SEP = IS_WINDOWS ? ';' : ':';
 const HOME = process.env.HOME || process.env.USERPROFILE || '';
 const PATH_LOOKUP_CACHE_TTL_MS = 30 * 1000;
 
+let knownBinDirsCache = { value: null, at: 0 };
 let extraBinDirsCache = { value: null, at: 0, path: '' };
 const whichBinaryCache = new Map();
 
 /**
- * Get all extra binary directories that should be checked beyond process.env.PATH.
- * Returns deduplicated list of existing directories.
+ * Every directory an agent CLI is known to land in, filtered to the ones that
+ * exist on this machine. Ranked: a copy the launcher installed outranks a copy
+ * the user installed, which outranks whatever the login shell happens to add.
+ *
+ * This is the whole curated set, INCLUDING dirs that are already on PATH —
+ * which is what separates it from getExtraBinDirs(). Anything resolving a
+ * binary off the filesystem wants this one: that lookup exists precisely for
+ * the cases where asking the shell failed, and a dir being on PATH is no
+ * evidence at all that `where`/`which` succeeded (see resolveBinaryInKnownDirs).
  */
-function getExtraBinDirs() {
-  const currentPATH = process.env.PATH || '';
+function getKnownBinDirs() {
   if (
-    extraBinDirsCache.value &&
-    extraBinDirsCache.path === currentPATH &&
-    Date.now() - extraBinDirsCache.at < PATH_LOOKUP_CACHE_TTL_MS
+    knownBinDirsCache.value &&
+    Date.now() - knownBinDirsCache.at < PATH_LOOKUP_CACHE_TTL_MS
   ) {
-    return [...extraBinDirsCache.value];
+    return [...knownBinDirsCache.value];
   }
 
   const dirs = [];
@@ -99,8 +105,6 @@ function getExtraBinDirs() {
   const seen = new Set();
   const value = dirs.filter(d => {
     if (!d || seen.has(d)) return false;
-    // Skip if already in PATH (case-insensitive on Windows)
-    if (IS_WINDOWS ? currentPATH.toLowerCase().includes(d.toLowerCase()) : currentPATH.includes(d)) return false;
     seen.add(d);
     try {
       return fs.statSync(d).isDirectory();
@@ -108,6 +112,32 @@ function getExtraBinDirs() {
       return false;
     }
   });
+  knownBinDirsCache = { value, at: Date.now() };
+  return [...value];
+}
+
+/**
+ * The known bin dirs that are NOT already on PATH — i.e. what has to be
+ * PREPENDED to build an environment in which every agent CLI resolves.
+ *
+ * Only ever use this to build a PATH. It is a strict subset of
+ * getKnownBinDirs(), and the dirs it drops (%APPDATA%\npm, /usr/local/bin, …)
+ * are the most common install locations there are, so using it as "the dirs to
+ * search" hides exactly the agents a user installed themselves.
+ */
+function getExtraBinDirs() {
+  const currentPATH = process.env.PATH || '';
+  if (
+    extraBinDirsCache.value &&
+    extraBinDirsCache.path === currentPATH &&
+    Date.now() - extraBinDirsCache.at < PATH_LOOKUP_CACHE_TTL_MS
+  ) {
+    return [...extraBinDirsCache.value];
+  }
+  const value = getKnownBinDirs().filter((d) =>
+    // Case-insensitive on Windows.
+    IS_WINDOWS ? !currentPATH.toLowerCase().includes(d.toLowerCase()) : !currentPATH.includes(d),
+  );
   extraBinDirsCache = { value, at: Date.now(), path: currentPATH };
   return [...value];
 }
@@ -176,7 +206,13 @@ function whichBinary(name) {
     const result = execSync(cmd, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, PATH: getEnhancedPATH() },
+      // getEnhancedEnv(), never `{...process.env, PATH}`: spreading process.env
+      // on Windows yields a "Path" key, so assigning PATH creates a SECOND path
+      // variable and which of the two the child reads is undefined. It also
+      // supplies ComSpec, without which execSync's shell cannot even start in an
+      // Electron process that has no cmd.exe on PATH — and a `where` that never
+      // ran looks exactly like a CLI that isn't installed.
+      env: getEnhancedEnv(),
       timeout: 5000,
       windowsHide: true,
     });
@@ -354,6 +390,35 @@ function _addAgentInstallerPaths(dirs) {
   _push(dirs, path.join(HOME, '.npm-global', 'bin'));
   _push(dirs, path.join(HOME, '.openagents', 'npm-global', 'bin'));
 
+  // codebuddy — the npm package drops the usual global shim, but CodeBuddy also
+  // ships a native build (the engine behind the WorkBuddy desktop app) that
+  // installs to its own directory. The codebuddy adapter has always searched
+  // these; the installer that decides whether it EXISTS had not.
+  _push(dirs, path.join(HOME, '.codebuddy', 'bin'));
+
+  // claude — `claude install` (the native, non-npm build) relocates the CLI to
+  // ~/.claude/local and reaches it through a shell alias, which a GUI process
+  // inherits no more than it inherits an rc-file PATH edit.
+  _push(dirs, path.join(HOME, '.claude', 'local'));
+
+  // hermes — the Unix installer's own bin dir. Its Windows counterparts are in
+  // _addWindowsPaths; this is the half nothing covered.
+  _push(dirs, path.join(HOME, '.hermes', 'bin'));
+
+  // pipx — `pipx install X` puts the executable in <PIPX_HOME>/venvs/X/bin and
+  // only SYMLINKS it into PIPX_BIN_DIR. When that link step is skipped, or its
+  // dir is one a GUI launch can't see, the venv copy is the only one there is.
+  // Enumerated rather than listed by name: aider, mini-swe-agent and openworker
+  // are all installable this way, and so is the next Python agent.
+  for (const root of _pipxHomes()) {
+    try {
+      const venvs = path.join(root, 'venvs');
+      for (const d of fs.readdirSync(venvs, { withFileTypes: true })) {
+        if (d.isDirectory()) _push(dirs, path.join(venvs, d.name, IS_WINDOWS ? 'Scripts' : 'bin'));
+      }
+    } catch {}
+  }
+
   // The plain ~/bin some installers fall back to when ~/.local/bin is absent.
   _push(dirs, path.join(HOME, 'bin'));
 
@@ -365,7 +430,30 @@ function _addAgentInstallerPaths(dirs) {
     // cursor-agent also ships under Programs\ on some Windows installs — the
     // cursor adapter checks both, the installer only knew one.
     _push(dirs, path.join(lad, 'Programs', 'cursor-agent'));
+    // codebuddy's native Windows install.
+    _push(dirs, path.join(lad, 'CodeBuddy', 'bin'));
+    // winget's shim dir — how GitHub Copilot CLI arrives on Windows for anyone
+    // who didn't take the npm route. The copilot adapter knew it; nothing else did.
+    _push(dirs, path.join(lad, 'Microsoft', 'WinGet', 'Links'));
   }
+}
+
+/**
+ * Roots pipx may keep its venvs under. PIPX_HOME wins when exported; otherwise
+ * pipx has moved its default once (~/.local/pipx → the platform user-data dir),
+ * so both layouts are still in the field.
+ */
+function _pipxHomes() {
+  if (process.env.PIPX_HOME) return [process.env.PIPX_HOME];
+  const roots = [path.join(HOME, '.local', 'pipx')];
+  if (IS_WINDOWS) {
+    if (process.env.LOCALAPPDATA) roots.push(path.join(process.env.LOCALAPPDATA, 'pipx', 'pipx'));
+  } else if (IS_MACOS) {
+    roots.push(path.join(HOME, 'Library', 'Application Support', 'pipx'));
+  } else {
+    roots.push(path.join(process.env.XDG_DATA_HOME || path.join(HOME, '.local', 'share'), 'pipx'));
+  }
+  return roots;
 }
 
 let npmPrefixCache;
@@ -767,6 +855,7 @@ function defaultAgentWorkdir(agentName) {
  * `whichBinary(name) === null` cached before install doesn't survive.
  */
 function clearBinaryLookupCache() {
+  knownBinDirsCache = { value: null, at: 0 };
   extraBinDirsCache = { value: null, at: 0, path: '' };
   whichBinaryCache.clear();
   // The login-shell / npm-prefix probes are deliberately NOT cleared: they each
@@ -785,7 +874,7 @@ function clearBinaryLookupCache() {
 function primeBinaryLookup() {
   try { loginShellDirs(); } catch {}
   try { _npmPrefix(); } catch {}
-  try { getExtraBinDirs(); } catch {}
+  try { getKnownBinDirs(); } catch {}
 }
 
 /**
@@ -845,9 +934,18 @@ const BIN_EXTS = IS_WINDOWS ? ['.cmd', '.exe', '.bat', ''] : [''];
  * find it" and then opened a terminal running a bare command that could only
  * fail with "'cursor-agent' is not recognized".
  *
- * Deliberately reuses getExtraBinDirs() rather than a second hardcoded list:
+ * Deliberately reuses getKnownBinDirs() rather than a second hardcoded list:
  * that list already IS the curated set, and a copy of it is exactly how the
  * launcher and the adapters drifted apart in the first place.
+ *
+ * It has to be the KNOWN dirs, not the extra ones. getExtraBinDirs() drops
+ * everything already on PATH, on the reasoning that PATH covers it — but the
+ * only way execution gets here is a `where`/`which` that ALREADY failed, and it
+ * fails wholesale on Windows (mangled OEM-codepage output on a non-English
+ * install, a 5s timeout, a cmd.exe that isn't resolvable from an Electron
+ * process). With the filter in place that failure erased every agent installed
+ * to a normal location — %APPDATA%\npm and friends — and the marketplace
+ * offered to install CodeBuddy/opencode/dsh over the copies already there.
  *
  * Runs only after a PATH lookup has already missed, so it can add resolutions
  * but never change one that already works.
@@ -868,7 +966,7 @@ function resolveBinaryInKnownDirs(names, agentType) {
   if (agentType) push(path.join(getRuntimePrefix(agentType), 'node_modules', '.bin'));
   push(path.join(HOME, '.openagents', 'nodejs', 'node_modules', '.bin'));
   try { push(path.dirname(process.execPath)); } catch {}
-  for (const d of getExtraBinDirs()) push(d);
+  for (const d of getKnownBinDirs()) push(d);
 
   for (const dir of dirs) {
     for (const name of list) {
@@ -887,6 +985,7 @@ function resolveBinaryInKnownDirs(names, agentType) {
 
 
 module.exports = {
+  getKnownBinDirs,
   getExtraBinDirs,
   getEnhancedPATH,
   getEnhancedEnv,

--- a/packages/agent-connector/test/agent-detection-matrix.test.js
+++ b/packages/agent-connector/test/agent-detection-matrix.test.js
@@ -65,35 +65,90 @@ const LOC = {
   uvCoworker: IS_WINDOWS
     ? 'AppData/Roaming/uv/tools/coworker/Scripts'
     : '.local/share/uv/tools/coworker/bin',
+  // The npm default prefix. On Windows that's %APPDATA%\npm — where `npm i -g`
+  // drops a shim for anyone who never relocated the prefix, i.e. most people.
+  // There is no in-HOME equivalent on Unix (the default is /usr/local), so
+  // cases using it are Windows-only.
+  npmDefault: IS_WINDOWS ? 'AppData/Roaming/npm' : null,
+  // CodeBuddy also ships a native build — the engine behind the WorkBuddy
+  // desktop app — which installs outside npm entirely.
+  codebuddyNative: IS_WINDOWS ? 'AppData/Local/CodeBuddy/bin' : '.codebuddy/bin',
+  // `claude install` (the native build) relocates the CLI here and reaches it
+  // through a shell alias a GUI process never sees.
+  claudeLocal: '.claude/local',
+  hermesHome: '.hermes/bin',
+  agyWin: IS_WINDOWS ? 'AppData/Local/agy/bin' : null,
+  // winget's shim dir — how the GitHub Copilot CLI arrives for a Windows user
+  // who didn't take the npm route.
+  winget: IS_WINDOWS ? 'AppData/Local/Microsoft/WinGet/Links' : null,
 }
 
+/** `pipx install <dist>` — the venv copy, which exists even when the shim doesn't. */
+const pipx = (dist) => `.local/pipx/venvs/${dist}/${IS_WINDOWS ? 'Scripts' : 'bin'}`
+
 /**
- * Where each agent's CLI actually lands, and how it got there. One case per
- * agent; the location is the one its own installer or the common package
- * manager for it would use, NOT a location invented to make the test pass.
+ * Where each agent's CLI actually lands, and how it got there.
+ *
+ * Every location listed is one its own installer or a common package manager
+ * for it really uses — never one invented to make the test pass. Agents get
+ * more than one case where they genuinely have more than one route onto a
+ * machine, because "installed" that only holds for the route WE would have
+ * taken is what makes the launcher offer to install a CLI that is already
+ * there. A null location is skipped (it doesn't exist on this platform).
  */
 const WHERE = {
-  aider: [LOC.localBin, 'uv tool / pipx'],
-  amp: [LOC.amp, 'ampcode.com/install.sh'],
-  antigravity: [LOC.localBin, 'antigravity.google/cli/install.sh'],
-  claude: [LOC.nvm20, 'npm -g under a non-default node version'],
-  cline: [LOC.pnpm, 'pnpm add -g'],
-  codebuddy: [LOC.nvm22, 'npm -g under a node version manager'],
-  codex: [LOC.npmPrefix, 'npm -g with a relocated prefix'],
-  commandcode: [LOC.bun, 'bun install -g'],
-  copilot: [LOC.localBin, 'npm -g with prefix=~/.local'],
-  cursor: [LOC.cursor, 'cursor.com/install'],
-  deepseek: [LOC.yarn, 'yarn global add'],
-  gemini: [LOC.nvm22, 'npm -g under a node version manager'],
-  goose: [LOC.localBin, 'block/goose release installer'],
-  hermes: [LOC.localBin, 'hermes-agent install.sh'],
-  kimi: [LOC.kimi, '@moonshot-ai/kimi-code postinstall (native build)'],
-  'mini-swe-agent': [LOC.localBin, 'pip install --user'],
-  nanoclaw: [LOC.localBin, 'external runtime'],
-  openclaw: [LOC.homeBin, 'installed into ~/bin'],
-  opencode: [LOC.opencode, 'opencode.ai/install'],
-  openworker: [LOC.uvCoworker, 'uv tool install git+github.com/andrewyng/openworker'],
-  pi: [LOC.nvm20, 'npm -g under a non-default node version'],
+  aider: [
+    [LOC.localBin, 'uv tool / pipx'],
+    [pipx('aider-chat'), 'pipx install aider-chat (venv copy, shim not linked)'],
+  ],
+  amp: [[LOC.amp, 'ampcode.com/install.sh']],
+  antigravity: [
+    [LOC.localBin, 'antigravity.google/cli/install.sh'],
+    [LOC.agyWin, 'antigravity.google/cli/install.ps1'],
+  ],
+  claude: [
+    [LOC.nvm20, 'npm -g under a non-default node version'],
+    [LOC.claudeLocal, '`claude install` (native build)'],
+  ],
+  cline: [[LOC.pnpm, 'pnpm add -g']],
+  codebuddy: [
+    [LOC.nvm22, 'npm -g under a node version manager'],
+    [LOC.npmDefault, 'npm i -g @tencent-ai/codebuddy-code'],
+    [LOC.codebuddyNative, 'CodeBuddy native install'],
+  ],
+  codex: [[LOC.npmPrefix, 'npm -g with a relocated prefix']],
+  commandcode: [[LOC.bun, 'bun install -g']],
+  copilot: [
+    [LOC.localBin, 'npm -g with prefix=~/.local'],
+    [LOC.winget, 'winget install GitHub.CopilotCLI'],
+  ],
+  cursor: [[LOC.cursor, 'cursor.com/install']],
+  deepseek: [
+    [LOC.yarn, 'yarn global add'],
+    [LOC.npmDefault, 'npm i -g @deepseek-ai/dsh'],
+  ],
+  gemini: [[LOC.nvm22, 'npm -g under a node version manager']],
+  goose: [[LOC.localBin, 'block/goose release installer']],
+  hermes: [
+    [LOC.localBin, 'hermes-agent install.sh'],
+    [LOC.hermesHome, 'hermes-agent install.sh (~/.hermes/bin layout)'],
+  ],
+  kimi: [[LOC.kimi, '@moonshot-ai/kimi-code postinstall (native build)']],
+  'mini-swe-agent': [
+    [LOC.localBin, 'pip install --user'],
+    [pipx('mini-swe-agent'), 'pipx install mini-swe-agent'],
+  ],
+  nanoclaw: [[LOC.localBin, 'external runtime']],
+  openclaw: [[LOC.homeBin, 'installed into ~/bin']],
+  opencode: [
+    [LOC.opencode, 'opencode.ai/install'],
+    [LOC.npmDefault, 'npm i -g opencode-ai'],
+  ],
+  openworker: [
+    [LOC.uvCoworker, 'uv tool install git+github.com/andrewyng/openworker'],
+    [pipx('coworker'), 'pipx install coworker'],
+  ],
+  pi: [[LOC.nvm20, 'npm -g under a non-default node version']],
 }
 
 /**
@@ -155,7 +210,7 @@ describe('Agent detection matrix', () => {
   it('covers every registry entry — no agent may be added without a case', () => {
     const missing = ENTRIES
       .map((e) => e.name)
-      .filter((n) => !WHERE[n] && !ENTRIES.find((e) => e.name === n)?.install?.api_only);
+      .filter((n) => !WHERE[n]?.length && !ENTRIES.find((e) => e.name === n)?.install?.api_only);
     assert.deepEqual(missing, [], `add a real install location for: ${missing.join(', ')}`);
   });
 
@@ -180,32 +235,33 @@ describe('Agent detection matrix', () => {
       continue;
     }
 
-    const [relDir, how] = WHERE[name] || [];
-    if (!relDir) continue;
+    for (const [relDir, how] of WHERE[name] || []) {
+      if (!relDir) continue; // not a location that exists on this platform
 
-    it(`${name}: detected in ~/${relDir} (${how})`, (t) => {
-      const home = fs.mkdtempSync(path.join(os.tmpdir(), `oa-${name}-`));
-      try {
-        // getExtraBinDirs() legitimately includes the dir holding the running
-        // node binary, so on a developer machine that has this CLI installed
-        // next to its own node the synthetic HOME cannot isolate it. Skip
-        // rather than fail: on a clean checkout / CI runner this is never hit,
-        // and pretending otherwise would mean weakening the real assertion.
-        if (installInfo(home, name).installed) {
-          t.skip(`${install.binary || name} is installed on this machine outside the test HOME`);
-          return;
+      it(`${name}: detected in ~/${relDir} (${how})`, (t) => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), `oa-${name}-`));
+        try {
+          // getKnownBinDirs() legitimately includes the dir holding the running
+          // node binary, so on a developer machine that has this CLI installed
+          // next to its own node the synthetic HOME cannot isolate it. Skip
+          // rather than fail: on a clean checkout / CI runner this is never hit,
+          // and pretending otherwise would mean weakening the real assertion.
+          if (installInfo(home, name).installed) {
+            t.skip(`${install.binary || name} is installed on this machine outside the test HOME`);
+            return;
+          }
+          plantBinary(home, relDir, install.binary || name);
+          const info = installInfo(home, name);
+          assert.equal(info.installed, true, `${install.binary || name} in ~/${relDir} must be detected`);
+          // Installed outside ~/.openagents means the launcher must not claim it
+          // can uninstall or update it.
+          assert.equal(info.managed, false);
+          assert.equal(info.location, 'global');
+        } finally {
+          fs.rmSync(home, { recursive: true, force: true });
         }
-        plantBinary(home, relDir, install.binary || name);
-        const info = installInfo(home, name);
-        assert.equal(info.installed, true, `${install.binary || name} in ~/${relDir} must be detected`);
-        // Installed outside ~/.openagents means the launcher must not claim it
-        // can uninstall or update it.
-        assert.equal(info.managed, false);
-        assert.equal(info.location, 'global');
-      } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-      }
-    });
+      });
+    }
   }
 });
 

--- a/packages/agent-connector/test/binary-discovery.test.js
+++ b/packages/agent-connector/test/binary-discovery.test.js
@@ -187,3 +187,92 @@ describe('Binary discovery for GUI-launched processes', () => {
     assert.ok(!dirs.includes(shellOwned));
   });
 });
+
+/**
+ * The filesystem fallback, and the dirs it is allowed to forget.
+ *
+ * getExtraBinDirs() answers "what must I PREPEND to PATH", so it drops every
+ * dir already on PATH. resolveBinaryInKnownDirs() answers "where might this CLI
+ * be", and it only ever runs after `where`/`which` has ALREADY failed — which on
+ * Windows happens wholesale (OEM-codepage output on a non-English install, a 5s
+ * timeout, no resolvable cmd.exe in an Electron process). Feeding it the
+ * PATH-filtered list made that failure erase every agent installed to a normal
+ * location, and the marketplace offered to install CodeBuddy / opencode / dsh
+ * over copies already on the machine.
+ */
+describe('Filesystem fallback vs the PATH filter', () => {
+  let box;
+
+  before(() => {
+    box = fs.mkdtempSync(path.join(os.tmpdir(), 'oa-fallback-'));
+  });
+
+  after(() => {
+    try { fs.rmSync(box, { recursive: true, force: true }); } catch {}
+  });
+
+  /** Evaluate an expression against paths.js in a child, with PATH under test. */
+  function inChild(expr, { home: h, pathValue }) {
+    const out = execFileSync(
+      process.execPath,
+      ['-e', `const p=require(${JSON.stringify(PATHS_MODULE)});process.stdout.write(JSON.stringify(${expr}))`],
+      {
+        encoding: 'utf-8',
+        timeout: 30000,
+        env: {
+          HOME: h,
+          USERPROFILE: h,
+          PATH: pathValue,
+          SystemRoot: process.env.SystemRoot,
+          ComSpec: process.env.ComSpec,
+          ...(IS_WINDOWS
+            ? {
+                APPDATA: path.join(h, 'AppData', 'Roaming'),
+                LOCALAPPDATA: path.join(h, 'AppData', 'Local'),
+              }
+            : {}),
+          OPENAGENTS_SKIP_SHELL_PATH: '1',
+        },
+      },
+    );
+    return JSON.parse(out);
+  }
+
+  /** A synthetic HOME with opencode installed where its own installer puts it. */
+  function homeWithOpencode() {
+    const h = fs.mkdtempSync(path.join(box, 'home-'));
+    const dir = path.join(h, '.opencode', 'bin');
+    fs.mkdirSync(dir, { recursive: true });
+    const bin = path.join(dir, IS_WINDOWS ? 'opencode.cmd' : 'opencode');
+    fs.writeFileSync(bin, IS_WINDOWS ? '@echo 1.0.0' : '#!/bin/sh\necho 1.0.0\n', 'utf-8');
+    if (!IS_WINDOWS) fs.chmodSync(bin, 0o755);
+    return { home: h, dir, bin };
+  }
+
+  it('finds a CLI whose directory is already on PATH', () => {
+    const { home: h, dir, bin } = homeWithOpencode();
+    // The dir IS on PATH — the state a user who ran the installer and restarted
+    // is in, and the one getExtraBinDirs() filters away.
+    const found = inChild("p.resolveBinaryInKnownDirs(['opencode'], 'opencode')", {
+      home: h,
+      pathValue: [dir, IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin'].join(IS_WINDOWS ? ';' : ':'),
+    });
+    assert.equal(found, bin, 'a resolvable CLI must not become invisible for being on PATH');
+  });
+
+  it('getKnownBinDirs keeps what getExtraBinDirs drops', () => {
+    const { home: h, dir } = homeWithOpencode();
+    const pathValue = [dir, IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin'].join(IS_WINDOWS ? ';' : ':');
+    assert.ok(inChild('p.getKnownBinDirs()', { home: h, pathValue }).includes(dir), 'known dirs');
+    assert.ok(!inChild('p.getExtraBinDirs()', { home: h, pathValue }).includes(dir), 'extra dirs');
+  });
+
+  it('getExtraBinDirs stays a subset of getKnownBinDirs', () => {
+    const { home: h } = homeWithOpencode();
+    const pathValue = IS_WINDOWS ? process.env.PATH : '/usr/bin:/bin';
+    const known = new Set(inChild('p.getKnownBinDirs()', { home: h, pathValue }));
+    for (const d of inChild('p.getExtraBinDirs()', { home: h, pathValue })) {
+      assert.ok(known.has(d), `${d} is offered for PATH but not searched`);
+    }
+  });
+});

--- a/packages/agent-connector/test/resolve-binary-known-dirs.test.js
+++ b/packages/agent-connector/test/resolve-binary-known-dirs.test.js
@@ -63,7 +63,11 @@ describe('resolveBinaryInKnownDirs', () => {
   test('handles empty and missing input without throwing', () => {
     assert.strictEqual(resolveBinaryInKnownDirs([], 'cursor'), null);
     assert.strictEqual(resolveBinaryInKnownDirs(null, 'cursor'), null);
-    assert.strictEqual(resolveBinaryInKnownDirs(['x'], undefined), null);
+    // A name nobody could have installed: the search now covers dirs that are
+    // also on PATH, so a one-letter placeholder like "x" matches /opt/X11/bin/x
+    // on a machine that has XQuartz — a real hit, and nothing to do with the
+    // "no agentType given" case this asserts.
+    assert.strictEqual(resolveBinaryInKnownDirs([`oa-absent-${process.pid}`], undefined), null);
   });
 });
 


### PR DESCRIPTION
## The report

> 本地安装了 codebuddy, opencode, DeepSeek harness. 但是 openagents 并没有检查到.

The marketplace offered to install a second copy of tools already on the machine, and Configure refused to sign in to them.

## Root cause

Detection asks the system where a command lives (`where`/`which`) and, when that answer is unusable, falls back to searching the directories agent CLIs are known to occupy.

The fallback (`resolveBinaryInKnownDirs`) was reading `getExtraBinDirs()`, which answers a *different* question — "what must I PREPEND to PATH" — and therefore drops every directory that is already on PATH.

But the only way the fallback runs at all is a `where`/`which` that **already failed**, and on Windows that fails wholesale: mangled OEM-codepage output on a non-English install, a 5s timeout, or an Electron process with no resolvable `cmd.exe`. The directories the filter removes are the most common install locations there are (`%APPDATA%\npm` and friends), so a single failed lookup erased every self-installed agent at once.

Agents the launcher itself installs live in `~/.openagents/runtimes` and resolve through their own earlier tier, which is why they kept working and hid the pattern.

## Changes

- **Split the two questions.** New `getKnownBinDirs()` is the full curated set; `getExtraBinDirs()` is that set minus what is already on PATH. `resolveBinaryInKnownDirs()` uses the former, PATH construction keeps the latter.
- **`whichBinary()` now runs the lookup with `getEnhancedEnv()`** instead of `{...process.env, PATH}`. Spreading `process.env` on Windows yields a `Path` key, so assigning `PATH` created a second path variable with undefined precedence, and nothing supplied `ComSpec` — a `where` that never ran looks exactly like a CLI that isn't installed. (`getEnhancedEnv`'s own comment documents this hazard; the call site predates it.)
- **Taught `paths.js` the install routes only the adapters knew**: CodeBuddy's native build (`~/.codebuddy/bin`, `%LOCALAPPDATA%\CodeBuddy\bin`), `claude install` (`~/.claude/local`), the Hermes installer's own `~/.hermes/bin`, winget's shim dir on Windows, and pipx venvs (enumerated — aider, mini-swe-agent and openworker are all installable that way).

## Tests

- New `Filesystem fallback vs the PATH filter` suite. The key case — a CLI whose directory *is* on PATH must still resolve — was verified red against the pre-fix code, so it genuinely pins the bug.
- `agent-detection-matrix` widened from one location per agent to every route its CLI really takes onto a machine; codebuddy / opencode / deepseek each gained the npm-default-prefix case that this report is about.
- Full core suite: 1531 passed, 0 failed.

## Release

`agent-connector` → **0.2.179**. No launcher code changes, so its version and changelog are untouched: the launcher's bootstrap downloads the newest core, so users pick this up as soon as the package publishes, and the next launcher release can raise the pinned dep (currently 0.2.177) along with whatever else it carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)