### PR TITLE
Ship GitHub Copilot CLI, plus agent rename and workspace-aware removal

### DIFF
--- a/docs/agents/github-copilot-cli.md
+++ b/docs/agents/github-copilot-cli.md
@@ -127,6 +127,36 @@ Copilot is marked `unverifiable` in the registry, so absence of a token yields
 run result** — auth/authorization failures are classified from live stderr (see
 [Common errors](#common-errors)).
 
+### The launcher's own sign-in probe
+
+The registry flag above is about the **core**, which has no per-platform creds
+path for Copilot. The **launcher** does have one, so a sign-in completed in the
+terminal flips the agent to Ready without the user confirming anything.
+
+It reads `~/.copilot/config.json`, which the CLI maintains itself and where a
+completed login records `loggedInUsers: [{ host, login }]` (plus a
+`lastLoggedInUser`). This is an **identity list, not a credential** — the token
+is in the OS credential store, never in this file, and the probe reads nothing
+out of it beyond whether the list is non-empty.
+
+Two properties of that file are worth knowing if you touch this:
+
+- **It is JSONC.** A two-line `//` header explains that user settings belong in
+  `settings.json`. A strict `JSON.parse` throws on it, which is exactly the bug
+  this probe was written against: the launcher reported "sign-in not confirmed"
+  to a user the terminal had just greeted by name. `credsVerdict` now retries
+  with a **string-aware** comment strip — necessary because the same file stores
+  `"host": "https://github.com"`, and a naive regex would cut that value at its
+  `//` and corrupt the parse it was meant to rescue.
+- **The field is an array.** `![]` is `false` in JavaScript, so an empty list
+  would have read as *signed in*. Empty containers now count as no value.
+
+There is deliberately **no host guard**. Entries carry a `host`, so a GHE
+(`GH_HOST` / `COPILOT_GH_HOST`) session for a different host is conceivable —
+but that behaviour is unverified, and a guard written on a guess would report
+signed-out for working setups. The milder failure is preferred: a wrong-host
+session reads as signed in, and the CLI's own run result corrects it.
+
 OpenAgents **never** reads, prints, or forwards your token: it does not run
 commands that echo a token, never logs env-var values, never reads the system
 keychain contents, and never sends any token to the workspace frontend.
@@ -294,18 +324,52 @@ storage remains governed by **your** Copilot setup.
   `--secret-env-vars=`, `--no-remote`), the **tool IDs** `shell`/`write`, the
   **token env vars**, and **error/stderr/exit-code behaviour** for
   unauth/invalid-token/stale-resume.
-- **NOT verified:** the **success-path JSONL event schema** (text/tool/file/done
-  event names on stdout). No Copilot subscription was available in CI, and
-  auth fails before any model output, so no successful-task JSONL could be
-  captured. The parser's success-event mapping (`EVENT_KIND_BY_TYPE`) is
-  therefore best-effort, intentionally narrow, and isolated to one table;
-  unknown events degrade to a redacted diagnostic and never crash a task or fake
-  a completion. **Confirm against a real authenticated run before relying on
-  rich tool/file event rendering.**
-- Whether a non-interactive run **emits a session id on stdout** is unverified;
-  resume-by-name and a one-session-per-task fallback cover this honestly.
+- **Success-path JSONL schema — now captured** from a live authenticated run
+  (CLI **v1.0.83**), and nothing the original guess predicted was right. Real
+  events are `namespace.verb` and carry their payload under **`data`**:
+
+  | Real event | Mapped to | Field |
+  |---|---|---|
+  | `assistant.message_delta` | `text_delta` | `data.deltaContent` |
+  | `assistant.reasoning_delta` | `reasoning` | `data.deltaContent` |
+  | `result` (**flat**, not under `data`) | `done` | `sessionId`, `exitCode`, `usage` |
+  | `session.usage_checkpoint`, `session.auto_mode_resolved`, `model.call_finished` | `usage` | — |
+
+  The guessed names (`text.delta`, `message.delta`, `content_block_delta`,
+  `assistant.message`, …) matched **nothing**, and the envelope was never
+  unwrapped — so every answer parsed as empty and the user was told **"No
+  response generated"** for turns the CLI had completed successfully
+  (`"outcome":"success"`, exit 0, one premium request billed).
+
+  `assistant.reasoning` is deliberately **not** mapped: it repeats the deltas as
+  one block afterwards, and mapping both narrates the thinking twice.
+
+  Full observed type list: `assistant.turn_start`, `assistant.reasoning_delta`,
+  `assistant.reasoning`, `assistant.message_start`, `assistant.message_delta`,
+  `assistant.turn_end`, `assistant.idle`, `model.call_start`,
+  `model.call_finished`, `session.auto_mode_resolved`,
+  `session.usage_checkpoint`, `session.tools_updated`, `session.skills_loaded`,
+  `session.mcp_servers_loaded`, `session.mcp_server_status_changed`,
+  `session.custom_agents_updated`, `user.message`, `result`.
+- **Still NOT captured: tool / file / shell / permission events.** The captured
+  turn was a plain greeting, so none appeared. The inferred names for those
+  remain in the table as a net and are marked as such — an unrecognized event is
+  logged and ignored, never rendered. Replace them from a real tool-using turn
+  rather than adding more guesses.
+- **Session id: resolved.** A non-interactive run *does* emit one — but only in
+  the terminal `result` frame, with no session event earlier in the stream. The
+  adapter captures it there, which is what makes `--resume` work at all.
 - No Python SDK adapter ships (the Python daemon was removed; the Node.js
   agent-connector is the runtime). The Python registry entry is catalog-only.
-- The launcher surfaces a token field rather than a dedicated "Login" button for
-  Copilot, because there is no verified non-interactive status command to drive
-  a hosted-login probe (auth errors only surface at run time, on stderr).
+- The launcher offers a "Login" button (it opens a terminal on the CLI, where
+  `/login` is run) with the token field kept as an optional alternative — see
+  `KEY_OPTIONAL_LOGIN_AGENTS` and `DUAL_LOGIN_AGENTS` in the launcher's
+  `auth-specs.ts`. It reads the sign-in back off disk, so a completed login
+  turns the agent Ready on its own; see the section below.
+- **Copilot Free** permits auto model selection only. Leaving the model empty is
+  the default on both surfaces and the adapter passes `--model` only when
+  `COPILOT_MODEL` is set, so Free accounts work unchanged — but naming a
+  concrete model is refused by the service. For that reason the registry's model
+  list carries no `auto` entry: the workspace form already renders its own
+  "Auto" option meaning *unset*, and a second `auto` that resolved to
+  `--model auto` was both redundant and the choice most likely to be picked.

--- a/packages/agent-connector/package-lock.json
+++ b/packages/agent-connector/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.177",
+  "version": "0.2.181",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openagents-org/agent-launcher",
-      "version": "0.2.177",
+      "version": "0.2.181",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",

--- a/packages/agent-connector/package.json
+++ b/packages/agent-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagents-org/agent-launcher",
-  "version": "0.2.180",
+  "version": "0.2.181",
   "description": "OpenAgents Launcher — install, configure, and run AI coding agents from your terminal",
   "main": "src/index.js",
   "bin": {

--- a/packages/agent-connector/src/adapters/copilot-stream-parser.js
+++ b/packages/agent-connector/src/adapters/copilot-stream-parser.js
@@ -168,17 +168,50 @@ function parseLine(line) {
  * When real samples are available, extend THIS table only.
  */
 const EVENT_KIND_BY_TYPE = {
-  // session lifecycle / identity (kind only mapped when an id is also present)
+  // ── CAPTURED from a real authenticated run (CLI v1.0.83) ────────────────
+  // Every name in this block was read off a live JSONL stream, not inferred.
+  // The payload of each sits under `data` (see the `data` unwrap in
+  // classifyEvent) — except `result`, which is flat.
+  //
+  // The full type list observed in one turn: assistant.turn_start,
+  // assistant.reasoning_delta, assistant.reasoning, assistant.message_start,
+  // assistant.message_delta, assistant.turn_end, assistant.idle,
+  // model.call_start, model.call_finished, session.auto_mode_resolved,
+  // session.usage_checkpoint, session.tools_updated, session.skills_loaded,
+  // session.mcp_servers_loaded, session.mcp_server_status_changed,
+  // session.custom_agents_updated, user.message, result.
+  //
+  // The ones with no entry here are deliberate: they carry no content the
+  // workspace shows (lifecycle bookkeeping, or `user.message`, which is our
+  // own prompt echoed back). They degrade to `unknown`, which is logged and
+  // ignored — mapping them would put noise in the chat.
+  'assistant.message_delta': 'text_delta',   // data.deltaContent — THE answer
+  'assistant.reasoning': 'reasoning',        // data.content — ONE whole block
+  result: 'done',                            // flat: sessionId, exitCode, usage
+  // NOT mapped on purpose: `assistant.reasoning_delta`. Copilot streams at
+  // TOKEN granularity — 81 deltas for one short thought in the captured turn —
+  // and every adapter here narrates progress in whole blocks (claude sends
+  // `block.text`, codex `item.text`). Mapping the deltas posted one chat
+  // message per token: a column of "How" / "can" / "I" / "help" / "?" in the
+  // workspace. `assistant.reasoning` carries the same content as a single
+  // block afterwards, so that is what gets narrated.
+  'session.usage_checkpoint': 'usage',
+  'session.auto_mode_resolved': 'usage',     // data.chosenModel under Auto
+  'model.call_finished': 'usage',
+
+  // ── INFERRED — no live sample yet ───────────────────────────────────────
+  // The captured turn was a plain greeting, so no tool/file/shell/permission
+  // event appeared in it. The names below predate that capture and are kept
+  // as a net: they cost nothing (the real names above are matched first) and
+  // an unrecognized event is logged, never rendered. Replace them the moment
+  // a tool-using turn is captured — do not add more guesses.
   session: 'session', 'session.created': 'session', 'session.started': 'session',
   session_started: 'session', thread: 'session', 'thread.started': 'session',
-  // streaming assistant text (qualified names only — no bare 'delta'/'token')
   'text.delta': 'text_delta', text_delta: 'text_delta',
   'message.delta': 'text_delta', 'assistant.delta': 'text_delta',
   content_block_delta: 'text_delta',
-  // final assistant text (qualified/explicit names only — no bare 'message')
   text: 'text', 'message.completed': 'text', 'assistant.message': 'text',
   assistant: 'text', completion: 'text', agent_message: 'text',
-  // reasoning / status narration
   reasoning: 'reasoning', thinking: 'reasoning', thought: 'reasoning',
   status: 'reasoning', progress: 'reasoning',
   // tool calls
@@ -250,7 +283,14 @@ function classifyEvent(obj) {
     const itemKind = itemType ? EVENT_KIND_BY_TYPE[itemType.toLowerCase()] : undefined;
     if (itemKind) kind = itemKind;
   }
-  const src = item || obj;
+  // Copilot puts every event's payload under `data`, with the envelope
+  // (type/id/timestamp/parentId) on the outside — so reading fields off the
+  // top level found nothing and the answer came back empty. `result` is the
+  // one exception: it is flat, and falls through to `obj` here.
+  const data = (obj.data && typeof obj.data === 'object' && !Array.isArray(obj.data))
+    ? obj.data
+    : null;
+  const src = item || data || obj;
 
   switch (kind) {
     case 'session': {
@@ -261,7 +301,9 @@ function classifyEvent(obj) {
       return { kind: 'session', sessionId };
     }
     case 'text_delta': {
-      const text = _coerceText(src.delta) ?? _coerceText(src.text) ?? _coerceText(src.content) ?? _coerceText(src);
+      // `deltaContent` is Copilot's own field name, verified on v1.0.83.
+      const text = _coerceText(src.deltaContent) ?? _coerceText(src.delta)
+        ?? _coerceText(src.text) ?? _coerceText(src.content) ?? _coerceText(src);
       return { kind: 'text_delta', text: text || '' };
     }
     case 'text': {
@@ -269,7 +311,8 @@ function classifyEvent(obj) {
       return { kind: 'text', text: text || '' };
     }
     case 'reasoning': {
-      const text = _coerceText(src.text) ?? _coerceText(src.reasoning) ?? _coerceText(src.message)
+      const text = _coerceText(src.deltaContent) ?? _coerceText(src.text)
+        ?? _coerceText(src.reasoning) ?? _coerceText(src.message)
         ?? _coerceText(src.content) ?? _firstString(src, ['status', 'label', 'title']) ?? '';
       return { kind: 'reasoning', text };
     }
@@ -313,7 +356,14 @@ function classifyEvent(obj) {
     }
     case 'done': {
       const status = _firstString(src, ['status', 'reason', 'result']) || 'completed';
-      return { kind: 'done', status };
+      // The `result` frame is also where the real session id finally shows up
+      // — there is no session event earlier in the stream. Carrying it here is
+      // what lets the next turn resume instead of starting over. Read from the
+      // top level too: `result` is flat, so `src` is already `obj`, but an
+      // `item`-wrapped variant would not be.
+      const sessionId = _firstString(src, ['sessionId', 'session_id'])
+        ?? _firstString(obj, ['sessionId', 'session_id']);
+      return sessionId ? { kind: 'done', status, sessionId } : { kind: 'done', status };
     }
     case 'error': {
       const err = (src.error && typeof src.error === 'object') ? src.error : src;

--- a/packages/agent-connector/src/adapters/copilot.js
+++ b/packages/agent-connector/src/adapters/copilot.js
@@ -606,10 +606,14 @@ class CopilotAdapter extends BaseAdapter {
             }
             break;
           case 'text_delta':
-            // Streamed interim text is shown live as `thinking`; the final
-            // `text` event (if any) is the authoritative answer.
+            // Accumulate only — never narrate. These deltas ARE the final
+            // answer being streamed a token at a time (Copilot's
+            // `assistant.message_delta`), and the answer is posted in full
+            // when the turn ends. Sending each one as `thinking` published the
+            // reply twice: once as a column of one-word messages, then again
+            // whole.
             if (sawToolSinceText) { finalParts.length = 0; deltaBuf = ''; sawToolSinceText = false; }
-            if (ev.text) { deltaBuf += ev.text; try { await this.sendThinking(channel, ev.text); } catch {} }
+            if (ev.text) deltaBuf += ev.text;
             break;
           case 'text':
             // A complete message supersedes the deltas streamed for this block.
@@ -655,6 +659,13 @@ class CopilotAdapter extends BaseAdapter {
             errorEvent = errorEvent || { message: ev.message, code: ev.code };
             break;
           case 'done':
+            // Copilot reports its session id only in the terminal `result`
+            // frame — no session event precedes it — so this is the one place
+            // a resumable id can be captured.
+            if (ev.sessionId && this._channelSessions[channel] !== ev.sessionId) {
+              this._channelSessions[channel] = ev.sessionId;
+              this._saveSessions();
+            }
             break;
           case 'unknown':
             // Preserve a redacted diagnostic; never crash the task.

--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -43,6 +43,7 @@ class Daemon {
     this._statusInterval = null;
     this._cmdInterval = null;
     this._nodeHeartbeatInterval = null;  // device-level heartbeat (connect-a-node)
+    this._displayNameInterval = null;    // pulls workspace-side renames back
     this._nodeClients = new Map();       // workspace_id -> WorkspaceClient, one per pairing
     this._runningCommands = new Set();   // node-command ids currently executing
     this._runtimes = [];                 // detected agent runtimes for the node view
@@ -222,6 +223,50 @@ class Daemon {
       if (!id || this._runningCommands.has(id)) continue;
       this._runningCommands.add(id);
       this._runNodeCommand(n, cmd).finally(() => this._runningCommands.delete(id));
+    }
+  }
+
+  /**
+   * Reflect workspace-side renames back onto this device.
+   *
+   * The workspace is treated as authoritative for the label, which needs no
+   * timestamps to be correct: a rename started on the device writes to the
+   * workspace FIRST and only then to local config (see
+   * AgentConnector.setAgentDisplayName), so by the time this reads, the
+   * workspace already holds whatever the device just set. Anything different
+   * from local therefore came from the workspace and should win.
+   *
+   * Never throws — a workspace that is unreachable simply leaves the labels
+   * as they are until the next pass.
+   */
+  async _syncDisplayNames() {
+    let pairings = [];
+    try {
+      pairings = require('./node-config').listPairings();
+    } catch { return; }
+
+    for (const n of pairings) {
+      if (!n.workspace_id || !n.token) continue;
+      let members = [];
+      try {
+        members = await this._nodeClientFor(n).getAgents(n.workspace_id, n.token);
+      } catch { continue; }
+
+      const byName = new Map(members.map((m) => [m.agentName, m]));
+      for (const a of this.config.getAgents()) {
+        // Scoped to this pairing's workspace, like _buildRoster: an agent in
+        // another workspace must never be relabelled from this one.
+        if (!this._agentOnNodeWorkspace(a, n)) continue;
+        const remote = byName.get(a.name);
+        if (!remote) continue;
+        const local = a.display_name || null;
+        const wanted = remote.displayName || null;
+        if (local === wanted) continue;
+        try {
+          this.config.updateAgent(a.name, { display_name: wanted || undefined });
+          this._log(`display name for ${a.name} updated from workspace`);
+        } catch {}
+      }
     }
   }
 
@@ -608,6 +653,15 @@ async _runNodeCommand(n, cmd) {
       15000,
     );
 
+    // Pull display-name renames made in the workspace back onto the device, so
+    // the two sides agree whichever one the user typed into. Separate from the
+    // 10s heartbeat on purpose: a label changes rarely and this is an extra
+    // request per paired workspace, so it runs a sixth as often.
+    this._displayNameInterval = setInterval(
+      () => this._syncDisplayNames(),
+      60000,
+    );
+
     // Detect installed/logged-in agent runtimes for the Add-agent gallery. Runs
     // in a child process (off the event loop), refreshed periodically.
     this._refreshRuntimes();
@@ -658,6 +712,7 @@ async _runNodeCommand(n, cmd) {
     if (this._nodeHeartbeatInterval) clearInterval(this._nodeHeartbeatInterval);
     if (this._credReconcileInterval) clearInterval(this._credReconcileInterval);
     if (this._runtimesInterval) clearInterval(this._runtimesInterval);
+    if (this._displayNameInterval) clearInterval(this._displayNameInterval);
     if (this._probeStartupTimer) clearTimeout(this._probeStartupTimer);
     if (this._probeInterval) clearInterval(this._probeInterval);
     if (this._configWatcher) { try { this._configWatcher.close(); } catch {} }

--- a/packages/agent-connector/src/index.js
+++ b/packages/agent-connector/src/index.js
@@ -84,6 +84,10 @@ class AgentConnector {
       const network = networks.find((n) => n.slug === a.network || n.id === a.network);
       return {
         name: a.name,
+        // The label to show. `name` stays the identity — callers that key on
+        // it (sessions, working dirs, workspace membership) must keep using
+        // `name`, never this.
+        displayName: a.display_name || null,
         type,
         role: a.role || 'worker',
         network: a.network || null,
@@ -97,6 +101,95 @@ class AgentConnector {
 
   addAgent({ name, type, role, path, env }) {
     this.config.addAgent({ name, type: type || 'openclaw', role: role || 'worker', path, env });
+    return { success: true };
+  }
+
+  /**
+   * The workspace an agent is bound to, as a ready-to-use client — or null
+   * when it is local-only or its network is no longer configured.
+   *
+   * Each network carries its own endpoint (a self-hosted workspace is not the
+   * official one), so the client is built per call rather than reusing
+   * `this.workspace`, the same way removeWorkspace does.
+   */
+  _workspaceClientFor(agentName) {
+    const agent = this.config.getAgent(agentName);
+    if (!agent || !agent.network) return null;
+    const network = this.config
+      .getNetworks()
+      .find((n) => n.slug === agent.network || n.id === agent.network);
+    if (!network || !network.id) return null;
+    const endpoint = network.endpoint || (this.workspace && this.workspace.endpoint);
+    const { WorkspaceClient } = require('./workspace-client');
+    return { client: new WorkspaceClient(endpoint), network };
+  }
+
+  /**
+   * Set (or clear, with an empty value) an agent's display label.
+   *
+   * The agent's `name` is its identity — it keys daemon.yaml, the working
+   * directory under ~/.openagents/agents, its sessions and its workspace
+   * membership — so renaming NEVER touches it. What changes is the label the
+   * launcher and the workspace show, which is precisely what the workspace
+   * already models as `display_name` next to `agent_name`.
+   *
+   * When the agent is in a workspace the new label is pushed there too, so the
+   * two sides agree. A workspace that rejects it (a name another member
+   * already answers to) fails the whole call rather than leaving the label
+   * changed on one side only.
+   */
+  async setAgentDisplayName(name, displayName) {
+    const agent = this.config.getAgent(name);
+    if (!agent) throw new Error(`Agent '${name}' not found`);
+    const label = (displayName || '').trim();
+
+    const bound = this._workspaceClientFor(name);
+    if (bound) {
+      await bound.client.setMemberDisplayName(
+        bound.network.id,
+        bound.network.token || '',
+        name,
+        label,
+      );
+    }
+    // Local write comes second: if the workspace refused the label, nothing
+    // here has changed and the two sides are still in agreement.
+    this.config.updateAgent(name, { display_name: label || undefined });
+    return { success: true, displayName: label || null };
+  }
+
+  /**
+   * Drop an agent's member row from the workspace it joined.
+   *
+   * Deliberately SEPARATE from removeAgent rather than a flag on it. Removing
+   * an agent is a synchronous local edit that `agn remove` and the TUI call
+   * without awaiting, inside a try/catch — making it async would turn a thrown
+   * error into an unhandled rejection those callers can no longer see. So the
+   * network half lives here, and a caller that wants both awaits this first:
+   * failing to reach the workspace then leaves the agent intact locally, which
+   * is the recoverable order.
+   *
+   * A local-only agent is a no-op success — there is nothing over there.
+   */
+  async removeAgentFromWorkspace(name) {
+    const bound = this._workspaceClientFor(name);
+    if (!bound) return { success: true, skipped: true };
+    try {
+      await bound.client.removeMember(
+        bound.network.id,
+        bound.network.token || '',
+        name,
+      );
+    } catch (e) {
+      // 404 is the goal state, reached by someone else: the member row is
+      // already gone, or the whole workspace is. Treating it as a failure
+      // would strand the agent on this device — removal happens local-last, so
+      // an error here means it cannot be removed at all. Anything else (a
+      // network blip, an auth failure) is real and must stop the removal so
+      // the user can retry rather than lose track of a live membership.
+      if (!e || e.status !== 404) throw e;
+      return { success: true, alreadyGone: true };
+    }
     return { success: true };
   }
 

--- a/packages/agent-connector/src/index.js
+++ b/packages/agent-connector/src/index.js
@@ -286,9 +286,36 @@ class AgentConnector {
     return { success: true };
   }
 
+  /**
+   * Local half of leaving a workspace: forget the binding, keep the agent.
+   *
+   * Synchronous, and deliberately still local-only — `agn disconnect` and the
+   * TUI call it without awaiting, inside a try/catch, so an async version
+   * would turn a throw into an unhandled rejection they can no longer see.
+   * Callers that want the membership dropped too use leaveWorkspace below.
+   */
   disconnectWorkspace(agentName) {
     this.config.setAgentNetwork(agentName, null);
     return { success: true };
+  }
+
+  /**
+   * Leave a workspace properly: drop the member row over there, and unbind
+   * here — the agent itself stays, with its config, credentials and working
+   * directory, ready to join another workspace.
+   *
+   * Leaving only the local half is the bug this replaces. The device stopped
+   * showing the agent as connected while the workspace went on listing it as a
+   * member, and nothing in the launcher could reach that row any more. The
+   * workspace-level "remove a workspace" action learned this same lesson
+   * already (see removeWorkspace) — this is the agent-level equivalent.
+   *
+   * Workspace first, local second: a failure there leaves the agent bound and
+   * retryable rather than orphaning a membership.
+   */
+  async leaveWorkspace(agentName) {
+    await this.removeAgentFromWorkspace(agentName);
+    return this.disconnectWorkspace(agentName);
   }
 
   async removeWorkspace(slug) {

--- a/packages/agent-connector/src/workspace-client.js
+++ b/packages/agent-connector/src/workspace-client.js
@@ -85,6 +85,40 @@ class WorkspaceClient {
   }
 
   /**
+   * Remove one agent from a workspace via
+   * DELETE /v1/workspaces/{workspaceId}/members/{agentName}.
+   *
+   * Unlike deleteWorkspace above this is NOT best-effort: the caller offered
+   * the user a choice ("also remove it from the workspace"), so a failure has
+   * to be reported rather than swallowed — silently leaving the member behind
+   * is the exact problem this exists to fix.
+   */
+  async removeMember(workspaceId, token, agentName) {
+    await this._delete(
+      `/v1/workspaces/${workspaceId}/members/${encodeURIComponent(agentName)}`,
+      this._wsHeaders(token),
+    );
+  }
+
+  /**
+   * Rename one agent's DISPLAY name in a workspace, via
+   * PATCH /v1/workspaces/{workspaceId}/members/{agentName}.
+   *
+   * The agent's identity (`agent_name`) is untouched — this is the label the
+   * workspace shows and accepts as an @-mention alias, which is why the server
+   * rejects one that clashes with another member. An empty string clears the
+   * label there, falling back to `agent_name`, which is exactly what clearing
+   * the display name on this side means too.
+   */
+  async setMemberDisplayName(workspaceId, token, agentName, displayName) {
+    return this._patch(
+      `/v1/workspaces/${workspaceId}/members/${encodeURIComponent(agentName)}`,
+      { display_name: displayName || '' },
+      this._wsHeaders(token),
+    );
+  }
+
+  /**
    * Join a workspace via POST /v1/join.
    */
   async joinNetwork(agentName, token, { network, agentType, serverHost, workingDir } = {}) {
@@ -514,6 +548,10 @@ class WorkspaceClient {
     const agents = (result && result.agents) || [];
     return agents.map((a) => ({
       agentName: (a.address || '').replace('openagents:', ''),
+      // The workspace's label for this agent, or null when it has none and
+      // falls back to agentName. Carried so a rename made in the workspace can
+      // be reflected back on the device.
+      displayName: a.display_name || null,
       role: a.role || 'member',
       status: a.status || 'offline',
       enabledSkills: a.enabled_skills || null,

--- a/packages/agent-connector/test/copilot-stream-parser.test.js
+++ b/packages/agent-connector/test/copilot-stream-parser.test.js
@@ -252,3 +252,81 @@ describe('copilot end-to-end stream (no duplicate final text)', () => {
     assert.equal(kinds.filter((k) => k === 'text').length, 1);
   });
 });
+
+describe('copilot real stream (captured from CLI v1.0.83)', () => {
+  /**
+   * Verbatim lines from a live authenticated turn, de-identified only in the
+   * uuids. This is the schema the guessed table missed completely: every real
+   * type is `namespace.verb`, and every payload sits under `data` — so the
+   * answer parsed as nothing and the user got "No response generated" for a
+   * turn the CLI had in fact completed (`outcome":"success"`, exit 0).
+   */
+  const REAL = [
+    '{"type":"assistant.turn_start","data":{"turnId":"0"},"id":"a1"}\n',
+    '{"type":"model.call_start","data":{"turnId":"0","model":"gpt-5.6-luna"},"ephemeral":true,"id":"a2"}\n',
+    '{"type":"assistant.reasoning_delta","data":{"reasoningId":"r1","deltaContent":"Th"},"ephemeral":true,"id":"a3a"}\n',
+    '{"type":"assistant.reasoning_delta","data":{"reasoningId":"r1","deltaContent":"ink"},"ephemeral":true,"id":"a3b"}\n',
+    '{"type":"assistant.reasoning_delta","data":{"reasoningId":"r1","deltaContent":"ing"},"ephemeral":true,"id":"a3c"}\n',
+    '{"type":"assistant.message_start","data":{"messageId":"m1","phase":"final_answer"},"ephemeral":true,"id":"a4"}\n',
+    '{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"Hello"},"ephemeral":true,"id":"a5"}\n',
+    '{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"!"},"ephemeral":true,"id":"a6"}\n',
+    '{"type":"model.call_finished","data":{"turnId":"0","outcome":"success"},"ephemeral":true,"id":"a7"}\n',
+    '{"type":"assistant.reasoning","data":{"reasoningId":"r1","content":"Thinking, whole block"},"id":"a8"}\n',
+    '{"type":"assistant.turn_end","data":{"turnId":"0"},"id":"a9"}\n',
+    '{"type":"result","timestamp":"2026-09-10T15:09:52.383Z","sessionId":"00f9c63e-2446-420d-8986-cf0bdca8d9bd","exitCode":0,"usage":{"premiumRequests":1}}',
+  ];
+
+  it('reads the answer out of assistant.message_delta', () => {
+    const text = run(REAL)
+      .filter((e) => e.kind === 'text_delta')
+      .map((e) => e.text)
+      .join('');
+    assert.equal(text, 'Hello!');
+  });
+
+  it('unwraps `data` rather than reading the envelope', () => {
+    // The whole bug in one assertion: without the unwrap the delta events
+    // classify but carry an empty string, which reaches the user as
+    // "No response generated" instead of the answer.
+    const deltas = run(REAL).filter((e) => e.kind === 'text_delta');
+    assert.equal(deltas.length, 2);
+    assert.ok(deltas.every((d) => d.text.length > 0));
+  });
+
+  it('takes the session id off the terminal result frame', () => {
+    // There is no session event anywhere earlier in a real stream; without
+    // this the next turn can never resume.
+    const done = run(REAL).filter((e) => e.kind === 'done');
+    assert.equal(done.length, 1);
+    assert.equal(done[0].sessionId, '00f9c63e-2446-420d-8986-cf0bdca8d9bd');
+  });
+
+  it('narrates thinking as ONE block, not one message per token', () => {
+    // The regression this guards: Copilot streams reasoning a token at a time
+    // (81 deltas for one short thought on the real run). Mapping the deltas
+    // posted a chat message each — a column of one-word bullets — so only the
+    // whole `assistant.reasoning` block is narrated.
+    const reasoning = run(REAL).filter((e) => e.kind === 'reasoning');
+    assert.equal(reasoning.length, 1);
+    assert.equal(reasoning[0].text, 'Thinking, whole block');
+  });
+
+  it('never turns an answer token into its own event', () => {
+    // Same shape of bug on the answer side: message_delta IS the final answer
+    // arriving piecewise, so it must accumulate silently and never be narrated.
+    const evs = run(REAL);
+    const deltas = evs.filter((e) => e.kind === 'text_delta');
+    assert.equal(deltas.length, 2);
+    // No 'text' event — nothing re-publishes the answer mid-stream.
+    assert.equal(evs.filter((e) => e.kind === 'text').length, 0);
+  });
+
+  it('leaves lifecycle bookkeeping unrendered', () => {
+    // turn_start / message_start / turn_end / call_start carry nothing a user
+    // should see. They must not become text, reasoning, or a premature done.
+    const kinds = run(REAL).map((e) => e.kind);
+    assert.equal(kinds.filter((k) => k === 'done').length, 1);
+    assert.equal(kinds.filter((k) => k === 'text').length, 0);
+    assert.ok(kinds.includes('unknown'));
+  });
+});

--- a/packages/agent-connector/test/index.test.js
+++ b/packages/agent-connector/test/index.test.js
@@ -168,6 +168,55 @@ describe('AgentConnector workspace removal', () => {
     assert.equal(connector.config.getAgent('a1').name, 'a1');
   });
 
+  it('leaveWorkspace drops the member row but keeps the agent', async () => {
+    // The bug this replaces: unbinding locally while the workspace kept
+    // listing the agent, with nothing in the launcher able to reach that row.
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    connector.config.setAgentNetwork('a1', 'ws-slug');
+    const removed = [];
+    connector._workspaceClientFor = () => ({
+      client: { removeMember: async (ws, tok, n) => removed.push(n) },
+      network: { id: 'ws-1', token: 't' },
+    });
+
+    await connector.leaveWorkspace('a1');
+    assert.deepEqual(removed, ['a1']);
+    const agent = connector.config.getAgent('a1');
+    assert.equal(agent.name, 'a1');          // still here, with its config
+    assert.ok(!agent.network);               // and no longer bound
+  });
+
+  it('leaveWorkspace keeps the binding when the workspace call fails', async () => {
+    // Unbinding anyway would orphan the membership — the exact outcome this
+    // whole change exists to prevent.
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    connector.config.setAgentNetwork('a1', 'ws-slug');
+    connector._workspaceClientFor = () => ({
+      client: {
+        removeMember: async () => {
+          const e = new Error('Bad gateway');
+          e.status = 502;
+          throw e;
+        },
+      },
+      network: { id: 'ws-1', token: 't' },
+    });
+
+    await assert.rejects(() => connector.leaveWorkspace('a1'));
+    assert.equal(connector.config.getAgent('a1').network, 'ws-slug');
+  });
+
+  it('keeps disconnectWorkspace synchronous for agn/TUI callers', () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    connector.config.setAgentNetwork('a1', 'ws-slug');
+    const result = connector.disconnectWorkspace('a1');
+    assert.equal(typeof result.then, 'undefined');
+    assert.ok(!connector.config.getAgent('a1').network);
+  });
+
   it('keeps removeAgent synchronous so its callers keep working', () => {
     // `agn remove` and the TUI call this without awaiting, inside a try/catch.
     // Making it async would turn a throw into an unhandled rejection they can

--- a/packages/agent-connector/test/index.test.js
+++ b/packages/agent-connector/test/index.test.js
@@ -44,3 +44,138 @@ describe('AgentConnector instance env', () => {
     assert.deepEqual(connector.getAgentInstanceEnv('agent-b'), { LLM_MODEL: 'model-b' });
   });
 });
+
+describe('AgentConnector display names', () => {
+  /** Stand in for the workspace half so no network is involved. */
+  function stubWorkspace(connector, impl) {
+    connector._workspaceClientFor = () => ({
+      client: impl,
+      network: { id: 'ws-1', token: 't' },
+    });
+  }
+
+  it('keeps `name` as the identity and stores the label beside it', () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'copilot-jade-robin', type: 'copilot' });
+    connector._workspaceClientFor = () => null; // local-only agent
+
+    return connector.setAgentDisplayName('copilot-jade-robin', 'My Copilot')
+      .then(() => {
+        const [agent] = connector.config.getAgents();
+        // The identity is what keys the working dir, sessions and membership.
+        assert.equal(agent.name, 'copilot-jade-robin');
+        assert.equal(agent.display_name, 'My Copilot');
+        assert.equal(connector.listAgents()[0].displayName, 'My Copilot');
+      });
+  });
+
+  it('pushes the label to the workspace before writing it locally', async () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    const calls = [];
+    stubWorkspace(connector, {
+      setMemberDisplayName: async (ws, token, name, label) => {
+        calls.push({ ws, name, label });
+      },
+    });
+
+    await connector.setAgentDisplayName('a1', 'Renamed');
+    assert.deepEqual(calls, [{ ws: 'ws-1', name: 'a1', label: 'Renamed' }]);
+    assert.equal(connector.config.getAgent('a1').display_name, 'Renamed');
+  });
+
+  it('leaves both sides unchanged when the workspace rejects the label', async () => {
+    // The workspace refuses a label another member already answers to (it
+    // doubles as an @-mention alias). Writing locally anyway would leave the
+    // two sides permanently disagreeing about what this agent is called.
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    stubWorkspace(connector, {
+      setMemberDisplayName: async () => {
+        throw new Error('Display name conflicts with another member');
+      },
+    });
+
+    await assert.rejects(() => connector.setAgentDisplayName('a1', 'Taken'));
+    assert.equal(connector.config.getAgent('a1').display_name, undefined);
+  });
+
+  it('clears the label back to nothing on an empty value', async () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    connector._workspaceClientFor = () => null;
+
+    await connector.setAgentDisplayName('a1', 'Something');
+    await connector.setAgentDisplayName('a1', '   ');
+    // Cleared, not deleted: the key round-trips through YAML as null rather
+    // than disappearing. What matters is that nothing downstream reads it as a
+    // label — listAgents reports null and the UI falls back to `name`.
+    assert.ok(!connector.config.getAgent('a1').display_name);
+    assert.equal(connector.listAgents()[0].displayName, null);
+  });
+});
+
+describe('AgentConnector workspace removal', () => {
+  it('drops the member row, and is a no-op for a local-only agent', async () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'local-only', type: 'copilot' });
+    connector._workspaceClientFor = () => null;
+
+    const res = await connector.removeAgentFromWorkspace('local-only');
+    assert.equal(res.skipped, true);
+    // Nothing over there to remove, and the agent is untouched here.
+    assert.equal(connector.config.getAgent('local-only').name, 'local-only');
+  });
+
+  it('treats a 404 as done — the member row is already gone', async () => {
+    // Removal is local-LAST, so a failure here means the agent cannot be
+    // removed at all. A workspace that has since been deleted, or a member
+    // someone already removed over there, would otherwise strand it here
+    // forever with no way to clean it up.
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    connector._workspaceClientFor = () => ({
+      client: {
+        removeMember: async () => {
+          const e = new Error('Member not found');
+          e.status = 404;
+          throw e;
+        },
+      },
+      network: { id: 'ws-1', token: 't' },
+    });
+
+    const res = await connector.removeAgentFromWorkspace('a1');
+    assert.equal(res.alreadyGone, true);
+  });
+
+  it('still refuses on a transient failure, so nothing is lost silently', async () => {
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    connector._workspaceClientFor = () => ({
+      client: {
+        removeMember: async () => {
+          const e = new Error('Bad gateway');
+          e.status = 502;
+          throw e;
+        },
+      },
+      network: { id: 'ws-1', token: 't' },
+    });
+
+    await assert.rejects(() => connector.removeAgentFromWorkspace('a1'));
+    // The agent is untouched here, so the user can retry.
+    assert.equal(connector.config.getAgent('a1').name, 'a1');
+  });
+
+  it('keeps removeAgent synchronous so its callers keep working', () => {
+    // `agn remove` and the TUI call this without awaiting, inside a try/catch.
+    // Making it async would turn a throw into an unhandled rejection they can
+    // no longer see, so the network half lives in removeAgentFromWorkspace.
+    const connector = new AgentConnector({ configDir: tmpDir });
+    connector.addAgent({ name: 'a1', type: 'copilot' });
+    const result = connector.removeAgent('a1');
+    assert.equal(typeof result.then, 'undefined');
+    assert.equal(connector.config.getAgents().length, 0);
+  });
+});

--- a/packages/launcher/changelog/0.9.28.json
+++ b/packages/launcher/changelog/0.9.28.json
@@ -1,0 +1,57 @@
+{
+  "version": "0.9.28",
+  "date": "2026-09-10",
+  "entries": [
+    {
+      "type": "feature",
+      "title": {
+        "en": "GitHub Copilot CLI is now a supported agent",
+        "zh": "GitHub Copilot CLI 现已成为受支持的 Agent"
+      },
+      "description": {
+        "en": "Install it from the marketplace and add it to a workspace. Sign in with your GitHub account — the agent turns Ready on its own once you do. On the Copilot Free plan, leave the model empty.",
+        "zh": "可从应用市场安装并加入工作区。使用 GitHub 账号登录即可，登录完成后 Agent 会自行变为就绪。若使用 Copilot Free 方案，请将模型留空。"
+      }
+    },
+    {
+      "type": "feature",
+      "title": {
+        "en": "Agents can be renamed",
+        "zh": "智能体可以重命名"
+      },
+      "description": {
+        "en": "Rename from the row's menu. An agent in a workspace is renamed on both sides. Clear the field to restore the original name.",
+        "zh": "在行内菜单中重命名。已加入工作区的智能体会两侧同步。清空输入框即可恢复原名。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Signing in no longer opens a spare empty terminal window",
+        "zh": "登录时不再多出一个空白终端窗口"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Removing an agent now removes it from its workspace too",
+        "zh": "移除智能体时会一并从工作区移除"
+      },
+      "description": {
+        "en": "No need to remove it a second time from the workspace itself.",
+        "zh": "不再需要另外到工作区中移除一次。"
+      }
+    },
+    {
+      "type": "improvement",
+      "title": {
+        "en": "Agent row actions stay in one place at any window size",
+        "zh": "智能体行内的操作按钮位置不再随窗口变化"
+      },
+      "description": {
+        "en": "Configure has moved into the row menu, where actions are grouped by what they do.",
+        "zh": "「配置」已移入行内菜单，菜单中的操作按性质分组。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/changelog/0.9.28.json
+++ b/packages/launcher/changelog/0.9.28.json
@@ -43,6 +43,17 @@
       }
     },
     {
+      "type": "fix",
+      "title": {
+        "en": "Leaving a workspace now leaves it on both sides",
+        "zh": "退出工作区现在会在两侧同时生效"
+      },
+      "description": {
+        "en": "The agent stays here, ready to join another workspace.",
+        "zh": "智能体保留在本机，可加入其他工作区。"
+      }
+    },
+    {
       "type": "improvement",
       "title": {
         "en": "Agent row actions stay in one place at any window size",

--- a/packages/launcher/package-lock.json
+++ b/packages/launcher/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.26",
+  "version": "0.9.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openagents-launcher",
-      "version": "0.9.26",
+      "version": "0.9.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
-        "@openagents-org/agent-launcher": "0.2.177",
+        "@openagents-org/agent-launcher": "0.2.180",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -1690,9 +1690,9 @@
       }
     },
     "node_modules/@openagents-org/agent-launcher": {
-      "version": "0.2.177",
-      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.177.tgz",
-      "integrity": "sha512-L3ORw5Hk4vuKxauO4UaV9dVZP33vSmCMX3wtLSvzjPLKy4ff3wryWW9QCp2FIi5ggjBtrdNkD+3V0q/GHnYP9g==",
+      "version": "0.2.180",
+      "resolved": "https://registry.npmjs.org/@openagents-org/agent-launcher/-/agent-launcher-0.2.180.tgz",
+      "integrity": "sha512-PPIO4hPE33oor/33Svtmlr8Hx7EvwIU/D7seCF+oMHFpcT8XtwHfEftgvgwqdgBjxMm1eLaS663dYhSc/3r3Mw==",
       "license": "MIT",
       "dependencies": {
         "blessed": "^0.1.81",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
-    "@openagents-org/agent-launcher": "0.2.177",
+    "@openagents-org/agent-launcher": "0.2.180",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -1452,11 +1452,27 @@ export class AgentManager extends EventEmitter {
     return { success: true }
   }
 
+  /**
+   * Leave the workspace on BOTH sides, keeping the agent itself.
+   *
+   * Unbinding locally while the workspace kept the member row left it listed
+   * there with nothing in the launcher able to reach it. Falls back to the
+   * local-only unbind on a core too old to know leaveWorkspace, so an outdated
+   * core degrades to the previous behaviour instead of failing outright.
+   */
   async disconnectWorkspace(agentName: string): Promise<unknown> {
-    const disconnectWorkspace = this._connector!.disconnectWorkspace as (
-      name: string,
-    ) => void
-    disconnectWorkspace.call(this._connector, agentName)
+    const leave = this._connector!.leaveWorkspace as
+      | ((n: string) => Promise<unknown>)
+      | undefined
+    if (typeof leave === "function") {
+      await leave.call(this._connector, agentName)
+    } else {
+      const disconnectWorkspace = this._connector!.disconnectWorkspace as (
+        name: string,
+      ) => void
+      disconnectWorkspace.call(this._connector, agentName)
+    }
+    this._agentsCache = { value: [], at: 0 }
     this.signalReload()
     return { success: true }
   }

--- a/packages/launcher/src/main/agent-manager.ts
+++ b/packages/launcher/src/main/agent-manager.ts
@@ -772,7 +772,33 @@ export class AgentManager extends EventEmitter {
     return { success: true, agent: agentConfig }
   }
 
-  async removeAgent(name: string): Promise<unknown> {
+  /**
+   * Remove an agent, optionally dropping its workspace membership too.
+   *
+   * Order matters: the workspace call goes FIRST, so a network failure leaves
+   * the agent intact locally and the user can retry. Removing locally first
+   * would strand a member row nobody can reach any more — the very state this
+   * option exists to prevent.
+   *
+   * `fromWorkspace` on a core too old to offer removeAgentFromWorkspace is
+   * reported rather than silently skipped, so nobody is told the workspace was
+   * cleaned up when it was not.
+   */
+  async removeAgent(
+    name: string,
+    opts?: { fromWorkspace?: boolean },
+  ): Promise<unknown> {
+    if (opts?.fromWorkspace) {
+      const drop = this._connector!.removeAgentFromWorkspace as
+        | ((n: string) => Promise<unknown>)
+        | undefined
+      if (typeof drop !== "function") {
+        throw new Error(
+          "This version of the agent core cannot remove a workspace membership. Update the core, or remove the agent from the workspace directly.",
+        )
+      }
+      await drop.call(this._connector, name)
+    }
     try {
       await this.stopAgent(name)
     } catch {}
@@ -781,6 +807,25 @@ export class AgentManager extends EventEmitter {
     // See addAgent: bust the cache so the deleted agent doesn't linger.
     this._agentsCache = { value: [], at: 0 }
     return { success: true }
+  }
+
+  /**
+   * Set an agent's display label, which is pushed to its workspace when it has
+   * one (the core does that half — see setAgentDisplayName). The agent's
+   * `name` is its identity and is never touched.
+   */
+  async renameAgent(name: string, displayName: string): Promise<unknown> {
+    const rename = this._connector!.setAgentDisplayName as
+      | ((n: string, d: string) => Promise<unknown>)
+      | undefined
+    if (typeof rename !== "function") {
+      throw new Error(
+        "This version of the agent core cannot rename agents. Update the core to use this.",
+      )
+    }
+    const result = await rename.call(this._connector, name, displayName)
+    this._agentsCache = { value: [], at: 0 }
+    return result ?? { success: true }
   }
 
   async updateAgent(

--- a/packages/launcher/src/main/agents/auth-specs.ts
+++ b/packages/launcher/src/main/agents/auth-specs.ts
@@ -638,6 +638,40 @@ export const DUAL_LOGIN_AGENTS: Record<string, HostedLoginSpec> = {
     loggedOutPattern: /not authenticated|not signed in|not logged in/i,
     apiKeyEnv: "COMMAND_CODE_API_KEY",
   },
+  copilot: {
+    // GitHub Copilot CLI has no login subcommand and no non-interactive status
+    // command: signing in is `/login` INSIDE the session (or the CLI doing it
+    // for you on first run), and the token it gets lands in the OS credential
+    // store, not on disk. So the login command is the BARE binary —
+    // needsRealTerminal() routes that to a terminal window — and sign-in is
+    // read off disk like gemini's and codebuddy's.
+    //
+    // What the CLI does write is its own config, which records who is signed
+    // in: `loggedInUsers: [{ host, login }]` plus a `lastLoggedInUser`. That is
+    // an identity list, not a credential — the token itself is never in this
+    // file, and nothing here reads a value out of it beyond "is the list
+    // non-empty". Two properties of that file drove the probe changes:
+    //
+    //   - it is JSONC. A two-line `//` header explains that user settings
+    //     belong in settings.json, so a strict JSON.parse throws and the
+    //     verdict used to degrade to "cannot tell" for a plainly signed-in
+    //     user. credsVerdict now falls back to a string-aware comment strip.
+    //   - the field is an ARRAY, and `![]` is false — an empty list would have
+    //     read as SIGNED IN. isEmptyField treats empty containers as no value.
+    //
+    // Deliberately no credsGuard. The entries carry a `host`, and a GHE
+    // (GH_HOST / COPILOT_GH_HOST) sign-in for a different host is conceivable —
+    // but that behaviour is unverified here, and a guard written on a guess
+    // would report signed-OUT for working setups. The honest failure mode is
+    // the milder one: a wrong-host session reads as signed in and the CLI's own
+    // run result corrects it.
+    loginCommand: "copilot",
+    statusArgs: [],
+    credsFiles: [{ path: ".copilot/config.json", key: "loggedInUsers" }],
+    apiKeyEnv: "COPILOT_GITHUB_TOKEN",
+    terminalHint:
+      "Signing in to GitHub. If the CLI does not sign you in on its own, type /login. Close this window once it says you are signed in.",
+  },
   codebuddy: {
     // CodeBuddy Code has no login subcommand at all (verified on 2.146.0: the
     // CLI exposes config/mcp/plugin/daemon/… and nothing auth-shaped). Signing
@@ -707,6 +741,20 @@ export const KEY_OPTIONAL_LOGIN_AGENTS = new Set<string>([
   // ~/.kimi-code/) OR a KIMI_API_KEY the adapter maps onto the CLI's
   // KIMI_MODEL_* env-provider contract.
   "kimi",
+  // GitHub Copilot CLI: a GitHub sign-in (`copilot` → /login, the browser
+  // device flow) OR a COPILOT_GITHUB_TOKEN. Both of its registry env fields are
+  // already declared optional, so there is nothing to relax — what this entry
+  // buys is the authMode: without it the mere presence of those fields forces
+  // onboarding into "env" mode and asks for a token, when the smoother and
+  // far more common first-run path is the CLI sign-in.
+  //
+  // Like codebuddy above it is NOT in LAUNCHER_AUTH_OVERRIDES (the registry's
+  // own fields are right), its login_command is the BARE binary, and it is ALSO
+  // in DUAL_LOGIN_AGENTS — which is what gives that sign-in a probe: the
+  // identity list the CLI records in ~/.copilot/config.json. The registry still
+  // marks it `unverifiable` because the CORE has no per-platform creds path for
+  // it; the launcher does.
+  "copilot",
   // CodeBuddy Code: a CodeBuddy/WorkBuddy account sign-in OR a
   // CODEBUDDY_API_KEY / CODEBUDDY_AUTH_TOKEN.
   //
@@ -744,7 +792,7 @@ export const CORE_AGENTS: readonly string[] = [
   "kimi",
   "gemini",
   // Amp (Sourcegraph): external curl install + `amp login`/AMP_API_KEY auth.
-  // aider/goose/copilot/cline are intentionally NOT in this set — they stay
+  // aider/goose/cline are intentionally NOT in this set — they stay
   // "coming soon" (visible but not installable) so the supported download list
   // is the core agents + amp.
   "amp",
@@ -823,6 +871,31 @@ export const CORE_AGENTS: readonly string[] = [
   // core's adapter map, so a core older than the first one shipping the
   // codebuddy adapter degrades to "unsupported" rather than a broken install.
   "codebuddy",
+  // GitHub Copilot CLI (`copilot`): the official standalone terminal agent
+  // shipped as `@github/copilot` — NOT the retired `gh copilot` extension. We
+  // detect and launch the `copilot` executable only and never invoke `gh`.
+  //
+  // Three things to know before touching this line:
+  //
+  //   - auth is a GitHub sign-in, not a key we collect, so it is listed in
+  //     KEY_OPTIONAL_LOGIN_AGENTS and DUAL_LOGIN_AGENTS: onboarding drives
+  //     `copilot` /login, the optional COPILOT_GITHUB_TOKEN field stays as a
+  //     backup, and a completed sign-in is read back off disk so the agent
+  //     turns Ready on its own.
+  //   - the login command is the BARE binary, like Copilot's peers gemini and
+  //     codebuddy — signing in is `/login` INSIDE the TUI. needsRealTerminal()
+  //     already routes bare-binary logins to a terminal window generically, so
+  //     no name has to be added to TERMINAL_ONLY_LOGIN for that to work.
+  //   - the Copilot Free plan can only use auto model selection. Leaving the
+  //     model empty is what the adapter already does (it passes `--model` only
+  //     when COPILOT_MODEL is set), so Free accounts work out of the box as
+  //     long as nothing pre-seeds a concrete model id.
+  //
+  // Same core-before-marketplace ordering as the entries above: listing it here
+  // only stamps it installable, and addAgent still intersects with the installed
+  // core's adapter map. The copilot adapter ships in core 0.2.180 (verified in
+  // the published tarball), which is what packages/launcher depends on.
+  "copilot",
   // NanoClaw is intentionally NOT in this set: it's a BETA external
   // containerized runtime bridged via a native NanoClaw `openagents` channel,
   // so it stays "coming soon" (visible but not installable) and out of

--- a/packages/launcher/src/main/agents/login-probe.test.ts
+++ b/packages/launcher/src/main/agents/login-probe.test.ts
@@ -184,3 +184,71 @@ describe("credsVerdict — CodeBuddy's session, and which site it is for", () =>
     )
   })
 })
+
+describe("credsVerdict — Copilot's sign-in, read out of a JSONC config", () => {
+  const copilot = DUAL_LOGIN_AGENTS.copilot
+  let home: string
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-home-"))
+    fs.mkdirSync(path.join(home, ".copilot"))
+  })
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true })
+  })
+
+  const config = (body: string): void =>
+    fs.writeFileSync(path.join(home, ".copilot", "config.json"), body)
+
+  /**
+   * Verbatim shape captured from a real signed-in machine (v1.0.83), with the
+   * account renamed. The two leading `//` lines and the `https://` inside a
+   * value are the whole reason this case exists.
+   */
+  const SIGNED_IN = `// User settings belong in settings.json.
+// This file is managed automatically.
+{
+  "firstLaunchAt": "2026-07-21T12:33:08.482Z",
+  "appTipShown": true,
+  "loggedInUsers": [{ "host": "https://github.com", "login": "octocat" }],
+  "lastLoggedInUser": { "host": "https://github.com", "login": "octocat" }
+}`
+
+  it("reads a signed-in user through the file's // header", () => {
+    // The reported bug: a strict JSON.parse throws on the header, which used to
+    // land in the catch and report "cannot tell" for a user the terminal had
+    // just greeted by name.
+    config(SIGNED_IN)
+    expect(credsVerdict(copilot, home)).toBe(true)
+  })
+
+  it("does not cut a value in half at its //", () => {
+    // A comment stripper that did not track string state would truncate
+    // "https://github.com" and turn the whole file into a parse error.
+    config(SIGNED_IN)
+    expect(credsVerdict(copilot, home)).not.toBe(null)
+  })
+
+  it("treats an empty user list as signed out", () => {
+    // `![]` is false, so an empty array would otherwise sail through as a
+    // sign-in — the shape a signed-out CLI leaves behind.
+    config('{ "loggedInUsers": [] }')
+    expect(credsVerdict(copilot, home)).toBe(false)
+  })
+
+  it("says signed out when the CLI has written no config at all", () => {
+    expect(credsVerdict(copilot, home)).toBe(false)
+  })
+
+  it("stays unknown when the config is there but truly unreadable", () => {
+    config("{ this is not json, commented or otherwise")
+    expect(credsVerdict(copilot, home)).toBe(null)
+  })
+
+  it("never spawns the bare binary as a probe", () => {
+    // `copilot` with no subcommand launches the full-screen TUI. The creds file
+    // is what keeps the probe off it; statusArgs stays empty as a statement.
+    expect(copilot.statusArgs).toEqual([])
+    expect(copilot.credsFiles?.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/launcher/src/main/agents/login-probe.ts
+++ b/packages/launcher/src/main/agents/login-probe.ts
@@ -49,6 +49,74 @@ import { windowsExecutable } from "../win-exec"
  * the parsed file and the agent's saved env, for a CLI that keeps one session
  * across several services. Nothing here is logged — the same files hold tokens.
  */
+/**
+ * Strip `//` line comments, leaving string literals alone.
+ *
+ * Only ever reached after a strict parse has already failed, so a plain JSON
+ * file never goes through it. The string tracking is the whole point: the very
+ * file this exists for records `"host": "https://github.com"`, and a regex that
+ * did not know it was inside a string would cut that value in half and turn a
+ * signed-in user into a parse error.
+ */
+function stripLineComments(text: string): string {
+  let out = ""
+  let inString = false
+  let escaped = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      out += ch
+      if (escaped) escaped = false
+      else if (ch === "\\") escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') {
+      inString = true
+      out += ch
+      continue
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      // Advance to just before the newline; the loop's own i++ then lands on
+      // it, so the line break survives into `out`.
+      while (i + 1 < text.length && text[i + 1] !== "\n") i++
+      continue
+    }
+    out += ch
+  }
+  return out
+}
+
+/**
+ * `JSON.parse`, tolerating a `//`-commented config. Copilot's config.json opens
+ * with a two-line header explaining that user settings belong elsewhere, and a
+ * strict parse throws on it — which used to land in the catch below and report
+ * "cannot tell" for a user who was plainly signed in.
+ */
+function parseJsonc(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return JSON.parse(stripLineComments(text))
+  }
+}
+
+/**
+ * Whether a creds field counts as carrying no value.
+ *
+ * `active: null` is how Gemini records a signed-OUT account, so the file's
+ * existence proves nothing. Empty containers are the same statement in a
+ * different shape — Copilot's `loggedInUsers` is an ARRAY, and `![]` is false,
+ * so a signed-out user with an empty list would otherwise read as signed in.
+ */
+function isEmptyField(field: unknown): boolean {
+  if (field == null) return true
+  if (typeof field === "string") return !field.trim()
+  if (Array.isArray(field)) return field.length === 0
+  if (typeof field === "object") return Object.keys(field).length === 0
+  return !field
+}
+
 export function credsVerdict(
   spec: HostedLoginSpec,
   homeDir: string = os.homedir(),
@@ -60,11 +128,9 @@ export function credsVerdict(
     try {
       if (!fs.existsSync(file)) continue
       if (!c.key) return true
-      const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf-8"))
+      const parsed: unknown = parseJsonc(fs.readFileSync(file, "utf-8"))
       const field = (parsed as Record<string, unknown> | null)?.[c.key]
-      // `active: null` is how Gemini records a signed-OUT account, so the field
-      // has to carry a value — the file's existence proves nothing.
-      if (typeof field === "string" ? !field.trim() : !field) continue
+      if (isEmptyField(field)) continue
       // A session that exists but belongs to another service (CodeBuddy's
       // international sign-in under a China-pinned agent) authenticates nothing
       // here, and saying so is the difference between "Login required" and a

--- a/packages/launcher/src/main/index.ts
+++ b/packages/launcher/src/main/index.ts
@@ -1110,8 +1110,17 @@ function setupIPC(): void {
   ipcMain.handle("agents:add", (_e, config) =>
     requireManager().addAgent(config),
   )
-  ipcMain.handle("agents:remove", (_e, name) =>
-    requireManager().removeAgent(name),
+  ipcMain.handle("agents:remove", (_e, name, opts) =>
+    requireManager().removeAgent(name, {
+      fromWorkspace: !!(opts as { fromWorkspace?: boolean } | undefined)
+        ?.fromWorkspace,
+    }),
+  )
+  ipcMain.handle("agents:rename", (_e, name: string, displayName: string) =>
+    requireManager().renameAgent(
+      asName(name, "agent name"),
+      String(displayName ?? ""),
+    ),
   )
   ipcMain.handle("agents:update", (_e, name, config) =>
     requireManager().updateAgent(name, config),
@@ -2335,14 +2344,36 @@ function setupIPC(): void {
           `openagents-login-${Date.now()}.sh`,
         )
         fs.writeFileSync(tmpSh, lines.join("\n") + "\n", "utf-8")
+        // `do script` ALWAYS opens a new window, which is right when Terminal
+        // is already up — taking over a window the user is working in would be
+        // worse. But when Terminal is NOT running, launching it makes it open
+        // its own default window first, and `do script` then adds a second one:
+        // the user gets two windows, one of which sits at a bare prompt having
+        // run nothing. So the not-running case targets `window 1`, the one
+        // Terminal just made for itself, instead of opening another.
+        //
+        // `in window 1` fails if the user configured Terminal to open no window
+        // at startup, hence the fallback — without it that configuration would
+        // get no window at all, which is worse than the spare one.
+        const target = `". ${sq(tmpSh)}"`
+        const osa = [
+          'if application "Terminal" is running then',
+          `  tell application "Terminal" to do script ${target}`,
+          "else",
+          '  tell application "Terminal"',
+          "    launch",
+          "    try",
+          `      do script ${target} in window 1`,
+          "    on error",
+          `      do script ${target}`,
+          "    end try",
+          "  end tell",
+          "end if",
+          'tell application "Terminal" to activate',
+        ]
         spawn(
           "osascript",
-          [
-            "-e",
-            `tell app "Terminal" to do script ". ${sq(tmpSh)}"`,
-            "-e",
-            'tell app "Terminal" to activate',
-          ],
+          osa.flatMap((line) => ["-e", line]),
           { detached: true, stdio: "ignore" },
         )
       } catch {}

--- a/packages/launcher/src/preload/index.ts
+++ b/packages/launcher/src/preload/index.ts
@@ -16,7 +16,10 @@ contextBridge.exposeInMainWorld('api', {
   getSupportedAgentTypes: () => ipcRenderer.invoke('agents:supported-types'),
   getAgentCoreInfo: () => ipcRenderer.invoke('agents:core-info'),
   addAgent: (config: unknown) => ipcRenderer.invoke('agents:add', config),
-  removeAgent: (name: string) => ipcRenderer.invoke('agents:remove', name),
+  removeAgent: (name: string, opts?: { fromWorkspace?: boolean }) =>
+    ipcRenderer.invoke('agents:remove', name, opts),
+  renameAgent: (name: string, displayName: string) =>
+    ipcRenderer.invoke('agents:rename', name, displayName),
   updateAgent: (name: string, config: unknown) => ipcRenderer.invoke('agents:update', name, config),
   setAgentWorkingDir: (name: string, dir: string) => ipcRenderer.invoke('agents:set-workdir', name, dir),
 

--- a/packages/launcher/src/renderer/components/setup-wizard/index.tsx
+++ b/packages/launcher/src/renderer/components/setup-wizard/index.tsx
@@ -146,7 +146,9 @@ export default function SetupWizard({
                   onChange={w.setAgentName}
                   defaultName={w.defaultName}
                   connection={connection}
+                  pairedWorkspaces={w.pairedWorkspaces}
                   pairedWorkspace={w.pairedWorkspace}
+                  onPairedWorkspaceChange={w.setPairedWorkspaceSlug}
                   connectOnCreate={w.connectOnCreate}
                   onConnectOnCreateChange={w.setConnectOnCreate}
                 />

--- a/packages/launcher/src/renderer/components/setup-wizard/setup-create-step.tsx
+++ b/packages/launcher/src/renderer/components/setup-wizard/setup-create-step.tsx
@@ -5,6 +5,13 @@ import { Field, FieldDescription, FieldLabel } from "@renderer/components/ui/fie
 import { Input } from "@renderer/components/ui/input"
 import { Badge } from "@renderer/components/ui/badge"
 import { Checkbox } from "@renderer/components/ui/checkbox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select"
 import { cn } from "@renderer/lib/utils"
 
 /** How the agent will authenticate, and whether that is actually settled. */
@@ -30,7 +37,9 @@ export function SetupCreateStep({
   onChange,
   defaultName,
   connection,
+  pairedWorkspaces,
   pairedWorkspace,
+  onPairedWorkspaceChange,
   connectOnCreate,
   onConnectOnCreateChange,
 }: {
@@ -39,8 +48,11 @@ export function SetupCreateStep({
   defaultName: string
   /** null for an agent with nothing to connect — then there is no card. */
   connection: ConnectionRecap | null
-  /** The workspace this device is paired with, or null for local-only. */
+  /** Every workspace this device is paired with; empty for local-only. */
+  pairedWorkspaces: Array<{ slug: string; name: string | null }>
+  /** The one the agent will join — an entry of the list above, or null. */
   pairedWorkspace: { slug: string; name: string | null } | null
+  onPairedWorkspaceChange: (slug: string) => void
   connectOnCreate: boolean
   onConnectOnCreateChange: (v: boolean) => void
 }): React.JSX.Element {
@@ -71,19 +83,47 @@ export function SetupCreateStep({
       </Field>
 
       {/* The one line that stops this funnel dead-ending local-only: with a
-          paired workspace the new agent joins it on creation (default on). */}
+          paired workspace the new agent joins it on creation (default on).
+
+          A device can be paired with several workspaces. With one, the sentence
+          names it and there is nothing to choose. With more, it has to be a
+          choice — this used to bind to whichever pairing happened to be first
+          and never said so, so a second workspace could only be discovered
+          after the agent had already joined the wrong one. */}
       {pairedWorkspace && (
-        <label className="flex cursor-pointer items-center gap-2.5 rounded-xl border bg-card px-4 py-3">
-          <Checkbox
-            checked={connectOnCreate}
-            onCheckedChange={(v) => onConnectOnCreateChange(v === true)}
-          />
-          <span className="text-sm">
-            {t("onboarding.wizard.createInstance.connectTo", {
-              name: pairedWorkspace.name || pairedWorkspace.slug,
-            })}
-          </span>
-        </label>
+        <div className="rounded-xl border bg-card px-4 py-3">
+          <label className="flex cursor-pointer items-center gap-2.5">
+            <Checkbox
+              checked={connectOnCreate}
+              onCheckedChange={(v) => onConnectOnCreateChange(v === true)}
+            />
+            <span className="text-sm">
+              {pairedWorkspaces.length > 1
+                ? t("onboarding.wizard.createInstance.connectToWorkspace")
+                : t("onboarding.wizard.createInstance.connectTo", {
+                    name: pairedWorkspace.name || pairedWorkspace.slug,
+                  })}
+            </span>
+          </label>
+          {pairedWorkspaces.length > 1 && (
+            <Select
+              value={pairedWorkspace.slug}
+              onValueChange={onPairedWorkspaceChange}
+              disabled={!connectOnCreate}
+            >
+              <SelectTrigger className="mt-2.5 w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {pairedWorkspaces.map((w) => (
+                  <SelectItem key={w.slug} value={w.slug}>
+                    {w.name || w.slug}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
       )}
 
       {connection && (

--- a/packages/launcher/src/renderer/components/setup-wizard/use-setup-wizard.ts
+++ b/packages/launcher/src/renderer/components/setup-wizard/use-setup-wizard.ts
@@ -63,8 +63,17 @@ interface SetupWizardState {
    */
   defaultName: string
   submitting: boolean
-  /** The workspace this device is paired with, or null for local-only. */
+  /**
+   * Every workspace this device is paired with. A device can be a node in
+   * several at once, and the wizard used to read only the singular field on
+   * node status — which is `workspaces[0]`, not a choice — so a user with two
+   * workspaces silently got whichever one happened to be first.
+   */
+  pairedWorkspaces: Array<{ slug: string; name: string | null }>
+  /** The one the new agent will join: `pairedWorkspaces` entry, or null. */
   pairedWorkspace: { slug: string; name: string | null } | null
+  /** Pick a different one. No-op for a slug this device is not paired with. */
+  setPairedWorkspaceSlug: (slug: string) => void
   /** Whether the new agent joins that workspace on creation (default on). */
   connectOnCreate: boolean
   setConnectOnCreate: (v: boolean) => void
@@ -115,11 +124,18 @@ export function useSetupWizard({
   const [defaultName, setDefaultName] = useState("")
   const [agentName, setAgentName] = useState("")
   const [submitting, setSubmitting] = useState(false)
-  const [pairedWorkspace, setPairedWorkspace] = useState<{
-    slug: string
-    name: string | null
-  } | null>(null)
+  const [pairedWorkspaces, setPairedWorkspaces] = useState<
+    Array<{ slug: string; name: string | null }>
+  >([])
+  const [pairedSlug, setPairedSlug] = useState<string | null>(null)
   const [connectOnCreate, setConnectOnCreate] = useState(true)
+
+  // The selection, resolved against the live list so a workspace that was
+  // unpaired while the wizard sat open can never be the one we bind to.
+  const pairedWorkspace =
+    pairedWorkspaces.find((w) => w.slug === pairedSlug) ??
+    pairedWorkspaces[0] ??
+    null
 
   const loginCommand = entry?.check_ready?.login_command || null
 
@@ -151,17 +167,27 @@ export function useSetupWizard({
     setAuthTab(loginCommand ? "cli" : "key")
     setConnectOnCreate(true)
     // The Marketplace funnel used to dead-end local-only; with pairing-first
-    // the wizard finishes the job by binding to the paired workspace.
+    // the wizard finishes the job by binding to a paired workspace.
+    //
+    // Read the LIST, not the singular field. The singular one is just
+    // `workspaces[0]` (see getNodeStatus), so on a device paired with more
+    // than one it silently picked for the user.
     window.api
       .getNodeStatus()
-      .then((st) =>
-        setPairedWorkspace(
-          st?.workspaceSlug
-            ? { slug: st.workspaceSlug, name: st.workspaceName || null }
-            : null,
-        ),
-      )
-      .catch(() => setPairedWorkspace(null))
+      .then((st) => {
+        const all = (st?.workspaces || [])
+          .filter((w) => !!w.workspaceSlug)
+          .map((w) => ({
+            slug: w.workspaceSlug as string,
+            name: w.workspaceName || null,
+          }))
+        setPairedWorkspaces(all)
+        setPairedSlug(all[0]?.slug ?? null)
+      })
+      .catch(() => {
+        setPairedWorkspaces([])
+        setPairedSlug(null)
+      })
     ;(async () => {
       const [envFields, saved] = await Promise.all([
         window.api.getEnvFields(entry.name).catch(() => [] as EnvField[]),
@@ -356,7 +382,9 @@ export function useSetupWizard({
     setAgentName,
     defaultName,
     submitting,
+    pairedWorkspaces,
     pairedWorkspace,
+    setPairedWorkspaceSlug: setPairedSlug,
     connectOnCreate,
     setConnectOnCreate,
     startLogin,

--- a/packages/launcher/src/renderer/i18n/locales/en/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/agents.json
@@ -29,6 +29,7 @@
     "cancel": "Cancel",
     "removeTitle": "Remove {{name}}?",
     "removeBody": "This will stop and remove <1>{{name}}</1>.",
+    "alsoRemovedFromWorkspace": "Its membership in {{workspace}} is removed as well — otherwise it would stay there as a member this launcher can no longer reach.",
     "health": {
       "notConfigured": "Not configured",
       "notInstalled": "Not installed",
@@ -47,7 +48,9 @@
       "notConnectedYet": "{{name}} hasn't joined a workspace yet — click Join workspace first.",
       "startingEllipsis": "Starting {{name}}…",
       "couldntStart": "Couldn't start {{name}}: {{message}}",
-      "error": "Error: {{message}}"
+      "error": "Error: {{message}}",
+      "removedEverywhere": "Removed '{{name}}' and its workspace membership",
+      "renamed": "Renamed"
     },
     "sorts": {
       "recent": "Recently active",
@@ -95,7 +98,9 @@
     "workspaceLine": "Workspace · {{name}}",
     "emptyTitle": "No agents yet",
     "emptyNoMatchTitle": "Nothing matches that search",
-    "emptyNoFilterMatchTitle": "Nothing matches this filter"
+    "emptyNoFilterMatchTitle": "Nothing matches this filter",
+    "rename": "Rename",
+    "theWorkspace": "the workspace"
   },
   "newDialog": {
     "title": "New Agent",
@@ -347,5 +352,13 @@
     "tryAgain": "Try again",
     "useTerminal": "Sign in in a terminal",
     "verifying": "Confirming sign-in…"
+  },
+  "renameDialog": {
+    "title": "Rename {{name}}",
+    "description": "This changes the label shown here and in the agent's workspace. Its identity is unchanged, so sessions, working directory and workspace membership all stay as they are.",
+    "label": "Display name",
+    "hint": "Leave empty to go back to {{name}}.",
+    "save": "Save",
+    "saving": "Saving…"
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/en/onboarding.json
+++ b/packages/launcher/src/renderer/i18n/locales/en/onboarding.json
@@ -307,7 +307,8 @@
       "model": "Model: {{model}}",
       "creating": "Creating…",
       "createAgent": "Create agent",
-      "connectTo": "Connect to {{name}} (this device is paired)"
+      "connectTo": "Connect to {{name}} (this device is paired)",
+      "connectToWorkspace": "Connect to a workspace (this device is paired with several)"
     }
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/agents.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/agents.json
@@ -29,6 +29,7 @@
     "cancel": "取消",
     "removeTitle": "移除 {{name}}？",
     "removeBody": "这将停止并移除 <1>{{name}}</1>。",
+    "alsoRemovedFromWorkspace": "其在 {{workspace}} 中的成员身份也会一并移除 —— 否则它会以启动器再也无法触及的成员身份留在那里。",
     "health": {
       "notConfigured": "未配置",
       "notInstalled": "未安装",
@@ -47,7 +48,9 @@
       "notConnectedYet": "{{name}} 还没有加入工作区 —— 请先点击「加入工作区」。",
       "startingEllipsis": "正在启动 {{name}}…",
       "couldntStart": "无法启动 {{name}}：{{message}}",
-      "error": "错误：{{message}}"
+      "error": "错误：{{message}}",
+      "removedEverywhere": "已移除「{{name}}」及其工作区成员身份",
+      "renamed": "已重命名"
     },
     "sorts": {
       "recent": "最近活跃",
@@ -95,7 +98,9 @@
     "workspaceLine": "工作区 · {{name}}",
     "emptyTitle": "还没有智能体",
     "emptyNoMatchTitle": "没有匹配的智能体",
-    "emptyNoFilterMatchTitle": "该筛选下没有智能体"
+    "emptyNoFilterMatchTitle": "该筛选下没有智能体",
+    "rename": "重命名",
+    "theWorkspace": "工作区"
   },
   "newDialog": {
     "title": "新建智能体",
@@ -347,5 +352,13 @@
     "tryAgain": "重试",
     "useTerminal": "用终端登录",
     "verifying": "正在确认登录…"
+  },
+  "renameDialog": {
+    "title": "重命名 {{name}}",
+    "description": "这会修改此处以及该智能体所在工作区中显示的名称。其身份标识不变，因此会话、工作目录与工作区成员身份都保持原样。",
+    "label": "显示名称",
+    "hint": "留空则恢复为 {{name}}。",
+    "save": "保存",
+    "saving": "正在保存…"
   }
 }

--- a/packages/launcher/src/renderer/i18n/locales/zh/onboarding.json
+++ b/packages/launcher/src/renderer/i18n/locales/zh/onboarding.json
@@ -307,7 +307,8 @@
       "model": "模型：{{model}}",
       "creating": "正在创建…",
       "createAgent": "创建智能体",
-      "connectTo": "接入 {{name}}（本设备已配对）"
+      "connectTo": "接入 {{name}}（本设备已配对）",
+      "connectToWorkspace": "接入工作区（本设备已配对多个）"
     }
   }
 }

--- a/packages/launcher/src/renderer/pages/agents/components/agent-actions.ts
+++ b/packages/launcher/src/renderer/pages/agents/components/agent-actions.ts
@@ -8,8 +8,21 @@ export interface AgentActionHandlers {
   onToggle: (a: Agent) => void
   onOpenTerminal: (a: Agent) => void
   onConfigure: (a: Agent) => void
+  onRename: (a: Agent) => void
   onConnect: (a: Agent) => void
   onDisconnect: (a: Agent) => void
   onOpenWorkspace: (a: Agent) => void
   onRemove: (a: Agent) => void
+}
+
+/**
+ * What an agent is called on screen.
+ *
+ * `name` is the identity — it keys the config, the working directory, the
+ * sessions and the workspace membership, and every action still takes it. The
+ * label is only ever what the user reads, so this is the one place that
+ * decides which of the two to show.
+ */
+export function agentLabel(a: Agent): string {
+  return a.displayName?.trim() || a.name
 }

--- a/packages/launcher/src/renderer/pages/agents/components/agent-card.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/agent-card.tsx
@@ -7,6 +7,7 @@ import {
   FolderClosed,
   KeyRound,
   MoreHorizontal,
+  Pencil,
   Play,
   SlidersHorizontal,
   Square,
@@ -31,7 +32,7 @@ import { cn } from "@renderer/lib/utils"
 import { formatHealthLabel } from "../format-health-label"
 import type { AgentRow } from "../use-agents-view"
 import { AgentErrorDialog } from "./agent-error-dialog"
-import type { AgentActionHandlers } from "./agent-actions"
+import { agentLabel, type AgentActionHandlers } from "./agent-actions"
 
 interface Props extends AgentActionHandlers {
   row: AgentRow
@@ -64,6 +65,7 @@ export function AgentCard({
   onToggle,
   onOpenTerminal,
   onConfigure,
+  onRename,
   onConnect,
   onDisconnect,
   onOpenWorkspace,
@@ -90,8 +92,11 @@ export function AgentCard({
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
-            <span className="truncate text-sm font-semibold" title={agent.name}>
-              {agent.name}
+            <span
+              className="truncate text-sm font-semibold"
+              title={agentLabel(agent)}
+            >
+              {agentLabel(agent)}
             </span>
             <span className="flex shrink-0 items-center gap-1">
               <span
@@ -225,6 +230,14 @@ export function AgentCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            {/* Same grouping as the table: edit, then run, then destroy.
+                Configure is the tile's own button, so only Rename appears in
+                this first group here. */}
+            <DropdownMenuItem onClick={() => onRename(agent)}>
+              <Pencil />
+              {t("agents.list.rename")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
             {/* Nothing to start or stop without a workspace — there is no
                 message source and no process, so both are offers the launcher
                 cannot keep. Joining one is the only move, and the tile's own

--- a/packages/launcher/src/renderer/pages/agents/components/agents-table.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/agents-table.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import {
   KeyRound,
   MoreHorizontal,
+  Pencil,
   Play,
   SlidersHorizontal,
   Square,
@@ -33,7 +34,7 @@ import { STATE_TEXT_CLASS } from "@renderer/lib/agent-state"
 import { cn } from "@renderer/lib/utils"
 import type { AgentRow } from "../use-agents-view"
 import { AgentErrorDialog } from "./agent-error-dialog"
-import type { AgentActionHandlers } from "./agent-actions"
+import { agentLabel, type AgentActionHandlers } from "./agent-actions"
 
 const COLUMNS = [
   "agent",
@@ -44,6 +45,21 @@ const COLUMNS = [
   "lastActive",
   "actions",
 ] as const
+
+/**
+ * Columns that render something of a known, fixed size — an icon, a status
+ * word, a relative timestamp, a pair of buttons. They are collapsed onto their
+ * content so the remaining width goes to `agent` / `provider` / `workspace`,
+ * which truncate. The alternative is what this table used to do: share the
+ * width evenly, overflow the viewport at the 1200px minimum, and let the
+ * container clip the actions column out of sight.
+ */
+const SHRINK_COLUMNS = new Set<string>([
+  "auth",
+  "status",
+  "lastActive",
+  "actions",
+])
 
 interface Props extends AgentActionHandlers {
   rows: AgentRow[]
@@ -60,6 +76,7 @@ export function AgentsTable({
   onToggle,
   onOpenTerminal,
   onConfigure,
+  onRename,
   onConnect,
   onDisconnect,
   onOpenWorkspace,
@@ -81,6 +98,12 @@ export function AgentsTable({
                 className={cn(
                   c === "actions" && "text-center",
                   c === "auth" && "text-center",
+                  // Columns whose content is a fixed size take only what they
+                  // need (`w-px` collapses a table column onto its content),
+                  // so every pixel of pressure lands on the three that can
+                  // truncate instead of on the buttons. Without this the
+                  // actions column was the one that got cut off the screen.
+                  SHRINK_COLUMNS.has(c) && "w-px whitespace-nowrap",
                 )}
               >
                 {t(`agents.list.columns.${c}`)}
@@ -109,9 +132,17 @@ export function AgentsTable({
                     <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
                       <AgentIcon type={agent.type} size={18} />
                     </span>
-                    <div className="min-w-0 max-w-36">
-                      <div className="truncate text-sm font-medium">
-                        {agent.name}
+                    {/* Widths step up with the window instead of being fixed
+                        at the roomy value. Seven columns at the 1200px minimum
+                        only fit if the three truncating ones give way there;
+                        holding max-w-36/40 at every size is what pushed the
+                        row past the viewport and cut the actions column off. */}
+                    <div className="min-w-0 max-w-28 xl:max-w-32 2xl:max-w-36">
+                      <div
+                        className="truncate text-sm font-medium"
+                        title={agentLabel(agent)}
+                      >
+                        {agentLabel(agent)}
                       </div>
                       <div className="truncate font-mono text-xs text-muted-foreground">
                         {agent.type}
@@ -121,13 +152,21 @@ export function AgentsTable({
                 </TableCell>
 
                 <TableCell>
-                  <div className="max-w-40 truncate text-sm">{providerLabel}</div>
-                  <div className="max-w-40 truncate text-xs text-muted-foreground">
+                  <div
+                    className="max-w-28 truncate text-sm xl:max-w-36 2xl:max-w-40"
+                    title={providerLabel}
+                  >
+                    {providerLabel}
+                  </div>
+                  <div
+                    className="max-w-28 truncate text-xs text-muted-foreground xl:max-w-36 2xl:max-w-40"
+                    title={model || undefined}
+                  >
                     {model || "—"}
                   </div>
                 </TableCell>
 
-                <TableCell className="text-center">
+                <TableCell className="whitespace-nowrap text-center">
                   {/* Icon only, with the wording on hover: spelled out, this
                       column cost more width than the fact is worth. */}
                   {auth ? (
@@ -156,9 +195,9 @@ export function AgentsTable({
                     <Button
                       variant="link"
                       size="sm"
-                      className="h-auto max-w-40 justify-start px-0 text-sm"
+                      className="h-auto max-w-28 justify-start px-0 text-sm xl:max-w-36 2xl:max-w-40"
                       aria-label={t("agents.list.openWorkspace")}
-                      title={t("agents.list.openWorkspace")}
+                      title={workspace}
                       onClick={() => onOpenWorkspace(agent)}
                     >
                       <span className="truncate">{workspace}</span>
@@ -171,7 +210,7 @@ export function AgentsTable({
                 {/* One line, always. The error text itself opens in a dialog —
                     printing it here made rows grow past their fixed height and
                     widened the column at every other column's expense. */}
-                <TableCell>
+                <TableCell className="whitespace-nowrap">
                   <div className="flex items-center gap-1">
                     <span
                       className={cn(
@@ -190,11 +229,11 @@ export function AgentsTable({
                   </div>
                 </TableCell>
 
-                <TableCell className="text-xs text-muted-foreground">
+                <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
                   {relativeTimeAgo(t, lastActiveAt) || "—"}
                 </TableCell>
 
-                <TableCell>
+                <TableCell className="whitespace-nowrap">
                   {/* The menu only ever adds what the row does not already
                       show: repeating Configure in both read as a duplicate. */}
                   <div className="flex items-center justify-center gap-1.5">
@@ -219,19 +258,11 @@ export function AgentsTable({
                       </Button>
                     )}
 
-                    {/* Below 1536px the row cannot hold three controls without
-                        the table scrolling sideways, so Configure moves into
-                        the menu — it is never in both places at once. */}
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="hidden 2xl:inline-flex"
-                      data-testid={`agent-configure-${agent.name}`}
-                      onClick={() => onConfigure(agent)}
-                    >
-                      {t("agents.list.configure")}
-                    </Button>
-
+                    {/* One inline action, then the menu. Configure used to sit
+                        here too, appearing above 1536px and moving into the
+                        menu below it — so the same action had no fixed home and
+                        the row width changed with the window. It now lives in
+                        the menu at every size. */}
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button
@@ -243,13 +274,18 @@ export function AgentsTable({
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          className="2xl:hidden"
-                          onClick={() => onConfigure(agent)}
-                        >
+                        {/* Grouped by what the action does to the agent:
+                            edit it, run it, then destroy it — separated so the
+                            last group is never one slip away from the first. */}
+                        <DropdownMenuItem onClick={() => onRename(agent)}>
+                          <Pencil />
+                          {t("agents.list.rename")}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => onConfigure(agent)}>
                           <SlidersHorizontal />
                           {t("agents.list.configure")}
                         </DropdownMenuItem>
+                        {(connected || agent.network) && <DropdownMenuSeparator />}
                         {/* Nothing to start or stop without a workspace —
                             there is no message source and no process, so both
                             are offers the launcher cannot keep. Joining one is

--- a/packages/launcher/src/renderer/pages/agents/components/rename-agent-dialog.tsx
+++ b/packages/launcher/src/renderer/pages/agents/components/rename-agent-dialog.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@renderer/components/ui/dialog"
+import { Button } from "@renderer/components/ui/button"
+import { Field, FieldDescription, FieldLabel } from "@renderer/components/ui/field"
+import { Input } from "@renderer/components/ui/input"
+import type { Agent } from "@renderer/types"
+import { agentLabel } from "./agent-actions"
+
+interface Props {
+  /** The agent being renamed; null keeps the dialog closed. */
+  agent: Agent | null
+  onClose: () => void
+  onSubmit: (displayName: string) => Promise<void>
+}
+
+/**
+ * Rename one agent — which sets a display LABEL, never the agent's identity.
+ *
+ * `agent.name` keys the config, the working directory under
+ * ~/.openagents/agents, the agent's sessions and its workspace membership, so
+ * it is deliberately immutable and shown here read-only. An agent in a
+ * workspace has its label pushed there too, so both sides read the same thing;
+ * the workspace refuses a label another member already answers to (it doubles
+ * as an @-mention alias), and that refusal fails the rename rather than
+ * leaving the two sides disagreeing.
+ */
+export function RenameAgentDialog({
+  agent,
+  onClose,
+  onSubmit,
+}: Props): React.JSX.Element {
+  const { t } = useTranslation()
+  const [value, setValue] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  // Seed from the current label each time a different agent is opened, so the
+  // field never shows the previous agent's name for a frame.
+  useEffect(() => {
+    if (agent) setValue(agent.displayName?.trim() || "")
+  }, [agent])
+
+  const trimmed = value.trim()
+  const unchanged = trimmed === (agent?.displayName?.trim() || "")
+
+  const submit = async (): Promise<void> => {
+    if (!agent || saving || unchanged) return
+    setSaving(true)
+    try {
+      await onSubmit(trimmed)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={!!agent} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent data-testid="rename-agent">
+        <DialogHeader>
+          <DialogTitle>
+            {t("agents.renameDialog.title", {
+              name: agent ? agentLabel(agent) : "",
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("agents.renameDialog.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody>
+          <Field>
+            <FieldLabel htmlFor="agent-rename-input">
+              {t("agents.renameDialog.label")}
+            </FieldLabel>
+            <Input
+              id="agent-rename-input"
+              autoFocus
+              value={value}
+              placeholder={agent?.name || ""}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void submit()
+              }}
+            />
+            <FieldDescription>
+              {/* Says what clearing does, because an empty field is a real
+                  choice here rather than an incomplete form. */}
+              {t("agents.renameDialog.hint", { name: agent?.name || "" })}
+            </FieldDescription>
+          </Field>
+        </DialogBody>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            {t("agents.list.cancel")}
+          </Button>
+          <Button onClick={() => void submit()} disabled={saving || unchanged}>
+            {saving
+              ? t("agents.renameDialog.saving")
+              : t("agents.renameDialog.save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/launcher/src/renderer/pages/agents/index.test.tsx
+++ b/packages/launcher/src/renderer/pages/agents/index.test.tsx
@@ -110,6 +110,20 @@ async function createAndReachConfigure(
   await screen.findByText(/no configuration required/i)
 }
 
+/**
+ * Open one row's Configure dialog.
+ *
+ * Configure lives in the row's overflow menu at every window size. It used to
+ * be an inline button above 1536px and a menu item below, so the same action
+ * had no fixed home and the row's width changed with the window.
+ */
+async function openConfigureMenu(
+  user: ReturnType<typeof userEvent.setup>,
+): Promise<void> {
+  await user.click(screen.getByRole("button", { name: /more actions/i }))
+  await user.click(await screen.findByRole("menuitem", { name: /configure/i }))
+}
+
 describe("Agents page — new agent connect flow", () => {
   it("opens the Connect Workspace dialog after a new agent is configured", async () => {
     installApi()
@@ -366,7 +380,7 @@ describe("Configure dialog — Gemini auth states", () => {
     const user = userEvent.setup()
     render(<Agents showToast={showToast} />)
     await screen.findByText("gem-1")
-    await user.click(screen.getByRole("button", { name: /configure/i }))
+    await openConfigureMenu(user)
     await screen.findByText(/configure gem-1/i)
     return api
   }
@@ -468,7 +482,7 @@ describe("Configure dialog — other agents unaffected", () => {
     const user = userEvent.setup()
     render(<Agents showToast={showToast} />)
     await screen.findByText("plain-1")
-    await user.click(screen.getByRole("button", { name: /configure/i }))
+    await openConfigureMenu(user)
     expect(await screen.findByText(/no configuration required/i)).toBeInTheDocument()
     expect(api.refreshLogin).toBeUndefined()
   })
@@ -490,7 +504,7 @@ describe("Configure dialog — other agents unaffected", () => {
     const user = userEvent.setup()
     render(<Agents showToast={showToast} />)
     await screen.findByText("kimi-1")
-    await user.click(screen.getByRole("button", { name: /configure/i }))
+    await openConfigureMenu(user)
     expect(await screen.findByText(/Kimi API key/i)).toBeInTheDocument()
     expect(screen.queryByText(/no configuration required/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/sign-in detected/i)).not.toBeInTheDocument()
@@ -532,7 +546,7 @@ describe("Configure dialog — hosted-login agent with an optional key", () => {
     const user = userEvent.setup()
     render(<Agents showToast={showToast} />)
     await screen.findByText("cur-1")
-    await user.click(screen.getByRole("button", { name: /configure/i }))
+    await openConfigureMenu(user)
     await screen.findByText(/configure cur-1/i)
     return api
   }

--- a/packages/launcher/src/renderer/pages/agents/index.tsx
+++ b/packages/launcher/src/renderer/pages/agents/index.tsx
@@ -5,6 +5,7 @@ import { useShallow } from "zustand/react/shallow"
 import { Trans, useTranslation } from "react-i18next"
 import AgentIcon from "../../components/AgentIcon"
 import { ConfirmDialog, EmptyState } from "../../components/ui-kit"
+import { RenameAgentDialog } from "./components/rename-agent-dialog"
 import { Cpu, FilterX, Plus, SearchX } from "lucide-react"
 import { Button } from "../../components/ui/button"
 import { Card } from "../../components/ui/card"
@@ -26,6 +27,7 @@ import {
 } from "./use-agents-view"
 import { useAgentActions } from "./use-agent-actions"
 import type { AgentActionHandlers } from "./components/agent-actions"
+import type { Agent } from "@renderer/types"
 
 export { formatHealthLabel } from "./format-health-label"
 
@@ -71,6 +73,7 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
   // an existing agent (where closing Configure should not prompt to connect).
   const [connectAfterConfigure, setConnectAfterConfigure] = useState(false)
   const [removeTarget, setRemoveTarget] = useState<string | null>(null)
+  const [renameTarget, setRenameTarget] = useState<Agent | null>(null)
   const [search, setSearch] = useState("")
   const [filter, setFilter] = useState<AgentFilter>("all")
   const [sort, setSort] = useState<AgentSort>("recent")
@@ -118,6 +121,7 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
   const {
     toggleAgent,
     removeAgent,
+    renameAgent,
     disconnectAgent,
     openWorkspace,
     openAgentChat,
@@ -135,6 +139,7 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
       setConnectWsAgent(a.name)
       setConnectWsOpen(true)
     },
+    onRename: (a) => setRenameTarget(a),
     onDisconnect: (a) => disconnectAgent(a.name),
     onOpenWorkspace: (a) => openWorkspace(a),
     onRemove: (a) => setRemoveTarget(a.name),
@@ -325,9 +330,33 @@ export default function Agents({ showToast }: AgentsProps): React.JSX.Element {
         confirmLabel={t("agents.list.remove")}
         cancelLabel={t("agents.list.cancel")}
         onConfirm={() => {
-          if (removeTarget) removeAgent(removeTarget)
+          if (removeTarget) removeAgent(removeTarget, { fromWorkspace: true })
         }}
         onCancel={() => setRemoveTarget(null)}
+      >
+        {/* Stated, not asked. Leaving the membership behind was never a useful
+            choice: once the agent is gone from here there is no way back to it,
+            so the workspace would keep a member nobody can reach or clean up.
+            `fromWorkspace` is a no-op for an agent that never joined one. */}
+        {agents.find((a) => a.name === removeTarget)?.network && (
+          <p className="m-0 rounded-lg border bg-muted/40 px-3 py-2.5 text-left text-xs leading-relaxed">
+            {t("agents.list.alsoRemovedFromWorkspace", {
+              workspace:
+                agents.find((a) => a.name === removeTarget)?.networkName ||
+                t("agents.list.theWorkspace"),
+            })}
+          </p>
+        )}
+      </ConfirmDialog>
+
+      <RenameAgentDialog
+        agent={renameTarget}
+        onClose={() => setRenameTarget(null)}
+        onSubmit={async (displayName) => {
+          if (!renameTarget) return
+          await renameAgent(renameTarget.name, displayName)
+          setRenameTarget(null)
+        }}
       />
     </section>
   )

--- a/packages/launcher/src/renderer/pages/agents/use-agent-actions.ts
+++ b/packages/launcher/src/renderer/pages/agents/use-agent-actions.ts
@@ -11,7 +11,11 @@ type ShowToast = (msg: string, type?: ToastType) => void
 
 export interface AgentActions {
   toggleAgent: (agent: Agent) => Promise<void>
-  removeAgent: (name: string) => Promise<void>
+  removeAgent: (
+    name: string,
+    opts?: { fromWorkspace?: boolean },
+  ) => Promise<void>
+  renameAgent: (name: string, displayName: string) => Promise<void>
   disconnectAgent: (name: string) => Promise<void>
   openWorkspace: (agent: Agent) => Promise<void>
   openAgentChat: (agent: Agent) => Promise<void>
@@ -108,11 +112,47 @@ export function useAgentActions(
     }
   }
 
-  const removeAgent = async (name: string): Promise<void> => {
+  const removeAgent = async (
+    name: string,
+    opts?: { fromWorkspace?: boolean },
+  ): Promise<void> => {
     onRemoved?.()
     try {
-      await window.api.removeAgent(name)
-      showToast(t("agents.list.toast.removed", { name }), "success")
+      await window.api.removeAgent(name, opts)
+      showToast(
+        t(
+          opts?.fromWorkspace
+            ? "agents.list.toast.removedEverywhere"
+            : "agents.list.toast.removed",
+          { name },
+        ),
+        "success",
+      )
+      refresh()
+    } catch (err: unknown) {
+      showToast(
+        t("agents.list.toast.error", { message: (err as Error).message }),
+        "error",
+      )
+      // The workspace half runs first and the agent is still here when it
+      // fails, so the list has to come back rather than stay as the dialog
+      // left it.
+      refresh()
+    }
+  }
+
+  /**
+   * Rename = set a display label. The agent's `name` is its identity and never
+   * changes, so nothing that addresses it (sessions, working dir, workspace
+   * membership) is disturbed.
+   */
+  const renameAgent = async (
+    name: string,
+    displayName: string,
+  ): Promise<void> => {
+    try {
+      await window.api.renameAgent(name, displayName)
+      showToast(t("agents.list.toast.renamed"), "success")
       refresh()
     } catch (err: unknown) {
       showToast(
@@ -208,5 +248,12 @@ export function useAgentActions(
     }
   }
 
-  return { toggleAgent, removeAgent, disconnectAgent, openWorkspace, openAgentChat }
+  return {
+    toggleAgent,
+    removeAgent,
+    renameAgent,
+    disconnectAgent,
+    openWorkspace,
+    openAgentChat,
+  }
 }

--- a/packages/launcher/src/renderer/types/index.ts
+++ b/packages/launcher/src/renderer/types/index.ts
@@ -45,7 +45,13 @@ export interface CliLoginEvent {
 }
 
 export interface Agent {
+  /** Identity. Keys config, working dir, sessions and workspace membership. */
   name: string
+  /**
+   * Label to show instead of `name`, when the user has set one. Never use it
+   * to address an agent — every API still takes `name`.
+   */
+  displayName?: string | null
   type: string
   state: AgentState
   health: HealthCheck | null
@@ -521,7 +527,11 @@ declare global {
       getSupportedAgentTypes(): Promise<string[]>
       getAgentCoreInfo(): Promise<unknown>
       addAgent(config: { name: string; type: string; path?: string }): Promise<unknown>
-      removeAgent(name: string): Promise<unknown>
+      removeAgent(
+        name: string,
+        opts?: { fromWorkspace?: boolean },
+      ): Promise<unknown>
+      renameAgent(name: string, displayName: string): Promise<unknown>
       updateAgent(name: string, config: unknown): Promise<unknown>
       setAgentWorkingDir(name: string, dir: string): Promise<{ success: boolean; path?: string }>
       startAgent(name: string): Promise<unknown>

--- a/registry/copilot.json
+++ b/registry/copilot.json
@@ -70,11 +70,6 @@
   ],
   "models": [
     {
-      "id": "auto",
-      "label": "Auto (Copilot model selection)",
-      "category": "chat"
-    },
-    {
       "id": "gpt-5.6-sol",
       "label": "GPT-5.6 Sol",
       "category": "chat"

--- a/workspace/backend/registry/copilot.json
+++ b/workspace/backend/registry/copilot.json
@@ -70,11 +70,6 @@
   ],
   "models": [
     {
-      "id": "auto",
-      "label": "Auto (Copilot model selection)",
-      "category": "chat"
-    },
-    {
       "id": "gpt-5.6-sol",
       "label": "GPT-5.6 Sol",
       "category": "chat"


### PR DESCRIPTION
Turns GitHub Copilot CLI into a supported agent, fixes what that exposed, and adds two things about managing agents that came up while testing it.

## GitHub Copilot CLI

Copilot already had an adapter, a registry entry, icons and docs — but `CORE_AGENTS` never listed it, so it sat in the marketplace greyed out as "coming soon" and never appeared in onboarding. It is now a supported download.

Turning it on immediately showed that the stream parser had never been checked against a real run. A live transcript (CLI **v1.0.83**) proved every guessed event name wrong, and the payload sits under `data`, which was never unwrapped — so every answer parsed as empty and users were told **"No response generated"** for turns the CLI had completed successfully and billed (`"outcome":"success"`, exit 0, one premium request).

| Real event | → | Field |
|---|---|---|
| `assistant.message_delta` | `text_delta` | `data.deltaContent` |
| `assistant.reasoning` | `reasoning` | `data.content` |
| `result` (flat) | `done` | `sessionId`, `exitCode` |

Copilot streams at **token** granularity — 81 deltas for one short thought — so deltas now accumulate silently instead of being narrated. Publishing each one posted the reply twice: first as a column of one-word chat messages, then again whole. Progress narration uses the complete `assistant.reasoning` block, matching every other adapter.

`result` is also the only place a session id appears, which is what makes `--resume` work.

Tool/file/shell events still have no live sample and are labelled as inferred rather than quietly trusted.

## Sign-in fixes (general, not Copilot-specific)

- The launcher told a user "sign-in not confirmed" right after the terminal greeted them by name. Copilot's config is **JSONC**, so a strict `JSON.parse` threw and the verdict degraded to "cannot tell"; and it records accounts as an **array**, where `![]` is false — an empty list would have read as signed *in*. Both handled, with a string-aware comment strip so the `https://github.com` stored in that same file isn't cut in half.
- Signing in while Terminal.app wasn't running opened **two** windows, one of them empty. `do script` launches Terminal, which opens a window of its own, then asks for another.

## Agent rename

Agents were stuck with their generated name. Renaming sets a display **label** and never `name`, which keys `daemon.yaml`, the working directory, sessions and workspace membership. The workspace already models this exact split (`display_name` beside `agent_name`).

Two-way sync, with no timestamps needed: the label goes to the workspace **first** and only then to local config, so a label the workspace refuses (it doubles as an @-mention alias) leaves both sides agreeing — and that ordering is what makes "workspace wins" correct when the daemon pulls renames back every 60s via `/v1/discover`, which already returned `display_name`. **No backend change required.**

## Removal now covers the workspace

Removing an agent only ever removed it locally; it stayed a member of its workspace, and with the agent gone from the launcher there was no way left to reach it. Removal now does both.

- Workspace half runs **first**, so a failure leaves the agent here to retry.
- **404 counts as done** — a workspace that has since been deleted must not strand the agent forever.
- It's a separate method, not a flag on `removeAgent`: `agn remove` and the TUI call that synchronously inside a `try/catch`, and making it async would turn a throw into an unhandled rejection they can no longer see.

## Row actions and table width

Configure was a button above 1536px and a menu item below it, so the same action had no fixed home and the row's width changed with the window. It's in the menu at every size now, grouped by what each action does.

The table had also stopped fitting: seven columns overflowed the 1200px minimum window, and the column clipped off-screen was **Actions** — the one holding the buttons. Fixed-size columns now collapse onto their content so the pressure lands on the three that can truncate.

## Setup wizard

It bound new agents to whichever paired workspace happened to be first, without saying so — `getNodeStatus()` returns a list and the wizard read only the singular field. It now offers a picker when the device is paired with more than one.

## Versions

- `agent-connector` → **0.2.181** (publishes on merge to develop)
- `launcher` → **0.9.28**, dependency deliberately left at the published `0.2.180` so `npm install` resolves during CI; it can point at `0.2.181` once that is on npm.

## Verification

- agent-connector: **1575 passed**, 0 failed
- launcher: **482 passed**, `tsc -b` clean, release-notes check passes
- The parser fix was replayed against 109 real event lines from the reporter's daemon log: 0 chat messages emitted for progress, answer reassembled intact
- Detection matrix confirms Copilot is found when the user installed the CLI themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)