### PR TITLE
fix(core): find and run agent CLIs across the Windows/WSL boundary

### DIFF
--- a/packages/agent-connector/src/adapters/aider.js
+++ b/packages/agent-connector/src/adapters/aider.js
@@ -35,7 +35,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, resolveWslBinary } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { whichBinary, getEnhancedEnv, aiderBinDirs } = require('../paths');
@@ -262,7 +266,7 @@ class AiderAdapter extends BaseAdapter {
     // PATH (nvm/fnm/volta/homebrew + the Aider install dirs added to paths.js)
     // — covers the GUI/daemon "not on PATH" case for uv-tool / pipx / pip-user
     // installs.
-    const resolved = whichBinary('aider');
+    const resolved = whichBinary('aider', { allowWsl: false });
     if (resolved) return resolved;
 
     // Explicit fallback over every real install dir (XDG bin, XDG_DATA_HOME/../
@@ -274,7 +278,10 @@ class AiderAdapter extends BaseAdapter {
         if (fs.existsSync(c)) return c;
       }
     }
-    return null;
+    // Nothing native anywhere. Last of all, look inside WSL: a CLI the user
+    // installed in their distro is a real install, and the marked path it comes
+    // back as is what the spawn bridge in ../wsl turns into a wsl.exe run.
+    return resolveWslBinary('aider');
   }
 
   // ------------------------------------------------------------------

--- a/packages/agent-connector/src/adapters/amp.js
+++ b/packages/agent-connector/src/adapters/amp.js
@@ -25,7 +25,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, resolveWslBinary } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
@@ -123,7 +127,7 @@ class AmpAdapter extends BaseAdapter {
     // the Amp installer's ~/.amp/bin. This is what makes detection work inside
     // a GUI- or daemon-spawned process that did NOT inherit the user's
     // interactive shell PATH (the common "installed but not found" case).
-    const resolved = whichBinary('amp');
+    const resolved = whichBinary('amp', { allowWsl: false });
     if (resolved) return resolved;
 
     // Tier 2: explicit known install dirs as a last resort. The official
@@ -145,7 +149,10 @@ class AmpAdapter extends BaseAdapter {
       if (c && fs.existsSync(c)) return c;
     }
 
-    return null;
+    // Nothing native anywhere. Last of all, look inside WSL: a CLI the user
+    // installed in their distro is a real install, and the marked path it comes
+    // back as is what the spawn bridge in ../wsl turns into a wsl.exe run.
+    return resolveWslBinary('amp');
   }
 
   /**

--- a/packages/agent-connector/src/adapters/antigravity.js
+++ b/packages/agent-connector/src/adapters/antigravity.js
@@ -17,7 +17,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, resolveWslBinary } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { whereBinary } = require('../paths');
@@ -131,7 +135,10 @@ class AntigravityAdapter extends BaseAdapter {
     for (const c of candidates) {
       if (fs.existsSync(c)) return c;
     }
-    return null;
+    // Nothing native anywhere. Last of all, look inside WSL: a CLI the user
+    // installed in their distro is a real install, and the marked path it comes
+    // back as is what the spawn bridge in ../wsl turns into a wsl.exe run.
+    return resolveWslBinary('agy');
   }
 
   /**

--- a/packages/agent-connector/src/adapters/claude.js
+++ b/packages/agent-connector/src/adapters/claude.js
@@ -14,7 +14,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle, redactSecrets } = require('./utils');

--- a/packages/agent-connector/src/adapters/cline.js
+++ b/packages/agent-connector/src/adapters/cline.js
@@ -26,7 +26,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, execFile, spawn } = require('child_process');
+const { execSync, execFile } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/adapters/codebuddy.js
+++ b/packages/agent-connector/src/adapters/codebuddy.js
@@ -49,7 +49,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, spawn } = require('child_process');
+const { execFileSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/adapters/codex.js
+++ b/packages/agent-connector/src/adapters/codex.js
@@ -15,7 +15,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, resolveWslBinary } = require('../wsl');
 const http = require('http');
 const https = require('https');
 
@@ -165,7 +169,10 @@ class CodexAdapter extends BaseAdapter {
       if (fs.existsSync(c)) return c;
     }
 
-    return null;
+    // Nothing native anywhere. Last of all, look inside WSL: a CLI the user
+    // installed in their distro is a real install, and the marked path it comes
+    // back as is what the spawn bridge in ../wsl turns into a wsl.exe run.
+    return resolveWslBinary('codex');
   }
 
   _buildSystemContext(channelName) {

--- a/packages/agent-connector/src/adapters/commandcode.js
+++ b/packages/agent-connector/src/adapters/commandcode.js
@@ -45,7 +45,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, spawn } = require('child_process');
+const { execFileSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/adapters/copilot.js
+++ b/packages/agent-connector/src/adapters/copilot.js
@@ -38,7 +38,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, execFileSync, spawn } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');

--- a/packages/agent-connector/src/adapters/cursor.js
+++ b/packages/agent-connector/src/adapters/cursor.js
@@ -12,7 +12,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/adapters/deepseek.js
+++ b/packages/agent-connector/src/adapters/deepseek.js
@@ -47,7 +47,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, spawn, execSync } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { whichBinary, getEnhancedEnv } = require('../paths');

--- a/packages/agent-connector/src/adapters/gemini.js
+++ b/packages/agent-connector/src/adapters/gemini.js
@@ -11,7 +11,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, resolveWslBinary } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { whereBinary } = require('../paths');
@@ -183,7 +187,10 @@ class GeminiAdapter extends BaseAdapter {
       if (fs.existsSync(c)) return c;
     }
 
-    return null;
+    // Nothing native anywhere. Last of all, look inside WSL: a CLI the user
+    // installed in their distro is a real install, and the marked path it comes
+    // back as is what the spawn bridge in ../wsl turns into a wsl.exe run.
+    return resolveWslBinary('gemini');
   }
 
   // The Gemini CLI refuses to run non-interactively unless an auth method is

--- a/packages/agent-connector/src/adapters/goose.js
+++ b/packages/agent-connector/src/adapters/goose.js
@@ -28,7 +28,11 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
-const { spawn, execSync, execFileSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { GooseStreamParser, classifyGooseError, redactSecrets } = require('./goose-stream');

--- a/packages/agent-connector/src/adapters/hermes.js
+++ b/packages/agent-connector/src/adapters/hermes.js
@@ -17,7 +17,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, bridgeSpawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { buildOpenclawSystemPrompt } = require('./workspace-prompt');
@@ -71,9 +75,6 @@ class HermesAdapter extends BaseAdapter {
 
   _findHermesBinary() {
     const home = os.homedir();
-    // Reset each call. When set, this._hermesBin is a path INSIDE WSL and must
-    // be invoked as `wsl -e <path> …` rather than spawned natively.
-    this._hermesViaWsl = false;
 
     // Tier 1: PATH (enriched env so we see the dirs the launcher adds; a fresh
     // install updates the user PATH, which the running daemon won't pick up).
@@ -112,40 +113,13 @@ class HermesAdapter extends BaseAdapter {
       if (fs.existsSync(c)) return c;
     }
 
-    // Tier 3: Deep scan of every known bin dir.
+    // Tier 3: Deep scan of every known bin dir — which ends inside WSL when
+    // nothing native turned up, so a hermes the user set up in their distro is
+    // found here and comes back marked for the ../wsl spawn bridge. Native
+    // Windows (Tiers 1-2) is still preferred.
     const viaWhich = whichBinary('hermes');
     if (viaWhich) return viaWhich;
 
-    // Tier 4 (Windows only): fall back to a WSL install if one exists. Native
-    // Windows (Tiers 1-3) is preferred, but a user who set hermes up inside
-    // WSL2 still works — resolve its absolute in-WSL path; _runHermes then
-    // invokes it as `wsl -e <path> …`.
-    if (IS_WINDOWS) {
-      const wslPath = this._resolveWslHermes();
-      if (wslPath) {
-        this._hermesViaWsl = true;
-        return wslPath;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Resolve hermes's absolute path inside the default WSL distro, or null.
-   * Uses a login shell (`bash -lc`) so the installer's PATH additions
-   * (~/.local/bin) are visible. Returns an absolute Linux path like
-   * /home/<user>/.local/bin/hermes.
-   */
-  _resolveWslHermes() {
-    if (!IS_WINDOWS) return null;
-    try {
-      const out = execSync('wsl.exe -e bash -lc "command -v hermes"', {
-        encoding: 'utf-8', timeout: 8000, windowsHide: true,
-      }).trim();
-      const p = out.split(/\r?\n/).map((s) => s.trim()).find(Boolean);
-      if (p && p.startsWith('/')) return p;
-    } catch {}
     return null;
   }
 
@@ -314,23 +288,17 @@ class HermesAdapter extends BaseAdapter {
 
     const env = { ...(this.agentEnv || process.env) };
 
-    // On Windows hermes lives inside WSL: invoke `wsl -e <wsl-hermes-path> …`.
-    // `-e` runs the binary directly (no shell), so every arg — including the
-    // multi-line prompt in `-q` — passes through verbatim with no quoting hazard.
-    // hermes then uses its own config (~/.hermes inside WSL) for model/keys.
-    let spawnBin = this._hermesBin;
-    let spawnArgs = args;
-    if (this._hermesViaWsl) {
-      spawnBin = 'wsl.exe';
-      spawnArgs = ['-e', this._hermesBin, ...args];
-    }
-
-    const proc = spawn(spawnBin, spawnArgs, {
+    // A hermes that lives inside WSL is rewritten to `wsl.exe -e <path> …` by
+    // the bridge in ../wsl (which also forces detached off, there being no
+    // process group on the far side, and hands the distro the agent's env via
+    // WSLENV). hermes then uses its own config — ~/.hermes inside the distro —
+    // for model and keys. Nothing to special-case here.
+    const proc = spawn(this._hermesBin, args, {
       env,
       stdio: ['ignore', 'pipe', 'pipe'],
-      // No process group on Windows / WSL (can't signal a group); windowsHide
-      // keeps the wsl.exe console from flashing up.
-      detached: !IS_WINDOWS && !this._hermesViaWsl,
+      // No process group on Windows (can't signal one); windowsHide keeps a
+      // console from flashing up.
+      detached: !IS_WINDOWS,
       windowsHide: true,
     });
     this._channelProcesses[channelName] = proc;
@@ -469,9 +437,10 @@ class HermesAdapter extends BaseAdapter {
 
     const { execFileSync } = require('child_process');
     const run = (args) => {
-      const spawnBin = probe._hermesViaWsl ? 'wsl.exe' : bin;
-      const spawnArgs = probe._hermesViaWsl ? ['-e', bin, ...args] : args;
-      execFileSync(spawnBin, spawnArgs, {
+      // Same rewrite the spawn bridge does, for the one call here that needs to
+      // be synchronous: an in-distro hermes is only reachable through wsl.exe.
+      const { file, args: argv } = bridgeSpawn(bin, args);
+      execFileSync(file, argv, {
         stdio: 'ignore',
         timeout: 20000,
         windowsHide: true,

--- a/packages/agent-connector/src/adapters/kimi.js
+++ b/packages/agent-connector/src/adapters/kimi.js
@@ -29,7 +29,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const LlmDirectAdapter = require('./llm-direct');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/adapters/mini.js
+++ b/packages/agent-connector/src/adapters/mini.js
@@ -50,7 +50,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn, resolveWslBinary } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { whichBinary, getEnhancedEnv, aiderBinDirs } = require('../paths');
@@ -178,7 +182,7 @@ class MiniSweAgentAdapter extends BaseAdapter {
     // Shared cross-platform resolver runs `which`/`where` against an ENHANCED
     // PATH (nvm/fnm/volta/homebrew + pip/pipx/uv user-install dirs) — covers the
     // GUI/daemon "installed but not on PATH" case for a `pip install`.
-    const resolved = whichBinary('mini');
+    const resolved = whichBinary('mini', { allowWsl: false });
     if (resolved) return this._resolveExePreference(resolved, IS_WINDOWS);
 
     // Explicit fallback over the pip/pipx/uv user-install bin dirs plus the uv
@@ -201,7 +205,10 @@ class MiniSweAgentAdapter extends BaseAdapter {
         if (fs.existsSync(c)) return c;
       }
     }
-    return null;
+    // Nothing native anywhere. Last of all, look inside WSL: a CLI the user
+    // installed in their distro is a real install, and the marked path it comes
+    // back as is what the spawn bridge in ../wsl turns into a wsl.exe run.
+    return resolveWslBinary('mini');
   }
 
   /**

--- a/packages/agent-connector/src/adapters/openclaw.js
+++ b/packages/agent-connector/src/adapters/openclaw.js
@@ -14,7 +14,11 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { spawn, execSync } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt } = require('./utils');

--- a/packages/agent-connector/src/adapters/opencode.js
+++ b/packages/agent-connector/src/adapters/opencode.js
@@ -14,7 +14,11 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, redactSecrets } = require('./utils');

--- a/packages/agent-connector/src/adapters/openworker.js
+++ b/packages/agent-connector/src/adapters/openworker.js
@@ -42,7 +42,11 @@ const net = require('net');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
-const { spawn, execFileSync } = require('child_process');
+const { execFileSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/adapters/pi.js
+++ b/packages/agent-connector/src/adapters/pi.js
@@ -34,7 +34,11 @@ const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, execSync, spawn } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
+// spawn() here is the WSL bridge from ../wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('../wsl');
 
 const BaseAdapter = require('./base');
 const { formatAttachmentsForPrompt, SESSION_DEFAULT_RE, generateSessionTitle } = require('./utils');

--- a/packages/agent-connector/src/daemon.js
+++ b/packages/agent-connector/src/daemon.js
@@ -2,7 +2,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const { spawn, execSync, execFileSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
+// spawn() here is the WSL bridge from ./wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('./wsl');
 const os = require('os');
 const { WorkspaceClient } = require('./workspace-client');
 const { getEnhancedEnv, whichBinary, IS_WINDOWS, defaultAgentWorkdir } = require('./paths');

--- a/packages/agent-connector/src/installer.js
+++ b/packages/agent-connector/src/installer.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const { execSync, exec } = require('child_process');
 const { whichBinary, getEnhancedEnv, getRuntimePrefix, clearBinaryLookupCache, aiderBinDirs, resolveBinaryInKnownDirs } = require('./paths');
+const { isWslBinary, bridgedCommandString, wslHomeUnc } = require('./wsl');
 const { EnvManager } = require('./env');
 const { nodeDistUrls, installRegistry } = require('./mirrors');
 const { readinessReason, REASON } = require('./adapters/health-status');
@@ -171,6 +172,13 @@ class Installer {
         return { installed: true, managed: true, location: 'marker' };
       }
       return { installed: false, managed: false, location: null };
+    }
+
+    // Installed inside a WSL distro. Never 'managed': the launcher did not put
+    // it there and cannot uninstall it, and the isolated-runtime bookkeeping
+    // below is all about Windows paths that an in-distro binary can never match.
+    if (isWslBinary(binaryPath)) {
+      return { installed: true, managed: false, location: 'wsl' };
     }
 
     // Verify it's not a stale shim pointing to a missing package
@@ -580,6 +588,11 @@ class Installer {
    * shebang), so it's applied on every platform for consistency.
    */
   _versionProbeCommand(binary) {
+    // A binary inside WSL has to be asked through wsl.exe; running the Linux
+    // path as a Windows command yields "not recognized" and the marketplace
+    // then shows an installed agent with no version at all.
+    const bridged = bridgedCommandString(binary, ['--version']);
+    if (bridged) return bridged;
     if (/\.(mjs|cjs|js)$/i.test(binary)) {
       return `"${this._nodeBinary()}" "${binary}" --version`;
     }
@@ -744,14 +757,14 @@ class Installer {
     // authoritative; the legacy parser treats an empty {} as ready.
     const credsReady = checkReady.creds_json_has_entries
       ? false
-      : this._checkCredsReady(checkReady);
+      : this._checkCredsReady(checkReady, agentType);
     // Content-free credential probes (opt-in via check_ready). Detect agents
     // whose sign-in is a local OAuth/credential FILE (e.g. Gemini's
     // ~/.gemini/oauth_creds.json) or a service-account file path, WITHOUT
     // parsing or logging the token. Additive: agents that don't declare
     // creds_no_parse / creds_path_env get identical behavior to before.
-    const credsFile = this._evaluateCredsFile(checkReady);
-    const credsPathReady = this._checkCredsPathEnv(checkReady, savedEnv);
+    const credsFile = this._evaluateCredsFile(checkReady, agentType);
+    const credsPathReady = this._checkCredsPathEnv(checkReady, savedEnv, agentType);
 
     let cliReady = false;
     if (checkReady.status_command && binary) {
@@ -839,10 +852,10 @@ class Installer {
     return keys.some((key) => !!(source && source[key]));
   }
 
-  _checkCredsReady(checkReady) {
+  _checkCredsReady(checkReady, agentType) {
     if (checkReady.creds_file) {
       try {
-        const credsPath = checkReady.creds_file.replace('~', os.homedir());
+        const credsPath = this._expandHome(checkReady.creds_file, agentType);
         if (fs.existsSync(credsPath)) {
           const stat = fs.statSync(credsPath);
           if (stat.isDirectory()) return fs.readdirSync(credsPath).length > 0;
@@ -862,12 +875,36 @@ class Installer {
     return false;
   }
 
-  /** Expand a leading "~" to the running user's home directory. */
-  _expandHome(p) {
+  /**
+   * Expand a leading "~" to the home directory the AGENT writes its sign-in to.
+   *
+   * Normally the running user's. For an agent that resolved inside WSL it is
+   * the distro's $HOME, reached over the \\wsl.localhost mount — `claude login`
+   * run in the distro leaves ~/.claude there, and expanding against the Windows
+   * profile instead reports a signed-in agent as "Not logged in".
+   */
+  _expandHome(p, agentType) {
     if (typeof p !== 'string' || !p) return p;
-    if (p === '~') return os.homedir();
-    if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+    const home = this._homeForAgent(agentType);
+    if (p === '~') return home;
+    if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(home, p.slice(2));
     return p;
+  }
+
+  /**
+   * Where this agent's dotfiles live, as a path this process can read. Falls
+   * back to the running user's home for every native install — and for a WSL
+   * one whose distro home could not be resolved, which is no worse than the
+   * behaviour before the WSL tier existed.
+   */
+  _homeForAgent(agentType) {
+    if (!agentType) return os.homedir();
+    try {
+      if (isWslBinary(this._whichBinary(agentType))) {
+        return wslHomeUnc() || os.homedir();
+      }
+    } catch { /* resolution is best-effort; the host home is the safe answer */ }
+    return os.homedir();
   }
 
   /**
@@ -881,9 +918,9 @@ class Installer {
    * against the running user's home (the daemon/launcher user), not the
    * renderer/browser user.
    */
-  _credsFileState(checkReady) {
+  _credsFileState(checkReady, agentType) {
     if (!checkReady || !checkReady.creds_file) return 'absent';
-    const p = this._expandHome(checkReady.creds_file);
+    const p = this._expandHome(checkReady.creds_file, agentType);
     let exists = false;
     try { exists = fs.existsSync(p); } catch { return 'unreadable'; }
     if (!exists) return 'absent';
@@ -922,11 +959,11 @@ class Installer {
    * parse + match `creds_key` via _checkCredsReady) keep their exact behavior.
    * Returns { ready, unreadable }.
    */
-  _evaluateCredsFile(checkReady) {
+  _evaluateCredsFile(checkReady, agentType) {
     if (!checkReady || !checkReady.creds_file || !checkReady.creds_no_parse) {
       return { ready: false, unreadable: false };
     }
-    const state = this._credsFileState(checkReady);
+    const state = this._credsFileState(checkReady, agentType);
     return { ready: state === 'present', unreadable: state === 'unreadable' };
   }
 
@@ -936,14 +973,14 @@ class Installer {
    * exists and is a readable file — a non-empty value alone is NOT enough.
    * Checks both the process env and the agent's saved env.
    */
-  _checkCredsPathEnv(checkReady, savedEnv) {
+  _checkCredsPathEnv(checkReady, savedEnv, agentType) {
     const names = checkReady && checkReady.creds_path_env;
     if (!Array.isArray(names) || !names.length) return false;
     for (const name of names) {
       const raw = ((process.env[name] || (savedEnv && savedEnv[name]) || '') + '').trim();
       if (!raw) continue;
       try {
-        const p = this._expandHome(raw);
+        const p = this._expandHome(raw, agentType);
         if (!fs.existsSync(p)) continue;
         fs.accessSync(p, fs.constants.R_OK);
         if (fs.statSync(p).isFile()) return true;
@@ -1568,8 +1605,12 @@ class Installer {
     const managed = this._resolveManagedBinary(agentType, entry, binary, aliases);
     if (managed) return managed;
 
+    // allowWsl:false — whichBinary would otherwise end its own search inside
+    // the distro, and this method still has two NATIVE tiers to run below. A
+    // Windows copy must win over a WSL one; resolveBinaryInKnownDirs() reaches
+    // the distro at the very end, once everything on this side has missed.
     for (const candidate of [binary, ...aliases]) {
-      const found = whichBinary(candidate);
+      const found = whichBinary(candidate, { allowWsl: false });
       if (found) return found;
     }
     // Fallback: resolve the installed package's OWN bin from its package.json

--- a/packages/agent-connector/src/paths.js
+++ b/packages/agent-connector/src/paths.js
@@ -12,6 +12,12 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { execSync, execFileSync } = require('child_process');
+const {
+  isRunningInWsl,
+  resolveWslBinary,
+  clearWslBinaryCache,
+  wslBinDirs,
+} = require('./wsl');
 
 const IS_WINDOWS = process.platform === 'win32';
 const IS_MACOS = process.platform === 'darwin';
@@ -183,24 +189,84 @@ function getEnhancedEnv(baseEnv) {
 
 /**
  * Find a binary by name. Returns full path or null.
+ *
+ * On Windows the search ends INSIDE WSL when nothing native turned up: an agent
+ * CLI the user installed in their distro is a real, usable install, and the
+ * Linux path that comes back is what adapters hand to the wsl.js spawn bridge.
+ * It is deliberately the last thing tried — a native copy always wins — and
+ * `allowWsl: false` opts out for callers (installer.js) that have further
+ * native tiers of their own to run first.
+ *
+ * @param {string} name
+ * @param {{allowWsl?: boolean}} [opts]
  */
-function whichBinary(name) {
+function whichBinary(name, { allowWsl = true } = {}) {
   if (!name) return null;
   const currentPATH = process.env.PATH || '';
-  const cacheKey = `${name}\0${currentPATH}`;
+  const cacheKey = `${name}\0${currentPATH}\0${allowWsl ? 'wsl' : 'native'}`;
   const cached = whichBinaryCache.get(cacheKey);
   if (cached && Date.now() - cached.at < PATH_LOOKUP_CACHE_TTL_MS) {
     return cached.value;
   }
 
-  // On a non-English Windows the console OUTPUT codepage is OEM (e.g. 936/GBK on
-  // zh-CN), so `where` prints a path whose non-ASCII bytes don't match the utf-8
-  // decoding execSync does — a Chinese username comes back mangled (e.g.
-  // `C:\Users\??.?[\…`) and yields ENOENT downstream. We can't reliably re-encode
-  // it (and forcing `chcp` is unsafe under windowsHide's console-less cmd), so we
-  // existence-check every hit and only return one that's real; a mangled path
-  // fails and the caller falls through to its Node-derived tiers (built from
-  // process.env / os.homedir, which the OS hands us as correct UTF-16).
+  let value = _whichNative(name);
+  if (!value && allowWsl) value = resolveWslBinary(name);
+  whichBinaryCache.set(cacheKey, { value, at: Date.now() });
+  return value;
+}
+
+/** The PATH lookup proper — `where`/`which`, this side of any boundary. */
+function _whichNative(name) {
+  let hits = _runWhich(name);
+
+  if (isRunningInWsl()) {
+    // Interop puts the Windows PATH on the distro's PATH, so `which claude`
+    // happily answers /mnt/c/Users/…/AppData/Roaming/npm/claude — npm's
+    // extensionless POSIX shim, a sh script that execs node.exe with Windows
+    // paths. Linux cannot run it, and returning it turns "not installed" into
+    // the more confusing "installed but every run fails". Only a real PE image
+    // crosses back this way, which interop does exec with argv intact.
+    hits = hits.filter((h) => !_isWindowsMount(h) || /\.exe$/i.test(h));
+    // `which cursor-agent` can't see cursor-agent.exe — the name on disk
+    // carries the suffix — so ask for it explicitly before giving up.
+    if (!hits.length && !/\.exe$/i.test(name)) hits = _runWhich(`${name}.exe`);
+  }
+
+  let value = hits[0] || null;
+  if (IS_WINDOWS && hits.length) {
+    // `where` can list npm's extensionless POSIX shim (node_modules/.bin/
+    // claude, a sh script) ahead of claude.cmd. Windows cannot execute that
+    // file — spawning it fails and the probe misreports an installed CLI as
+    // "not installed" while the chat adapters (which prefer .cmd) work fine.
+    // Prefer a hit Windows can run; failing that, a runnable sibling of the
+    // shim; only then fall back to the raw first hit.
+    const RUNNABLE = /\.(cmd|exe|bat|com)$/i;
+    const runnable = hits.find((h) => RUNNABLE.test(h));
+    if (runnable) {
+      value = runnable;
+    } else {
+      for (const h of hits) {
+        const sibling = ['.cmd', '.exe', '.bat'].map((e) => h + e).find((c) => fs.existsSync(c));
+        if (sibling) { value = sibling; break; }
+      }
+    }
+  }
+  return value;
+}
+
+/**
+ * Existing paths `where`/`which` reports for a name, in its own order.
+ *
+ * On a non-English Windows the console OUTPUT codepage is OEM (e.g. 936/GBK on
+ * zh-CN), so `where` prints a path whose non-ASCII bytes don't match the utf-8
+ * decoding execSync does — a Chinese username comes back mangled (e.g.
+ * `C:\Users\??.?[\…`) and yields ENOENT downstream. We can't reliably re-encode
+ * it (and forcing `chcp` is unsafe under windowsHide's console-less cmd), so we
+ * existence-check every hit and only return ones that are real; a mangled path
+ * fails and the caller falls through to its Node-derived tiers (built from
+ * process.env / os.homedir, which the OS hands us as correct UTF-16).
+ */
+function _runWhich(name) {
   const cmd = IS_WINDOWS ? `where ${name}` : `which ${name}`;
   try {
     const result = execSync(cmd, {
@@ -221,31 +287,19 @@ function whichBinary(name) {
       const hit = line.trim();
       if (hit && fs.existsSync(hit)) hits.push(hit);
     }
-    let value = hits[0] || null;
-    if (IS_WINDOWS && hits.length) {
-      // `where` can list npm's extensionless POSIX shim (node_modules/.bin/
-      // claude, a sh script) ahead of claude.cmd. Windows cannot execute that
-      // file — spawning it fails and the probe misreports an installed CLI as
-      // "not installed" while the chat adapters (which prefer .cmd) work fine.
-      // Prefer a hit Windows can run; failing that, a runnable sibling of the
-      // shim; only then fall back to the raw first hit.
-      const RUNNABLE = /\.(cmd|exe|bat|com)$/i;
-      const runnable = hits.find((h) => RUNNABLE.test(h));
-      if (runnable) {
-        value = runnable;
-      } else {
-        for (const h of hits) {
-          const sibling = ['.cmd', '.exe', '.bat'].map((e) => h + e).find((c) => fs.existsSync(c));
-          if (sibling) { value = sibling; break; }
-        }
-      }
-    }
-    whichBinaryCache.set(cacheKey, { value, at: Date.now() });
-    return value;
+    return hits;
   } catch {
-    whichBinaryCache.set(cacheKey, { value: null, at: Date.now() });
-    return null;
+    return [];
   }
+}
+
+/**
+ * A path on a Windows drive as mounted inside a distro (/mnt/c/…). /mnt is
+ * WSL's default automount root and the only one interop puts on PATH itself;
+ * a distro that moved it in /etc/wsl.conf simply gets the old behaviour.
+ */
+function _isWindowsMount(p) {
+  return /^\/mnt\/[a-z]\//i.test(String(p || ''));
 }
 
 /**
@@ -916,6 +970,7 @@ function clearBinaryLookupCache() {
   knownBinDirsCache = { value: null, at: 0 };
   extraBinDirsCache = { value: null, at: 0, path: '' };
   whichBinaryCache.clear();
+  clearWslBinaryCache();
   // The login-shell / npm-prefix probes are deliberately NOT cleared: they each
   // cost a process spawn, they answer a question about the machine rather than
   // about any install, and this is called after every install/uninstall.
@@ -933,6 +988,11 @@ function primeBinaryLookup() {
   try { loginShellDirs(); } catch {}
   try { _npmPrefix(); } catch {}
   try { getKnownBinDirs(); } catch {}
+  // The WSL side has the same shape of cost — one `wsl.exe -e bash -ilc` to
+  // learn the distro's login PATH — and it is paid by the first lookup that
+  // misses natively, which is the marketplace enumerating agents nobody has
+  // installed. Warm it here instead.
+  try { wslBinDirs(); } catch {}
 }
 
 /**
@@ -1035,7 +1095,11 @@ function resolveBinaryInKnownDirs(names, agentType) {
       }
     }
   }
-  return null;
+
+  // Nothing native anywhere: the last place left to look is inside WSL, whose
+  // filesystem none of the dirs above can reach. Last by construction — a
+  // Windows copy of the CLI is always preferred to an in-distro one.
+  return resolveWslBinary(list);
 }
 
 

--- a/packages/agent-connector/src/probe.js
+++ b/packages/agent-connector/src/probe.js
@@ -26,7 +26,10 @@
  */
 
 const os = require('os');
-const { spawn } = require('child_process');
+// spawn() here is the WSL bridge from ./wsl: same signature as
+// child_process.spawn, and a straight pass-through unless the resolved CLI
+// lives on the other side of the Windows/WSL boundary.
+const { spawn } = require('./wsl');
 const { getEnhancedEnv } = require('./paths');
 const { shouldUseShellForBinary } = require('./adapters/health-status');
 const { formatAuthGuidance } = require('./auth-guidance');

--- a/packages/agent-connector/src/wsl.js
+++ b/packages/agent-connector/src/wsl.js
@@ -1,0 +1,579 @@
+/**
+ * The Windows/WSL boundary — making agent CLIs on the other side of it both
+ * DETECTABLE and RUNNABLE.
+ *
+ * Two setups reported the same symptom ("my agent is installed, the launcher
+ * says Not installed"), and they are mirror images of each other:
+ *
+ *   1. Launcher/daemon on native Windows, the agent CLI installed inside a WSL
+ *      distro. Every tier of the existing detection (`where`, %APPDATA%\npm,
+ *      ~/.openagents, the known-bin-dir sweep in paths.js) looks at the Windows
+ *      filesystem only, so a perfectly good `claude` at
+ *      /home/<user>/.nvm/versions/node/v22.14.0/bin/claude is invisible. Hermes
+ *      grew a one-off fallback for exactly this (adapters/hermes.js) and no
+ *      other agent had one.
+ *   2. Connector running INSIDE a distro, the agent CLI installed on the
+ *      Windows side. `which claude` misses because the file is `claude.cmd`,
+ *      and even when found, a Windows shim cannot be exec'd from Linux.
+ *
+ * The representation stays a plain string, so detection keeps its signatures
+ * and only the SPAWN site needs to know the difference: an in-distro binary
+ * comes back prefixed, as `wsl:/home/u/.local/bin/claude`. The prefix is there
+ * rather than relying on "an absolute path starting with / on win32" because
+ * that inference is silently wrong for any caller that deals in POSIX paths on
+ * Windows for its own reasons — it would bridge a path nobody meant as WSL, and
+ * a marker that can be triggered by accident is worse than no marker.
+ *
+ * The mirror direction needs no marker: a path ending in .exe/.cmd/.bat while
+ * we are running inside a distro is unambiguously a Windows binary.
+ *
+ * Cost: resolution never spawns wsl.exe per binary. One probe per process
+ * (30s TTL) reads the distro's login PATH, and every later lookup is a
+ * filesystem check through the \\wsl.localhost UNC mount — which Windows serves
+ * without starting a distro session.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const { spawn: nodeSpawn, execFileSync } = require('child_process');
+
+const IS_WINDOWS = process.platform === 'win32';
+const PROBE_TIMEOUT_MS = 10000;
+const CACHE_TTL_MS = 30 * 1000;
+
+/** Marks a resolved path as living inside the distro: `wsl:/home/u/bin/claude`. */
+const WSL_PREFIX = 'wsl:';
+
+/** Env names that must never cross the boundary: each side has its own. */
+const ENV_NEVER_FORWARD = new Set(
+  [
+    'PATH', 'HOME', 'USER', 'USERNAME', 'USERPROFILE', 'LOGNAME', 'SHELL',
+    'PWD', 'OLDPWD', 'TEMP', 'TMP', 'TMPDIR', 'APPDATA', 'LOCALAPPDATA',
+    'PROGRAMFILES', 'PROGRAMFILES(X86)', 'PROGRAMDATA', 'SYSTEMROOT',
+    'SYSTEMDRIVE', 'WINDIR', 'COMSPEC', 'PATHEXT', 'WSLENV', 'WSL_DISTRO_NAME',
+    'WSL_INTEROP', 'NODE_OPTIONS', 'NVM_DIR', 'NVM_BIN', 'VOLTA_HOME',
+    // getEnhancedEnv() sets LANG for the Windows console's benefit. Ubuntu
+    // generates C.UTF-8 and not en_US.UTF-8, so forwarding it makes every CLI
+    // in the distro open with a setlocale warning it had no reason to print.
+    'LANG', 'LC_ALL',
+  ].map((n) => n.toUpperCase()),
+);
+
+// ---------------------------------------------------------------------------
+// Which side of the boundary are we on?
+// ---------------------------------------------------------------------------
+
+let inWslCache;
+
+/**
+ * True when THIS process is running inside a WSL distro.
+ *
+ * WSL_DISTRO_NAME is set by modern WSL but is lost by anything that sanitises
+ * the environment, so the kernel release string — which carries "microsoft" on
+ * both WSL1 and WSL2 — is the authority and the env var only a fast path.
+ */
+function isRunningInWsl() {
+  if (inWslCache !== undefined) return inWslCache;
+  inWslCache = false;
+  if (process.platform !== 'linux') return inWslCache;
+  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) {
+    inWslCache = true;
+    return inWslCache;
+  }
+  try {
+    const release = fs.readFileSync('/proc/sys/kernel/osrelease', 'utf-8');
+    inWslCache = /microsoft|wsl/i.test(release);
+  } catch {
+    /* not Linux-with-procfs — leave false */
+  }
+  return inWslCache;
+}
+
+// ---------------------------------------------------------------------------
+// Windows side: is there a distro to talk to at all?
+// ---------------------------------------------------------------------------
+
+let distrosCache = { value: null, at: 0 };
+
+/**
+ * Registered, non-broken distro names, default first.
+ *
+ * `wsl.exe -l -q` writes UTF-16LE (it is one of wsl.exe's own management
+ * commands, unlike `-e` which passes the child's bytes straight through), so it
+ * is read as a buffer and decoded explicitly — a utf-8 read yields NUL-riddled
+ * garbage that no name ever matches.
+ *
+ * An empty list is the normal answer on a machine where `wsl --install` was
+ * never finished: wsl.exe EXISTS in System32 on every Windows 11 install, so
+ * its presence proves nothing and only a registered distro does.
+ */
+function wslDistros() {
+  if (!IS_WINDOWS) return [];
+  if (distrosCache.value && Date.now() - distrosCache.at < CACHE_TTL_MS) {
+    return [...distrosCache.value];
+  }
+  let names = [];
+  try {
+    const buf = execFileSync('wsl.exe', ['-l', '-q'], {
+      timeout: PROBE_TIMEOUT_MS,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 1024 * 1024,
+    });
+    names = buf
+      .toString('utf16le')
+      .split(/\r?\n/)
+      .map((l) => l.replace(/\0/g, '').trim())
+      .filter(Boolean);
+  } catch {
+    names = [];
+  }
+  distrosCache = { value: names, at: Date.now() };
+  return [...names];
+}
+
+/** True when a WSL distro is registered and reachable from this Windows host. */
+function isWslAvailable() {
+  return IS_WINDOWS && wslDistros().length > 0;
+}
+
+/** The distro every bridged command targets — wsl.exe's own default. */
+function defaultDistro() {
+  return wslDistros()[0] || null;
+}
+
+// ---------------------------------------------------------------------------
+// Windows side: reaching into the distro's filesystem without starting one
+// ---------------------------------------------------------------------------
+
+let uncRootCache = { value: null, at: 0 };
+
+/**
+ * The UNC prefix that maps the default distro's root into Windows, or null.
+ * WSL2 serves \\wsl.localhost\<distro>; WSL1 and older builds only \\wsl$\.
+ */
+function _uncRoot() {
+  if (uncRootCache.at && Date.now() - uncRootCache.at < CACHE_TTL_MS) {
+    return uncRootCache.value;
+  }
+  const distro = defaultDistro();
+  if (!distro) return null;
+  let root = null;
+  for (const prefix of ['\\\\wsl.localhost\\', '\\\\wsl$\\']) {
+    const candidate = prefix + distro;
+    try {
+      if (fs.existsSync(candidate)) { root = candidate; break; }
+    } catch {
+      /* an unreachable share throws rather than returning false */
+    }
+  }
+  uncRootCache = { value: root, at: Date.now() };
+  return root;
+}
+
+/**
+ * The distro's $HOME as a path Windows can read, or null.
+ *
+ * An agent installed in WSL keeps its sign-in where IT lives — ~/.claude,
+ * ~/.gemini, ~/.codex inside the distro — so a readiness check that expands "~"
+ * against the Windows profile finds nothing and calls a signed-in agent
+ * "Not logged in".
+ */
+function wslHomeUnc() {
+  const home = _shellProbe().home;
+  return home ? toUncPath(home) : null;
+}
+
+/** Map an in-distro absolute path to the UNC path Windows can stat. */
+function toUncPath(linuxPath) {
+  const root = _uncRoot();
+  if (!root || !linuxPath || !linuxPath.startsWith('/')) return null;
+  return root + linuxPath.replace(/\//g, '\\');
+}
+
+// ---------------------------------------------------------------------------
+// Windows side: what the distro's login shell would put on PATH
+// ---------------------------------------------------------------------------
+
+const PROBE_DELIM = '__OPENAGENTS_WSL__';
+let shellProbeCache = { value: null, at: 0 };
+
+/**
+ * One wsl.exe call per process (30s TTL) that answers everything later lookups
+ * need: the login PATH, $HOME, and the real automount root.
+ *
+ * `bash -ilc` — INTERACTIVE as well as login — because the version managers
+ * that actually hold the agent CLIs write to ~/.bashrc, and Ubuntu's stock
+ * ~/.bashrc returns early for a non-interactive shell BEFORE the nvm/fnm block
+ * at the bottom ever runs. A plain `-lc` therefore reports a PATH with no nvm
+ * in it, which is precisely the install this whole module exists to find.
+ * stderr is dropped: an interactive shell with no tty warns about job control.
+ */
+function _shellProbe() {
+  const empty = { dirs: [], home: null, automount: '/mnt/' };
+  if (shellProbeCache.at && Date.now() - shellProbeCache.at < CACHE_TTL_MS) {
+    return shellProbeCache.value || empty;
+  }
+  if (!isWslAvailable()) return empty;
+
+  const script =
+    'echo ' + PROBE_DELIM + '; echo "$PATH"; echo "$HOME"; ' +
+    "wslpath -u 'C:\\' 2>/dev/null || echo /mnt/c/";
+
+  let out = null;
+  for (const argv of [['-e', 'bash', '-ilc', script], ['-e', 'sh', '-lc', script]]) {
+    try {
+      const raw = execFileSync('wsl.exe', argv, {
+        encoding: 'utf-8',
+        timeout: PROBE_TIMEOUT_MS,
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        maxBuffer: 4 * 1024 * 1024,
+      });
+      const idx = raw.indexOf(PROBE_DELIM);
+      if (idx === -1) continue;
+      const lines = raw.slice(idx + PROBE_DELIM.length).split(/\r?\n/).map((l) => l.trim());
+      const pathLine = lines[1];
+      const homeLine = lines[2];
+      const cRoot = lines[3];
+      if (!pathLine) continue;
+      const dirs = [];
+      for (const d of pathLine.split(':')) {
+        const dir = d.trim();
+        // /mnt/<drive> entries are the Windows PATH bounced back by interop.
+        // They hold Windows binaries, never the in-distro install we are after.
+        if (dir && dir.startsWith('/') && !/^\/mnt\/[a-z]\//i.test(dir) && !dirs.includes(dir)) {
+          dirs.push(dir);
+        }
+      }
+      // `wslpath -u 'C:\'` answers /mnt/c/ by default, but /etc/wsl.conf can
+      // move the automount root — derive it rather than hardcoding /mnt.
+      let automount = '/mnt/';
+      const m = /^(\/.*\/)c\/?$/i.exec(cRoot || '');
+      if (m) automount = m[1];
+      out = { dirs, home: homeLine && homeLine.startsWith('/') ? homeLine : null, automount };
+      break;
+    } catch {
+      /* try the next shell */
+    }
+  }
+  shellProbeCache = { value: out || empty, at: Date.now() };
+  return shellProbeCache.value;
+}
+
+/**
+ * Every in-distro directory an agent CLI can plausibly live in: the login
+ * PATH first (it is the ground truth for how the user installed things), then
+ * the same curated set paths.js keeps for native Linux, so a CLI whose
+ * installer only edited a shell rc file we could not read is still found.
+ */
+function wslBinDirs() {
+  const probe = _shellProbe();
+  const dirs = [...probe.dirs];
+  const home = probe.home;
+  const push = (d) => { if (d && !dirs.includes(d)) dirs.push(d); };
+  if (home) {
+    push(home + '/.local/bin');
+    push(home + '/.npm-global/bin');
+    push(home + '/.openagents/nodejs/node_modules/.bin');
+    push(home + '/.cursor/bin');
+    push(home + '/.amp/bin');
+    push(home + '/.opencode/bin');
+    push(home + '/.cargo/bin');
+    push(home + '/bin');
+  }
+  push('/usr/local/bin');
+  push('/usr/bin');
+  push('/home/linuxbrew/.linuxbrew/bin');
+  return dirs;
+}
+
+const wslBinaryCache = new Map();
+
+/**
+ * Resolve an agent binary inside the default distro, or null.
+ *
+ * Returns the path as the DISTRO sees it, behind the `wsl:` marker
+ * (`wsl:/home/u/.local/bin/claude`) — the inner path is what `wsl.exe -e` must
+ * be handed. Existence is proved through the UNC mount, so a machine with WSL
+ * installed but no distro pays nothing beyond the single cached distro listing.
+ *
+ * @param {string|string[]} names binary name(s), e.g. 'claude' or ['cursor-agent','agent']
+ * @returns {string|null} marked in-distro path
+ */
+function resolveWslBinary(names) {
+  if (!IS_WINDOWS) return null;
+  const list = (Array.isArray(names) ? names : [names]).filter(Boolean);
+  if (!list.length) return null;
+  const key = list.join('\0');
+  const cached = wslBinaryCache.get(key);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.value;
+
+  let value = null;
+  if (isWslAvailable() && _uncRoot()) {
+    const dirs = wslBinDirs();
+    search:
+    for (const dir of dirs) {
+      for (const name of list) {
+        const linuxPath = dir.replace(/\/+$/, '') + '/' + name;
+        const unc = toUncPath(linuxPath);
+        if (!unc) continue;
+        try {
+          if (fs.existsSync(unc) && fs.statSync(unc).isFile()) {
+            value = WSL_PREFIX + linuxPath;
+            break search;
+          }
+        } catch {
+          /* unreadable path — keep looking */
+        }
+      }
+    }
+  }
+  wslBinaryCache.set(key, { value, at: Date.now() });
+  return value;
+}
+
+/**
+ * Forget which binaries were found, so an agent installed into the distro while
+ * the launcher is already running is picked up. Called from
+ * paths.clearBinaryLookupCache(); the distro listing and the login-shell probe
+ * survive it deliberately — they each cost a wsl.exe start, and they describe
+ * the machine rather than any one install.
+ */
+function clearWslBinaryCache() {
+  wslBinaryCache.clear();
+}
+
+/** Full reset, including the per-process probes. For tests and rare rescans. */
+function clearWslCache() {
+  distrosCache = { value: null, at: 0 };
+  uncRootCache = { value: null, at: 0 };
+  shellProbeCache = { value: null, at: 0 };
+  wslBinaryCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Classifying a resolved binary
+// ---------------------------------------------------------------------------
+
+/** A binary that lives inside WSL and must be run through wsl.exe. */
+function isWslBinary(bin) {
+  return typeof bin === 'string' && bin.startsWith(WSL_PREFIX);
+}
+
+/** The in-distro path behind the marker, for anything that has to see it raw. */
+function wslBinaryPath(bin) {
+  return isWslBinary(bin) ? bin.slice(WSL_PREFIX.length) : bin;
+}
+
+/**
+ * A Windows binary seen from inside a distro, classified by whether it can
+ * actually be run from here:
+ *   'exe'  — a real PE image; Linux exec + WSL interop runs it with argv intact.
+ *   'shim' — a .cmd/.bat batch file. Only cmd.exe can run one, and cmd.exe
+ *            rebuilds its command line from a single string, so every &, |, ^,
+ *            > and " in a prompt would be reinterpreted as shell syntax. We
+ *            refuse rather than corrupt (or worse, execute) user text.
+ *
+ * `inWsl` is injectable for the same reason win-exec.ts injects its platform:
+ * this branch only ever runs inside a distro, and a test that can only run
+ * there is a test that never runs.
+ */
+function windowsBinaryKind(bin, inWsl = isRunningInWsl()) {
+  if (!inWsl || typeof bin !== 'string') return null;
+  if (/\.exe$/i.test(bin)) return 'exe';
+  if (/\.(cmd|bat)$/i.test(bin)) return 'shim';
+  return null;
+}
+
+/** Path as the Windows side sees it (best effort; UNC for in-distro paths). */
+function toWindowsPath(p) {
+  if (!p || !p.startsWith('/')) return p;
+  const root = isRunningInWsl() ? '/mnt/' : _shellProbe().automount;
+  const escaped = root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp('^' + escaped + '([a-z])(/|$)', 'i').exec(p);
+  if (m) {
+    return m[1].toUpperCase() + ':\\' + p.slice(m[0].length).replace(/\//g, '\\');
+  }
+  if (isRunningInWsl()) {
+    const distro = process.env.WSL_DISTRO_NAME;
+    return distro ? '\\\\wsl.localhost\\' + distro + p.replace(/\//g, '\\') : p;
+  }
+  return toUncPath(p) || p;
+}
+
+/** Path as the distro sees it (best effort; drive letters only). */
+function toWslPath(p) {
+  if (!p || !/^[A-Za-z]:[\\/]/.test(p)) return p;
+  const root = isRunningInWsl() ? '/mnt/' : _shellProbe().automount;
+  return root + p[0].toLowerCase() + '/' + p.slice(3).replace(/\\/g, '/');
+}
+
+// ---------------------------------------------------------------------------
+// The spawn bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Which environment entries should cross into the distro.
+ *
+ * Only what the CALLER added on top of this process's own environment: those
+ * are the agent's credentials, endpoints and workspace settings, and they are
+ * the entire reason a bridged agent would otherwise start up unauthenticated.
+ * Anything inherited unchanged from Windows is dropped — the distro has its own
+ * PATH/HOME/TEMP, and handing it Windows values breaks the shell before the
+ * agent is even reached.
+ */
+function _forwardedEnvNames(env) {
+  if (!env) return [];
+  const names = [];
+  for (const [k, v] of Object.entries(env)) {
+    if (v == null) continue;
+    if (ENV_NEVER_FORWARD.has(k.toUpperCase())) continue;
+    if (Object.prototype.hasOwnProperty.call(process.env, k) && process.env[k] === v) continue;
+    names.push(k);
+  }
+  return names;
+}
+
+/**
+ * WSLENV is the only channel Windows has for handing variables to a distro —
+ * without it `wsl.exe -e` starts with a clean Linux environment and every
+ * OPENAGENTS_* / *_API_KEY the adapter set is silently dropped.
+ *
+ * A value that is a Windows path gets the `/p` flag (and a `;`-separated list
+ * of them `/l`) so WSL translates it on the way in, instead of handing the
+ * agent a `D:\work` that means nothing on the other side.
+ */
+function _withWslEnv(env) {
+  const out = { ...(env || process.env) };
+  const entries = [];
+  for (const name of _forwardedEnvNames(out)) {
+    const value = String(out[name]);
+    const looksLikePath = (s) => /^[A-Za-z]:[\\/]/.test(s);
+    let flag = '';
+    // The list test comes first: a `C:\a;D:\b` also matches the single-path
+    // pattern on its first segment, and tagging it /p would hand the distro one
+    // mangled string instead of a translated PATH-style list.
+    if (value.includes(';') && value.split(';').filter(Boolean).every(looksLikePath)) {
+      flag = '/l';
+    } else if (looksLikePath(value)) {
+      flag = '/p';
+    }
+    entries.push(name + flag);
+  }
+  if (out.WSLENV) entries.unshift(out.WSLENV);
+  if (entries.length) out.WSLENV = entries.join(':');
+  return out;
+}
+
+function _existsDir(p) {
+  try { return fs.existsSync(p); } catch { return false; }
+}
+
+/**
+ * Translate argv entries that are Windows paths into the distro's view of them.
+ *
+ * Adapters pass real paths on the command line — `--add-dir D:\work`,
+ * `--config C:\Users\…\settings.json` — and a Windows path handed to a Linux
+ * process is simply a file that does not exist. The entry has to BE a path and
+ * that path has to EXIST for it to be rewritten, so ordinary prompt text (which
+ * is prose, and does not name a real file) is never touched.
+ */
+function _translateArgs(args) {
+  return args.map((a) => {
+    const s = String(a);
+    if (!/^[A-Za-z]:[\\/]/.test(s)) return a;
+    if (!_existsDir(s)) return a;
+    return toWslPath(s);
+  });
+}
+
+/**
+ * Rewrite a (file, args, opts) triple so it runs on the right side of the
+ * boundary. A no-op — the same triple back — for every ordinary local binary,
+ * which is why callers can use it unconditionally.
+ *
+ * @throws {Error} when the binary is a Windows .cmd/.bat shim seen from inside
+ *   WSL: there is no way to run one without letting cmd.exe re-parse the
+ *   prompt, so the caller gets an actionable message instead of mangled input.
+ *
+ * @param {{inWsl?: boolean}} [seam] test injection — see windowsBinaryKind.
+ */
+function bridgeSpawn(file, args = [], opts = {}, seam = {}) {
+  if (isWslBinary(file)) {
+    return {
+      file: 'wsl.exe',
+      args: ['-e', wslBinaryPath(file), ..._translateArgs(args)],
+      opts: {
+        ...opts,
+        env: _withWslEnv(opts.env),
+        // wsl.exe inherits this process's Windows cwd and translates it for the
+        // distro, so opts.cwd is handed through untouched — but only if it
+        // really exists, since spawn() itself fails ENOENT otherwise and that
+        // reads as "the agent isn't installed".
+        cwd: opts.cwd && _existsDir(opts.cwd) ? opts.cwd : undefined,
+        // A shell would be asked to run a Linux path as a Windows command, and
+        // there is no process group to detach into on the far side of wsl.exe.
+        shell: false,
+        detached: false,
+        windowsHide: true,
+      },
+    };
+  }
+
+  if (windowsBinaryKind(file, seam.inWsl) === 'shim') {
+    throw new Error(
+      'Cannot run the Windows CLI ' + file + ' from inside WSL: .cmd/.bat shims have to ' +
+      'go through cmd.exe, which would re-interpret the prompt text. Install the agent ' +
+      'inside this distro (e.g. npm install -g …), or run the launcher on Windows.',
+    );
+  }
+  // A '.exe' needs no rewrite: WSL interop execs a PE image directly and
+  // preserves argv exactly, unlike the shim case above.
+
+  return { file, args, opts };
+}
+
+/**
+ * child_process.spawn with the boundary handled. Same signature, same return —
+ * drop-in for every adapter that spawns an agent CLI.
+ */
+function spawn(file, args = [], opts = {}) {
+  const bridged = bridgeSpawn(file, args, opts);
+  return nodeSpawn(bridged.file, bridged.args, bridged.opts);
+}
+
+/**
+ * A shell command string that runs `<bin> <args…>` across the boundary, for the
+ * execSync-based version/verify probes. Returns null when no bridging applies
+ * and the caller should build its own command exactly as before.
+ */
+function bridgedCommandString(bin, args = []) {
+  if (!isWslBinary(bin)) return null;
+  const quoted = [wslBinaryPath(bin), ...args]
+    .map((a) => '"' + String(a).replace(/"/g, '\\"') + '"')
+    .join(' ');
+  return 'wsl.exe -e ' + quoted;
+}
+
+module.exports = {
+  isRunningInWsl,
+  isWslAvailable,
+  wslDistros,
+  defaultDistro,
+  wslBinDirs,
+  wslHomeUnc,
+  resolveWslBinary,
+  clearWslBinaryCache,
+  clearWslCache,
+  isWslBinary,
+  wslBinaryPath,
+  windowsBinaryKind,
+  toWindowsPath,
+  toWslPath,
+  toUncPath,
+  bridgeSpawn,
+  bridgedCommandString,
+  spawn,
+};

--- a/packages/agent-connector/test/wsl.test.js
+++ b/packages/agent-connector/test/wsl.test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+/**
+ * The Windows/WSL boundary (src/wsl.js).
+ *
+ * No distro is needed and none is started: every case here is about the
+ * REWRITE — what argv, env and options a resolved binary turns into — which is
+ * where the boundary bugs actually live. `wsl:` marking, WSLENV composition,
+ * argument translation and the refusal to run a Windows .cmd from inside Linux
+ * are all pure functions of their inputs.
+ *
+ * The `inWsl` seam is injected for the same reason win-exec.ts injects its
+ * platform: the mirror direction only ever runs inside a distro, and a test
+ * that can only run there is a test that never runs.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('os');
+const path = require('path');
+
+const {
+  isWslBinary,
+  wslBinaryPath,
+  windowsBinaryKind,
+  bridgeSpawn,
+  bridgedCommandString,
+  toWslPath,
+} = require('../src/wsl');
+
+const WSL_CLAUDE = 'wsl:/home/u/.local/bin/claude';
+
+describe('marking an in-distro binary', () => {
+  it('recognises a marked path and hands back the path behind it', () => {
+    assert.equal(isWslBinary(WSL_CLAUDE), true);
+    assert.equal(wslBinaryPath(WSL_CLAUDE), '/home/u/.local/bin/claude');
+  });
+
+  it('does not claim a bare POSIX path', () => {
+    // The whole reason the marker exists: plenty of callers deal in POSIX
+    // paths for their own reasons, and bridging one nobody meant as WSL would
+    // send an ordinary local binary through wsl.exe.
+    assert.equal(isWslBinary('/usr/bin/mini'), false);
+    assert.equal(isWslBinary('C:\\npm\\claude.cmd'), false);
+    assert.equal(isWslBinary(null), false);
+  });
+
+  it('leaves an unmarked path untouched when stripping', () => {
+    assert.equal(wslBinaryPath('/usr/bin/mini'), '/usr/bin/mini');
+  });
+});
+
+describe('bridgeSpawn — Windows host, CLI inside the distro', () => {
+  it('runs the CLI through wsl.exe with argv intact', () => {
+    const { file, args } = bridgeSpawn(WSL_CLAUDE, ['-p', 'fix A && B > c']);
+    assert.equal(file, 'wsl.exe');
+    assert.deepEqual(args, ['-e', '/home/u/.local/bin/claude', '-p', 'fix A && B > c']);
+  });
+
+  it('forwards what the caller ADDED to the environment, and nothing else', () => {
+    const { opts } = bridgeSpawn(WSL_CLAUDE, [], {
+      env: { ...process.env, ANTHROPIC_API_KEY: 'sk-test', OPENAGENTS_ENDPOINT: 'https://x' },
+    });
+    const forwarded = String(opts.env.WSLENV).split(':');
+    assert.ok(forwarded.includes('ANTHROPIC_API_KEY'));
+    assert.ok(forwarded.includes('OPENAGENTS_ENDPOINT'));
+    // Without this the distro would start with a clean environment and the
+    // agent would come up unauthenticated.
+    assert.ok(forwarded.length >= 2);
+  });
+
+  it('never hands the distro a Windows PATH or HOME', () => {
+    const { opts } = bridgeSpawn(WSL_CLAUDE, [], {
+      env: { ...process.env, PATH: 'C:\\somewhere', HOME: 'C:\\Users\\u', TOKEN: 't' },
+    });
+    const forwarded = String(opts.env.WSLENV || '').split(':');
+    assert.equal(forwarded.includes('PATH'), false);
+    assert.equal(forwarded.includes('HOME'), false);
+    assert.ok(forwarded.includes('TOKEN'));
+  });
+
+  it('asks WSL to translate path-valued variables', () => {
+    const { opts } = bridgeSpawn(WSL_CLAUDE, [], {
+      env: { ...process.env, ONE_DIR: 'D:\\work', MANY_DIRS: 'C:\\a;D:\\b', PLAIN: 'hello' },
+    });
+    const forwarded = String(opts.env.WSLENV).split(':');
+    assert.ok(forwarded.includes('ONE_DIR/p'), 'a single Windows path gets /p');
+    assert.ok(forwarded.includes('MANY_DIRS/l'), 'a list of them gets /l');
+    assert.ok(forwarded.includes('PLAIN'), 'an ordinary value is forwarded untagged');
+  });
+
+  it('keeps an existing WSLENV rather than replacing it', () => {
+    const { opts } = bridgeSpawn(WSL_CLAUDE, [], {
+      env: { ...process.env, WSLENV: 'ALREADY/p', TOKEN: 't' },
+    });
+    assert.ok(String(opts.env.WSLENV).startsWith('ALREADY/p:'));
+  });
+
+  it('translates a path-shaped argument that really is a path', () => {
+    // Adapters pass real directories on the command line (--add-dir D:\work);
+    // a Windows path is simply a missing file to a Linux process.
+    const real = os.tmpdir();
+    const { args } = bridgeSpawn(WSL_CLAUDE, ['--add-dir', real]);
+    assert.equal(args[3], toWslPath(real));
+    assert.ok(args[3].startsWith('/'), 'the distro gets a Linux path');
+  });
+
+  it('leaves prompt text alone even when it mentions a Windows path', () => {
+    const missing = path.join('D:\\', 'no-such-dir-' + Date.now(), 'x');
+    const { args } = bridgeSpawn(WSL_CLAUDE, ['-p', missing]);
+    assert.equal(args[3], missing);
+  });
+
+  it('turns off the shell and detaching, which cannot apply across the boundary', () => {
+    const { opts } = bridgeSpawn(WSL_CLAUDE, [], { shell: true, detached: true });
+    assert.equal(opts.shell, false);
+    assert.equal(opts.detached, false);
+    assert.equal(opts.windowsHide, true);
+  });
+
+  it('drops a cwd that does not exist instead of failing the spawn', () => {
+    // spawn() itself throws ENOENT for a missing cwd, and that reads to the
+    // caller exactly like "the agent is not installed".
+    const gone = bridgeSpawn(WSL_CLAUDE, [], { cwd: 'C:\\no\\such\\dir' });
+    assert.equal(gone.opts.cwd, undefined);
+    const here = bridgeSpawn(WSL_CLAUDE, [], { cwd: os.tmpdir() });
+    assert.equal(here.opts.cwd, os.tmpdir());
+  });
+});
+
+describe('bridgeSpawn — inside the distro, CLI on the Windows side', () => {
+  const inWsl = { inWsl: true };
+
+  it('runs a real .exe unchanged — interop preserves argv', () => {
+    const r = bridgeSpawn('/mnt/c/cursor/cursor-agent.exe', ['-p', 'hi'], {}, inWsl);
+    assert.equal(r.file, '/mnt/c/cursor/cursor-agent.exe');
+    assert.deepEqual(r.args, ['-p', 'hi']);
+  });
+
+  it('refuses a .cmd shim, with a message naming the fix', () => {
+    assert.throws(
+      () => bridgeSpawn('/mnt/c/npm/claude.cmd', ['-p', 'hi'], {}, inWsl),
+      (e) => /cmd\.exe/.test(e.message) && /install the agent/i.test(e.message),
+    );
+  });
+
+  it('classifies by extension only while we are inside a distro', () => {
+    assert.equal(windowsBinaryKind('/mnt/c/npm/claude.cmd', true), 'shim');
+    assert.equal(windowsBinaryKind('/mnt/c/x/agent.exe', true), 'exe');
+    assert.equal(windowsBinaryKind('/usr/bin/claude', true), null);
+    assert.equal(windowsBinaryKind('/mnt/c/npm/claude.cmd', false), null);
+  });
+});
+
+describe('bridgeSpawn — everything else', () => {
+  it('is a pass-through for an ordinary local binary', () => {
+    const opts = { cwd: 'C:\\no\\such\\dir', shell: true, detached: true };
+    const r = bridgeSpawn('C:\\npm\\claude.cmd', ['-p'], opts);
+    assert.equal(r.file, 'C:\\npm\\claude.cmd');
+    assert.deepEqual(r.args, ['-p']);
+    // Untouched, including the options the WSL branch would have overridden.
+    assert.equal(r.opts, opts);
+  });
+});
+
+describe('an agent that only exists inside the distro', () => {
+  const { Installer } = require('../src/installer');
+  const fs = require('fs');
+
+  const registry = {
+    getEntry: (name) =>
+      name === 'claude'
+        ? { name: 'claude', install: { binary: 'claude', npm_package: '@anthropic-ai/claude-code' } }
+        : null,
+  };
+
+  function installer() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oa-wsl-'));
+    return new Installer(registry, dir);
+  }
+
+  it('reports it as installed, and never as one the launcher manages', () => {
+    // The reported bug: a working `claude` in the distro read as "Not
+    // installed", so the marketplace offered to install a second copy.
+    const inst = installer();
+    inst._whichBinary = () => WSL_CLAUDE;
+    assert.deepEqual(inst.getInstallInfo('claude'), {
+      installed: true,
+      managed: false,
+      location: 'wsl',
+    });
+  });
+
+  it('asks it for its version through wsl.exe', () => {
+    const inst = installer();
+    assert.equal(
+      inst._versionProbeCommand(WSL_CLAUDE),
+      'wsl.exe -e "/home/u/.local/bin/claude" "--version"',
+    );
+    // Native resolution is untouched.
+    assert.equal(inst._versionProbeCommand('C:\\npm\\claude.cmd'), '"C:\\npm\\claude.cmd" --version');
+  });
+
+  it('resolves ~ against the host home for every native install', () => {
+    const inst = installer();
+    inst._whichBinary = () => 'C:\\npm\\claude.cmd';
+    assert.equal(inst._expandHome('~/.claude/sessions', 'claude'), path.join(os.homedir(), '.claude/sessions'));
+    assert.equal(inst._expandHome('~/.claude/sessions'), path.join(os.homedir(), '.claude/sessions'));
+  });
+});
+
+describe('bridgedCommandString', () => {
+  it('builds a wsl.exe command line for a marked binary', () => {
+    assert.equal(
+      bridgedCommandString(WSL_CLAUDE, ['--version']),
+      'wsl.exe -e "/home/u/.local/bin/claude" "--version"',
+    );
+  });
+
+  it('answers null for a native binary, so the caller builds its own', () => {
+    assert.equal(bridgedCommandString('C:\\npm\\claude.cmd', ['--version']), null);
+  });
+});

--- a/packages/launcher/changelog/0.9.29.json
+++ b/packages/launcher/changelog/0.9.29.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.9.29",
+  "date": "2026-09-11",
+  "entries": [
+    {
+      "type": "fix",
+      "title": {
+        "en": "Agents installed inside WSL are found and can run",
+        "zh": "安装在 WSL 中的智能体现在可以被识别并运行"
+      },
+      "description": {
+        "en": "A CLI you installed in a WSL distribution used to read as Not installed, and the marketplace offered to install a second copy of it. It is detected now, keeps the sign-in you did inside the distribution, and runs there — including from the Login button.",
+        "zh": "装在 WSL 发行版里的 CLI 以前显示为「未安装」，应用市场还会再装一份。现在可以正确识别，沿用你在发行版内完成的登录，并在发行版内运行，登录按钮同样可用。"
+      }
+    }
+  ]
+}

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagents-launcher",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "description": "OpenAgents Launcher — install, configure, and manage your AI agents",
   "main": "out/main/index.js",
   "homepage": "https://github.com/openagents-org/openagents",

--- a/packages/launcher/src/main/win-exec.test.ts
+++ b/packages/launcher/src/main/win-exec.test.ts
@@ -31,6 +31,22 @@ describe("windowsExecutable", () => {
     })
   })
 
+  it("starts a WSL-resolved CLI through wsl.exe", () => {
+    expect(win("wsl:/home/u/.local/bin/claude")).toEqual({
+      command: 'wsl.exe -e "/home/u/.local/bin/claude"',
+      shell: true,
+    })
+  })
+
+  it("routes a WSL CLI through wsl.exe on every host platform", () => {
+    // The marker only ever comes from a Windows host, but the binary behind it
+    // is Linux either way — nothing else can start it.
+    expect(windowsExecutable("wsl:/usr/bin/codex", "darwin")).toEqual({
+      command: 'wsl.exe -e "/usr/bin/codex"',
+      shell: true,
+    })
+  })
+
   it("picks the .cmd shim sitting next to the extensionless script", () => {
     expect(
       win("C:\\nvm4w\\nodejs\\claude", ["C:\\nvm4w\\nodejs\\claude.cmd"]),
@@ -124,5 +140,11 @@ describe("shellCommandFor", () => {
 
   it("doesn't double-quote what is already quoted", () => {
     expect(win("C:\\bin\\amp.cmd")).toBe('"C:\\bin\\amp.cmd"')
+  })
+
+  it("keeps the wsl.exe prefix for an in-distro CLI", () => {
+    expect(win("wsl:/home/u/.local/bin/claude")).toBe(
+      'wsl.exe -e "/home/u/.local/bin/claude"',
+    )
   })
 })

--- a/packages/launcher/src/main/win-exec.ts
+++ b/packages/launcher/src/main/win-exec.ts
@@ -18,6 +18,9 @@ import fs from "fs"
  *                                   Windows Script Host, which is not node.
  *   C:\bin\amp.cmd                  spawnable, but only through a shell (Node
  *                                   refuses .cmd directly since CVE-2024-27980).
+ *   wsl:/home/u/.local/bin/claude   a CLI installed inside a WSL distro. Not a
+ *                                   Windows executable at all — wsl.exe has to
+ *                                   start it (see the core's wsl.js).
  *
  * So: keep `.exe` as-is, prefer a real Windows shim sitting next to whatever we
  * were given, and run a bare .js through `node` rather than letting the shell
@@ -37,6 +40,13 @@ export function windowsExecutable(
   platform: string = process.platform,
   exists: (p: string) => boolean = fs.existsSync,
 ): { command: string; shell: boolean } {
+  // A CLI the core resolved inside WSL, marked `wsl:/home/u/.local/bin/claude`.
+  // It is a Linux binary: only wsl.exe can start it, on any host platform, so
+  // this branch comes before the non-Windows early return. Shaped as a command
+  // STRING (shell: true) like the .cmd branch below, which is what lets callers
+  // append their own arguments — `login`, `--version` — after it.
+  if (bin.startsWith("wsl:"))
+    return { command: `wsl.exe -e "${bin.slice(4)}"`, shell: true }
   if (platform !== "win32") return { command: bin, shell: false }
   if (/\.exe$/i.test(bin)) return { command: bin, shell: false }
   if (/\.(cmd|bat)$/i.test(bin)) return { command: `"${bin}"`, shell: true }


### PR DESCRIPTION
An agent CLI installed inside WSL reads as **Not installed** on Windows, and the marketplace offers to install a second copy of a tool that is already there. Every tier of detection — `where`, `%APPDATA%\npm`, `~/.openagents`, the known-bin-dir sweep in `paths.js` — looks at the Windows filesystem only, so `/home/<user>/.nvm/versions/node/v22.14.0/bin/claude` is invisible. Hermes had grown a one-off fallback for exactly this; no other agent had one.

Detecting it is only half a fix. A Linux path handed to `CreateProcess` is an ENOENT, which would trade "not installed" for "installed but every run fails" — so `src/wsl.js` does both halves.

## Windows host, CLI inside the distro

- **Resolution** costs one `wsl.exe` start per process, not one per binary. A single `bash -ilc` probe reads the distro's login PATH — **interactive** as well as login, because Ubuntu's stock `~/.bashrc` returns early for a non-interactive shell *before* the nvm block at the bottom, so `-lc` reports a PATH with no nvm in it, which is precisely the install we are looking for. Every later lookup is a filesystem check through the `\wsl.localhost` mount, which Windows serves without starting a distro. `primeBinaryLookup()` warms it alongside the existing login-shell probe.
- **Running** goes through a spawn bridge with `child_process.spawn`'s signature, so the 22 spawn sites changed an import and nothing else. It rewrites to `wsl.exe -e <path> …` and carries across what the adapter *added* to the environment via `WSLENV` — without which the distro starts clean and every agent comes up unauthenticated. Path-valued vars are tagged `/p` (a `;`-list `/l`), as are argv entries that are real existing directories (`--add-dir D:\work`). Prose is left alone: an argument has to **be** a path **and** exist to be rewritten.
- **Readiness** expands `~` against the distro's home for an agent that resolved there. `claude login` run in WSL leaves `~/.claude` in the distro; expanding against the Windows profile called a signed-in agent "Not logged in".

## Connector inside a distro, CLI on the Windows side

Handled where it can be handled honestly. Interop puts the Windows PATH on the distro's PATH, so `which claude` was answering with npm's extensionless POSIX shim — a sh script that execs `node.exe` with Windows paths, which Linux cannot run. Those hits are dropped now, and a `.exe` is looked up under its real name and spawned directly (interop preserves argv). A `.cmd`/`.bat` shim is **refused** with a message naming the fix rather than run through `cmd.exe`: cmd rebuilds its command line from a single string, so every `&`, `|`, `^` and `"` in a prompt would be reinterpreted as shell syntax.

## Notes for review

- The marker is an explicit `wsl:` prefix, not "an absolute path starting with `/` on win32". The inference was the first thing tried and it bridged POSIX paths that callers meant literally — a marker that can be triggered by accident is worse than no marker.
- Hermes loses its private copy and uses the shared path, which also gains it the `WSLENV` forwarding it never had.
- `openclaw` is deliberately untouched: it resolves through a `.cmd` shim to an `.mjs` it runs with the host's node, and that shape does not cross the boundary.
- Known gaps, degraded rather than broken: a registry entry whose liveness check is only `check_ready.alt_check` (a bare command string) still probes natively, and `install.verify_win` likewise. Neither gates installation or chat.
