### PR TITLE
feat(workspace): serve collaborator rows with the account's name and picture

### DIFF
--- a/workspace/backend/app/routers/workspaces.py
+++ b/workspace/backend/app/routers/workspaces.py
@@ -25,7 +25,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
 from app import naming
@@ -1475,10 +1475,45 @@ def delete_workspace(
 # Collaborator management (email-based sharing)
 # ---------------------------------------------------------------------------
 
-def _format_collaborator(c: WorkspaceCollaborator) -> dict:
+def _user_cards(db: Session, emails) -> dict:
+    """`email -> (display_name, avatar_url)` for the accounts behind [emails].
+
+    `workspace_collaborators` is keyed by email and predates accounts: it
+    carries whatever display name the client happened to send and has never
+    had a picture. The `users` row is where the profile actually lives, so it
+    is looked up here rather than duplicated into the collaborator row, which
+    would go stale the moment someone changes their photo.
+
+    One query for the whole list — a per-row lookup would turn the member list
+    into an N+1.
+    """
+    wanted = {(e or "").strip().lower() for e in emails if e}
+    if not wanted:
+        return {}
+    rows = db.execute(
+        select(User.email, User.display_name, User.avatar_url).where(
+            func.lower(User.email).in_(wanted)
+        )
+    ).all()
+    return {email.lower(): (display_name, avatar_url) for email, display_name, avatar_url in rows}
+
+
+def _format_collaborator(c: WorkspaceCollaborator, cards: Optional[dict] = None) -> dict:
+    """Serialize a collaborator, enriched with their account profile.
+
+    [cards] comes from `_user_cards`. Omitting it still yields a valid row —
+    one with no picture — so a caller without a session at hand degrades to
+    the shape this endpoint always returned rather than failing.
+
+    The account's display name wins over the collaborator row's: the row's is
+    a snapshot from whichever client last posted, the account's is what its
+    owner set on purpose.
+    """
+    name, avatar = (cards or {}).get((c.email or "").lower(), (None, None))
     return {
         "email": c.email,
-        "displayName": c.display_name,
+        "displayName": name or c.display_name,
+        "avatarUrl": avatar,
         "role": c.role,
         "addedBy": c.added_by,
         "addedAt": c.added_at.isoformat() if c.added_at else None,
@@ -1501,7 +1536,9 @@ def list_collaborators(
     if not _verify_workspace_access(workspace, x_workspace_token, authorization):
         return json_response(ResponseCode.UNAUTHORIZED, "Invalid credentials")
 
-    collabs = [_format_collaborator(c) for c in (workspace.collaborators or [])]
+    rows = workspace.collaborators or []
+    cards = _user_cards(db, [c.email for c in rows])
+    collabs = [_format_collaborator(c, cards) for c in rows]
     return success_response({
         "collaborators": collabs,
         "owner": workspace.creator_email,
@@ -1549,7 +1586,9 @@ async def record_presence(
             WorkspaceCollaborator.email == email,
         )
     ).scalar_one_or_none()
-    return success_response(_format_collaborator(existing) if existing else {"email": email})
+    return success_response(
+        _format_collaborator(existing, _user_cards(db, [email])) if existing else {"email": email}
+    )
 
 
 @router.post("/{workspace_id}/collaborators")
@@ -1596,7 +1635,7 @@ def add_collaborator(
         existing.role = body.role
         db.commit()
         db.refresh(existing)
-        return success_response(_format_collaborator(existing))
+        return success_response(_format_collaborator(existing, _user_cards(db, [email])))
 
     collab = WorkspaceCollaborator(
         workspace_id=workspace.id,
@@ -1607,7 +1646,7 @@ def add_collaborator(
     db.add(collab)
     db.commit()
     db.refresh(collab)
-    return success_response(_format_collaborator(collab))
+    return success_response(_format_collaborator(collab, _user_cards(db, [email])))
 
 
 @router.delete("/{workspace_id}/collaborators/{email}")

--- a/workspace/backend/tests/test_collaborators.py
+++ b/workspace/backend/tests/test_collaborators.py
@@ -239,3 +239,85 @@ class TestCollaboratorAuth:
             )
             assert resp.status_code == 200
             assert resp.json()["code"] == 0
+
+
+# ===========================================================================
+# Profile enrichment — the picture and name come from the account, not from
+# whatever the collaborator row was created with.
+# ===========================================================================
+
+class TestCollaboratorProfiles:
+
+    AVATAR = "data:image/png;base64,iVBORw0KGgo="
+
+    def _account(self, db, email, display_name=None, avatar_url=None):
+        from app.models import User
+        user = User(email=email, display_name=display_name, avatar_url=avatar_url)
+        db.add(user)
+        db.commit()
+        return user
+
+    def test_list_carries_the_account_avatar(self, client, db, workspace):
+        self._account(db, "alice@example.com", "Alice Liddell", self.AVATAR)
+        headers = {"X-Workspace-Token": workspace["token"]}
+        client.post(
+            f"/v1/workspaces/{workspace['id']}/collaborators",
+            json={"email": "alice@example.com"},
+            headers=headers,
+        )
+
+        resp = client.get(
+            f"/v1/workspaces/{workspace['id']}/collaborators",
+            headers=headers,
+        )
+        row = next(
+            c for c in resp.json()["data"]["collaborators"]
+            if c["email"] == "alice@example.com"
+        )
+        assert row["avatarUrl"] == self.AVATAR
+        # The account's own name wins over the collaborator row's snapshot.
+        assert row["displayName"] == "Alice Liddell"
+
+    def test_collaborator_without_an_account_still_lists(self, client, workspace):
+        """Invited but never signed in: a null picture, not a 500."""
+        headers = {"X-Workspace-Token": workspace["token"]}
+        client.post(
+            f"/v1/workspaces/{workspace['id']}/collaborators",
+            json={"email": "ghost@example.com"},
+            headers=headers,
+        )
+
+        resp = client.get(
+            f"/v1/workspaces/{workspace['id']}/collaborators",
+            headers=headers,
+        )
+        row = next(
+            c for c in resp.json()["data"]["collaborators"]
+            if c["email"] == "ghost@example.com"
+        )
+        assert row["avatarUrl"] is None
+
+    def test_add_returns_the_same_enriched_shape(self, client, db, workspace):
+        """The POST response feeds the list straight away — it must match."""
+        self._account(db, "bob@example.com", "Bob", self.AVATAR)
+        resp = client.post(
+            f"/v1/workspaces/{workspace['id']}/collaborators",
+            json={"email": "bob@example.com"},
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+        data = resp.json()["data"]
+        assert data["avatarUrl"] == self.AVATAR
+        assert data["displayName"] == "Bob"
+
+    def test_presence_ping_returns_the_avatar(self, client, db, workspace):
+        """Self-registration on workspace open is where most rows come from."""
+        self._account(db, "carol@example.com", "Carol", self.AVATAR)
+        resp = client.post(
+            f"/v1/workspaces/{workspace['id']}/presence",
+            json={"senderEmail": "Carol@Example.com", "senderDisplayName": "C"},
+            headers={"X-Workspace-Token": workspace["token"]},
+        )
+        data = resp.json()["data"]
+        # Matched case-insensitively: the collaborator row is lowercased on
+        # write, the account row is not guaranteed to be.
+        assert data["avatarUrl"] == self.AVATAR


### PR DESCRIPTION
## What

`GET /v1/workspaces/{id}/collaborators` (and the POST/presence responses that share its shape) now carry `avatarUrl`, and prefer the account's display name over the collaborator row's snapshot.

## Why

`workspace_collaborators` is email-keyed and predates accounts. It stores whatever display name the client happened to send and has never had a picture, so every client rendering a member list or an @-mention row had nothing to draw but an initial — even though the user's photo has been sitting in `users.avatar_url` all along (`/v1/account/profile` writes it, `/team` already returns it).

## How

- `_user_cards(db, emails)` resolves `email -> (display_name, avatar_url)` in **one** query, case-insensitively; the list endpoint passes it once for every row rather than looking up per row.
- The profile is read at serialization time, not copied into the collaborator row — a copy would go stale the moment someone changes their photo.
- A collaborator who was invited but never signed in comes back with `avatarUrl: null`, not an error.

Purely additive to the response shape; no migration, no behavior change for existing fields other than a better `displayName`.

## Tests

Four cases in `tests/test_collaborators.py`: list carries the avatar and the account name; no-account collaborator lists with a null picture; the POST response matches the list shape; the presence ping matches case-insensitively.

`pytest tests` — 861 passed. The 28 pre-existing failures on `develop` (integrations, login-session, migration-schema, ssrf) are unchanged and unrelated.