### PR TITLE
feat(workspace): add a single-device test push endpoint

### DIFF
--- a/workspace/backend/app/routers/devices.py
+++ b/workspace/backend/app/routers/devices.py
@@ -4,6 +4,7 @@ Device registration endpoints for mobile push notifications.
 
 POST   /v1/devices/register    Upsert an FCM token for the calling workspace
 DELETE /v1/devices/register    Forget an FCM token (called on logout / uninstall)
+POST   /v1/devices/test-push   Send one push to one device, for diagnosis
 
 Both iOS and Android register the same way: the token is an FCM registration
 token, not a raw APNs device token, and `services/fcm_client.py` is the only
@@ -53,6 +54,26 @@ class RegisterDeviceRequest(BaseModel):
 class DeregisterDeviceRequest(BaseModel):
     network: str
     fcm_token: str
+
+
+class TestPushRequest(BaseModel):
+    network: str
+    # Required, and deliberately so. Scoping the send by `user_email` would
+    # wake every device that person owns, and scoping by workspace would
+    # wake the whole team — neither is what "send me a test push" means.
+    # The caller names the one device it wants woken: its own.
+    fcm_token: str
+    # Tags the `data` payload exactly as the real fan-out would, so the
+    # client-side tap handling can be exercised per reason. Free-form
+    # rather than an enum, matching `PushReason` on the client: a value
+    # this backend has never heard of is still a deliverable notification.
+    reason: str = "task_completed"
+    # Goes out as `data.channel`, which is what the app turns into a route
+    # on tap. Leave it empty to exercise the other branch — the
+    # notification that names no thread and so opens the app where it was.
+    channel: Optional[str] = None
+    title: Optional[str] = None
+    body: Optional[str] = None
 
 
 @router.post("/devices/register")
@@ -145,3 +166,128 @@ def deregister_device(
     ).delete()
     db.commit()
     return success_response({"deleted": deleted})
+
+
+@router.post("/devices/test-push")
+def test_push(
+    body: TestPushRequest,
+    db: Session = Depends(get_db),
+    x_workspace_token: Optional[str] = Header(None),
+    authorization: Optional[str] = Header(None),
+):
+    """Send one push to one device and report, in detail, what happened.
+
+    Exists because "the notification didn't arrive" has six or seven
+    distinct causes spread across three systems, and the ordinary path
+    (post an event → `push.fanout_for_event`) silently collapses most of
+    them into "nothing happened": an unconfigured deployment, a device
+    that was never registered, a `prefs` switch left off, and a message
+    `_should_push` declined all look identical from the outside. This
+    endpoint answers each of those questions separately in its response
+    body, so one button tap in the app localizes the fault.
+
+    What it deliberately does *not* do is reimplement the fan-out. It
+    skips `_should_push` (the caller has already decided they want a
+    push) and it skips the `prefs` gate — but it *reports* what the
+    prefs gate would have done, which is the diagnostic half of it. A
+    test push that got suppressed by a switch the user forgot they
+    flipped would be exactly as uninformative as the silence it is
+    meant to explain.
+
+    Not a spam vector despite sending on request: it needs workspace
+    credentials, and the token must already be registered *in that
+    workspace*, so the set of devices it can reach is the set the caller
+    could already reach by posting a message. An unregistered token is
+    refused rather than forwarded to FCM.
+    """
+    workspace = db.execute(
+        select(Workspace).where(_workspace_filter(body.network))
+    ).scalar_one_or_none()
+    if not workspace:
+        return json_response(ResponseCode.NOT_FOUND, "Network not found")
+    if not _verify_workspace_access(workspace, x_workspace_token, authorization):
+        return json_response(ResponseCode.UNAUTHORIZED, "Workspace access denied")
+
+    device = db.execute(
+        select(DeviceToken).where(
+            DeviceToken.workspace_id == str(workspace.id),
+            DeviceToken.fcm_token == body.fcm_token,
+        )
+    ).scalar_one_or_none()
+    if not device:
+        # The common first-run failure, and worth its own message: the app
+        # asked for a test push before `POST /v1/devices/register` had
+        # succeeded, which on iOS usually means the APNs token hadn't
+        # landed yet when the app started up.
+        return json_response(
+            ResponseCode.NOT_FOUND,
+            "This device is not registered in this workspace — register it "
+            "first (POST /v1/devices/register), then retry.",
+        )
+
+    from app.services.fcm_client import PushAlert, _messaging_ready, send_push
+    from app.services.push import _prefs_allow
+
+    # Asked before sending so the answer is reported even when the send
+    # is a no-op: `send_push` returns ([], []) both for "not configured"
+    # and for "nothing to send", and telling those apart is most of the
+    # point of this endpoint.
+    configured = _messaging_ready()
+
+    reason = (body.reason or "task_completed").strip() or "task_completed"
+    channel = (body.channel or "").strip()
+
+    alert = PushAlert(
+        title=body.title or "Test notification",
+        body=body.body or f"Test push (reason={reason}) from the backend.",
+        thread_id=channel or None,
+    )
+    # Same shape as `push._build_data_payload`, so a tap goes through the
+    # client's real routing code rather than a special case.
+    data = {
+        "reason": reason,
+        "channel": channel,
+        "event_id": "test-push",
+        "event_type": "devices.test_push",
+        "source": "system:test-push",
+    }
+
+    sent, dead = send_push([device.fcm_token], alert, data)
+
+    if dead:
+        # FCM has told us this registration is gone for good. Drop it for
+        # the same reason the fan-out does, or every later push to this
+        # workspace keeps paying for a token that can never be delivered.
+        db.query(DeviceToken).filter(
+            DeviceToken.workspace_id == str(workspace.id),
+            DeviceToken.fcm_token == device.fcm_token,
+        ).delete()
+        db.commit()
+
+    logger.info(
+        "devices: test push workspace=%s reason=%s sent=%d dead=%d configured=%s",
+        workspace.id, reason, len(sent), len(dead), configured,
+    )
+
+    return success_response({
+        # False here is the whole answer: FIREBASE_CREDENTIALS_JSON is
+        # unset or unusable on this deployment, and no push of any kind
+        # has ever left it.
+        "configured": configured,
+        "sent": len(sent) > 0,
+        # True means the token was rejected permanently and has just been
+        # deleted — re-register (restart the app) and try again.
+        "token_dead": len(dead) > 0,
+        "device_type": device.device_type,
+        # Null means this device is invisible to `mention` and `chat`
+        # pushes in the real fan-out, whatever this test says: both scope
+        # their `device_tokens` query by email.
+        "user_email": device.user_email,
+        # What the real fan-out would have done with this reason. False
+        # means a switch on the Notifications screen is off, and an
+        # ordinary push for this reason would never have been sent even
+        # though this test one was.
+        "prefs_would_allow": _prefs_allow(device.prefs, reason),
+        "reason": reason,
+        "channel": channel or None,
+    })

--- a/workspace/backend/tests/test_devices.py
+++ b/workspace/backend/tests/test_devices.py
@@ -131,3 +131,146 @@ class TestDeregisterDevice:
             "network": workspace["id"], "fcm_token": "TOKEN",
         })
         assert resp.status_code == 401
+
+
+class TestTestPush:
+    """`/v1/devices/test-push` — the one-button push diagnosis.
+
+    `send_push` is patched throughout: these cover the endpoint's gating
+    and its report, not FCM delivery, and an unpatched call would try to
+    reach Google from the test suite.
+    """
+
+    def _register(self, client, workspace, token="TOKEN-TP", **extra):
+        body = {
+            "network": workspace["id"], "fcm_token": token,
+            "device_type": "ios",
+        }
+        body.update(extra)
+        return client.post("/v1/devices/register", json=body,
+                           headers={"X-Workspace-Token": workspace["token"]})
+
+    def test_sends_to_the_named_device(self, client, workspace, monkeypatch):
+        self._register(client, workspace)
+        calls = []
+
+        def fake_send(tokens, alert, data=None):
+            calls.append((list(tokens), alert, data))
+            return list(tokens), []
+
+        monkeypatch.setattr("app.services.fcm_client.send_push", fake_send)
+        monkeypatch.setattr("app.services.fcm_client._messaging_ready", lambda: True)
+
+        resp = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-TP",
+            "reason": "mention", "channel": "general",
+        }, headers={"X-Workspace-Token": workspace["token"]})
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()["data"]
+        assert data["sent"] is True
+        assert data["configured"] is True
+        # Exactly one device woken — the one asked for, nobody else's.
+        assert len(calls) == 1
+        assert calls[0][0] == ["TOKEN-TP"]
+        # Payload matches the real fan-out's shape so the tap handler is
+        # exercised for real.
+        assert calls[0][2]["reason"] == "mention"
+        assert calls[0][2]["channel"] == "general"
+
+    def test_unregistered_token_is_refused(self, client, workspace, monkeypatch):
+        sent = []
+        monkeypatch.setattr(
+            "app.services.fcm_client.send_push",
+            lambda tokens, alert, data=None: (sent.extend(tokens), ([], []))[1],
+        )
+        resp = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "SOMEONE-ELSES-TOKEN",
+        }, headers={"X-Workspace-Token": workspace["token"]})
+        assert resp.status_code == 404
+        # The point of the refusal: an arbitrary token never reaches FCM.
+        assert sent == []
+
+    def test_requires_auth(self, client, workspace):
+        resp = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-TP",
+        })
+        assert resp.status_code == 401
+
+    def test_reports_unconfigured_deployment(self, client, workspace, monkeypatch):
+        self._register(client, workspace, token="TOKEN-NOFCM")
+        # What a deployment with no FIREBASE_CREDENTIALS_JSON actually
+        # does: returns empty-empty, indistinguishable from success
+        # unless `configured` is reported separately. That's the bug this
+        # endpoint exists to make visible.
+        monkeypatch.setattr("app.services.fcm_client._messaging_ready", lambda: False)
+        monkeypatch.setattr(
+            "app.services.fcm_client.send_push",
+            lambda tokens, alert, data=None: ([], []),
+        )
+        resp = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-NOFCM",
+        }, headers={"X-Workspace-Token": workspace["token"]})
+        data = resp.json()["data"]
+        assert data["configured"] is False
+        assert data["sent"] is False
+
+    def test_reports_prefs_that_would_have_muted_it(self, client, workspace, monkeypatch):
+        self._register(
+            client, workspace, token="TOKEN-MUTED",
+            prefs={"taskCompletions": False, "mentions": True},
+        )
+        monkeypatch.setattr("app.services.fcm_client._messaging_ready", lambda: True)
+        monkeypatch.setattr(
+            "app.services.fcm_client.send_push",
+            lambda tokens, alert, data=None: (list(tokens), []),
+        )
+        h = {"X-Workspace-Token": workspace["token"]}
+
+        muted = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-MUTED",
+            "reason": "task_completed",
+        }, headers=h).json()["data"]
+        # Still sent — a test push bypasses the switches on purpose — but
+        # the report says an ordinary one would have been dropped.
+        assert muted["sent"] is True
+        assert muted["prefs_would_allow"] is False
+
+        allowed = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-MUTED",
+            "reason": "mention",
+        }, headers=h).json()["data"]
+        assert allowed["prefs_would_allow"] is True
+
+    def test_dead_token_is_pruned(self, client, workspace, monkeypatch):
+        self._register(client, workspace, token="TOKEN-DEAD")
+        monkeypatch.setattr("app.services.fcm_client._messaging_ready", lambda: True)
+        monkeypatch.setattr(
+            "app.services.fcm_client.send_push",
+            lambda tokens, alert, data=None: ([], list(tokens)),
+        )
+        h = {"X-Workspace-Token": workspace["token"]}
+        data = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-DEAD",
+        }, headers=h).json()["data"]
+        assert data["token_dead"] is True
+        # Row is gone, so the next call can't find it.
+        again = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-DEAD",
+        }, headers=h)
+        assert again.status_code == 404
+
+    def test_missing_email_is_surfaced(self, client, workspace, monkeypatch):
+        # Registered without user_email — invisible to mention/chat pushes
+        # in the real fan-out no matter what this endpoint manages to send.
+        self._register(client, workspace, token="TOKEN-NOEMAIL")
+        monkeypatch.setattr("app.services.fcm_client._messaging_ready", lambda: True)
+        monkeypatch.setattr(
+            "app.services.fcm_client.send_push",
+            lambda tokens, alert, data=None: (list(tokens), []),
+        )
+        data = client.post("/v1/devices/test-push", json={
+            "network": workspace["id"], "fcm_token": "TOKEN-NOEMAIL",
+        }, headers={"X-Workspace-Token": workspace["token"]}).json()["data"]
+        assert data["sent"] is True
+        assert data["user_email"] is None


### PR DESCRIPTION
## 为什么

现在要确认「推送到底通没通」，只能去翻 Railway 日志——因为正常链路把所有失败原因都压成了同一种沉默：

- 部署上没配 `FIREBASE_CREDENTIALS_JSON`（`fcm_client._messaging_ready()` 返回 False，静默跳过，警告还只打一次）
- 设备压根没注册成功（iOS 冷启动时 APNs token 还没下来）
- 通知开关被关了（`prefs` 拦掉）
- `_should_push` 判定这条消息不该推

这四种从外面看完全一样，都是「什么都没发生」。

## 做了什么

`POST /v1/devices/test-push` 给**一台指定设备**发一条推送，并把上面每种原因**分开汇报**：

```json
{
  "configured": true,          // 这个部署到底能不能发
  "sent": true,
  "token_dead": false,         // FCM 永久拒绝，行已删除
  "device_type": "ios",
  "user_email": "you@x.com",   // null = 真实链路下 mention/chat 永远到不了这台设备
  "prefs_would_allow": true,   // 真实推送会不会被开关静音
  "reason": "task_completed",
  "channel": "general"
}
```

发送**故意绕过 prefs 开关**——一条被自己忘了关的开关静音掉的测试推送，和它本来要解释的那种沉默一样没有信息量。但 `prefs_would_allow` 会如实汇报真实链路的结果。

`data` 载荷和 `push._build_data_payload` 形状一致，所以点击走的是客户端真实的路由代码，不是特例分支。

## 安全边界

- `fcm_token` 必填，不从 `user_email` 或 workspace 推断 → 影响范围恒定为一台设备
- 该 token 必须**已注册在这个 workspace**，否则 404 且不转发给 FCM → 不会变成一个能给任意 token 发推送的中继
- 鉴权沿用 `_verify_workspace_access`，和 register/deregister 一致

换句话说，它能触达的设备集合 = 调用方本来发条消息就能触达的集合。

## 测试

新增 7 个测试，覆盖：只推给指定设备、未注册 token 被拒（并断言 FCM 未被调用）、需要鉴权、未配置部署的汇报、prefs 静音的汇报、死 token 被清理、缺 `user_email` 被暴露。

`tests/test_devices.py` + `tests/test_push.py` 共 54 个测试全过（在本分支 base 上跑的，不是本地脏工作区）。

## 其它

分支从 `origin/develop` 切出，只含这两个文件、纯新增 289 行、无删除。