### PR TITLE
fix(launcher): hold agent installs back to a release the agents' Node can run

### DIFF
--- a/packages/launcher/changelog/0.9.30.json
+++ b/packages/launcher/changelog/0.9.30.json
@@ -14,17 +14,6 @@
       }
     },
     {
-      "type": "improvement",
-      "title": {
-        "en": "CodeBuddy is labelled as WorkBuddy's engine in the marketplace",
-        "zh": "应用市场中的 CodeBuddy 现在标注了 WorkBuddy"
-      },
-      "description": {
-        "en": "Searching the marketplace for \"WorkBuddy\" already found CodeBuddy Code — they are the same engine — but the result was titled only \"CodeBuddy Code\", leaving you to guess whether you had found the right thing. The card now reads \"CodeBuddy Code (WorkBuddy)\". A test now covers that search, so the tag it depends on cannot be dropped unnoticed.",
-        "zh": "在应用市场中搜索「WorkBuddy」原本就能找到 CodeBuddy Code —— 两者本是同一套引擎 —— 但结果标题只写了「CodeBuddy Code」，需要你自行判断是否找对了。现在卡片显示为「CodeBuddy Code (WorkBuddy)」。该搜索现已有测试覆盖，其所依赖的标签不会再被无声地删除。"
-      }
-    },
-    {
       "type": "fix",
       "title": {
         "en": "The agent catalog no longer differs between the launcher and the workspace",
@@ -33,6 +22,28 @@
       "description": {
         "en": "The catalog was kept in three hand-synced copies, and they had drifted. Kimi's generic-key mapping existed only in the workspace's copy, so the same setting behaved differently depending on where it was read. Gemini's description and its not-signed-in message still described sign-in as it worked before Google ended individual accounts for that CLI in June 2026. mini-SWE-agent shipped with no icon in three of the four places one is needed, and Antigravity in one. All of these now come from a single source, and a check keeps them there.",
         "zh": "该目录此前以三份手工同步的副本存在，并且已经出现分歧。Kimi 的通用密钥映射只存在于工作区那一份中，导致同一项设置因读取位置不同而行为不一致。Gemini 的说明及其未登录提示，描述的仍是 Google 于 2026 年 6 月停止为该命令行工具提供个人账号之前的登录方式。mini-SWE-agent 在四处需要图标的位置中有三处缺失图标，Antigravity 缺失一处。现在这些内容统一来自单一来源，并由校验持续保证一致。"
+      }
+    },
+    {
+      "type": "fix",
+      "title": {
+        "en": "Updating or installing OpenClaw no longer fails",
+        "zh": "更新或安装 OpenClaw 不再失败"
+      },
+      "description": {
+        "en": "When an agent's newest release requires a newer Node.js than the launcher provides, the newest compatible release is installed instead.",
+        "zh": "当某个智能体的最新版本要求高于启动器所提供的 Node.js 版本时，将改为安装与之兼容的最新版本。"
+      }
+    },
+    {
+      "type": "improvement",
+      "title": {
+        "en": "CodeBuddy is labelled as WorkBuddy's engine in the marketplace",
+        "zh": "应用市场中的 CodeBuddy 现在标注了 WorkBuddy"
+      },
+      "description": {
+        "en": "Searching the marketplace for \"WorkBuddy\" already found CodeBuddy Code — they are the same engine — but the result was titled only \"CodeBuddy Code\", leaving you to guess whether you had found the right thing. The card now reads \"CodeBuddy Code (WorkBuddy)\". A test now covers that search, so the tag it depends on cannot be dropped unnoticed.",
+        "zh": "在应用市场中搜索「WorkBuddy」原本就能找到 CodeBuddy Code —— 两者本是同一套引擎 —— 但结果标题只写了「CodeBuddy Code」，需要你自行判断是否找对了。现在卡片显示为「CodeBuddy Code (WorkBuddy)」。该搜索现已有测试覆盖，其所依赖的标签不会再被无声地删除。"
       }
     }
   ]

--- a/packages/launcher/src/main/agents/install-service.test.ts
+++ b/packages/launcher/src/main/agents/install-service.test.ts
@@ -25,12 +25,38 @@ vi.mock("fs", () => {
   return { ...api, default: api }
 })
 
+// The install cases run npm as a fake process that records its argv and exits
+// 0, and read the registry from a fixture instead of the network.
+const spawned: string[][] = []
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>()
+  const { EventEmitter } = await import("events")
+  const stream = () =>
+    Object.assign(new EventEmitter(), { setEncoding: () => undefined })
+  const spawn = (_cmd: string, args: string[]) => {
+    spawned.push(args)
+    const proc = Object.assign(new EventEmitter(), {
+      stdout: stream(),
+      stderr: stream(),
+    })
+    setTimeout(() => proc.emit("close", 0), 0)
+    return proc
+  }
+  return { ...actual, default: { ...actual, spawn }, spawn }
+})
+let npmInfo: unknown = null
+vi.mock("./npm-registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./npm-registry")>()),
+  fetchNpmInfo: async () => npmInfo,
+}))
+
 import path from "path"
 
 import { InstallService } from "./install-service"
 import { CONFIG_DIR, INSTALLED_HISTORY_FILE, PORTABLE_NODE_DIR } from "./paths"
 
 const npmInstall = "npm install -g @openai/codex"
+const openclawInstall = "npm install -g openclaw@latest"
 const script = "powershell -c irm cursor.com/install | iex"
 const REGISTRY: Record<string, Record<string, unknown>> = {
   // npm-backed: has a package dir we can check.
@@ -41,6 +67,16 @@ const REGISTRY: Record<string, Record<string, unknown>> = {
       macos: npmInstall,
       linux: npmInstall,
       windows: npmInstall,
+    },
+  },
+  // npm-backed and floating on `latest` — the shape the Node check guards.
+  openclaw: {
+    name: "openclaw",
+    install: {
+      binary: "openclaw",
+      macos: openclawInstall,
+      linux: openclawInstall,
+      windows: openclawInstall,
     },
   },
   // Script-installed: no package, so the records are all we have.
@@ -208,5 +244,80 @@ describe("getInstalledVersion — globally installed CLIs", () => {
 
   it("stays null when no binary resolves at all", () => {
     expect(makeService(none).getInstalledVersion("codex")).toBe(null)
+  })
+})
+
+/**
+ * openclaw 2026.9.3 raised its floor to Node 24.16 with a preinstall script
+ * that exits non-zero below it. The launcher installs and runs agents on its
+ * portable Node 22, so from 2026-09-11 every openclaw update — and every fresh
+ * install — failed, while the badge kept offering the release that couldn't
+ * install.
+ */
+describe("when npm's latest refuses the agents' Node", () => {
+  const NODE_22_OK = ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+  const NODE_24_ONLY = ">=24.16.0 <25 || >=26.1.0"
+
+  beforeEach(() => {
+    spawned.length = 0
+    npmInfo = {
+      "dist-tags": { latest: "2026.9.4" },
+      versions: {
+        "2026.9.2": { engines: { node: NODE_22_OK } },
+        "2026.9.3": { engines: { node: NODE_24_ONLY } },
+        "2026.9.4": { engines: { node: NODE_24_ONLY } },
+      },
+    }
+  })
+
+  function service(node: string | null) {
+    const installStreaming = vi.fn(async () => ({ success: true }))
+    const svc = new InstallService({
+      connector: () => ({
+        registry: { getEntry: (t: string) => REGISTRY[t] || null },
+        installer: { hasNodejs: () => true, installStreaming },
+      }),
+      clearCatalogCache: () => undefined,
+      getCatalog: async () => [{ ...REGISTRY.openclaw, installed: true }],
+      resolveBinary: none,
+      nodeVersion: async () => node,
+    })
+    return { svc, installStreaming }
+  }
+
+  it("offers the newest release that runs, not one that can't install", async () => {
+    const { svc } = service("22.22.3")
+    const [update] = await svc.checkAgentUpdates({ force: true })
+    expect(update.latest).toBe("2026.9.2")
+  })
+
+  it("updates to that release, and says why it isn't the newest", async () => {
+    const log: string[] = []
+    const result = await service("22.22.3").svc.updateAgentTypeStreaming(
+      "openclaw",
+      (d) => log.push(d),
+    )
+    expect(result).toMatchObject({ success: true, version: "2026.9.2" })
+    expect(spawned[0]).toContain("openclaw@2026.9.2")
+    expect(log.join("")).toContain("requires Node >=24.16.0")
+  })
+
+  it("installs it fresh the same way, instead of handing the core `latest`", async () => {
+    const { svc, installStreaming } = service("22.22.3")
+    await svc.installAgentTypeStreaming("openclaw", () => undefined)
+    expect(installStreaming).not.toHaveBeenCalled()
+    expect(spawned[0]).toContain("openclaw@2026.9.2")
+  })
+
+  it.each(["24.20.0", null])("changes nothing on Node %s", async (node) => {
+    // New enough, or no Node to ask: `latest` as before, and a fresh install
+    // stays with the core, which owns the full install pipeline.
+    const { svc, installStreaming } = service(node)
+    const [update] = await svc.checkAgentUpdates({ force: true })
+    expect(update.latest).toBe("2026.9.4")
+    await svc.updateAgentTypeStreaming("openclaw", () => undefined)
+    expect(spawned[0]).toContain("openclaw@latest")
+    await svc.installAgentTypeStreaming("openclaw", () => undefined)
+    expect(installStreaming).toHaveBeenCalledOnce()
   })
 })

--- a/packages/launcher/src/main/agents/install-service.ts
+++ b/packages/launcher/src/main/agents/install-service.ts
@@ -6,7 +6,8 @@
  * no-op for a bare `npm install -g <pkg>` and a downgrade for a pinned
  * `<pkg>@0.83.0`, which is why "Update to v0.84.1" used to reinstall 0.83.0 and
  * the badge never cleared. Anything npm-backed updates via `@latest` instead —
- * see updateAgentTypeStreaming.
+ * see updateAgentTypeStreaming — held back to the newest release the agents'
+ * Node can run when npm's `latest` refuses it (see _heldBackVersion).
  */
 import path from "path"
 import fs from "fs"
@@ -14,14 +15,21 @@ import { spawn } from "child_process"
 import { readPathEnv, withPathEnv } from "../env"
 import {
   NO_NPM_PACKAGE,
+  parseNpmInstallCommand,
   pinnedVersion,
   resolveNpmPackage,
 } from "../../shared/npm-install-spec"
 import { CONFIG_DIR, INSTALLED_HISTORY_FILE, PORTABLE_NODE_DIR } from "./paths"
 import { appendDaemonLog } from "./daemon-process"
-import { platformKey, resolveNpmInvocation } from "./runtime"
+import {
+  agentNodeVersion,
+  platformKey,
+  resolveNpmInvocation,
+} from "./runtime"
 import {
   fetchNpmInfo,
+  nodeEngineRange,
+  resolveInstallableVersion,
   resolveLatestVersion,
   sortedPublishedVersions,
 } from "./npm-registry"
@@ -49,6 +57,8 @@ export interface InstallServiceDeps {
   getCatalog: () => Promise<unknown[]>
   /** Absolute path to an agent's CLI, or null — the global-install escape hatch. */
   resolveBinary: (type: string) => string | null
+  /** The Node agents install and run on (agentNodeVersion); a seam for tests. */
+  nodeVersion?: () => Promise<string | null>
 }
 
 export class InstallService {
@@ -62,6 +72,10 @@ export class InstallService {
 
   private get _connector(): Record<string, unknown> {
     return this.deps.connector() as Record<string, unknown>
+  }
+
+  private _nodeVersion(): Promise<string | null> {
+    return (this.deps.nodeVersion || agentNodeVersion)().catch(() => null)
   }
 
   clearUpdatesCache(): void {
@@ -96,7 +110,8 @@ export class InstallService {
     // to start on any other. Overriding that pin with `latest` below would hand
     // the user a runtime their agent cannot run, on a FRESH install, with no
     // hint about how to get back. This case is checked first for that reason.
-    const supported = this.supportedVersion(this.getRegistryEntry(agentType))
+    const entry = this.getRegistryEntry(agentType)
+    const supported = this.supportedVersion(entry)
     if (supported) return this.installAtVersionTag(agentType, supported, onData)
 
     // A registry command that freezes a version (`pi-coding-agent@0.83.0`) is a
@@ -105,8 +120,26 @@ export class InstallService {
     // user an old build while the page next to the button already advertises
     // the newest one, so the pin is overridden here too, not just on update.
     // Dist-tags (`@latest`, `@beta`) float on their own and are left alone.
-    const pinned = pinnedVersion(this._installCommand(agentType))
-    if (pinned) return this.installAtVersionTag(agentType, "latest", onData)
+    const cmd = this._installCommand(agentType)
+    if (pinnedVersion(cmd))
+      return this.installAtVersionTag(agentType, "latest", onData)
+
+    // A floating npm command (`openclaw@latest`, or bare) is the core's to run,
+    // unless npm's `latest` refuses the Node agents run on — then the newest
+    // release that does is installed here instead (see _heldBackVersion). Same
+    // order the core keeps: prerequisites before anything downloads, and Node
+    // before the version check, which needs a Node to ask.
+    const npmPkg = this.resolveNpmPackage(entry)
+    const { pkg, spec } = parseNpmInstallCommand(cmd)
+    if (npmPkg && pkg && (!spec || spec === "latest")) {
+      const core = this._connector.installer as {
+        _assertPrereqs?: (t: string, e: unknown, d: (s: string) => void) => void
+      }
+      core?._assertPrereqs?.(agentType, entry, onData)
+      await this._ensureNode(onData)
+      const heldBack = await this._heldBackVersion(npmPkg, onData)
+      if (heldBack) return this.installAtVersionTag(agentType, heldBack, onData)
+    }
 
     const installer = this._connector.installer as Record<string, unknown>
     const installStreaming = installer.installStreaming as (
@@ -298,7 +331,9 @@ export class InstallService {
    *
    * The version the UI advertises comes from npm's `latest` dist-tag
    * (`_loadAgentUpdates`), so `latest` is the only target that keeps the button
-   * honest — EXCEPT for an entry declaring `install.supported_version`, where
+   * honest — both sides holding it back alike when the agents' Node cannot run
+   * it (see _heldBackVersion) — EXCEPT for an entry declaring
+   * `install.supported_version`, where
    * the pin is the target for both the button and the badge (see
    * `supportedVersion`). Non-npm installers (curl / pip / echo) keep the original pipeline:
    * they have no version to pin and their scripts already fetch the newest
@@ -512,26 +547,14 @@ export class InstallService {
       }
     }
 
-    // Bootstrap Node the way the core installer does before its own npm call.
-    // This path used to run only for updates and channel switches, where a
-    // runtime is already on disk; a first install of a version-pinned agent
-    // now lands here too, and on a machine with no Node the npm spawn below
-    // would simply fail.
-    const installer = this._connector.installer as {
-      hasNodejs?: () => boolean
-      installNodejs?: (onData?: (d: string) => void) => Promise<unknown>
-    }
-    try {
-      if (
-        typeof installer?.hasNodejs === "function" &&
-        !installer.hasNodejs() &&
-        typeof installer.installNodejs === "function"
-      ) {
-        await installer.installNodejs(onData)
-      }
-    } catch (e) {
-      if (onData) onData(`\nCould not prepare Node.js: ${String(e)}\n`)
-    }
+    await this._ensureNode(onData)
+
+    // `latest` means the newest release this machine can run, which is not
+    // always npm's `latest` — see _heldBackVersion.
+    const spec =
+      target === "latest"
+        ? (await this._heldBackVersion(npmPkg, onData)) || target
+        : target
 
     const prefixDir = path.join(CONFIG_DIR, "runtimes", agentType)
     fs.mkdirSync(prefixDir, { recursive: true })
@@ -540,7 +563,7 @@ export class InstallService {
       "--save",
       "--prefix",
       prefixDir,
-      `${npmPkg}@${target}`,
+      `${npmPkg}@${spec}`,
     ]
 
     // Invoke bundled `node npm-cli.js` directly (no shell) so non-ASCII home
@@ -570,7 +593,7 @@ export class InstallService {
           this._markInstalledInCore(agentType)
           // Read what actually landed — for dist-tags the resolved version
           // can differ from the input string ("beta" → "2.1.144-beta.3").
-          const resolved = this.getInstalledVersion(agentType) || target
+          const resolved = this.getInstalledVersion(agentType) || spec
           if (onData) onData(`\nInstalled ${npmPkg}@${resolved}.\n`)
           resolve({ success: true, version: resolved })
         } else {
@@ -582,6 +605,62 @@ export class InstallService {
         }
       })
     })
+  }
+
+  /**
+   * Bootstrap Node the way the core installer does before its own npm call.
+   * installAtVersionTag used to run only for updates and channel switches,
+   * where a runtime is already on disk; first installs land there too now, and
+   * on a machine with no Node its npm spawn would simply fail. A failure here
+   * is reported and swallowed — npm's own error says the rest.
+   */
+  private async _ensureNode(onData: (data: string) => void): Promise<void> {
+    const installer = this._connector.installer as {
+      hasNodejs?: () => boolean
+      installNodejs?: (onData?: (d: string) => void) => Promise<unknown>
+    }
+    try {
+      if (
+        typeof installer?.hasNodejs === "function" &&
+        !installer.hasNodejs() &&
+        typeof installer.installNodejs === "function"
+      ) {
+        await installer.installNodejs(onData)
+      }
+    } catch (e) {
+      if (onData) onData(`\nCould not prepare Node.js: ${String(e)}\n`)
+    }
+  }
+
+  /**
+   * The release to install instead of `latest` when `latest` refuses the Node
+   * agents run on here; null when `latest` is fine, or when there is no
+   * telling (no Node to ask, npm unreachable).
+   *
+   * Every npm agent is installed and run on the launcher's portable Node, and
+   * upstreams raise their floor without notice: openclaw 2026.9.3 moved to
+   * Node >=24.16 with a preinstall script that exits non-zero below it, so on
+   * the bundled Node 22 every update and every fresh install of it failed.
+   * The badge reads the same answer (_loadAgentUpdates), so what the button
+   * offers is what this installs.
+   */
+  private async _heldBackVersion(
+    npmPkg: string,
+    onData: (data: string) => void,
+  ): Promise<string | null> {
+    const node = await this._nodeVersion()
+    if (!node) return null
+    const info = await fetchNpmInfo(npmPkg).catch(() => null)
+    const latest = resolveLatestVersion(info)
+    const target = resolveInstallableVersion(info, node)
+    if (!latest || !target || target === latest) return null
+    if (onData)
+      onData(
+        `${npmPkg}@${latest} requires Node ${nodeEngineRange(info, latest)}, ` +
+          `but agents here run on Node ${node} — installing ${target}, the ` +
+          `newest release that supports it.\n\n`,
+      )
+    return target
   }
 
   /**
@@ -686,6 +765,8 @@ export class InstallService {
     const historyByName = new Map(
       this.listInstalledAgents().map((r) => [r.name, r.version]),
     )
+    // Asked once for the whole list: every agent runs on the same Node.
+    const node = await this._nodeVersion()
 
     return Promise.all(
       installedEntries.map(async (entry) => {
@@ -700,7 +781,9 @@ export class InstallService {
         const pinned = this.supportedVersion(entry)
         if (pinned) return { name, current, latest: pinned }
         const info = await fetchNpmInfo(npmPkg).catch(() => null)
-        return { name, current, latest: resolveLatestVersion(info) }
+        // The newest release this Node can run, which is what an update
+        // installs (see _heldBackVersion) — never a badge no update can clear.
+        return { name, current, latest: resolveInstallableVersion(info, node) }
       }),
     )
   }
@@ -720,17 +803,25 @@ export class InstallService {
     if (!npmPkg)
       return { versions: [], homepage, latest: null, error: NO_NPM_PACKAGE }
     try {
-      const info = await fetchNpmInfo(npmPkg)
+      const [info, node] = await Promise.all([
+        fetchNpmInfo(npmPkg),
+        this._nodeVersion(),
+      ])
       const time = info.time || {}
       // Show pre-releases in the changelog list (useful for visibility), but
-      // return `latest` as the stable dist-tag so the detail page's
-      // "Update to vX" computation matches what `npm install` actually fetches.
+      // return `latest` as the stable release an update would install — held
+      // back to what this Node can run, like the badge — so the detail page's
+      // "Update to vX" matches what actually lands.
       const versions = sortedPublishedVersions(info, {
         includePreRelease: true,
       })
         .slice(0, 12)
         .map((v) => ({ version: v, date: time[v] }))
-      return { versions, homepage, latest: resolveLatestVersion(info) }
+      return {
+        versions,
+        homepage,
+        latest: resolveInstallableVersion(info, node),
+      }
     } catch (e: unknown) {
       return {
         versions: [],

--- a/packages/launcher/src/main/agents/node-engines.test.ts
+++ b/packages/launcher/src/main/agents/node-engines.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { nodeSatisfies } from "./node-engines"
+
+// The ranges openclaw actually published either side of its move to Node 24:
+// 2026.9.2 still ran on the launcher's bundled Node 22.22.3, 2026.9.3 did not.
+const OPENCLAW_9_2 = ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+const OPENCLAW_9_3 = ">=24.16.0 <25 || >=26.1.0"
+
+describe("nodeSatisfies", () => {
+  it("reads openclaw's ranges the way npm does", () => {
+    expect(nodeSatisfies("22.22.3", OPENCLAW_9_2)).toBe(true)
+    expect(nodeSatisfies("22.22.3", OPENCLAW_9_3)).toBe(false)
+    expect(nodeSatisfies("24.20.0", OPENCLAW_9_3)).toBe(true)
+    expect(nodeSatisfies("25.0.0", OPENCLAW_9_3)).toBe(false)
+    expect(nodeSatisfies("v26.1.0", OPENCLAW_9_3)).toBe(true)
+  })
+
+  it.each([
+    ["22.22.3", ">=22.19.0", true],
+    ["20.11.0", ">= 22", false],
+    ["22.0.0", "22.x", true],
+    ["23.0.0", "22", false],
+    ["22.5.1", "^22.1.0", true],
+    ["23.0.0", "^22.1.0", false],
+    ["0.3.0", "^0.2.3", false],
+    ["22.2.0", "~22.1.0", false],
+    ["22.1.9", "~22.1", true],
+    ["22.9.0", "18 - 22", true],
+    ["23.0.0", "18 - 22", false],
+    ["22.22.3", "<=22.22.3", true],
+    ["22.22.4", "<=22.22.3", false],
+    ["22.22.3", ">22.22", false],
+    ["22.23.0", ">22.22", true],
+    ["22.0.0", "=22.0.0", true],
+    ["22.0.0", "*", true],
+    ["22.0.0", "", true],
+  ])("%s against %j is %s", (version, range, expected) => {
+    expect(nodeSatisfies(version, range)).toBe(expected)
+  })
+
+  it("says it can't tell rather than guessing no", () => {
+    // A "no" holds an agent back on an older release, so it has to be earned —
+    // a range nobody here can read is not evidence against the Node.
+    expect(nodeSatisfies("22.22.3", ">=22.0.0-rc.1")).toBe(null)
+    expect(nodeSatisfies("22.22.3", "node >= 18")).toBe(null)
+    expect(nodeSatisfies("nightly", ">=18")).toBe(null)
+  })
+
+  it("answers yes when one alternative is unreadable and another fits", () => {
+    expect(nodeSatisfies("22.22.3", ">=99.0.0-beta || >=22")).toBe(true)
+    expect(nodeSatisfies("20.0.0", ">=99.0.0-beta || >=22")).toBe(null)
+  })
+})

--- a/packages/launcher/src/main/agents/node-engines.ts
+++ b/packages/launcher/src/main/agents/node-engines.ts
@@ -1,0 +1,137 @@
+/**
+ * Does a Node version satisfy a package's `engines.node` range?
+ *
+ * Every npm agent is installed and run on one Node — the portable runtime in
+ * ~/.openagents/nodejs (see resolveNpmInvocation). npm only warns when a
+ * package's engines field rules that Node out, so nothing stopped the launcher
+ * asking for a release its own Node cannot run, until a package refused on its
+ * own: openclaw 2026.9.3 added a preinstall script that exits non-zero below
+ * Node 24.16, and every update on the bundled Node 22 failed.
+ *
+ * Covers the grammar packages actually write in `engines.node`: comparators
+ * (>= > <= < =), bare and partial versions (22, 22.1, 22.x, *), caret, tilde,
+ * hyphen ranges and `||`. Anything else — a pre-release tag, build metadata, a
+ * word where a version belongs — answers null, "can't tell", which callers
+ * treat as compatible: a wrong "no" would hold an agent back for nothing, so
+ * the answer is only ever no when it is certain.
+ */
+
+type Triple = [number, number, number]
+
+/** `lo` inclusive, `hi` exclusive; a missing end is open. */
+interface Interval {
+  lo?: Triple
+  hi?: Triple
+}
+
+/** Up to three parts; a missing or x/* part is null, and so is all after it. */
+const PARTIAL = /^v?(\d+|[xX*])(?:\.(\d+|[xX*]))?(?:\.(\d+|[xX*]))?$/
+
+function parsePartial(s: string): Array<number | null> | null {
+  const m = PARTIAL.exec(s)
+  if (!m) return null
+  const parts = [m[1], m[2], m[3]].map((p) =>
+    p === undefined || /^[xX*]$/.test(p) ? null : Number(p),
+  )
+  const wild = parts.indexOf(null)
+  return wild === -1 ? parts : parts.map((p, i) => (i < wild ? p : null))
+}
+
+function compare(a: Triple, b: Triple): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1
+  return 0
+}
+
+/**
+ * One comparator as the interval it allows, or null when it isn't one we read.
+ * Versions are whole numbers, so every operator reduces to `>=` and `<`:
+ * `>1.2.3` is `>=1.2.4`, and `<=22` is `<23.0.0`.
+ */
+function toInterval(comparator: string): Interval | null {
+  const m = /^(>=|<=|>|<|=|\^|~)?(.*)$/.exec(comparator)
+  const parts = m && parsePartial(m[2])
+  if (!m || !parts) return null
+  const op = m[1] || "="
+  const [major, minor, patch] = parts
+  // `<*` and `>*` match nothing; not worth modelling, so not read.
+  if (major === null) return op === "<" || op === ">" ? null : {}
+  const lo: Triple = [major, minor ?? 0, patch ?? 0]
+  // The first version past what was written: 22 → 23.0.0, 22.1 → 22.2.0.
+  const next: Triple =
+    minor === null
+      ? [major + 1, 0, 0]
+      : patch === null
+        ? [major, minor + 1, 0]
+        : [major, minor, patch + 1]
+  switch (op) {
+    case ">=":
+      return { lo }
+    case ">":
+      return { lo: next }
+    case "<":
+      return { hi: lo }
+    case "<=":
+      return { hi: next }
+    case "~":
+      return {
+        lo,
+        hi: minor === null ? [major + 1, 0, 0] : [major, minor + 1, 0],
+      }
+    case "^":
+      return {
+        lo,
+        hi:
+          major > 0 || minor === null
+            ? [major + 1, 0, 0]
+            : minor > 0 || patch === null
+              ? [0, minor + 1, 0]
+              : [0, 0, patch + 1],
+      }
+    default:
+      return { lo, hi: next }
+  }
+}
+
+/** A `||`-free range as its intervals, or null when any part isn't readable. */
+function parseSet(set: string): Interval[] | null {
+  const s = set.trim()
+  // `18 - 22`: a hyphen range, inclusive at both ends.
+  const hyphen = /^(\S+)\s+-\s+(\S+)$/.exec(s)
+  const comparators = hyphen
+    ? [`>=${hyphen[1]}`, `<=${hyphen[2]}`]
+    : s
+        .replace(/(>=|<=|>|<|=|\^|~)\s+/g, "$1")
+        .split(/\s+/)
+        .filter(Boolean)
+  const out: Interval[] = []
+  for (const c of comparators) {
+    const interval = toInterval(c)
+    if (!interval) return null
+    out.push(interval)
+  }
+  return out
+}
+
+/**
+ * True or false when the range can be read, null when it can't. One readable
+ * alternative that fits is enough for true, whatever the others say.
+ */
+export function nodeSatisfies(version: string, range: string): boolean | null {
+  const parts = parsePartial(version.trim())
+  if (!parts || parts.includes(null)) return null
+  const v = parts as Triple
+  let unreadable = false
+  for (const set of range.split("||")) {
+    const intervals = parseSet(set)
+    if (!intervals) {
+      unreadable = true
+      continue
+    }
+    const inside = intervals.every(
+      ({ lo, hi }) =>
+        (!lo || compare(v, lo) >= 0) && (!hi || compare(v, hi) < 0),
+    )
+    if (inside) return true
+  }
+  return unreadable ? null : false
+}

--- a/packages/launcher/src/main/agents/npm-registry.test.ts
+++ b/packages/launcher/src/main/agents/npm-registry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveInstallableVersion, type NpmRegistryInfo } from "./npm-registry"
+
+const NODE_22_OK = ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+const NODE_24_ONLY = ">=24.16.0 <25 || >=26.1.0"
+
+// openclaw on npm, 2026-09-11: `latest` had just moved to a Node 24 floor. The
+// beta accepts Node 22 here on purpose — `npm install` would never pick it, so
+// holding back must not either.
+const openclaw: NpmRegistryInfo = {
+  "dist-tags": { latest: "2026.9.4" },
+  versions: {
+    "2026.9.1": { engines: { node: NODE_22_OK } },
+    "2026.9.2": { engines: { node: NODE_22_OK } },
+    "2026.9.3": { engines: { node: NODE_24_ONLY } },
+    "2026.9.4": { engines: { node: NODE_24_ONLY } },
+    "2026.9.5-beta.1": { engines: { node: NODE_22_OK } },
+  },
+}
+
+describe("resolveInstallableVersion", () => {
+  it("holds back to the newest stable release the agents' Node can run", () => {
+    expect(resolveInstallableVersion(openclaw, "22.22.3")).toBe("2026.9.2")
+  })
+
+  it("is plain `latest` once the Node is new enough", () => {
+    expect(resolveInstallableVersion(openclaw, "24.20.0")).toBe("2026.9.4")
+  })
+
+  it("is plain `latest` when the Node is unknown", () => {
+    expect(resolveInstallableVersion(openclaw, null)).toBe("2026.9.4")
+  })
+
+  it("is plain `latest` when no release runs on this Node at all", () => {
+    // Nothing to hold back to, so npm gets to try and print its own reason.
+    expect(resolveInstallableVersion(openclaw, "20.0.0")).toBe("2026.9.4")
+  })
+
+  it("never climbs above `latest`", () => {
+    const info: NpmRegistryInfo = {
+      "dist-tags": { latest: "2.0.0" },
+      versions: {
+        "1.0.0": {},
+        "2.0.0": { engines: { node: ">=24" } },
+        // Published but not tagged latest — a hotfix line, say.
+        "3.0.0": {},
+      },
+    }
+    expect(resolveInstallableVersion(info, "22.22.3")).toBe("1.0.0")
+  })
+
+  it("treats a missing or unreadable range as runnable", () => {
+    const info = (engines: unknown): NpmRegistryInfo => ({
+      "dist-tags": { latest: "2.0.0" },
+      versions: { "1.0.0": {}, "2.0.0": { engines } },
+    })
+    expect(resolveInstallableVersion(info(undefined), "22.22.3")).toBe("2.0.0")
+    expect(resolveInstallableVersion(info(["node >=0.6"]), "22.22.3")).toBe("2.0.0")
+    expect(resolveInstallableVersion(info({ node: "node >= 18" }), "22.22.3")).toBe("2.0.0")
+  })
+})

--- a/packages/launcher/src/main/agents/npm-registry.ts
+++ b/packages/launcher/src/main/agents/npm-registry.ts
@@ -5,10 +5,12 @@
  */
 import https from "https"
 import { npmRegistryBase } from "../mirror"
+import { nodeSatisfies } from "./node-engines"
 
 export interface NpmRegistryInfo {
   "dist-tags"?: { latest?: string }
-  versions?: Record<string, unknown>
+  /** Each version's manifest; `engines` is the only part read here. */
+  versions?: Record<string, { engines?: unknown } | undefined>
   time?: Record<string, string>
   homepage?: string
 }
@@ -95,4 +97,43 @@ export function resolveLatestVersion(
   const tagged = info?.["dist-tags"]?.latest
   if (tagged) return tagged
   return sortedPublishedVersions(info)[0] || null
+}
+
+/** The Node range a published version declares, or null when it declares none. */
+export function nodeEngineRange(
+  info: NpmRegistryInfo | null,
+  version: string,
+): string | null {
+  const engines = info?.versions?.[version]?.engines as
+    | { node?: unknown }
+    | undefined
+  const range = engines?.node
+  return typeof range === "string" && range.trim() ? range : null
+}
+
+/**
+ * The version an install should ask npm for on a machine whose agents run on
+ * `nodeVersion`: `latest` when that release accepts this Node, otherwise the
+ * newest earlier stable release that does.
+ *
+ * `latest` comes back unchanged when the Node is unknown, and when no release
+ * accepts it at all — guessing improves neither, and npm or the package then
+ * says why in its own words. A range that can't be read counts as accepting
+ * (see nodeSatisfies), so the answer only moves off `latest` on a definite no.
+ */
+export function resolveInstallableVersion(
+  info: NpmRegistryInfo | null,
+  nodeVersion: string | null,
+): string | null {
+  const latest = resolveLatestVersion(info)
+  if (!latest || !nodeVersion) return latest
+  const runs = (v: string): boolean => {
+    const range = nodeEngineRange(info, v)
+    return !range || nodeSatisfies(nodeVersion, range) !== false
+  }
+  if (runs(latest)) return latest
+  const older = sortedPublishedVersions(info).find(
+    (v) => compareVersionsDesc(v, latest) > 0 && runs(v),
+  )
+  return older || latest
 }

--- a/packages/launcher/src/main/agents/runtime.ts
+++ b/packages/launcher/src/main/agents/runtime.ts
@@ -4,10 +4,10 @@
  */
 import path from "path"
 import fs from "fs"
-import { spawnSync } from "child_process"
-import { withPathEnv } from "../env"
+import { execFile, spawnSync } from "child_process"
+import { readPathEnv, withPathEnv } from "../env"
 import { compareVersions } from "../../shared/version-compare"
-import { CONFIG_DIR, GLOBAL_CORE, LOCAL_CORE } from "./paths"
+import { CONFIG_DIR, GLOBAL_CORE, LOCAL_CORE, PORTABLE_NODE_DIR } from "./paths"
 
 /** The install-command key for this OS, as the shared registry spells it. */
 export function platformKey(): "macos" | "linux" | "windows" {
@@ -254,4 +254,35 @@ export function resolveNpmInvocation(): {
     preArgs: [],
     useShell: true,
   }
+}
+
+/**
+ * The Node that npm agents are installed and run on, as `22.22.3`: the
+ * portable runtime when there is one (the binary resolveNpmInvocation hands
+ * npm), otherwise the `node` an install's PATH finds. Null when neither
+ * answers. Asynchronous because the detail page asks every time it opens.
+ */
+export function agentNodeVersion(): Promise<string | null> {
+  const inv = resolveNpmInvocation()
+  const bin = inv.useShell ? "node" : inv.cmd
+  return new Promise((resolve) => {
+    try {
+      execFile(
+        bin,
+        ["--version"],
+        {
+          encoding: "utf-8",
+          timeout: 5000,
+          windowsHide: true,
+          env: withPathEnv(PORTABLE_NODE_DIR + path.delimiter + readPathEnv()),
+        },
+        (err, stdout) => {
+          const m = err ? null : /^v?(\d+\.\d+\.\d+)/.exec(stdout.trim())
+          resolve(m ? m[1] : null)
+        },
+      )
+    } catch {
+      resolve(null)
+    }
+  })
 }


### PR DESCRIPTION
## Summary

OpenClaw updates in the launcher were failing. Root cause, reproduced locally:

- openclaw **2026.9.3** raised its `engines.node` floor to `>=24.16.0 <25 || >=26.1.0` and added a `preinstall` script that exits non-zero below it.
- The launcher installs **and runs** every npm agent on its portable Node (`~/.openagents/nodejs`, **v22.22.3**, set in the core's `installNodejs`).
- So since 2026.9.4 became npm's `latest` (2026-09-11), every openclaw update — and every fresh install — failed, while the update badge kept offering the release that could not install. 2026.9.2 is the newest release that still runs on Node 22.

```
npm error [openclaw] error: this OpenClaw release requires Node >=24.16.0 <25 || >=26.1.0.
npm error [openclaw] detected Node 22.22.3 (exec: ~/.openagents/nodejs/bin/node).
```

## What changes

Anything that targets `latest` now resolves it to the newest stable release whose `engines.node` accepts the agents' Node:

- **Update** (`installAtVersionTag("latest")`) and **fresh install** of a floating npm command (`openclaw@latest`, bare `npm install -g <pkg>`) install that release; the install log says which release was held back and why.
- The **update badge** (`_loadAgentUpdates`) and the detail page's **"Update to vX"** (`getAgentChangelog`) report the same version, so the button only offers what can actually land.
- Rollback, Beta/Nightly channels and `supported_version` pins are untouched (explicit targets).
- Fail-open: an unknown Node, an unreachable registry, or an `engines` range the matcher can't read all keep the previous behaviour.

Files:
- `main/agents/node-engines.ts` — small `engines.node` range matcher (comparators, partials/x-ranges, `^`, `~`, hyphen, `||`); anything else answers "can't tell".
- `main/agents/npm-registry.ts` — `resolveInstallableVersion`, `nodeEngineRange`.
- `main/agents/runtime.ts` — `agentNodeVersion()` (the Node `resolveNpmInvocation` hands npm, else PATH's `node`).
- `main/agents/install-service.ts` — wiring; Node bootstrap extracted to `_ensureNode`.
- `changelog/0.9.30.json` — release note (entries re-sorted feature → fix → improvement).

No launcher version bump — this rides in the unreleased 0.9.30.

## Test plan

- [x] Reproduced the failure with the bundled Node 22.22.3 + `npm install openclaw@latest`
- [x] New unit tests: `node-engines.test.ts`, `npm-registry.test.ts`, openclaw scenarios in `install-service.test.ts`
- [x] `npx vitest run` (launcher): 52 files / 534 tests pass
- [x] `tsc -b` clean, `npm run check:changelog` OK
- [ ] Manual: with the bundled Node 22, openclaw on 2026.9.2 shows no update; an uninstall + install lands 2026.9.2 with the hold-back line in the log

## Follow-up

Getting openclaw past 2026.9.2 requires raising the portable Node to 24 LTS in the core installer (plus an upgrade path for existing `~/.openagents/nodejs` installs). That affects the daemon and every agent, so it's left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
